### PR TITLE
Update recorder docs - create PostgreSQL database with utf8 encoding

### DIFF
--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -325,6 +325,8 @@ createdb -E utf8 DB_NAME
 ```
 Where `DB_NAME` is the name of your database
 
+If the Database in use if not `utf8` adding `?client_encoding=utf8` to the `db_url` may solve any issue.
+
 For PostgreSQL you may have to install a few dependencies:
 
 ```bash

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -325,7 +325,7 @@ createdb -E utf8 DB_NAME
 ```
 Where `DB_NAME` is the name of your database
 
-If the Database in use if not `utf8` adding `?client_encoding=utf8` to the `db_url` may solve any issue.
+If the Database in use is not `utf8`, adding `?client_encoding=utf8` to the `db_url` may solve any issue.
 
 For PostgreSQL you may have to install a few dependencies:
 

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -319,6 +319,12 @@ Once Home Assistant finds the database, with the right level of permissions, all
 
 ### PostgreSQL
 
+Create the PostgreSQL database with `utf8` encoding. The PostgreSQL default encoding is `SQL_ASCII`. From the `postgres` user account;
+```bash
+createdb -E utf8 DB_NAME
+```
+Where `DB_NAME` is the name of your database
+
 For PostgreSQL you may have to install a few dependencies:
 
 ```bash


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
ref https://github.com/home-assistant/core/issues/44595

The issue appears to be caused by the PostgreSQL database I created first time not using `utf8` encoding. PostgreSQL default is `SQL_ASCII`.

Recreated the database with `utf8` encoding and the errors were not seen.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/44595

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
