### PR TITLE
Document `buttons` action support for `entities` card

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -117,7 +117,38 @@ double_tap_action:
 
 Rather than only displaying an entity's state as a text output, the Entities card supports multiple special rows for buttons, attributes, web links, dividers and sections, etc.
 
+### Attribute
+
+{% configuration %}
+type:
+  required: true
+  description: "`attribute`"
+  type: string
+entity:
+  required: true
+  description: Entity ID
+  type: string
+attribute:
+  required: true
+  description: Attribute to display from the entity
+  type: string
+prefix:
+  required: false
+  description: Text before entity state
+  type: string
+suffix:
+  required: false
+  description: Text after entity state
+  type: string
+name:
+  required: false
+  description: Overwrites friendly name
+  type: string
+{% endconfiguration %}
+
 ### Button
+
+Row with an (optional) icon, name and a single text button at the end of the row that can trigger a defined action. 
 
 {% configuration %}
 type:
@@ -149,6 +180,60 @@ double_tap_action:
   required: false
   description: Action taken on card double tap. See [action documentation](/lovelace/actions/#double-tap-action).
   type: map
+{% endconfiguration %}
+
+### Buttons
+
+Multiple buttons displayed in a single row next to each other. See examples further below.
+
+{% configuration %}
+type:
+  required: true
+  description: "`buttons`"
+  type: string
+entities:
+  required: true
+  description: A list of entities to show. Each entry is either an entity ID or a map.
+  type: list
+  keys:
+    entity:
+      required: true
+      description: Entity ID
+      type: string
+    icon:
+      required: false
+      description: Override the entity icon
+      type: string
+    image:
+      required: false
+      description: Override the entity image
+      type: string
+    name:
+      required: false
+      description: Label for the button
+      type: string
+    show_name:
+      required: false
+      description: If false, the button name is not shown
+      type: boolean
+      default: "true"
+    show_icon:
+      required: false
+      description: If false, the icon is not shown
+      type: boolean
+      default: "true"    
+    tap_action:
+      required: false
+      description: Action taken on card tap. See [action documentation](/lovelace/actions/#tap-action).
+      type: map
+    hold_action:
+      required: false
+      description: Action taken on card tap and hold. See [action documentation](/lovelace/actions/#hold-action).
+      type: map
+    double_tap_action:
+      required: false
+      description: Action taken on card double tap. See [action documentation](/lovelace/actions/#double-tap-action).
+      type: map
 {% endconfiguration %}
 
 ### Cast
@@ -269,79 +354,6 @@ icon:
   description: "Icon to display (e.g., `mdi:home`)"
   type: string
   default: "`mdi:link`"
-{% endconfiguration %}
-
-### Buttons
-
-Multiple buttons displayed in a single row next to each other. See examples further below.
-
-{% configuration %}
-type:
-  required: true
-  description: "`buttons`"
-  type: string
-entities:
-  required: true
-  description: A list of entities to show. Each entry is either an entity ID or a map.
-  type: list
-  keys:
-    entity:
-      required: true
-      description: Entity ID
-      type: string
-    icon:
-      required: false
-      description: Override the entity icon
-      type: string
-    image:
-      required: false
-      description: Override the entity image
-      type: string
-    name:
-      required: false
-      description: Label for the button
-      type: string
-    tap_action:
-      required: false
-      description: Action taken on card tap. See [action documentation](/lovelace/actions/#tap-action).
-      type: map
-    hold_action:
-      required: false
-      description: Action taken on card tap and hold. See [action documentation](/lovelace/actions/#hold-action).
-      type: map
-    double_tap_action:
-      required: false
-      description: Action taken on card double tap. See [action documentation](/lovelace/actions/#double-tap-action).
-      type: map
-{% endconfiguration %}
-
-### Attribute
-
-{% configuration %}
-type:
-  required: true
-  description: "`attribute`"
-  type: string
-entity:
-  required: true
-  description: Entity ID
-  type: string
-attribute:
-  required: true
-  description: Attribute to display from the entity
-  type: string
-prefix:
-  required: false
-  description: Text before entity state
-  type: string
-suffix:
-  required: false
-  description: Text after entity state
-  type: string
-name:
-  required: false
-  description: Overwrites friendly name
-  type: string
 {% endconfiguration %}
 
 ## Examples

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -210,8 +210,9 @@ entities:
       type: string
     name:
       required: false
-      description: Label for the button
+      description: Override the entity name
       type: string
+      default: Entity name
     show_name:
       required: false
       description: If false, the button name is not shown

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -11,7 +11,7 @@ To add the Entities card to your user interface, click the Lovelace menu (three 
 {% configuration %}
 type:
   required: true
-  description: entities
+  description: "`entities`"
   type: string
 entities:
   required: true
@@ -19,7 +19,7 @@ entities:
   type: list
 title:
   required: false
-  description: The card title.
+  description: Card title
   type: string
 icon:
   required: false
@@ -27,12 +27,12 @@ icon:
   type: string
 show_header_toggle:
   required: false
-  description: Button to turn on/off all entities.
+  description: Button to turn on/off all entities
   type: boolean
   default: true
 theme:
   required: false
-  description: Set to any theme within `themes.yaml`.
+  description: Set to any theme within `themes.yaml`
   type: string
 state_color:
   required: false
@@ -56,7 +56,7 @@ If you define entities as objects instead of strings (by adding `entity:` before
 {% configuration %}
 entity:
   required: true
-  description: Entity ID.
+  description: Entity ID
   type: string
 type:
   required: false
@@ -64,15 +64,15 @@ type:
   type: string
 name:
   required: false
-  description: Overwrites friendly name.
+  description: Overwrites friendly name
   type: string
 icon:
   required: false
-  description: Overwrites icon or entity picture.
+  description: Overwrites icon or entity picture
   type: string
 image:
   required: false
-  description: Overwrites entity picture.
+  description: Overwrites entity picture
   type: string
 secondary_info:
   required: false
@@ -92,7 +92,7 @@ footer:
   type: map
 action_name:
   required: false
-  description: Button label. (Only applies to `script` and `scene` rows)
+  description: Button label (only applies to `script` and `scene` rows)
   type: string
 state_color:
   required: false
@@ -126,15 +126,15 @@ type:
   type: string
 name:
   required: true
-  description: Main Label.
+  description: Main label
   type: string
 icon:
   required: false
-  description: An icon to display to the left of the label.
+  description: An icon to display to the left of the label
   type: string
 action_name:
   required: false
-  description: Button label.
+  description: Button label
   type: string
   default: "`Run`"
 tap_action:
@@ -162,11 +162,11 @@ type:
   type: string
 dashboard:
   required: false
-  description: Path to the dashboard of the view that needs to be shown.
+  description: Path to the dashboard of the view that needs to be shown
   type: string
 view:
   required: true
-  description: Path to the view that needs to be shown.
+  description: Path to the view that needs to be shown
   type: string
 name:
   required: false
@@ -180,7 +180,7 @@ icon:
   default: "`hass:television`"
 hide_if_unavailable:
   required: false
-  description: Hide this row if casting is not available in the browser.
+  description: Hide this row if casting is not available in the browser
   type: boolean
   default: false
 {% endconfiguration %}
@@ -196,24 +196,24 @@ type:
   type: string
 conditions:
   required: true
-  description: List of entity IDs and matching states.
+  description: List of entity IDs and matching states
   type: list
   keys:
     entity:
       required: true
-      description: Entity ID.
+      description: Entity ID
       type: string
     state:
       required: false
-      description: Entity state is equal to this value.*
+      description: Entity state is equal to this value*
       type: string
     state_not:
       required: false
-      description: Entity state is unequal to this value.*
+      description: Entity state is unequal to this value*
       type: string
 row:
   required: true
-  description: Row to display if all conditions match.
+  description: Row to display if all conditions match
   type: map
 {% endconfiguration %}
 
@@ -230,7 +230,7 @@ type:
   type: string
 style:
   required: false
-  description: Style the element using CSS.
+  description: Style the element using CSS
   type: map
   default: "height: 1px, background-color: var(--divider-color)"
 {% endconfiguration %}
@@ -291,16 +291,28 @@ entities:
       type: string
     icon:
       required: false
-      description: Override the entity icon.
+      description: Override the entity icon
       type: string
     image:
       required: false
-      description: Override the entity image.
+      description: Override the entity image
       type: string
     name:
       required: false
       description: Label for the button
       type: string
+    tap_action:
+      required: false
+      description: Action taken on card tap. See [action documentation](/lovelace/actions/#tap-action).
+      type: map
+    hold_action:
+      required: false
+      description: Action taken on card tap and hold. See [action documentation](/lovelace/actions/#hold-action).
+      type: map
+    double_tap_action:
+      required: false
+      description: Action taken on card double tap. See [action documentation](/lovelace/actions/#double-tap-action).
+      type: map
 {% endconfiguration %}
 
 ### Attribute
@@ -316,19 +328,19 @@ entity:
   type: string
 attribute:
   required: true
-  description: Attribute to display from the entity.
+  description: Attribute to display from the entity
   type: string
 prefix:
   required: false
-  description: Text before entity state.
+  description: Text before entity state
   type: string
 suffix:
   required: false
-  description: Text after entity state.
+  description: Text after entity state
   type: string
 name:
   required: false
-  description: Overwrites friendly name.
+  description: Overwrites friendly name
   type: string
 {% endconfiguration %}
 

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -32,7 +32,7 @@ show_header_toggle:
   default: true
 theme:
   required: false
-  description: Set to any theme within `themes.yaml`.
+  description: Override the used theme for this card with any loaded theme. For more information about themes, see the [frontend documentation](/integrations/frontend/).
   type: string
 state_color:
   required: false

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -51,7 +51,7 @@ footer:
 
 ## Options For Entities
 
-If you define entities as objects instead of strings (by adding `entity:` before entity ID), you can add more customization and configuration:
+If you define entities as objects instead of strings (by adding `entity:` before entity ID), you can add more customization and configuration.
 
 {% configuration %}
 entity:
@@ -142,13 +142,13 @@ suffix:
   type: string
 name:
   required: false
-  description: Overwrites friendly name
+  description: Overwrites friendly entity name
   type: string
 {% endconfiguration %}
 
 ### Button
 
-Row with an (optional) icon, name and a single text button at the end of the row that can trigger a defined action. 
+Row with an (optional) icon, label and a single text button at the end of the row that can trigger a defined action. 
 
 {% configuration %}
 type:
@@ -161,7 +161,7 @@ name:
   type: string
 icon:
   required: false
-  description: An icon to display to the left of the label
+  description: An icon to display to the left of the main label
   type: string
 action_name:
   required: false
@@ -210,7 +210,7 @@ entities:
       type: string
     name:
       required: false
-      description: Override the entity name
+      description: Override the friendly entity name
       type: string
       default: Entity name
     show_name:

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -82,14 +82,6 @@ format:
   required: false
   description: "How the state should be formatted. Currently only used for timestamp sensors. Valid values are: `relative`, `total`, `date`, `time` and `datetime`."
   type: string
-header:
-  required: false
-  description: Header widget to render. See [header documentation](/lovelace/header-footer/).
-  type: map
-footer:
-  required: false
-  description: Footer widget to render. See [footer documentation](/lovelace/header-footer/).
-  type: map
 action_name:
   required: false
   description: Button label (only applies to `script` and `scene` rows)

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -19,24 +19,24 @@ entities:
   type: list
 title:
   required: false
-  description: Card title
+  description: Card title.
   type: string
 icon:
   required: false
-  description: An icon to display to the left of the title
+  description: An icon to display to the left of the title.
   type: string
 show_header_toggle:
   required: false
-  description: Button to turn on/off all entities
+  description: Button to turn on/off all entities.
   type: boolean
   default: true
 theme:
   required: false
-  description: Set to any theme within `themes.yaml`
+  description: Set to any theme within `themes.yaml`.
   type: string
 state_color:
   required: false
-  description: Set to `true` to have icons colored when entity is active
+  description: Set to `true` to have icons colored when entity is active.
   type: boolean
   default: false
 header:
@@ -56,7 +56,7 @@ If you define entities as objects instead of strings (by adding `entity:` before
 {% configuration %}
 entity:
   required: true
-  description: Entity ID
+  description: Entity ID.
   type: string
 type:
   required: false
@@ -64,15 +64,15 @@ type:
   type: string
 name:
   required: false
-  description: Overwrites friendly name
+  description: Overwrites friendly name.
   type: string
 icon:
   required: false
-  description: Overwrites icon or entity picture
+  description: Overwrites icon or entity picture.
   type: string
 image:
   required: false
-  description: Overwrites entity picture
+  description: Overwrites entity picture.
   type: string
 secondary_info:
   required: false
@@ -84,11 +84,11 @@ format:
   type: string
 action_name:
   required: false
-  description: Button label (only applies to `script` and `scene` rows)
+  description: Button label (only applies to `script` and `scene` rows).
   type: string
 state_color:
   required: false
-  description: Set to `true` to have icons colored when entity is active
+  description: Set to `true` to have icons colored when entity is active.
   type: boolean
   default: false
 tap_action:
@@ -118,23 +118,23 @@ type:
   type: string
 entity:
   required: true
-  description: Entity ID
+  description: Entity ID.
   type: string
 attribute:
   required: true
-  description: Attribute to display from the entity
+  description: Attribute to display from the entity.
   type: string
 prefix:
   required: false
-  description: Text before entity state
+  description: Text before entity state.
   type: string
 suffix:
   required: false
-  description: Text after entity state
+  description: Text after entity state.
   type: string
 name:
   required: false
-  description: Overwrites friendly entity name
+  description: Overwrites friendly entity name.
   type: string
 {% endconfiguration %}
 
@@ -149,15 +149,15 @@ type:
   type: string
 name:
   required: true
-  description: Main label
+  description: Main label.
   type: string
 icon:
   required: false
-  description: An icon to display to the left of the main label
+  description: An icon to display to the left of the main label.
   type: string
 action_name:
   required: false
-  description: Button label
+  description: Button label.
   type: string
   default: "`Run`"
 tap_action:
@@ -190,29 +190,29 @@ entities:
   keys:
     entity:
       required: true
-      description: Entity ID
+      description: Entity ID.
       type: string
     icon:
       required: false
-      description: Override the entity icon
+      description: Override the entity icon.
       type: string
     image:
       required: false
-      description: Override the entity image
+      description: Override the entity image.
       type: string
     name:
       required: false
-      description: Override the friendly entity name
+      description: Override the friendly entity name.
       type: string
       default: Entity name
     show_name:
       required: false
-      description: If false, the button name is not shown
+      description: If false, the button name is not shown.
       type: boolean
       default: "true"
     show_icon:
       required: false
-      description: If false, the icon is not shown
+      description: If false, the icon is not shown.
       type: boolean
       default: "true"    
     tap_action:
@@ -240,25 +240,25 @@ type:
   type: string
 dashboard:
   required: false
-  description: Path to the dashboard of the view that needs to be shown
+  description: Path to the dashboard of the view that needs to be shown.
   type: string
 view:
   required: true
-  description: Path to the view that needs to be shown
+  description: Path to the view that needs to be shown.
   type: string
 name:
   required: false
-  description: Name to show in the row
+  description: Name to show in the row.
   type: string
   default: Home Assistant Cast
 icon:
   required: false
-  description: Icon to use
+  description: Icon to use.
   type: string
   default: "`hass:television`"
 hide_if_unavailable:
   required: false
-  description: Hide this row if casting is not available in the browser
+  description: Hide this row if casting is not available in the browser.
   type: boolean
   default: false
 {% endconfiguration %}
@@ -274,24 +274,24 @@ type:
   type: string
 conditions:
   required: true
-  description: List of entity IDs and matching states
+  description: List of entity IDs and matching states.
   type: list
   keys:
     entity:
       required: true
-      description: Entity ID
+      description: Entity ID.
       type: string
     state:
       required: false
-      description: Entity state is equal to this value*
+      description: Entity state is equal to this value.*
       type: string
     state_not:
       required: false
-      description: Entity state is unequal to this value*
+      description: Entity state is unequal to this value.*
       type: string
 row:
   required: true
-  description: Row to display if all conditions match
+  description: Row to display if all conditions match.
   type: map
 {% endconfiguration %}
 
@@ -308,7 +308,7 @@ type:
   type: string
 style:
   required: false
-  description: Style the element using CSS
+  description: Style the element using CSS.
   type: map
   default: "height: 1px, background-color: var(--divider-color)"
 {% endconfiguration %}
@@ -322,7 +322,7 @@ type:
   type: string
 label:
   required: false
-  description: Section label
+  description: Section label.
   type: string
 {% endconfiguration %}
 
@@ -335,16 +335,16 @@ type:
   type: string
 url:
   required: true
-  description: "Website URL (or internal URL e.g., `/hassio/dashboard` or `/panel_custom_name`)"
+  description: "Website URL (or internal URL e.g., `/hassio/dashboard` or `/panel_custom_name`)."
   type: string
 name:
   required: false
-  description: Link label
+  description: Link label.
   type: string
   default: URL path
 icon:
   required: false
-  description: "Icon to display (e.g., `mdi:home`)"
+  description: "Icon to display (e.g., `mdi:home`)."
   type: string
   default: "`mdi:link`"
 {% endconfiguration %}


### PR DESCRIPTION
## Proposed change
The `buttons` type in an `entities` card already support the same action handler logic as a `button`  row, but it was not mentioned here. Same fopr `show_icon` and  `show_name`.

Sorted the special row types alphabetically.

Tried to align the full-stop logic. Only use it if the description actually has multiple sentences.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
