### PR TITLE
Add docs for RainMachine entity services

### DIFF
--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -34,83 +34,100 @@ This integration can be configured via the Home Assistant UI by navigating to
 Disable a RainMachine program. This will mark the program switch as
 `Unavailable` in the UI.
 
-| Service Data Attribute    | Optional | Description             |
-|---------------------------|----------|-------------------------|
-| `program_id`              |      no  | The program to disable  |
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `program_id  `              |      no  | The program to disable                                      |
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.disable_zone`
 
 Disable a RainMachine zone. This will mark the zone switch as
 `Unavailable` in the UI.
 
-| Service Data Attribute    | Optional | Description             |
-|---------------------------|----------|-------------------------|
-| `zone_id`                 |      no  | The zone to disable     |
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `zone_id  `                 |      no  | The program to disable                                      |
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.enable_program`
 
 Enable a RainMachine program.
 
-| Service Data Attribute    | Optional | Description             |
-|---------------------------|----------|-------------------------|
-| `program_id`              |      no  | The program to enable   |
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `program_id  `              |      no  | The program to enable                                       |
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.enable_zone`
 
 Enable a RainMachine zone.
 
-| Service Data Attribute    | Optional | Description             |
-|---------------------------|----------|-------------------------|
-| `zone_id`                 |      no  | The zone to enable      |
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `zone_id  `                 |      no  | The zone to enable                                          |
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.pause_watering`
 
 Pause all watering activities for a number of seconds.
 
-| Service Data Attribute    | Optional | Description                    |
-|---------------------------|----------|--------------------------------|
-| `seconds`                 |      no  | The number of seconds to pause |
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `seconds`                   |      no  | The number of seconds to pause                              |
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.start_program`
 
 Start a RainMachine program.
 
-| Service Data Attribute    | Optional | Description          |
-|---------------------------|----------|----------------------|
-| `program_id`              |      no  | The program to start |
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `program_id  `              |      no  | The program to start                                        |
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.start_zone`
 
 Start a RainMachine zone for a set number of seconds.
 
-| Service Data Attribute    | Optional | Description                                          |
-|---------------------------|----------|------------------------------------------------------|
-| `zone_id`                 |      no  | The zone to start                                    |
-| `zone_run_time`           |      yes | The number of seconds to run; defaults to 60 seconds |
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `zone_id`                   |      no  | The zone to start                                           |
+| `zone_run_time`             |      yes | The number of seconds to run; defaults to 60 seconds        |
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.stop_all`
 
 Stop all watering activities.
 
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
+
 ### `rainmachine.stop_program`
 
 Stop a RainMachine program.
 
-| Service Data Attribute    | Optional | Description          |
-|---------------------------|----------|----------------------|
-| `program_id`              |      no  | The program to stop  |
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `program_id  `              |      no  | The program to stop                                         |
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.stop_zone`
 
 Stop a RainMachine zone.
 
-| Service Data Attribute    | Optional | Description          |
-|---------------------------|----------|----------------------|
-| `zone_id`                 |      no  | The zone to stop     |
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `zone_id  `                 |      no  | The zone to stop                                            |
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.unpause_watering`
 
 Unpause all watering activities.
+
+| Service Data Attribute    | Optional | Description                                                 |
+|---------------------------|----------|-------------------------------------------------------------|
+| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ## Switch
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR updates the RainMachine documentation to reflect the migration of services to entity services.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/44139
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
