### PR TITLE
Integration search filter improvements

### DIFF
--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -119,13 +119,16 @@ allComponents.pop(); // remove placeholder element at the end
     function init() {
       // do the lowerCase transformation once
       for (i = 0; i < allComponents.length; i++) {
-        title = allComponents[i].title;
+        title = allComponents[i].title.toLowerCase();
         domain = allComponents[i].domain;
         title_normalized = title
           .normalize("NFD")
           .replace(/[\u0300-\u036f]/g, "");
-        allComponents[i].titleLC = title.toLowerCase();
-        allComponents[i].search = `${title} ${title_normalized} ${domain}`;
+        title_dedashed = title.replace(/[-_]/g, " ");
+        title_normalized_dedashed = title_normalized.replace(/[-_]/g, " ");
+
+        allComponents[i].titleLC = title;
+        allComponents[i].search = `${title} ${title_normalized} ${title_dedashed} ${title_normalized_dedashed} ${domain}`;
       }
 
       // sort the components alphabetically

--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -118,8 +118,14 @@ allComponents.pop(); // remove placeholder element at the end
 
     function init() {
       // do the lowerCase transformation once
-      for (i = 0; i < (allComponents.length); i++) {
-        allComponents[i].titleLC = allComponents[i].title.toLowerCase();
+      for (i = 0; i < allComponents.length; i++) {
+        title = allComponents[i].title;
+        domain = allComponents[i].domain;
+        title_normalized = title
+          .normalize("NFD")
+          .replace(/[\u0300-\u036f]/g, "");
+        allComponents[i].titleLC = title.toLowerCase();
+        allComponents[i].search = `${title} ${title_normalized} ${domain}`;
       }
 
       // sort the components alphabetically
@@ -175,8 +181,10 @@ allComponents.pop(); // remove placeholder element at the end
           // search through title and category
           search = decodeURIComponent(hash).substring(8).toLowerCase();
           filter = function (comp) {
-            return (comp.titleLC.indexOf(search) !== -1) ||
-              (comp.cat.find(c => c.includes("#")) != undefined);
+            return (
+              comp.search.indexOf(search) !== -1 ||
+              comp.cat.find((c) => c.includes("#")) != undefined
+            );
           };
 
         } else if (hash === '#featured' || hash === '') {


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR generates a "search" string for each integration on the integrations overview page. Besides the title of the integration, it also contains a title of the integration that has been normalized (e.g., all diacritics are converted) and added the domain as well.

This allows for filtering the integrations overview by e.g., `tradfri` (which right now isn't possible, because it is spelled as `trådfri`.

Also, searching on domain is now possible as well (e.g., `apple_tv`).

![image](https://user-images.githubusercontent.com/195327/103444457-ab595400-4c68-11eb-962e-6a926d7fd8eb.png)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: closes #15557

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
