### PR TITLE
update for xknx 0.16.1 - event_register service

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -205,7 +205,7 @@ You can also use the `homeassistant.update_entity` service call to issue GroupVa
 
 ### Register Event
 
-The `knx.event_register` service can be used to register (or unregister) group addresses to fire `knx_event` Events. Events for group addresses matching the `event_filter` attribute in configuration.yaml can not be unregistered. See [knx_event](#events)
+The `knx.event_register` service can be used to register (or unregister) group addresses to fire `knx_event` Events. Events for group addresses matching the `event_filter` attribute in `configuration.yaml` can not be unregistered. See [knx_event](#events)
 
 {% configuration %}
 address:
@@ -221,7 +221,7 @@ remove:
 
 ### Register Exposure
 
-The `knx.exposure_register` service can be used to register (or unregister) exposures to the KNX bus. Exposures defined in configuration.yaml can not be unregistered. Per address only one exposure can be registered. See [expose](#exposing-entity-states-entity-attributes-or-time-to-knx-bus)
+The `knx.exposure_register` service can be used to register (or unregister) exposures to the KNX bus. Exposures defined in `configuration.yaml` can not be unregistered. Per address only one exposure can be registered. See [expose](#exposing-entity-states-entity-attributes-or-time-to-knx-bus)
 
 {% configuration %}
 remove:

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -219,18 +219,6 @@ remove:
   default: false
 {% endconfiguration %}
 
-### Register Exposure
-
-The `knx.exposure_register` service can be used to register (or unregister) exposures to the KNX bus. Exposures defined in `configuration.yaml` can not be unregistered. Per address only one exposure can be registered. See [expose](#exposing-entity-states-entity-attributes-or-time-to-knx-bus)
-
-{% configuration %}
-remove:
-  description: In addition to the configuration variables of [expose](#exposing-entity-states-entity-attributes-or-time-to-knx-bus) `remove` set to `True` can be used to remove exposures. Only `address` is required for removal.
-  required: false
-  type: boolean
-  default: false
-{% endconfiguration %}
-
 ## Exposing entity states, entity attributes or time to KNX bus
 
 KNX integration is able to expose entity states or attributes to KNX bus. The integration will broadcast any change of the exposed value to the KNX bus and answer read requests to the specified group address. It is also possible to expose the current time.

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -157,23 +157,17 @@ local_ip:
 
 ```yaml
 knx:
-  fire_event: true
-  fire_event_filter: ["1/0/*", "6/2,3,4-6/*"]
+  event_filter: ["1/0/*", "6/2,3,4-6/*"]
 ```
 
 {% configuration %}
-fire_event:
-  description: If set to True, platform will write all received KNX messages to event bus
-  required: inclusive
-  type: boolean
-  default: false
-fire_event_filter:
-  description: If `fire_event` is set `fire_event_filter` has to be specified. `fire_event_filter` defines a list of patterns for filtering KNX addresses. Only telegrams which match this pattern are sent to the Home Assistant event bus.
-  required: inclusive
+event_filter:
+  description: Defines a list of patterns for filtering KNX group addresses. Telegrams with destination addresses matching this pattern are sent to the Home Assistant event bus as `knx_event`.
+  required: false
   type: [list, string]
 {% endconfiguration %}
 
-Every telegram that matches the filter will be announced on the event bus as a `knx_event` event containing data attributes
+Every telegram that matches the filter with its destination field will be announced on the event bus as a `knx_event` event containing data attributes
 
 - `data` contains the raw payload data (eg. 1 or "[12, 55]").
 - `destination` the KNX group address the telegram is sent to as string (eg. "1/2/3).
@@ -183,7 +177,9 @@ Every telegram that matches the filter will be announced on the event bus as a `
 
 ## Services
 
-In order to directly interact with the KNX bus, you can use the following service:
+In order to directly interact with the KNX bus, you can use the following services:
+
+### Send
 
 ```txt
 Domain: knx
@@ -203,7 +199,37 @@ type:
   type: [string, integer, float]
 {% endconfiguration %}
 
+### Read
+
 You can also use the `homeassistant.update_entity` service call to issue GroupValueRead requests for all `*state_address` of a device.
+
+### Register Event
+
+The `knx.event_register` service can be used to register (or unregister) group addresses to fire `knx_event` Events. Events for group addresses matching the `event_filter` attribute in configuration.yaml can not be unregistered. See [knx_event](#events)
+
+{% configuration %}
+address:
+  description: Group address that shall be added or removed.
+  required: true
+  type: string
+remove:
+  description: If `True` the group address will be removed.
+  required: false
+  type: boolean
+  default: false
+{% endconfiguration %}
+
+### Register Exposure
+
+The `knx.exposure_register` service can be used to register (or unregister) exposures to the KNX bus. Exposures defined in configuration.yaml can not be unregistered. Per address only one exposure can be registered. See [expose](#exposing-entity-states-entity-attributes-or-time-to-knx-bus)
+
+{% configuration %}
+remove:
+  description: In addition to the configuration variables of [expose](#exposing-entity-states-entity-attributes-or-time-to-knx-bus) `remove` set to `True` can be used to remove exposures. Only `address` is required for removal.
+  required: false
+  type: boolean
+  default: false
+{% endconfiguration %}
 
 ## Exposing entity states, entity attributes or time to KNX bus
 
@@ -238,6 +264,10 @@ knx:
 ```
 
 {% configuration %}
+address:
+  description: Group address state or attribute updates will be sent to. GroupValueRead requests will be answered.
+  type: string
+  required: true
 type:
   description: Type of the exposed value. Either 'binary', 'time', 'date', 'datetime' or any supported type of [KNX Sensor](#sensor) (e.g., "temperature" or "humidity").
   type: string
@@ -258,10 +288,6 @@ default:
   type: [boolean, string, integer, float]
   default: None
   required: false
-address:
-  description: KNX group address.
-  type: string
-  required: true
 {% endconfiguration %}
 
 ## Binary Sensor


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- added documentation for new event_register service
- updated some changed names

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45248
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
