### PR TITLE
Add ecobee humidifier

### DIFF
--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -131,7 +131,7 @@ The ecobee climate entity has some extra attributes to represent the state of th
 | `equipment_running` | This is a comma-separated list of equipment that is currently running.
 | `fan_min_on_time` | The minimum amount of time (in minutes) that the fan will run per hour. This is determined by the minimum fan runtime setting which can be changed in the ecobee app or on the thermostat itself.
 | `humidifier_mode` | This is only shown if a humidifier is controlled by ecobee and displays the current humidifier mode.
-| `humidifier_modes` | This is only shown if a humidifier is controlled by ecobee and displays the valid humidifier modes: `auto` / `off` / `manual`
+| `humidifier_modes` | This is only shown if a humidifier is controlled by ecobee and displays the valid humidifier modes: `auto` / `off` / `manual`.
 
 ## Services
 

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -18,6 +18,7 @@ ha_domain: ecobee
 ha_platforms:
   - binary_sensor
   - climate
+  - humidifier
   - notify
   - sensor
   - weather

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -142,7 +142,6 @@ Besides the standard services provided by the Home Assistant [Climate](/integrat
 - `ecobee.resume_program`
 - `ecobee.set_fan_min_on_time`
 - `ecobee.set_dst_mode`
-- `ecobee.set_humidifier_mode`
 - `ecobee.set_mic_mode`
 - `ecobee.set_occupancy_modes`
 

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -130,6 +130,8 @@ The ecobee climate entity has some extra attributes to represent the state of th
 | `climate_mode` | This is the climate mode that is active, or would be active if no override is active.
 | `equipment_running` | This is a comma-separated list of equipment that is currently running.
 | `fan_min_on_time` | The minimum amount of time (in minutes) that the fan will run per hour. This is determined by the minimum fan runtime setting which can be changed in the ecobee app or on the thermostat itself.
+| `humidifier_mode` | This is only shown if a humidifier is controlled by ecobee and displays the current humidifier mode.
+| `humidifier_modes` | This is only shown if a humidifier is controlled by ecobee and displays the valid humidifier modes: `auto` / `off` / `manual`
 
 ## Services
 

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -140,6 +140,7 @@ Besides the standard services provided by the Home Assistant [Climate](/integrat
 - `ecobee.resume_program`
 - `ecobee.set_fan_min_on_time`
 - `ecobee.set_dst_mode`
+- `ecobee.set_humidifier_mode`
 - `ecobee.set_mic_mode`
 - `ecobee.set_occupancy_modes`
 
@@ -195,6 +196,15 @@ Enable/disable automatic daylight savings time.
 | ---------------------- | -------- | ------------------------------------------------- |
 | `entity_id`            | yes      | ecobee thermostat on which to set daylight savings time mode |
 | `dst_enabled`          | no       | true or false                                     |
+
+### Service `ecobee.set_humidifier_mode`
+
+Set the humidifier mode.
+
+| Service data attribute | Optional | Description                                       |
+| ---------------------- | -------- | ------------------------------------------------- |
+| `entity_id`            | no       | ecobee thermostat on which to set the humidifier mode |
+| `humidifier_mode`      | no       | Mode to set humidifier (auto, off, or manual).    |
 
 ### Service `ecobee.set_mic_mode`
 

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Binary Sensor
   - Notifications
   - Climate
+  - Humidifier
   - Weather
 featured: true
 ha_release: 0.9
@@ -130,8 +131,6 @@ The ecobee climate entity has some extra attributes to represent the state of th
 | `climate_mode` | This is the climate mode that is active, or would be active if no override is active.
 | `equipment_running` | This is a comma-separated list of equipment that is currently running.
 | `fan_min_on_time` | The minimum amount of time (in minutes) that the fan will run per hour. This is determined by the minimum fan runtime setting which can be changed in the ecobee app or on the thermostat itself.
-| `humidifier_mode` | This is only shown if a humidifier is controlled by ecobee and displays the current humidifier mode.
-| `humidifier_modes` | This is only shown if a humidifier is controlled by ecobee and displays the valid humidifier modes: `auto` / `off` / `manual`.
 
 ## Services
 
@@ -198,15 +197,6 @@ Enable/disable automatic daylight savings time.
 | ---------------------- | -------- | ------------------------------------------------- |
 | `entity_id`            | yes      | ecobee thermostat on which to set daylight savings time mode |
 | `dst_enabled`          | no       | true or false                                     |
-
-### Service `ecobee.set_humidifier_mode`
-
-Set the humidifier mode.
-
-| Service data attribute | Optional | Description                                       |
-| ---------------------- | -------- | ------------------------------------------------- |
-| `entity_id`            | yes      | ecobee thermostat on which to set the humidifier mode |
-| `humidifier_mode`      | no       | Mode to set humidifier (auto, off, or manual).    |
 
 ### Service `ecobee.set_mic_mode`
 

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -205,7 +205,7 @@ Set the humidifier mode.
 
 | Service data attribute | Optional | Description                                       |
 | ---------------------- | -------- | ------------------------------------------------- |
-| `entity_id`            | no       | ecobee thermostat on which to set the humidifier mode |
+| `entity_id`            | yes      | ecobee thermostat on which to set the humidifier mode |
 | `humidifier_mode`      | no       | Mode to set humidifier (auto, off, or manual).    |
 
 ### Service `ecobee.set_mic_mode`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document ability to set the humidifier mode of an ecobee thermostat with a humidifier attached.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45003
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
