### PR TITLE
FRITZ!Box 6591 Cable is also compatible with the fritzbox integration

### DIFF
--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -24,6 +24,7 @@ There is currently support for the following device types within Home Assistant:
 #### Tested Devices
 
 - [FRITZ!Box 6490 Cable](https://en.avm.de/products/fritzbox/fritzbox-6490-cable/)
+- [FRITZ!Box 6591 Cable](https://en.avm.de/products/fritzbox/fritzbox-6591-cable/)
 - [FRITZ!Box 7590](https://en.avm.de/products/fritzbox/fritzbox-7590/)
 - [FRITZ!Box 7490](https://en.avm.de/service/fritzbox/fritzbox-7490/overview/)
 - [FRITZ!Box 7430](https://en.avm.de/service/fritzbox/fritzbox-7430/overview/)


### PR DESCRIPTION
## Proposed change

FRITZ!Box 6591 Cable is also compatible with the fritzbox integration

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
