### PR TITLE
Adds description on how to enable Local Push in nuki

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -287,7 +287,7 @@ source/_integrations/notion.markdown @bachya
 source/_integrations/nsw_fuel_station.markdown @nickw444
 source/_integrations/nsw_rural_fire_service_feed.markdown @exxamalte
 source/_integrations/nuheat.markdown @bdraco
-source/_integrations/nuki.markdown @pschmitt @pvizeli
+source/_integrations/nuki.markdown @pschmitt @pvizeli @steinerl
 source/_integrations/numato.markdown @clssn
 source/_integrations/nut.markdown @bdraco
 source/_integrations/nws.markdown @MatthewFlamm

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -24,7 +24,7 @@ lock:
     host: 192.168.1.120
     token: fe2345ef
     # webhook_id is required to activate `Local Push`
-    webhook_id: some_hook_id
+    webhook_id: nuki
 ```
 
 {% configuration %}
@@ -52,10 +52,10 @@ The component defaults to `Local Polling`.
 
 To activate `Local Push`, it is required to provide a `webhook_id` in the configuration.
 
-It is also required to register the Home Assistant webhook URL `http://your-home-assistant:8123/api/webhook/some_hook_id` as a callback endpoint on your Nuki Bridge via the [Nuki Bridge HTTP API](https://developer.nuki.io/page/nuki-bridge-http-api-1-12/4#heading--callback-add):
+It is also required to register the Home Assistant webhook URL `http://your-home-assistant:8123/api/webhook/nuki` as a callback endpoint on your Nuki Bridge via the [Nuki Bridge HTTP API](https://developer.nuki.io/page/nuki-bridge-http-api-1-12/4#heading--callback-add):
 
 ```shell
-curl http://192.168.1.120:8080/callback/add?token=fe2345ef&url=http%3A%2F%2Fyour-home-assistant%3A8123%2Fapi%2Fwebhook%2Fsome_hook_id
+curl http://192.168.1.120:8080/callback/add?token=fe2345ef&url=http%3A%2F%2Fyour-home-assistant%3A8123%2Fapi%2Fwebhook%2Fnuki
 ```
 
 **Note:** The Bridge API doesn't support HTTPS URLs. Also make sure to URL encode the parameter values.

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -4,10 +4,11 @@ description: Instructions on how to integrate a Nuki Smart Lock devices.
 ha_category:
   - Lock
 ha_release: 0.38
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ha_codeowners:
   - '@pschmitt'
   - '@pvizeli'
+  - '@steinerl'
 ha_domain: nuki
 ---
 
@@ -22,6 +23,8 @@ lock:
   - platform: nuki
     host: 192.168.1.120
     token: fe2345ef
+    # webhook_id is required to activate `Local Push`
+    webhook_id: some_hook_id
 ```
 
 {% configuration %}
@@ -38,7 +41,37 @@ token:
   description: The token that was defined when setting up the bridge.
   required: true
   type: string
+webhook_id:
+  description: An ID for the Nuki webhook endpoint, eg. `nuki`.
+  type: string
 {% endconfiguration %}
+
+### Local Push
+
+The component defaults to `Local Polling`.
+
+To activate `Local Push`, it is required to provide a `webhook_id` in the configuration.
+
+It is also required to register the Home Assistant webhook URL `http://your-home-assistant:8123/api/webhook/some_hook_id` as a callback endpoint on your Nuki Bridge via the [Nuki Bridge HTTP API](https://developer.nuki.io/page/nuki-bridge-http-api-1-12/4#heading--callback-add):
+
+```shell
+curl http://192.168.1.120:8080/callback/add?token=fe2345ef&url=http%3A%2F%2Fyour-home-assistant%3A8123%2Fapi%2Fwebhook%2Fsome_hook_id
+```
+
+**Note:** The Bridge API doesn't support HTTPS URLs. Also make sure to URL encode the parameter values.
+
+## Events
+
+### Event `nuki_bell_ring`
+
+Every time someone rings the bell on your Nuki Opener connected intercom system, a `nuki_bell_ring` event will be fired.
+
+**Note:** This event only gets fired when `Local Push` is used.
+
+Field | Description
+----- | -----------
+`nuki_id` | ID of the Nuki Device.
+`ring_action_timestamp` | Timestamp of when the bell was rang.
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR documents the necessary configuration changes for enabling the new `Local Push` support in the Nuki integration (added in home-assistant/core#44310).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#44310
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
