### PR TITLE
Adjust name of akasma74 custom integration

### DIFF
--- a/source/_posts/2021-01-21-security-disclosure.markdown
+++ b/source/_posts/2021-01-21-security-disclosure.markdown
@@ -33,7 +33,7 @@ The following have been found:
 - [Home Assistant Community Store](https://github.com/hacs/integration) (HACS) -- fixed in 1.10.0
 - [Dwains Lovelace Dashboard](https://github.com/dwainscheeren/dwains-lovelace-dashboard) -- fixed in 2.0.1
 - [Font Awesome](https://github.com/thomasloven/hass-fontawesome) -- fixed in 1.3.0
-- [Hass-Custom-Alarm](https://github.com/akasma74/Hass-Custom-Alarm) (akasma74) -- fixed in 1.12.8
+- [BWAlarm (ak74 edition)](https://github.com/akasma74/Hass-Custom-Alarm) -- fixed in 1.12.8
 - [Simple Icons](https://github.com/vigonotion/hass-simpleicons) -- fixed in 1.10.0
 - [Custom Updater](https://github.com/custom-components/custom_updater/) (deprecated) -- fixed in latest commit
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Changes the name of the akasma74 custom integration in the security disclosure to be more clear.
Based on feedback on the comments in this blog post.

The name used now, is taken from the manifest file.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
