### PR TITLE
Change NextTracks F-Droid information

### DIFF
--- a/source/_integrations/owntracks.markdown
+++ b/source/_integrations/owntracks.markdown
@@ -23,7 +23,7 @@ To configure OwnTracks, you must set it up via the integrations panel in the con
 
 ### Configuring the app - Android
 
-Install [OwnTracks](https://play.google.com/store/apps/details?id=org.owntracks.android) or [NextTracks](https://codeberg.org/nexttracks/android/releases) (Soon available from [F-Droid](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/6831)) application for Android.
+Install [OwnTracks](https://play.google.com/store/apps/details?id=org.owntracks.android) or [NextTracks](https://codeberg.org/nexttracks/android/releases) (Available from [F-Droid](https://f-droid.org/packages/org.nexttracks.android)) application for Android.
 
 In the app, open the sidebar and click on preferences, then on the connection. Change the following settings:
 


### PR DESCRIPTION
NextTracks is now available in F-Droid. 
Removed "Soon" and changed the URL from the GitLab merge request to the F-Droid app-page.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
