### PR TITLE
remove reference to tasmota

### DIFF
--- a/source/_integrations/tag.mqtt.markdown
+++ b/source/_integrations/tag.mqtt.markdown
@@ -71,11 +71,11 @@ To test, you can use the command line tool `mosquitto_pub` shipped with `mosquit
 Discover the tag scanner:
 
 ```bash
-mosquitto_pub -h 127.0.0.1 -t home-assistant/tag/0AFFD2/config -m '{"topic": "tasmota_0AFFD2/tag_scanned", "value_template": "{{ value_json.PN532.UID }}"}'
+mosquitto_pub -h 127.0.0.1 -t home-assistant/tag/0AFFD2/config -m '{"topic": "0AFFD2/tag_scanned", "value_template": "{{ value_json.PN532.UID }}"}'
 ```
 
 Generate tag scanned event:
 
 ```bash
-mosquitto_pub -h 127.0.0.1 -t tasmota_0AFFD2/tag_scanned -m '{"Time":"2020-09-28T17:02:10","PN532":{"UID":"E9F35959", "DATA":"ILOVETASMOTA"}}'
+mosquitto_pub -h 127.0.0.1 -t 0AFFD2/tag_scanned -m '{"Time":"2020-09-28T17:02:10","PN532":{"UID":"E9F35959", "DATA":"ILOVETASMOTA"}}'
 ```


### PR DESCRIPTION

## Proposed change
having tasmota in the topics is misleading since the proposed configuration will not work with standard tasmota topic structure


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
