### PR TITLE
updated sht31.markdown with added unique_id

### DIFF
--- a/source/_integrations/sht31.markdown
+++ b/source/_integrations/sht31.markdown
@@ -26,7 +26,11 @@ sensor:
 ```
 
 {% configuration %}
-  name:
+  unique_id:
+    description: An ID that uniquely identifies this sensor. Each monitored condition appends the specified unique_id: "unique_id"\_temperature or "unique_id"\_humidity
+    required: false
+    type: string
+ name:
     description: The name of the sensor. Temperature and Humidity will be added to the name for the sensor name.
     required: false
     default: SHT31


### PR DESCRIPTION
https://github.com/home-assistant/core/pull/44949

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Added unique_id to the sht31 integration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  home-assistant/core#44949
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
