### PR TITLE
Add troubleshooting regarding UPD multicast (vlans)

### DIFF
--- a/source/_integrations/motion_blinds.markdown
+++ b/source/_integrations/motion_blinds.markdown
@@ -87,7 +87,7 @@ The `cover.set_cover_position` will set the scaled position relative to the spac
 
 ## Troubleshooting
 
-Homeassistant uses the following UDP multicast adresses/ports for communication with the gateway:
+Home Assistant uses the following UDP multicast adresses/ports for communication with the gateway:
 - Motion hub receive UDP multicast 238.0.0.18:32100
 - Motion hub sending UDP multicast 238.0.0.18:32101
 
@@ -95,5 +95,5 @@ This communication needs to be allowed on your local network. If the blinds are 
 
 `Timeout of 5.0 sec occurred on 5 attempts while waiting on multicast push from update request, communication between gateway and blind might be bad.`
 
-Please make sure the motion gateway and the device running HomeAssistant are on the same vlan and multicasting is enabled/allowed by your router.
-If using seperate vlan's, make sure the 238.0.0.18:32100 and 238.0.0.18:32101 ports are open for communication between those vlan's (not tested or confirmed to work).
+Please make sure the motion gateway and the device running Home Assistant are on the same vlan and multicasting is enabled/allowed by your router.
+If using separate vlan's, make sure the 238.0.0.18:32100 and 238.0.0.18:32101 ports are open for communication between those vlan's (not tested or confirmed to work).

--- a/source/_integrations/motion_blinds.markdown
+++ b/source/_integrations/motion_blinds.markdown
@@ -87,9 +87,10 @@ The `cover.set_cover_position` will set the scaled position relative to the spac
 
 ## Troubleshooting
 
-Home Assistant uses the following UDP multicast adresses/ports for communication with the gateway:
-- Motion hub receive UDP multicast 238.0.0.18:32100
-- Motion hub sending UDP multicast 238.0.0.18:32101
+Home Assistant uses the following UDP multicast addresses/ports for communication with the gateway:
+
+- Motion hub receive UDP multicast `238.0.0.18:32100`
+- Motion hub sending UDP multicast `238.0.0.18:32101`
 
 This communication needs to be allowed on your local network. If the blinds are unavailable and you see error messages like:
 

--- a/source/_integrations/motion_blinds.markdown
+++ b/source/_integrations/motion_blinds.markdown
@@ -84,3 +84,16 @@ The `cover.set_cover_position` will set the scaled position relative to the spac
 | `entity_id`            |      yes | Name of the motion blind cover entity to control. For example `cover.TopDownBottomUp-Bottom-0001` |
 | `absolute_position`    |       no | Absolute position to move to. For example 70                                                      |
 | `width`                |      yes | Optionally specify the width that is covered, only for TDBU Combined entities. For example 30     |
+
+## Troubleshooting
+
+Homeassistant uses the following UDP multicast adresses/ports for communication with the gateway:
+- Motion hub receive UDP multicast 238.0.0.18:32100
+- Motion hub sending UDP multicast 238.0.0.18:32101
+
+This communication needs to be allowed on your local network. If the blinds are unavailable and you see error messages like:
+
+`Timeout of 5.0 sec occurred on 5 attempts while waiting on multicast push from update request, communication between gateway and blind might be bad.`
+
+Please make sure the motion gateway and the device running HomeAssistant are on the same vlan and multicasting is enabled/allowed by your router.
+If using seperate vlan's, make sure the 238.0.0.18:32100 and 238.0.0.18:32101 ports are open for communication between those vlan's (not tested or confirmed to work).

--- a/source/_integrations/motion_blinds.markdown
+++ b/source/_integrations/motion_blinds.markdown
@@ -96,5 +96,5 @@ This communication needs to be allowed on your local network. If the blinds are 
 
 `Timeout of 5.0 sec occurred on 5 attempts while waiting on multicast push from update request, communication between gateway and blind might be bad.`
 
-Please make sure the motion gateway and the device running Home Assistant are on the same vlan and multicasting is enabled/allowed by your router.
-If using separate vlan's, make sure the 238.0.0.18:32100 and 238.0.0.18:32101 ports are open for communication between those vlan's (not tested or confirmed to work).
+Please make sure the motion gateway and the device running Home Assistant are on the same VLAN and multicasting is enabled/allowed by your router.
+If using separate VLANs, make sure the 238.0.0.18:32100 and 238.0.0.18:32101 ports are open for communication between those VLANs (not tested or confirmed to work).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Help users with trouble regarding vlans and the motion blinds integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/45085 https://github.com/home-assistant/core/issues/45010

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
