### PR TITLE
Examples on effect, palette randomization for wled

### DIFF
--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -122,3 +122,39 @@ This service allows for loading a preset saved on the WLED device.
 | `preset`               | no       | ID of the preset slot to load from.                                                                             |
 
 More information on presets [is documented in the WLED Wiki](https://github.com/Aircoookie/WLED/wiki/Presets)
+
+## Example Automations
+
+### Activating Random Effect
+
+You can automate changing the effect using a service call like this:
+
+```
+service: wled.effect
+data:
+  entity_id: light.wled
+  effect: "{{ state_attr('light.wled', 'effect_list') | random }}"
+```
+
+### Activating Random Palette
+
+Activating a random palette is a bit more complicated as there is currently no way to obtain a list of available palettes.
+To go around this issue, one solution is to leverage the fact that palettes can be activated by their IDs.
+As the IDs are based on an incrementing counter, picking a random number between zero and the number of palettes minus one works.
+
+To do this, the first step is to use [WLED's JSON API](https://github.com/Aircoookie/WLED/wiki/JSON-API) find out how many palettes the device supports:
+
+```
+$ curl --silent http://<ip address of the wled device>/json | jq ".palettes | length"
+
+54
+```
+
+In this case (using WLED v0.11.0) there are 54 palettes, so the following service call will activate a random palette by its ID between 0 and 53:
+
+```
+service: wled.effect
+data:
+  entity_id: light.wled
+  palette: "{{ range(0,53) | random }}"
+```

--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -129,12 +129,16 @@ More information on presets [is documented in the WLED Wiki](https://github.com/
 
 You can automate changing the effect using a service call like this:
 
+{% raw %}
+
 ```yaml
 service: wled.effect
 data:
   entity_id: light.wled
   effect: "{{ state_attr('light.wled', 'effect_list') | random }}"
 ```
+
+{% endraw %}
 
 ### Activating Random Palette
 
@@ -152,9 +156,13 @@ $ curl --silent http://<ip address of the wled device>/json | jq ".palettes | le
 
 In this case (using WLED v0.11.0) there are 54 palettes, so the following service call will activate a random palette by its ID between 0 and 53:
 
+{% raw %}
+
 ```yaml
 service: wled.effect
 data:
   entity_id: light.wled
   palette: "{{ range(0,53) | random }}"
 ```
+
+{% endraw %}

--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -129,7 +129,7 @@ More information on presets [is documented in the WLED Wiki](https://github.com/
 
 You can automate changing the effect using a service call like this:
 
-```
+```yaml
 service: wled.effect
 data:
   entity_id: light.wled
@@ -144,7 +144,7 @@ As the IDs are based on an incrementing counter, picking a random number between
 
 To do this, the first step is to use [WLED's JSON API](https://github.com/Aircoookie/WLED/wiki/JSON-API) find out how many palettes the device supports:
 
-```
+```bash
 $ curl --silent http://<ip address of the wled device>/json | jq ".palettes | length"
 
 54
@@ -152,7 +152,7 @@ $ curl --silent http://<ip address of the wled device>/json | jq ".palettes | le
 
 In this case (using WLED v0.11.0) there are 54 palettes, so the following service call will activate a random palette by its ID between 0 and 53:
 
-```
+```yaml
 service: wled.effect
 data:
   entity_id: light.wled


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add examples on how to activate random effect & random palette.

Obsoletes #15972


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
