### PR TITLE
Tweak ping device_tracker docs

### DIFF
--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -100,4 +100,4 @@ count:
   type: integer
 {% endconfiguration %}
 
-See the [device tracker integration page](/integrations/device_tracker/) for instructions how to configure the people to be tracked.
+See the [person integration page](/integrations/person/) for instructions on how to configure the people to be tracked.

--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -86,14 +86,14 @@ To use this presence detection in your installation, add the following to your `
 device_tracker:
   - platform: ping
     hosts:
-      hostname: 192.168.2.10
+      device_name_1: 192.168.2.10
 ```
 
 {% configuration %}
 hosts:
-  description: List of device names and their corresponding IP address or hostname. Device names must conform to the standard requirements of lower case, numbers and underscore only - see [entity names](/docs/configuration/troubleshooting/#entity-names).
+  description: Map of device names and their corresponding IP address or hostname. Device names must conform to the standard requirements of lower case, numbers and underscore only - see [entity names](/docs/configuration/troubleshooting/#entity-names).
   required: true
-  type: list
+  type: map
 count:
   description: Number of packet used for each device (avoid false detection).
   required: false


### PR DESCRIPTION
## Proposed change

I've clarified the ping integration docs a little bit.  I could not figure out from the `device_tracker` example and the text that `hostname` (under `hosts`) was meant to be the device name. Also, the type is wrong, `hosts` is not a list but a map.

So based on the current docs I was trying to do this in my config which would not work:

```
device_tracker:
  - platform: ping
    hosts:
      - hostname: 192.168.2.10
      - hostname: 192.168.2.11
```

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
