### PR TITLE
Add note about default action override

### DIFF
--- a/source/lovelace/actions.markdown
+++ b/source/lovelace/actions.markdown
@@ -35,7 +35,7 @@ tap_action:
       required: true
       description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `url`, `none`)"
       type: string
-      default: "`toggle`" (some cards overwrite default to "`more-info`" if the provided entity cannot be toggled)
+      default: "`toggle` (some cards overwrite default to "`more-info`" if the provided entity cannot be toggled)"
     navigation_path:
       required: false
       description: "Path to navigate to (e.g., `/lovelace/0/`) when `action` defined as `navigate`"

--- a/source/lovelace/actions.markdown
+++ b/source/lovelace/actions.markdown
@@ -35,7 +35,7 @@ tap_action:
       required: true
       description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `url`, `none`)"
       type: string
-      default: "`toggle`"
+      default: "`toggle`" (some cards overwrite default to "`more-info`" if the provided entity cannot be toggled)
     navigation_path:
       required: false
       description: "Path to navigate to (e.g., `/lovelace/0/`) when `action` defined as `navigate`"

--- a/source/lovelace/actions.markdown
+++ b/source/lovelace/actions.markdown
@@ -35,7 +35,7 @@ tap_action:
       required: true
       description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `url`, `none`)"
       type: string
-      default: "`toggle` (some cards overwrite default to "`more-info`" if the provided entity cannot be toggled)"
+      default: "`toggle` (some cards overwrite default to `more-info` if the provided entity cannot be toggled)"
     navigation_path:
       required: false
       description: "Path to navigate to (e.g., `/lovelace/0/`) when `action` defined as `navigate`"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
