### PR TITLE
Add extra dict possible for send to Chromecast

### DIFF
--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -72,9 +72,10 @@ metadata: map - Media metadata object, one of the following:
     MusicTrackMediaMetadata, PhotoMediaMetadata.
 ```
 
-Documentaion:
-[Google Dev Documentaion MediaData](https://developers.google.com/cast/docs/reference/messages#MediaData)
-[Google Dev Documentaion MediaInformation](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation)
+Documentation:
+
+- [Google Dev Documentaion MediaData](https://developers.google.com/cast/docs/reference/messages#MediaData)
+- [Google Dev Documentaion MediaInformation](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation)
 
 
 Example of calling media_player service with title and image set:

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -68,6 +68,7 @@ current_time:
 autoplay:
   type: boolean
   description: Whether the media will automatically play.
+  default: true
   required: false
 stream_type:
   type: string
@@ -92,6 +93,7 @@ subtitle_id:
 enqueue:
   type: boolean
   description: If True, enqueue the media instead of play it.
+  default: false
   required: false
 media_info:
   type: map

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -48,6 +48,42 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | `entity_id`            |      yes | Target a specific media player. To target all media players, use `all`.                                                                                                                       |
 | `media_content_id`     |       no | A media identifier. The format of this is integration dependent. For example, you can provide URLs to Sonos and Cast but only a playlist ID to iTunes.                   |
 | `media_content_type`   |       no | A media type. Must be one of `music`, `tvshow`, `video`, `episode`, `channel` or `playlist`. For example, to play music you would set `media_content_type` to `music`. |
+| `extra`                |      yes | Extra dictionary data eg. title, thumb send to pychromecast. Possible values can be found below.
+
+
+Extra dictionary data:
+```
+#Info taken from: https://github.com/home-assistant-libs/pychromecast/blob/master/pychromecast/controllers/media.py
+title: str - title of the media.
+thumb: str - thumbnail image url.
+current_time: float - Seconds since beginning of content. If the content is
+    live content, and position is not specifed, the stream will start at the
+    live position
+autoplay: bool - whether the media will automatically play.
+stream_type: str - describes the type of media artifact as one of the
+    following: "NONE", "BUFFERED", "LIVE".
+subtitles: str - url of subtitle file to be shown on chromecast.
+subtitles_lang: str - language for subtitles.
+subtitles_mime: str - mimetype of subtitles.
+subtitle_id: int - id of subtitle to be loaded.
+enqueue: bool - if True, enqueue the media instead of play it.
+media_info: dict - additional MediaInformation attributes not explicitly listed.
+metadata: dict - media metadata object, one of the following:
+    GenericMediaMetadata, MovieMediaMetadata, TvShowMediaMetadata,
+    MusicTrackMediaMetadata, PhotoMediaMetadata.
+Docs:
+https://developers.google.com/cast/docs/reference/messages#MediaData
+https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation
+```
+
+Example of calling media_player service with title and image set:
+```
+media_content_type: music
+media_content_id: 'https://fake-home-assistant.io.stream/aac'
+extra:
+  thumb: 'https://brands.home-assistant.io/_/homeassistant/logo.png'
+  title: HomeAssitantRadio
+```
 
 #### Service `media_player.select_source`
 

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -63,7 +63,7 @@ thumb:
   required: false
 current_time:
   type: float
-  description: Seconds since beginning of content. If the content is live content, and position is not specifed, the stream will start at the live position
+  description: Seconds since the beginning of the content. If the content is live content, and the position is not specified, the stream will start at the live position.
   required: false
 autoplay:
   type: bool

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -52,25 +52,56 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 
 ##### Extra dictionary data
 
-```json
-title: string - Title of the media.
-thumb: string - Thumbnail image URL.
-current_time: float - Seconds since beginning of content. If the content is
-    live content, and position is not specifed, the stream will start at the
-    live position
-autoplay: bool - Whether the media will automatically play.
-stream_type: string - Describes the type of media artifact as one of the
-    following: "NONE", "BUFFERED", "LIVE".
-subtitles: str - URL of subtitle file to be shown on chromecast.
-subtitles_lang: string - Language for subtitles.
-subtitles_mime: string - Mimetype of subtitles.
-subtitle_id: int - Id of subtitle to be loaded.
-enqueue: bool - If True, enqueue the media instead of play it.
-media_info: map - Additional MediaInformation attributes not explicitly listed.
-metadata: map - Media metadata object, one of the following:
-    GenericMediaMetadata, MovieMediaMetadata, TvShowMediaMetadata,
-    MusicTrackMediaMetadata, PhotoMediaMetadata.
-```
+{% configuration %}
+title:
+  type: string
+  description: Title of the media.
+  required: false
+thumb:
+  type: string
+  description: Thumbnail image URL.
+  required: false
+current_time:
+  type: float
+  description: Seconds since beginning of content. If the content is live content, and position is not specifed, the stream will start at the live position
+  required: false
+autoplay:
+  type: bool
+  description: Whether the media will automatically play.
+  required: false
+stream_type:
+  type: string
+  description: Describes the type of media artifact as one of the following: "NONE", "BUFFERED", "LIVE".
+  required: false
+subtitles:
+  type: string
+  description: URL of subtitle file to be shown on chromecast.
+  required: false
+subtitles_lang:
+  type: string
+  description: Language for subtitles.
+  required: false
+subtitles_mime:
+  type :string
+  description: Mimetype of subtitles.
+  required: false
+subtitle_id:
+  type: int
+  description: Id of subtitle to be loaded.
+  required: false
+enqueue:
+  type: bool
+  description: If True, enqueue the media instead of play it.
+  required: false
+media_info:
+  type: map
+  description: Additional MediaInformation attributes not explicitly listed.
+  required: false
+metadata:
+  type: map
+  description: Media metadata object, one of the following: GenericMediaMetadata, MovieMediaMetadata, TvShowMediaMetadata, MusicTrackMediaMetadata, PhotoMediaMetadata.
+  required: false
+{% endconfiguration %}
 
 Documentation:
 

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -48,7 +48,7 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | `entity_id`            |      yes | Target a specific media player. To target all media players, use `all`.                                                                                                                       |
 | `media_content_id`     |       no | A media identifier. The format of this is integration dependent. For example, you can provide URLs to Sonos and Cast but only a playlist ID to iTunes.                   |
 | `media_content_type`   |       no | A media type. Must be one of `music`, `tvshow`, `video`, `episode`, `channel` or `playlist`. For example, to play music you would set `media_content_type` to `music`. |
-| `extra`                |      yes | Extra dictionary data eg. title, thumb send to pychromecast. Possible values can be found below.
+| `extra`                |      yes | Extra dictionary data to send, e.g., title, thumbnail. Possible values can be found below.
 
 
 #####Extra dictionary data

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -57,11 +57,11 @@ Info taken from: https://github.com/home-assistant-libs/pychromecast/blob/master
 | Extra attribute name | Type | Description                                                                                                                                                            |
 | -----------------------| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `title`            |      str | title of the media. |
-| `thumb`            |      str | thumbnail image url. |
+| `thumb`            |      str | thumbnail image URL. |
 | `current_time`            |      float | Seconds since beginning of content. If the content is live content, and position is not specifed, the stream will start at the live position. |
 | `autoplay`            |bool | whether the media will automatically play. |
 | `stream_type`            |str | describes the type of media artifact as one of the following: "NONE", "BUFFERED", "LIVE". |
-| `subtitles`            |str | url of subtitle file to be shown on chromecast. |
+| `subtitles`            |str | URL of subtitle file to be shown on chromecast. |
 | `subtitles_lang`            |str | language for subtitles. |
 | `subtitles_mime`            |str | mimetype of subtitles. |
 | `subtitle_id`            |int | id of subtitle to be loaded. |

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -90,7 +90,7 @@ subtitle_id:
   description: ID of subtitle to be loaded.
   required: false
 enqueue:
-  type: bool
+  type: boolean
   description: If True, enqueue the media instead of play it.
   required: false
 media_info:

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -50,8 +50,8 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | `media_content_type`   |       no | A media type. Must be one of `music`, `tvshow`, `video`, `episode`, `channel` or `playlist`. For example, to play music you would set `media_content_type` to `music`. |
 | `extra`                |      yes | Extra dictionary data to send, e.g., title, thumbnail. Possible values can be found below.
 
+##### Extra dictionary data
 
-#####Extra dictionary data
 Info taken from: https://github.com/home-assistant-libs/pychromecast/blob/master/pychromecast/controllers/media.py
 
 | Extra attribute name | Type | Description                                                                                                                                                            |

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -86,7 +86,7 @@ subtitles_mime:
   description: Mimetype of subtitles.
   required: false
 subtitle_id:
-  type: int
+  type: integer
   description: ID of subtitle to be loaded.
   required: false
 enqueue:

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -72,9 +72,9 @@ metadata: map - Media metadata object, one of the following:
     MusicTrackMediaMetadata, PhotoMediaMetadata.
 ```
 
-Docs:
-[Google Dev Docs MediaData](https://developers.google.com/cast/docs/reference/messages#MediaData)
-[Google Dev Docs MediaInformation](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation)
+Documentaion:
+[Google Dev Documentaion MediaData](https://developers.google.com/cast/docs/reference/messages#MediaData)
+[Google Dev Documentaion MediaInformation](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation)
 
 
 Example of calling media_player service with title and image set:

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -82,7 +82,7 @@ subtitles_lang:
   description: Language for subtitles.
   required: false
 subtitles_mime:
-  type :string
+  type: string
   description: Mimetype of subtitles.
   required: false
 subtitle_id:

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -71,7 +71,7 @@ autoplay:
   required: false
 stream_type:
   type: string
-  description: Describes the type of media artifact as one of the following: "NONE", "BUFFERED", "LIVE".
+  description: "Describes the type of media artifact as one of the following: `NONE`, `BUFFERED`, `LIVE`."
   required: false
 subtitles:
   type: string

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -66,7 +66,7 @@ current_time:
   description: Seconds since the beginning of the content. If the content is live content, and the position is not specified, the stream will start at the live position.
   required: false
 autoplay:
-  type: bool
+  type: boolean
   description: Whether the media will automatically play.
   required: false
 stream_type:

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -51,33 +51,32 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | `extra`                |      yes | Extra dictionary data eg. title, thumb send to pychromecast. Possible values can be found below.
 
 
-Extra dictionary data:
-```
-#Info taken from: https://github.com/home-assistant-libs/pychromecast/blob/master/pychromecast/controllers/media.py
-title: str - title of the media.
-thumb: str - thumbnail image url.
-current_time: float - Seconds since beginning of content. If the content is
-    live content, and position is not specifed, the stream will start at the
-    live position
-autoplay: bool - whether the media will automatically play.
-stream_type: str - describes the type of media artifact as one of the
-    following: "NONE", "BUFFERED", "LIVE".
-subtitles: str - url of subtitle file to be shown on chromecast.
-subtitles_lang: str - language for subtitles.
-subtitles_mime: str - mimetype of subtitles.
-subtitle_id: int - id of subtitle to be loaded.
-enqueue: bool - if True, enqueue the media instead of play it.
-media_info: dict - additional MediaInformation attributes not explicitly listed.
-metadata: dict - media metadata object, one of the following:
-    GenericMediaMetadata, MovieMediaMetadata, TvShowMediaMetadata,
-    MusicTrackMediaMetadata, PhotoMediaMetadata.
+#####Extra dictionary data
+Info taken from: https://github.com/home-assistant-libs/pychromecast/blob/master/pychromecast/controllers/media.py
+
+| Extra attribute name | Type | Description                                                                                                                                                            |
+| -----------------------| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`            |      str | title of the media. |
+| `thumb`            |      str | thumbnail image url. |
+| `current_time`            |      float | Seconds since beginning of content. If the content is live content, and position is not specifed, the stream will start at the live position. |
+| `autoplay`            |bool | whether the media will automatically play. |
+| `stream_type`            |str | describes the type of media artifact as one of the following: "NONE", "BUFFERED", "LIVE". |
+| `subtitles`            |str | url of subtitle file to be shown on chromecast. |
+| `subtitles_lang`            |str | language for subtitles. |
+| `subtitles_mime`            |str | mimetype of subtitles. |
+| `subtitle_id`            |int | id of subtitle to be loaded. |
+| `enqueue`            |bool | if True, enqueue the media instead of play it. |
+| `media_info`            |dict | additional MediaInformation attributes not explicitly listed. |
+| `metadata`            |dict | additional MediaInformation attributes not explicitly listed. |
+| `media_info`            |dict | media metadata object, one of the following: GenericMediaMetadata, MovieMediaMetadata, TvShowMediaMetadata, MusicTrackMediaMetadata, PhotoMediaMetadata. |
+
 Docs:
 https://developers.google.com/cast/docs/reference/messages#MediaData
 https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation
-```
+
 
 Example of calling media_player service with title and image set:
-```
+```yaml
 media_content_type: music
 media_content_id: 'https://fake-home-assistant.io.stream/aac'
 extra:

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -52,36 +52,42 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 
 ##### Extra dictionary data
 
-Info taken from: https://github.com/home-assistant-libs/pychromecast/blob/master/pychromecast/controllers/media.py
-
-| Extra attribute name | Type | Description                                                                                                                                                            |
-| -----------------------| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `title`            |      str | title of the media. |
-| `thumb`            |      str | thumbnail image URL. |
-| `current_time`            |      float | Seconds since beginning of content. If the content is live content, and position is not specifed, the stream will start at the live position. |
-| `autoplay`            |bool | whether the media will automatically play. |
-| `stream_type`            |str | describes the type of media artifact as one of the following: "NONE", "BUFFERED", "LIVE". |
-| `subtitles`            |str | URL of subtitle file to be shown on chromecast. |
-| `subtitles_lang`            |str | language for subtitles. |
-| `subtitles_mime`            |str | mimetype of subtitles. |
-| `subtitle_id`            |int | id of subtitle to be loaded. |
-| `enqueue`            |bool | if True, enqueue the media instead of play it. |
-| `media_info`            |dict | additional MediaInformation attributes not explicitly listed. |
-| `metadata`            |dict | additional MediaInformation attributes not explicitly listed. |
-| `media_info`            |dict | media metadata object, one of the following: GenericMediaMetadata, MovieMediaMetadata, TvShowMediaMetadata, MusicTrackMediaMetadata, PhotoMediaMetadata. |
+```json
+title: string - Title of the media.
+thumb: string - Thumbnail image URL.
+current_time: float - Seconds since beginning of content. If the content is
+    live content, and position is not specifed, the stream will start at the
+    live position
+autoplay: bool - Whether the media will automatically play.
+stream_type: string - Describes the type of media artifact as one of the
+    following: "NONE", "BUFFERED", "LIVE".
+subtitles: str - URL of subtitle file to be shown on chromecast.
+subtitles_lang: string - Language for subtitles.
+subtitles_mime: string - Mimetype of subtitles.
+subtitle_id: int - Id of subtitle to be loaded.
+enqueue: bool - If True, enqueue the media instead of play it.
+media_info: map - Additional MediaInformation attributes not explicitly listed.
+metadata: map - Media metadata object, one of the following:
+    GenericMediaMetadata, MovieMediaMetadata, TvShowMediaMetadata,
+    MusicTrackMediaMetadata, PhotoMediaMetadata.
+```
 
 Docs:
-https://developers.google.com/cast/docs/reference/messages#MediaData
-https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation
+[Google Dev Docs MediaData](https://developers.google.com/cast/docs/reference/messages#MediaData)
+[Google Dev Docs MediaInformation](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation)
 
 
 Example of calling media_player service with title and image set:
+
 ```yaml
-media_content_type: music
-media_content_id: 'https://fake-home-assistant.io.stream/aac'
-extra:
-  thumb: 'https://brands.home-assistant.io/_/homeassistant/logo.png'
-  title: HomeAssitantRadio
+entity_id: media_player.chromecast
+service: media_player.play_media
+data:
+  media_content_type: music
+  media_content_id: 'https://fake-home-assistant.io.stream/aac'
+  extra:
+    thumb: 'https://brands.home-assistant.io/_/homeassistant/logo.png'
+    title: HomeAssitantRadio
 ```
 
 #### Service `media_player.select_source`

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -99,7 +99,7 @@ media_info:
   required: false
 metadata:
   type: map
-  description: Media metadata object, one of the following: GenericMediaMetadata, MovieMediaMetadata, TvShowMediaMetadata, MusicTrackMediaMetadata, PhotoMediaMetadata.
+  description: "Media metadata object, one of the following: `GenericMediaMetadata`, `MovieMediaMetadata`, `TvShowMediaMetadata`, `MusicTrackMediaMetadata`, `PhotoMediaMetadata`."
   required: false
 {% endconfiguration %}
 

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -87,7 +87,7 @@ subtitles_mime:
   required: false
 subtitle_id:
   type: int
-  description: Id of subtitle to be loaded.
+  description: ID of subtitle to be loaded.
   required: false
 enqueue:
   type: bool


### PR DESCRIPTION
Add information what is possible to send with `media_player.play_media` to chromecast to got eg image in thumbnail or custom title on chromecast screen

## Proposed change
Documentation missing information about things already implemented in media_player.play_media service.
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
