### PR TITLE
Remove command line sensor hddtemp example

### DIFF
--- a/source/_integrations/sensor.command_line.markdown
+++ b/source/_integrations/sensor.command_line.markdown
@@ -60,26 +60,6 @@ json_attributes:
 
 In this section you find some real-life examples of how to use this sensor.
 
-### Hard drive temperature
-
-There are several ways to get the temperature of your hard drive. A simple solution is to use [hddtemp](https://savannah.nongnu.org/projects/hddtemp/).
-
-```bash
-hddtemp -n /dev/sda
-```
-
-To use this information, the entry for a command-line sensor in the `configuration.yaml` file will look like this.
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: command_line
-    name: HD Temperature
-    command: "hddtemp -n /dev/sda"
-    # If errors occur, make sure configuration file is encoded as UTF-8
-    unit_of_measurement: "°C"
-```
-
 ### CPU temperature
 
 Thanks to the [`proc`](https://en.wikipedia.org/wiki/Procfs) file system, various details about a system can be retrieved. Here the CPU temperature is of interest. Add something similar to your `configuration.yaml` file:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR removes the `hddtemp` from the command line sensor integration. My reasoning for this is:
1. `hddtemp` cannot be used with an HAOS-based installation or any other containerised set up. This is not clear on this page and leads to a poor experience.
2. We already have an [`hddtemp` integration](https://www.home-assistant.io/integrations/hddtemp/) which explains the limitations and requirements clearly and means there is no real use case for calling `hddtemp` in a command line sensor.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
