### PR TITLE
clarify that Shelly H&T is always affected by battery limitations, even if powered by USB

### DIFF
--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -109,4 +109,4 @@ Not all devices support all input events. You can check on [Shelly API Reference
 
 - Only supports firmware 1.8 and later
 - Support for RGB devices is limited
-- Support for battery-powered devices is limited
+- Support for battery-powered devices is limited (also applies to USB powered Shelly H&T)


### PR DESCRIPTION
## Proposed change

Shelly H&T is originally powered by a battery. However, there's an official USB power adapter. A USB powered device wakes up more frequently than a battery powered device, but still sleeps most of the time causing the same problems like battery only Shelly devices.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- See also https://github.com/home-assistant/core/issues/44180

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
