### PR TITLE
Add binary_sensor to zwave_js docs

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -2,6 +2,7 @@
 title: Z-Wave JS
 description: Instructions on how to integrate Z-Wave with Home Assistant via Z-Wave JS.
 ha_category:
+  - Binary Sensor
   - Hub
   - Light
   - Sensor
@@ -41,5 +42,5 @@ available.
 
 As this integration is still in the early stages there are some important limitations to be aware of.
 
-- Platform support is currently limited to basic `light`, `sensor`, and `switch` entities.
+- Platform support is currently limited to basic `binary_sensor`, `light`, `sensor`, and `switch` entities.
 - You will need to use another tool, such as [zwavejs2mqtt](https://github.com/zwave-js/zwavejs2mqtt), to include/exclude devices and manage device configuration.


### PR DESCRIPTION
## Proposed change
Update docs for zwave_js integration with support for binary_sensor.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

https://github.com/home-assistant/core/pull/45081

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
