### PR TITLE
Update Zerproc docs for new async backend

### DIFF
--- a/source/_integrations/zerproc.markdown
+++ b/source/_integrations/zerproc.markdown
@@ -9,6 +9,7 @@ ha_domain: zerproc
 ha_codeowners:
   - '@emlove'
 ha_config_flow: true
+ha_quality_scale: platinum
 ---
 
 This integration discovers nearby Zerproc lights and adds them to Home Assistant.
@@ -25,24 +26,4 @@ The integration will scan for nearby devices, and is completed if any are found.
 
 ## Additional information for Home Assistant Core on Python environments
 
-This integration requires `pybluez` to be installed. On Debian based installs, run:
-
-```bash
-sudo apt install bluetooth
-```
-
-Before you get started with this integration, please note that:
-
-- Requires access to the Bluetooth stack, see [Rootless Setup section](#rootless-setup) for further information
-
-## Rootless Setup
-
-Normally accessing the Bluetooth stack is reserved for `root`, but running programs that are networked as `root` is a bad security wise. To allow non-root access to the Bluetooth stack we can give Python 3 and `hcitool` the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](https://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
-
-```bash
-sudo apt-get install libcap2-bin
-sudo setcap 'cap_net_raw,cap_net_admin+eip' `readlink -f \`which python3\``
-sudo setcap 'cap_net_raw+ep' `readlink -f \`which hcitool\``
-```
-
-A restart of Home Assistant Core is required.
+This integration requires a working Bluetooth stack. Please refer to the [requirements of the underlying bleak library](https://bleak.readthedocs.io/en/latest/backends/index.html) for the operating system requirements.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR updates the Zerproc integration to reflect the new requirements for the Bluetooth backend.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/44357
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
