### PR TITLE
Daikin: Add region changing note

### DIFF
--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -112,3 +112,16 @@ Zones with the name `-` will be ignored, just as the AirBase application is work
 </div>
 
 Additionally the Daikin Streamer (air purifier) function can be toggled on supported devices using a switch.
+
+## Region Changing
+
+The European and United States controllers (Most likely the Australian controllers too) have an http api endpoint that allows you to change the controllers region so that other regional apps can be used. (Sometimes these controllers get exported to regions that can not download the app for the controllers region)
+
+`http://Daikin-IP-Address/common/set_regioncode?reg=XX` Replace XX with your region code of choice.
+
+Currently known region codes: 
+- AU
+- EU
+- JP
+- US
+- TH

--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -115,7 +115,7 @@ Additionally the Daikin Streamer (air purifier) function can be toggled on suppo
 
 ## Region Changing
 
-The European and United States controllers (Most likely the Australian controllers too) have an http api endpoint that allows you to change the controllers region so that other regional apps can be used. (Sometimes these controllers get exported to regions that can not download the app for the controllers region)
+The European and United States controllers (Most likely the Australian controllers too) have an HTTP API endpoint that allows you to change the controllers region so that other regional apps can be used. (Sometimes these controllers get exported to regions that can not download the app for the controllers region.)
 
 `http://Daikin-IP-Address/common/set_regioncode?reg=XX` Replace XX with your region code of choice.
 


### PR DESCRIPTION
## Proposed change
Adding a note about an http api endpoint that can be used to change the region of the controller so that for example a US controller can be controlled by the European Daikin Online Controller app.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
