### PR TITLE
Areas can not be used on entities, only devices

### DIFF
--- a/source/_integrations/config.markdown
+++ b/source/_integrations/config.markdown
@@ -50,7 +50,7 @@ This section enables you to override the name, change the entity ID or disable a
 
 ### Areas
 
-This section enables you to organize entities to physical areas of your home.
+This section enables you to organize devices to physical areas of your home. This does not work on entities.
 
 ### Automation
 


### PR DESCRIPTION
## Proposed change
There seems to be a lot of confusion on where and how you assign a area to a device.
This change corrects the documentation. 



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
