### PR TITLE
add_holiday to add_holidays

### DIFF
--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -98,7 +98,7 @@ binary_sensor:
 ```
 
 This example excludes Saturdays, Sundays and holidays. Two custom holidays are added.
-The date February 24th, 2020 is a Monday but will be excluded because it was added to the `add_holiday` configuration.
+The date February 24th, 2020 is a Monday but will be excluded because it was added to the `add_holidays` configuration.
 
 ```yaml
 # Example 2 configuration.yaml entry


### PR DESCRIPTION
to make it the same as the syntax off the definition


## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
