### PR TITLE
Update fan documentation for entity model separation of fan speeds into percentages and presets modes

### DIFF
--- a/source/_integrations/fan.markdown
+++ b/source/_integrations/fan.markdown
@@ -16,7 +16,10 @@ The Fan integration allows you to control and monitor Fan devices.
 ### Fan control services
 
 Available services:
-`fan.set_speed`, `fan.set_direction`, `fan.oscillate`, `fan.turn_on`, `fan.turn_off`, `fan.toggle`
+`fan.set_percentage`, `fan.set_direction`, `fan.oscillate`, `fan.turn_on`, `fan.turn_off`, `fan.toggle`
+
+Deprecated services:
+`fan.set_speed`
 
 <div class='note'>
 
@@ -24,14 +27,14 @@ Not all fan services may be available for your platform. You can check which ser
 
 </div>
 
-### Service `fan.set_speed`
+### Service `fan.set_percentage`
 
-Sets the speed for fan device.
+Sets the speed percentage for fan device.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that define the entity ID(s) of fan device(s) to control. To target all fan devices, use `all`.
-| `speed` | no | Speed setting
+| `percentage` | no | Percentage speed setting
 
 #### Automation example
 
@@ -41,10 +44,10 @@ automation:
     platform: time
     at: "07:15:00"
   action:
-    - service: fan.set_speed
+    - service: fan.set_percentage
       data:
         entity_id: fan.kitchen
-        speed: low
+        percentage: 33
 ```
 
 ### Service `fan.set_direction`
@@ -100,6 +103,7 @@ Turn fan device on. This is only supported if the fan device supports being turn
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that define the entity ID(s) of fan device(s) to control. To target all fan devices, use `all`.
+| `percentage` | yes | Percentage speed setting
 
 ### Service `fan.turn_off`
 
@@ -108,3 +112,27 @@ Turn fan device off. This is only supported if the fan device supports being tur
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that define the entity ID(s) of fan device(s) to control. To target all fan devices, use `all`.
+
+
+### Deprecated Service `fan.set_speed`
+
+Sets the speed for fan device.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that define the entity ID(s) of fan device(s) to control. To target all fan devices, use `all`.
+| `speed` | no | Speed setting
+
+#### Automation example
+
+```yaml
+automation:
+  trigger:
+    platform: time
+    at: "07:15:00"
+  action:
+    - service: fan.set_speed
+      data:
+        entity_id: fan.kitchen
+        speed: low
+```

--- a/source/_integrations/fan.markdown
+++ b/source/_integrations/fan.markdown
@@ -16,7 +16,7 @@ The Fan integration allows you to control and monitor Fan devices.
 ### Fan control services
 
 Available services:
-`fan.set_percentage`, `fan.set_direction`, `fan.oscillate`, `fan.turn_on`, `fan.turn_off`, `fan.toggle`
+`fan.set_percentage`, `fan.set_preset_mode`, `fan.set_direction`, `fan.oscillate`, `fan.turn_on`, `fan.turn_off`, `fan.toggle`
 
 Deprecated services:
 `fan.set_speed`
@@ -48,6 +48,30 @@ automation:
       data:
         entity_id: fan.kitchen
         percentage: 33
+```
+
+
+### Service `fan.set_preset_mode`
+
+Sets a preset mode for fan device.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that define the entity ID(s) of fan device(s) to control. To target all fan devices, use `all`.
+| `preset_mode` | no | The preset mode
+
+#### Automation example
+
+```yaml
+automation:
+  trigger:
+    platform: time
+    at: "07:15:00"
+  action:
+    - service: fan.set_preset_mode
+      data:
+        entity_id: fan.kitchen
+        preset_mode: auto
 ```
 
 ### Service `fan.set_direction`
@@ -104,6 +128,7 @@ Turn fan device on. This is only supported if the fan device supports being turn
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that define the entity ID(s) of fan device(s) to control. To target all fan devices, use `all`.
 | `percentage` | yes | Percentage speed setting
+| `preset_mode` | yes | The preset mode
 
 ### Service `fan.turn_off`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update fan documentation for entity model separation of fan speeds into percentages and presets modes

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45407
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
