### PR TITLE
Add a prerequisite

### DIFF
--- a/source/_integrations/rpi_gpio.markdown
+++ b/source/_integrations/rpi_gpio.markdown
@@ -13,6 +13,10 @@ ha_domain: rpi_gpio
 
 The `rpi_gpio` integration is the base for all related GPIO platforms in Home Assistant. There is no setup needed for the integration itself, for the platforms please check their corresponding pages.
 
+## Prerequisites
+
+* 32-bit installation is required for GPIO support
+
 ## Binary Sensor
 
 The `rpi_gpio` binary sensor platform allows you to read sensor values of the GPIOs of your [Raspberry Pi](https://www.raspberrypi.org/).

--- a/source/_integrations/rpi_gpio.markdown
+++ b/source/_integrations/rpi_gpio.markdown
@@ -15,7 +15,7 @@ The `rpi_gpio` integration is the base for all related GPIO platforms in Home As
 
 ## Prerequisites
 
-* 32-bit installation is required for GPIO support
+When you are running the Home Assistant Operating System, the 32-bits version of the OS is required in order to use this integration.
 
 ## Binary Sensor
 


### PR DESCRIPTION
The installation page states that 32-bit is required to use GPIO so it seems right that this page reports the same information.

## Proposed change
The PR [#14634](https://github.com/home-assistant/home-assistant.io/pull/14634) specified on the installation page that 32-bit is required to use GPIO so it looks right to me to add this info as a prerequisite on the GPIO integration page itself

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
