### PR TITLE
Document MQTT availability_mode

### DIFF
--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -57,7 +57,7 @@ availability:
       required: true
       type: string
 availability_mode:
-  description: When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all` a valid `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any` a valid `payload_available` must be received on at least one configured availability topics before the entity is marked as online. If set to `latest`, the last valid `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
+  description: When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all`, `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any`, `payload_available` must be received on at least one configured availability topic before the entity is marked as online. If set to `latest`, the last `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
   required: false
   type: string
   default: latest

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -57,7 +57,7 @@ availability:
       required: true
       type: string
 availability_mode:
-  When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all` a valid `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any` a valid `payload_available` must be received on at least one configured availability topics before the entity is marked as online. If set to `latest`, the last valid `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
+  description: When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all` a valid `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any` a valid `payload_available` must be received on at least one configured availability topics before the entity is marked as online. If set to `latest`, the last valid `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
   required: false
   type: string
   default: `latest`

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -60,7 +60,7 @@ availability_mode:
   description: When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all` a valid `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any` a valid `payload_available` must be received on at least one configured availability topics before the entity is marked as online. If set to `latest`, the last valid `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
   required: false
   type: string
-  default: `latest`
+  default: latest
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -56,6 +56,11 @@ availability:
       description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
+availability_mode:
+  When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all` a valid `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any` a valid `payload_available` must be received on at least one configured availability topics before the entity is marked as online. If set to `latest`, the last valid `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
+  required: false
+  type: string
+  default: `latest`
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document MQTT availability_mode.

Remaining components documented in #16210


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/44987

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
