### PR TITLE
Update ha_iot_class to local push

### DIFF
--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -11,7 +11,7 @@ ha_codeowners:
   - '@balloob'
   - '@bieniu'
   - '@thecode'
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ha_domain: shelly
 featured: true
 ha_config_flow: true


### PR DESCRIPTION
Shelly integration is using local push since HA 0.118
Integration is already working in local push, but I'm linking this to a parent issue in the codebase since the `CONNECTION_CLASS` in the integration also needs to be updated ([#44260](https://github.com/home-assistant/core/pull/44260)).

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#44260](https://github.com/home-assistant/core/pull/44260)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
