### PR TITLE
Add documentation for mqtt climate command templates

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -62,6 +62,11 @@ availability:
       description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
+availability_mode:
+  description: When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all`, `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any`, `payload_available` must be received on at least one configured availability topic before the entity is marked as online. If set to `latest`, the last `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
+  required: false
+  type: string
+  default: latest
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -62,11 +62,6 @@ availability:
       description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
-availability_mode:
-  description: When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all`, `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any`, `payload_available` must be received on at least one configured availability topic before the entity is marked as online. If set to `latest`, the last `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
-  required: false
-  type: string
-  default: latest
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
@@ -124,6 +119,10 @@ device:
       description: 'Identifier of a device that routes messages between this device and Home Assistant. Examples of such devices are hubs, or parent devices of a sub-device. This is used to show device topology in Home Assistant.'
       required: false
       type: string
+fan_mode_command_template:
+  description: A template to render the value sent to the `fan_mode_command_topic` with.
+  required: false
+  type: template
 fan_mode_command_topic:
   description: The MQTT topic to publish commands to change the fan mode.
   required: false
@@ -141,6 +140,10 @@ fan_modes:
   required: false
   default: ['auto', 'low', 'medium', 'high']
   type: list
+hold_command_template:
+  description: A template to render the value sent to the `hold_command_topic` with.
+  required: false
+  type: template
 hold_command_topic:
   description: The MQTT topic to publish commands to change the hold mode.
   required: false
@@ -178,6 +181,10 @@ min_temp:
   description: Minimum set point available.
   type: float
   required: false
+mode_command_template:
+  description: A template to render the value sent to the `mode_command_topic` with.
+  required: false
+  type: template
 mode_command_topic:
   description: The MQTT topic to publish commands to change the HVAC operation mode.
   required: false
@@ -244,6 +251,10 @@ send_if_off:
   required: false
   type: boolean
   default: true
+swing_mode_command_template:
+  description: A template to render the value sent to the `swing_mode_command_topic` with.
+  required: false
+  type: template
 swing_mode_command_topic:
   description: The MQTT topic to publish commands to change the swing mode.
   required: false
@@ -261,10 +272,18 @@ swing_modes:
   required: false
   default: ['on', 'off']
   type: list
+temperature_command_template:
+  description: A template to render the value sent to the `temperature_command_topic` with.
+  required: false
+  type: template
 temperature_command_topic:
   description: The MQTT topic to publish commands to change the target temperature.
   required: false
   type: string
+temperature_high_command_template:
+  description: A template to render the value sent to the `temperature_high_command_topic` with.
+  required: false
+  type: template
 temperature_high_command_topic:
   description: The MQTT topic to publish commands to change the high target temperature.
   required: false
@@ -277,6 +296,10 @@ temperature_high_state_topic:
   description: The MQTT topic to subscribe for changes in the target high temperature. If this is not set, the target high temperature works in optimistic mode (see below).
   required: false
   type: string
+temperature_low_command_template:
+  description: A template to render the value sent to the `temperature_low_command_topic` with.
+  required: false
+  type: template
 temperature_low_command_topic:
   description: The MQTT topic to publish commands to change the target low temperature.
   required: false
@@ -344,6 +367,8 @@ climate:
 {% endraw %}
 
 This will parse the incoming `"auto"` as JSON, resulting in `auto`. Obviously, in this case you could also just set `value_template: {% raw %}"{{ value_json }}"{% endraw %}`.
+
+Similarly for `*_command_topic`s, a template can be specified to render the outgoing payloads on these topics. 
 
 ### Example
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation for command templates being added in https://github.com/home-assistant/core/pull/44976


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/44976
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
