### PR TITLE
Add ozw to zwave migration section

### DIFF
--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -46,6 +46,19 @@ available.
 The secure network key is set in the settings for the ozwdaemon and
 not in the integration configuration.
 
+## Migrate from Z-Wave integration
+
+To migrate to the OpenZWave integration from the Z-Wave integration there's a
+wizard in the frontend configuration panel of the Z-Wave integration. The wizard
+will try to migrate the entity IDs, names, icons and areas of the entities and
+devices of your Z-Wave integration to your OpenZWave integration. At the end of
+the migration, the Z-Wave integration configuration entry will be removed.
+
+Make sure you take necessary backups, eg a Supervisor snapshot, before migrating
+to be able to restore the Z-Wave integration. The wizard may not be able to
+migrate all entity and device information. It will show you what entity and
+device information failed to migrate.
+
 ## Services
 
 ### Service `ozw.add_node`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- Add a section about migrating from Z-Wave to OpenZWave integration, in the OpenZWave docs.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/39081
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
