### PR TITLE
Fix FGKF-601 key names

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -869,12 +869,12 @@ Button three (X) release|3|7740
 Button four (Triangle) single tap|4|7680
 Button four (Triangle) hold|4|7800
 Button four (Triangle) release|4|7740
-Button five (Triangle) single tap|5|7680
-Button five (Triangle) hold|5|7800
-Button five (Triangle) release|5|7740
-Button six (Triangle) single tap|6|7680
-Button six (Triangle) hold|6|7800
-Button six (Triangle) release|6|7740
+Button five (Minus) single tap|5|7680
+Button five (Minus) hold|5|7800
+Button five (Minus) release|5|7740
+Button six (Plus) single tap|6|7680
+Button six (Plus) hold|6|7800
+Button six (Plus) release|6|7740
 
 Press circle and plus simultaneously to wake up the device.
 


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The names for the last two buttons (Minus and Plus) were probably cut/pasted from the fourth (Triangle).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
