### PR TITLE
 update fritz integration docs

### DIFF
--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -22,7 +22,7 @@ device_tracker:
 
 {% configuration %}
 host:
-  description: The IP address of your router, e.g., `192.168.1.1`. It is optional since every FRITZ!Box is also reachable by using the IP address 169.254.1.1.
+  description: The IP address of your router, e.g., `192.168.178.1`. It is optional since every FRITZ!Box is also reachable by using the IP address 169.254.1.1.
   required: false
   type: string
   default: 169.254.1.1
@@ -38,7 +38,7 @@ password:
 {% endconfiguration %}
 
 <div class='note'>
-It seems that it is not necessary to use the password in current generation FRITZ!Box routers because the necessary data can be retrieved anonymously.
+TR-064 needs to be enabled in the FRITZ!Box network settings for Home Assistant to login and read device info.
 </div>
 
 See the [device tracker integration page](/integrations/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
## Proposed change
 - Change example IP address to FRITZ!Box default
 - Edit the note that TR-064 needs to be enabled for the device_tracker integration to work. Took me a while to figure out why it was not working in my network.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
