### PR TITLE
Update denonavr.markdown

### DIFF
--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -44,6 +44,7 @@ Known supported devices:
 - Denon AVR-2312CI
 - Denon AVR-3311CI
 - Denon AVR-3312
+- Denon AVR-3313CI
 - Denon AVR-4810
 - Denon AVR-S710W
 - Denon AVR-S720W


### PR DESCRIPTION
Add Denon AVR-3313CI as a supported device.

## Proposed change
Add Denon AVR-3313CI as a supported device as this integration works with this AVR.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
