### PR TITLE
Add an nest event example automation

### DIFF
--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -337,6 +337,8 @@ action:
     data:
       title: motion detected
       message: front door motion detected
+      data:
+        image: /api/camera_proxy/camera.front_door
 mode: single
 ```
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -301,26 +301,7 @@ See [Automating Home Assistant](/getting-started/automation/) for the getting st
 
 ### Example
 
-The events for emitted to Home Assistant look like this..
-
-```json
-{
-    "event_type": "nest_event",
-    "data": {
-        "device_id": "37d6639fa63c348310d930825bb9e430",
-        "type": "camera_motion"
-    },
-    "origin": "LOCAL",
-    "time_fired": "2021-01-03T17:59:32.509459+00:00",
-    "context": {
-        "id": "7cf91c62a74c36ea6de0634c18138384",
-        "parent_id": null,
-        "user_id": null
-    }
-}
-```
-
-So an example automation looks like this..
+This automation will trigger when a `nest_event` event type with a type of `camera_motion` is received from the specified `device_id`.
 
 ```yaml
 alias: motion alert
@@ -341,6 +322,8 @@ action:
         image: /api/camera_proxy/camera.front_door
 mode: single
 ```
+
+The action in this section uses the [Android Companion App](https://companion.home-assistant.io/docs/notifications/notifications-basic/) and the camera proxy to send an notification with a snapshot from the camera.
 
 # Legacy Works With Nest API
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -305,14 +305,12 @@ This automation will trigger when a `nest_event` event type with a type of `came
 
 ```yaml
 alias: motion alert
-description: ''
 trigger:
   - platform: event
     event_type: nest_event
     event_data:
-      device_id: 37d6639fa63c348310d930825bb9e430
+      device_id: YOUR_DEVICE_ID
       type: camera_motion
-condition: []
 action:
   - service: notify.mobile_app_pixel_2
     data:
@@ -320,7 +318,6 @@ action:
       message: front door motion detected
       data:
         image: /api/camera_proxy/camera.front_door
-mode: single
 ```
 
 The action in this section uses the [Android Companion App](https://companion.home-assistant.io/docs/notifications/notifications-basic/) and the camera proxy to send an notification with a snapshot from the camera.

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -299,6 +299,46 @@ All Google Nest Cam models and the Google Nest Hello Video Doorbell support [Dev
 
 See [Automating Home Assistant](/getting-started/automation/) for the getting started guide on automations or the [Automation](/docs/automation/) documentation for full details.
 
+### Example
+
+The events for emitted to Home Assistant look like this..
+
+```json
+{
+    "event_type": "nest_event",
+    "data": {
+        "device_id": "37d6639fa63c348310d930825bb9e430",
+        "type": "camera_motion"
+    },
+    "origin": "LOCAL",
+    "time_fired": "2021-01-03T17:59:32.509459+00:00",
+    "context": {
+        "id": "7cf91c62a74c36ea6de0634c18138384",
+        "parent_id": null,
+        "user_id": null
+    }
+}
+```
+
+So an example automation looks like this..
+
+```yaml
+alias: motion alert
+description: ''
+trigger:
+  - platform: event
+    event_type: nest_event
+    event_data:
+      device_id: 37d6639fa63c348310d930825bb9e430
+      type: camera_motion
+condition: []
+action:
+  - service: notify.mobile_app_pixel_2
+    data:
+      title: motion detected
+      message: front door motion detected
+mode: single
+```
 
 # Legacy Works With Nest API
 


### PR DESCRIPTION
## Proposed change

I struggled a bit getting started with automations for this event
because I didn't know the event_type would actually be a `nest_event`.
This made me think that others might want to get a bit of a short cut
working with these events, so I am sharing my automation here to help
the next person along.

## Type of change

Adding additional documentation to the existing nest integration

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

I followed https://github.com/home-assistant/home-assistant.io/pull/15724 , and thought it could use just this little bit of additional information that makes it actionable to use in automations

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
