### PR TITLE
Added securitas direct documentation

### DIFF
--- a/source/_integrations/securitas_direct.markdown
+++ b/source/_integrations/securitas_direct.markdown
@@ -21,17 +21,34 @@ Securitas Direct can be integrated by adding the following `securitas_direct` se
 
 ## Configuration
 
-1. From Home Assistant, navigate to ‘Configuration’ then ‘Integrations’. Click the plus icon and type/select ‘Securitas Direct’.
-1. Choose your platform `Securitas Direct`.
+1. From Home Assistant, navigate to ‘Configuration’ then ‘Integrations’.
+1. Click the plus icon and type/select ‘Securitas Direct’.
 1. Enter your credentials and installation configuration.
-
 1. Click the Save button.
 
-| Attribute | Description | Required |
-| --------- | ----------- | ----------- |
-| `username` | Username for your Securitas Direct account.| `yes`
-| `password` | Password for your Securitas Direct account. | `yes`
-| `installation` | The number of your installation. To find information on installations run `pysecuritas -u USERNAME -p PASSWORD -c COUNTRY -l LANGUAGE INS`.| `yes`
-| `country` | Country identification (`PT`, `ES`, `FR`, `GB`, `IT`,...).| `default ES`
-| `lang` | Messages language (`pt`, `es`, `fr`, `en`, `it`,...).| `default es`
-| `code` | PIN code to activate or deactivate alarm.| `no`
+{% configuration %}
+username:
+  description: Username for your Securitas Direct account.
+  required: true
+  type: string
+password:
+  description: Password for your Securitas Direct account.
+  required: true
+  type: string
+installation:
+  description: The number of your installation. To find information on installations run `pysecuritas -u USERNAME -p PASSWORD -c COUNTRY -l LANGUAGE INS`.
+  required: false
+  type: string
+country:
+  description: Country identification (PT, ES, FR, GB, IT,...)
+  required: false
+  type: string
+lang:
+  description: Message language (pt, es, fr, en, it,...)
+  required: false
+  type: string
+code:
+  description: PIN code to activate or deactivate alarm.
+  required: false
+  type: integer
+{% endconfiguration %}

--- a/source/_integrations/securitas_direct.markdown
+++ b/source/_integrations/securitas_direct.markdown
@@ -26,29 +26,17 @@ Securitas Direct can be integrated by adding the following `securitas_direct` se
 1. Enter your credentials and installation configuration.
 1. Click the Save button.
 
-{% configuration %}
-username:
+{% configuration_basic %}
+Username:
   description: Username for your Securitas Direct account.
-  required: true
-  type: string
-password:
+Password:
   description: Password for your Securitas Direct account.
-  required: true
-  type: string
-installation:
+Installation:
   description: The number of your installation. To find information on installations run `pysecuritas -u USERNAME -p PASSWORD -c COUNTRY -l LANGUAGE INS`.
-  required: false
-  type: string
-country:
+Country:
   description: Country identification (PT, ES, FR, GB, IT,...)
-  required: false
-  type: string
-lang:
+Language:
   description: Message language (pt, es, fr, en, it,...)
-  required: false
-  type: string
-code:
+Code:
   description: PIN code to activate or deactivate alarm.
-  required: false
-  type: integer
-{% endconfiguration %}
+{% endconfiguration_basic %}

--- a/source/_integrations/securitas_direct.markdown
+++ b/source/_integrations/securitas_direct.markdown
@@ -1,0 +1,58 @@
+---
+title: Securitas Direct
+description: Instructions on how to setup Securitas Direct home security system on Home Assistant.
+ha_category:
+  - Hub
+  - Alarm
+ha_release: 2020.12
+ha_iot_class: Cloud Polling
+ha_domain: securitas_direct
+---
+
+The `securitas_direct` integration allows users to manage their Securitas Direct installation
+There is currently support for the following device types within Home Assistant:
+- **Alarm Control Panel**: Reports on the current alarm status and can be used to arm and disarm the system.
+
+## Configuration
+
+To integrate Verisure with Home Assistant, add the following section to your `configuration.yaml` file:
+
+Securitas Direct can be integrated by adding the following `securitas_direct` section to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+securitas_direct:
+  username: USERNAME
+  password: PASSWORD
+  installation: INSTALLATION_NUMBER
+  code: 1234
+  country: PT
+  lang: pt
+```
+
+{% configuration %}
+username:
+  description: Username for your Securitas Direct account.
+  required: true
+  type: string
+password:
+  description: Password for your Securitas Direct account.
+  required: true
+  type: string
+installation:
+  description: The number of your installation. To find information on installations run `pysecuritas -u USERNAME -p PASSWORD -c COUNTRY -l LANGUAGE INS`.
+  required: false
+  type: string
+country:
+  description: Country identification (PT, ES, FR, GB, IT,...)
+  required: false
+  type: string
+lang:
+  description: Message language (pt, es, fr, en, it,...)
+  required: false
+  type: string
+code:
+  description: PIN code to activate or deactivate alarm.
+  required: false
+  type: integer
+{% endconfiguration %}

--- a/source/_integrations/securitas_direct.markdown
+++ b/source/_integrations/securitas_direct.markdown
@@ -19,40 +19,19 @@ To integrate Verisure with Home Assistant, add the following section to your `co
 
 Securitas Direct can be integrated by adding the following `securitas_direct` section to your `configuration.yaml` file:
 
-```yaml
-# Example configuration.yaml entry
-securitas_direct:
-  username: USERNAME
-  password: PASSWORD
-  installation: INSTALLATION_NUMBER
-  code: 1234
-  country: PT
-  lang: pt
-```
+## Configuration
 
-{% configuration %}
-username:
-  description: Username for your Securitas Direct account.
-  required: true
-  type: string
-password:
-  description: Password for your Securitas Direct account.
-  required: true
-  type: string
-installation:
-  description: The number of your installation. To find information on installations run `pysecuritas -u USERNAME -p PASSWORD -c COUNTRY -l LANGUAGE INS`.
-  required: false
-  type: string
-country:
-  description: Country identification (PT, ES, FR, GB, IT,...)
-  required: false
-  type: string
-lang:
-  description: Message language (pt, es, fr, en, it,...)
-  required: false
-  type: string
-code:
-  description: PIN code to activate or deactivate alarm.
-  required: false
-  type: integer
-{% endconfiguration %}
+1. From Home Assistant, navigate to ‘Configuration’ then ‘Integrations’. Click the plus icon and type/select ‘Securitas Direct’.
+1. Choose your platform `Securitas Direct`.
+1. Enter your credentials and installation configuration.
+
+1. Click the Save button.
+
+| Attribute | Description | Required |
+| --------- | ----------- | ----------- |
+| `username` | Username for your Securitas Direct account.| `yes`
+| `password` | Password for your Securitas Direct account. | `yes`
+| `installation` | The number of your installation. To find information on installations run `pysecuritas -u USERNAME -p PASSWORD -c COUNTRY -l LANGUAGE INS`.| `yes`
+| `country` | Country identification (`PT`, `ES`, `FR`, `GB`, `IT`,...).| `default ES`
+| `lang` | Messages language (`pt`, `es`, `fr`, `en`, `it`,...).| `default es`
+| `code` | PIN code to activate or deactivate alarm.| `no`

--- a/source/_integrations/securitas_direct.markdown
+++ b/source/_integrations/securitas_direct.markdown
@@ -15,12 +15,6 @@ There is currently support for the following device types within Home Assistant:
 
 ## Configuration
 
-To integrate Verisure with Home Assistant, add the following section to your `configuration.yaml` file:
-
-Securitas Direct can be integrated by adding the following `securitas_direct` section to your `configuration.yaml` file:
-
-## Configuration
-
 1. From Home Assistant, navigate to ‘Configuration’ then ‘Integrations’.
 1. Click the plus icon and type/select ‘Securitas Direct’.
 1. Enter your credentials and installation configuration.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for the newly proposed [Securitas Direct](https://www.securitasdirect.pt) home security integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/44448
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2107

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards