### PR TITLE
Update troubleshooting.markdown

### DIFF
--- a/source/_docs/installation/troubleshooting.markdown
+++ b/source/_docs/installation/troubleshooting.markdown
@@ -43,3 +43,21 @@ For `iptables` systems (was the default for older distributions):
 iptables -I INPUT -p tcp --dport 8123 -j ACCEPT
 iptables-save > /etc/network/iptables.rules  # your rules may be saved elsewhere
 ```
+
+### System freezes
+
+Upon the first run or after an upgrade, Home Assistant uses a lot of resources to (re)compile all the integrations. 
+If you run out of memory and/or swap memory, your system will freeze.
+Increasing swap memory can help:
+
+```bash
+sudo dphys-swapfile swapoff
+sudo nano /etc/dphys-swapfile
+```
+
+Modify the line the sets the swapfile size. Set it equal to your memory or double your current setting: `CONF_SWAPSIZE = 925` then:
+
+```bash
+sudo dphys-swapfile swapon
+sudo systemctl restart dphys-swapfile.service
+```

--- a/source/_docs/installation/troubleshooting.markdown
+++ b/source/_docs/installation/troubleshooting.markdown
@@ -46,6 +46,7 @@ iptables-save > /etc/network/iptables.rules  # your rules may be saved elsewhere
 
 ### System freezes
 
+On small systems (such as a Pi2), not directly sypported by binaries (Python Wheels) you may run out of memory.
 Upon the first run or after an upgrade, Home Assistant uses a lot of resources to (re)compile all the integrations. 
 If you run out of memory and/or swap memory, your system will freeze.
 Increasing swap memory can help:


### PR DESCRIPTION
added suggestion to increase swap memory if your system freezes during first run

## Proposed change
<!-- 
    upgrading to Python3.8 and hass 2021.1.4 on my Raspberry Pi 2 caused it to freeze during compiling the new code.
    Increasing swap memory from 100 to 925 fixed the problem.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
