### PR TITLE
Add description of venetian blind tilt control configuration

### DIFF
--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -145,6 +145,16 @@ Binary sensors have only two states - "on" and "off". Many door or window openin
 
 For those devices, use the *off_delay* parameter. It defines a delay after, which a device will go back to an "Off" state. That "Off" state will be fired internally by Home Assistant, just as if the device fired it by itself. If a motion sensor can only send signals once every 5 seconds, sets the *off_delay* parameter to *seconds: 5*.
 
+#### Venetian blind mode
+
+Available only for RFY cover devices. Enables tilt control of venetian blind slats.
+
+Venetian blind motors which control slats tilt can be configured in one of two modes - US (short press of up/down buttons opens/closes the blind, long press controls tilt angle), or European (short press of up/down buttons controls tilt angle, long press opens/closes the blind). You can select one of the following settings depending on your blinds:
+
+- **Unknown** - default, tilt control is not enabled. Leave if the cover is not a venetian blind.
+- **US** - tilt control enabled for blinds in US tilt mode.
+- **EU** - tilt control enabled for blinds in European tilt mode.
+
 #### Options for PT-2262 devices under the Lighting4 protocol
 
 When a data packet is transmitted by a PT-2262 device using the Lighting4 protocol, there is no way to automatically extract the device identifier and the command from the packet. Each device has its own id/command length combination and the field lengths are not included in the data. One device that sends 2 different commands will be seen as 2 devices on Home Assistant. For such cases, the following options are available in order to circumvent the problem:

--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -149,7 +149,7 @@ For those devices, use the *off_delay* parameter. It defines a delay after, whic
 
 Available only for RFY cover devices. Enables tilt control of venetian blind slats.
 
-Venetian blind motors which control slats tilt can be configured in one of two modes - US (short press of up/down buttons opens/closes the blind, long press controls tilt angle), or European (short press of up/down buttons controls tilt angle, long press opens/closes the blind). You can select one of the following settings depending on your blinds:
+Venetian blind motors that control slats tilt can be configured in one of two modes - US (short press of up/down buttons opens/closes the blind, long-press controls tilt angle), or European (short press of up/down buttons controls tilt angle, long-press opens/closes the blind). You can select one of the following settings depending on your blinds:
 
 - **Unknown** - default, tilt control is not enabled. Leave if the cover is not a venetian blind.
 - **US** - tilt control enabled for blinds in US tilt mode.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/44309
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
