### PR TITLE
Input Datetime - Use the same layout for service

### DIFF
--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -133,40 +133,47 @@ If you have a `datetime` object you can use its `timestamp` method. Of if you ha
 ```yaml
 # Sets time to 05:30:00
 - service: input_datetime.set_datetime
-  data:
+  target:
     entity_id: input_datetime.XXX
+  data:
     time: '05:30:00'
 # Sets time to time from datetime object
 - service: input_datetime.set_datetime
-  data:
+  target:
     entity_id: input_datetime.XXX
+  data:
     time: "{{ now().strftime('%H:%M:%S') }}"
 # Sets date to 2020-08-24
 - service: input_datetime.set_datetime
-  data:
+  target:
     entity_id: input_datetime.XXX
+  data:
     date: '2020-08-24'
 # Sets date to date from datetime object
 - service: input_datetime.set_datetime
-  data:
+  target:
     entity_id: input_datetime.XXX
+  data:
     date: "{{ now().strftime('%Y-%m-%d') }}"
 # Sets date and time to 2020-08-25 05:30:00
 - service: input_datetime.set_datetime
-  data:
+  target:
     entity_id: input_datetime.XXX
+  data:
     datetime: '2020-08-25 05:30:00'
 # Sets date and time from datetime object
 - service: input_datetime.set_datetime
-  data:
+  target:
     entity_id: input_datetime.XXX
+  data:
     datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
 # Sets date and/or time from UNIX timestamp
 # This can be used whether the input_datetime has just a date,
 # or just a time, or has both
 - service: input_datetime.set_datetime
-  data:
+  target:
     entity_id: input_datetime.XXX
+  data:
     timestamp: "{{ now().timestamp() }}"
 ```
 

--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -133,33 +133,33 @@ If you have a `datetime` object you can use its `timestamp` method. Of if you ha
 ```yaml
 # Sets time to 05:30:00
 - service: input_datetime.set_datetime
-  entity_id: input_datetime.XXX
   data:
+    entity_id: input_datetime.XXX
     time: '05:30:00'
 # Sets time to time from datetime object
 - service: input_datetime.set_datetime
-  entity_id: input_datetime.XXX
   data:
+    entity_id: input_datetime.XXX
     time: "{{ now().strftime('%H:%M:%S') }}"
 # Sets date to 2020-08-24
 - service: input_datetime.set_datetime
-  entity_id: input_datetime.XXX
   data:
+    entity_id: input_datetime.XXX
     date: '2020-08-24'
 # Sets date to date from datetime object
 - service: input_datetime.set_datetime
-  entity_id: input_datetime.XXX
   data:
+    entity_id: input_datetime.XXX
     date: "{{ now().strftime('%Y-%m-%d') }}"
 # Sets date and time to 2020-08-25 05:30:00
 - service: input_datetime.set_datetime
-  entity_id: input_datetime.XXX
   data:
+    entity_id: input_datetime.XXX
     datetime: '2020-08-25 05:30:00'
 # Sets date and time from datetime object
 - service: input_datetime.set_datetime
-  entity_id: input_datetime.XXX
   data:
+    entity_id: input_datetime.XXX
     datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
 # Sets date and/or time from UNIX timestamp
 # This can be used whether the input_datetime has just a date,


### PR DESCRIPTION
## Proposed change
The layout of the service `input_datetime.set_datetime` was not the same in the examples

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
