### PR TITLE
Fix alexa_confirm.yaml example

### DIFF
--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -306,23 +306,24 @@ First create a file called `alexa_confirm.yaml` with something like the followin
 {% raw %}
 
 ```text
-{{ [
-  "OK",
-  "Sure",
-  "If you insist",
-  "Done",
-  "No worries",
-  "I can do that",
-  "Leave it to me",
-  "Consider it done",
-  "As you wish",
-  "By your command",
-  "Affirmative",
-  "Yes oh revered one",
-  "I will",
-  "As you decree, so shall it be",
-  "No Problem"
-] | random }}
+>
+  {{ [
+    "OK",
+    "Sure",
+    "If you insist",
+    "Done",
+    "No worries",
+    "I can do that",
+    "Leave it to me",
+    "Consider it done",
+    "As you wish",
+    "By your command",
+    "Affirmative",
+    "Yes oh revered one",
+    "I will",
+    "As you decree, so shall it be",
+    "No Problem"
+  ] | random }}
 ```
 
 {% endraw %}


### PR DESCRIPTION
Need a ">" before the template to make it valid yaml.  Current example did not pass 'Check Configuration' within home assistant.

## Proposed change
Alexa_confirm.yaml was invalid, and did not work

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  None
- Link to parent pull request in the Brands repository: None
- This PR fixes or closes issue:  None

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
