### PR TITLE
Update device-specific.markdown

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -54,7 +54,7 @@ You need to disable the on-board Bluetooth since the board requires the use of t
 
 For both processes below you will need to insert your SD card into your PC and open the `/boot/config.txt` file with your favorite text editor.
 
-#### The below information is for the Pi 4 specifically
+#### Raspberry Pi 4 procedure
 
 Add the following paramaters to the bottom of the `/boot/config.txt` file.
 
@@ -65,7 +65,7 @@ enable_uart=1
 
 Reboot your Pi 4 without the Razberry Z-Wave hat first. Then shutdown, add the hat back, and boot again.
 
-#### The below information is for the Pi 3 specifically
+#### Raspberry Pi 3 procedure
 
 ```text
 dtoverlay=pi3-disable-bt

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -54,9 +54,7 @@ You need to disable the on-board Bluetooth since the board requires the use of t
 
 For both processes below you will need to insert your SD card into your PC and open the `/boot/config.txt` file with your favorite text editor.
 
-----------
-The below information is for the Pi 4 specifically
-----------
+#####The below information is for the Pi 4 specifically
 
 Add the following paramaters to the bottom of the `/boot/config.txt` file.
 
@@ -67,9 +65,7 @@ enable_uart=1
 
 Reboot your Pi 4 without the Razberry Z-Wave hat first. Then shutdown, add the hat back, and boot again.
 
-----------
-The below information is for the Pi 3 specifically
-----------
+#####The below information is for the Pi 3 specifically
 
 ```text
 dtoverlay=pi3-disable-bt

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -52,6 +52,25 @@ echo -e -n "...turn on/off string from examples above..." | cu -l /dev/zstick -s
 
 You need to disable the on-board Bluetooth since the board requires the use of the hardware UART (and there's only one on the Pi3). You do this by adding the following to the end of `/boot/config.txt`:
 
+For both processes below you will need to insert your SD card into your PC and open the `/boot/config.txt` file with your favorite text editor.
+
+----------
+The below information is for the Pi 4 specifically
+----------
+
+Add the following paramaters to the bottom of the `/boot/config.txt` file.
+
+```text
+dtoverlay=disable-bt
+enable_uart=1
+```
+
+Reboot your Pi 4 without the Razberry Z-Wave hat first. Then shutdown, add the hat back, and boot again.
+
+----------
+The below information is for the Pi 3 specifically
+----------
+
 ```text
 dtoverlay=pi3-disable-bt
 ```

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -54,7 +54,7 @@ You need to disable the on-board Bluetooth since the board requires the use of t
 
 For both processes below you will need to insert your SD card into your PC and open the `/boot/config.txt` file with your favorite text editor.
 
-#####The below information is for the Pi 4 specifically
+#### The below information is for the Pi 4 specifically
 
 Add the following paramaters to the bottom of the `/boot/config.txt` file.
 
@@ -65,7 +65,7 @@ enable_uart=1
 
 Reboot your Pi 4 without the Razberry Z-Wave hat first. Then shutdown, add the hat back, and boot again.
 
-#####The below information is for the Pi 3 specifically
+#### The below information is for the Pi 3 specifically
 
 ```text
 dtoverlay=pi3-disable-bt


### PR DESCRIPTION
The original documentation did not detail out specific steps for different versions of the Raspberry Pi. This should put enough detail into the documentation to help alleviate the headache of newer users not being able to get Z-Wave integrations started.

## Proposed change

The documentation doesn't include actual device specific direction for different versions of the Raspberry Pi. This edit will help separate out the different steps needed in order to get Z-Wave working with the Razberry hat, at least for the Pi 3 and the Pi 4.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
