### PR TITLE
Default for the Number Selector is slider, not box

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -338,7 +338,7 @@ mode:
   description: This can be either `box` or `slider` mode.
   type: string
   required: false
-  default: box
+  default: slider
 {% endconfiguration %}
 
 ### Example number selectors


### PR DESCRIPTION
Very minor change, but in  all the blueprints I have created the Number Selector defaults to a `slider` not a `box`




## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
