### PR TITLE
Add docs for new zwave_js lock services

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -47,3 +47,26 @@ available.
 As this integration is still in the early stages there are some important limitations to be aware of.
 
 - You will need to use another tool, such as [zwavejs2mqtt](https://github.com/zwave-js/zwavejs2mqtt), to include/exclude devices and manage device configuration.
+
+## Services
+
+### Service `zwave_js.set_lock_usercode`
+
+This service will set the usercode of a lock to X at code slot Y.
+Valid usercodes are at least 4 digits.
+
+| Service Data Attribute | Required | Description                                          |
+| ---------------------- | -------- | ---------------------------------------------------- |
+| `entity_id`            | no       | Lock entity or list of entities to set the usercode. |
+| `code_slot`            | yes      | The code slot to set the usercode into.              |
+| `usercode`             | yes      | The code to set in the slot.                         |
+
+### Service `ozw.clear_lock_usercode`
+
+This service will clear the usercode of a lock in code slot X.
+Valid code slots are between 1-254.
+
+| Service Data Attribute | Required | Description                                            |
+| ---------------------- | -------- | ------------------------------------------------------ |
+| `entity_id`            | no       | Lock entity or list of entities to clear the usercode. |
+| `code_slot`            | yes      | The code slot to clear the usercode from.              |

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -61,7 +61,7 @@ Valid usercodes are at least 4 digits.
 | `code_slot`            | yes      | The code slot to set the usercode into.              |
 | `usercode`             | yes      | The code to set in the slot.                         |
 
-### Service `ozw.clear_lock_usercode`
+### Service `zwave_js.clear_lock_usercode`
 
 This service will clear the usercode of a lock in code slot X.
 Valid code slots are between 1-254.


### PR DESCRIPTION
## Proposed change
Adding documentation for the new `zwave_js` lock services.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45451
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
