### PR TITLE
Update sensor.rflink.markdown

### DIFF
--- a/source/_integrations/sensor.rflink.markdown
+++ b/source/_integrations/sensor.rflink.markdown
@@ -93,6 +93,7 @@ Sensor type values:
 - revision
 - noise_level
 - temperature
+- timestamp
 - uv_intensity
 - version
 - voltage


### PR DESCRIPTION


## Proposed change
<!-- 
    Add timestamp to the list of possible sensor_values to be used with update_time entities.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Maybe it will save someone else some time if it is indicated what sensor_type to be used toghether with the last_updated entity.  javicalle gave the solution here: https://community.home-assistant.io/t/configuration-rflink/214810/10 and it works just fine.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
