### PR TITLE
Note about isoformat() for frontend templates

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -195,7 +195,19 @@ The same thing can also be expressed as a filter:
 - Filter `timestamp_utc` converts a UNIX timestamp to its string representation representation as date/time in UTC timezone.
 - Filter `timestamp_custom(format_string, local_time=True)` converts an UNIX timestamp to its string representation based on a custom format, the use of a local timezone is default. Supports the standard [Python time formatting options](https://docs.python.org/3/library/time.html#time.strftime).  
 
-Note: [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970. Therefore, if used as a function's argument, it can be substituted with a numeric value (`int` or `float`):  
+<div class='note'>
+[UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970. Therefore, if used as a function's argument, it can be substituted with a numeric value (`int` or `float`):  
+</div>
+
+<div class='note warning'>
+If your template is returning a timestamp that should be displayed in the frontend (e.g., as a sensor entity with `device_class: timestamp`), you have to ensure that it is the ISO 8601 format (meaning it has the "T" separator between the date and time portion). Otherwise, frontend rendering on macOS and iOS devices will show an error. For Home Assistant internal timestamp fields such as an entity's `last_change` and `last_update` this is done out of the box. However, the following value template would result in the frontend error:
+
+`{{ states.sun.sun.last_updated }}` => `2021-01-04 12:27:08.036538+00:00`
+
+To fix it, enforce the ISO conversion via `isoformat()`:
+
+```{{ (states.sun.sun.last_updated).isoformat() }}``` => `2021-01-04T12:27:08.036538+00:00`	
+</div>
 
 {% raw %}
 ```yaml

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -203,13 +203,13 @@ The same thing can also be expressed as a filter:
 
 <div class='note warning'>
 	
-If your template is returning a timestamp that should be displayed in the frontend (e.g., as a sensor entity with `device_class: timestamp`), you have to ensure that it is the ISO 8601 format (meaning it has the "T" separator between the date and time portion). Otherwise, frontend rendering on macOS and iOS devices will show an error. For Home Assistant internal timestamp fields such as an entity's `last_change` and `last_update` this is done out of the box. However, the following value template would result in the frontend error:
+If your template is returning a timestamp that should be displayed in the frontend (e.g., as a sensor entity with `device_class: timestamp`), you have to ensure that it is the ISO 8601 format (meaning it has the "T" separator between the date and time portion). Otherwise, frontend rendering on macOS and iOS devices will show an error. The following value template would result in such an error:
 
-`{{ states.sun.sun.next_rising }}` => `2021-01-24 07:06:59+00:00` (missing "T" separator)
+`{{ states.sun.sun.last_changed }}` => `2021-01-24 07:06:59+00:00` (missing "T" separator)
 
 To fix it, enforce the ISO conversion via `isoformat()`:
 
-`{{ states.sun.sun.next_rising.isoformat() }}` => `2021-01-24T07:06:59+00:00` (contains "T" separator)
+`{{ states.sun.sun.last_changed.isoformat() }}` => `2021-01-24T07:06:59+00:00` (contains "T" separator)
 
 </div>
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -213,7 +213,11 @@ If your template is returning a timestamp that should be displayed in the fronte
 
 To fix it, enforce the ISO conversion via `isoformat()`:
 
+{% raw %}
+
 `{{ states.sun.sun.last_changed.isoformat() }}` => `2021-01-24T07:06:59+00:00` (contains "T" separator)
+
+{% endraw %}
 
 </div>
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -205,7 +205,11 @@ The same thing can also be expressed as a filter:
 	
 If your template is returning a timestamp that should be displayed in the frontend (e.g., as a sensor entity with `device_class: timestamp`), you have to ensure that it is the ISO 8601 format (meaning it has the "T" separator between the date and time portion). Otherwise, frontend rendering on macOS and iOS devices will show an error. The following value template would result in such an error:
 
+{% raw %}
+
 `{{ states.sun.sun.last_changed }}` => `2021-01-24 07:06:59+00:00` (missing "T" separator)
+
+{% endraw %}
 
 To fix it, enforce the ISO conversion via `isoformat()`:
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -196,17 +196,21 @@ The same thing can also be expressed as a filter:
 - Filter `timestamp_custom(format_string, local_time=True)` converts an UNIX timestamp to its string representation based on a custom format, the use of a local timezone is default. Supports the standard [Python time formatting options](https://docs.python.org/3/library/time.html#time.strftime).  
 
 <div class='note'>
-[UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970. Therefore, if used as a function's argument, it can be substituted with a numeric value (`int` or `float`):  
+	
+[UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970. Therefore, if used as a function's argument, it can be substituted with a numeric value (`int` or `float`).
+
 </div>
 
 <div class='note warning'>
+	
 If your template is returning a timestamp that should be displayed in the frontend (e.g., as a sensor entity with `device_class: timestamp`), you have to ensure that it is the ISO 8601 format (meaning it has the "T" separator between the date and time portion). Otherwise, frontend rendering on macOS and iOS devices will show an error. For Home Assistant internal timestamp fields such as an entity's `last_change` and `last_update` this is done out of the box. However, the following value template would result in the frontend error:
 
-`{{ states.sun.sun.last_updated }}` => `2021-01-04 12:27:08.036538+00:00` (missing "T" separator)
+`{{ states.sun.sun.next_rising }}` => `2021-01-24 07:06:59+00:00` (missing "T" separator)
 
 To fix it, enforce the ISO conversion via `isoformat()`:
 
-`{{ states.sun.sun.last_updated.isoformat() }}` => `2021-01-04T12:27:08.036538+00:00` (contains "T" separator)
+`{{ states.sun.sun.next_rising.isoformat() }}` => `2021-01-24T07:06:59+00:00` (contains "T" separator)
+
 </div>
 
 {% raw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -206,7 +206,7 @@ If your template is returning a timestamp that should be displayed in the fronte
 
 To fix it, enforce the ISO conversion via `isoformat()`:
 
-```{{ (states.sun.sun.last_updated).isoformat() }}``` => `2021-01-04T12:27:08.036538+00:00`	
+`{{ (states.sun.sun.last_updated).isoformat() }}` => `2021-01-04T12:27:08.036538+00:00`	
 </div>
 
 {% raw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -202,11 +202,11 @@ The same thing can also be expressed as a filter:
 <div class='note warning'>
 If your template is returning a timestamp that should be displayed in the frontend (e.g., as a sensor entity with `device_class: timestamp`), you have to ensure that it is the ISO 8601 format (meaning it has the "T" separator between the date and time portion). Otherwise, frontend rendering on macOS and iOS devices will show an error. For Home Assistant internal timestamp fields such as an entity's `last_change` and `last_update` this is done out of the box. However, the following value template would result in the frontend error:
 
-`{{ states.sun.sun.last_updated }}` => `2021-01-04 12:27:08.036538+00:00`
+`{{ states.sun.sun.last_updated }}` => `2021-01-04 12:27:08.036538+00:00` (missing "T" separator)
 
 To fix it, enforce the ISO conversion via `isoformat()`:
 
-`{{ (states.sun.sun.last_updated).isoformat() }}` => `2021-01-04T12:27:08.036538+00:00`	
+`{{ states.sun.sun.last_updated.isoformat() }}` => `2021-01-04T12:27:08.036538+00:00` (contains "T" separator)
 </div>
 
 {% raw %}


### PR DESCRIPTION
To prevent issues as reported here: https://github.com/home-assistant/frontend/issues/8072

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
