### PR TITLE
Add Discourse forum link to footer

### DIFF
--- a/source/_includes/site/footer.html
+++ b/source/_includes/site/footer.html
@@ -18,6 +18,7 @@
             <li><a href='https://alerts.home-assistant.io'>Home Assistant Alerts</a></li>
             <li><a href='https://developers.home-assistant.io'>Developers</a></li>
             <li><a href='https://data.home-assistant.io'>Data Science</a></li>
+            <li><a href='https://community.home-assistant.io'>Community Forum</a></li>
             <li><a href='mailto:hello@home-assistant.io'>Contact</a> (no support!)</li>
             <li><a href='/security/'>Security Vulnerabilities</a></li>
             <li><a href='/privacy/'>Privacy</a></li>


### PR DESCRIPTION
## Proposed change

The forum link was only present in the homepage and under the [Need help?](https://www.home-assistant.io/help/) page. I think it makes sense for it to be in the footer as well for ease of accessibility.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
