### PR TITLE
Add devices to HomematicIP Cloud

### DIFF
--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -101,9 +101,11 @@ Within this delay the device registration should be completed in the App, otherw
   * Motion Detector with Brightness Sensor - indoor (*HmIP-SMI*)
   * Motion Detector with Brightness Sensor - outdoor (*HmIP-SMO*)
   * Presence Sensor – indoor (*HmIP-SPI*)
+  * Rain Sensor (*HmIP-SRD*)
   * Water Sensor (*HmIP-SWD*)
   * Remote Control - 8x buttons (*HmIP-RC8*) (battery only)
   * Wall-mount Remote Control - 2x buttons (*HmIP-WRC2*) (battery only)
+  * Wall-mount Remote Control - flat - 2x buttons (*HmIP-WRCC2*) (battery only)
   * Wall-mount Remote Control - 6x buttons (*HmIP-WRC6*) (battery only)
   * Key Ring Remote Control - 4x buttons (*HmIP-KRC4*) (battery only)
   * Key Ring Remote Control - alarm  (*HmIP-KRCA*) (battery only)
@@ -175,6 +177,7 @@ Within this delay the device registration should be completed in the App, otherw
   * Switch Actuator for heating systems – 2x channels (*HmIP-WHS2*)
   * Wired Switch Actuator – 8x channels (*HMIPW-DRS8*)
   * Switch Actuator for DIN rail mount – 4x channels (*HMIP-DRSI4*)
+  * Switch Actuator for DIN rail mount – 1x channels (*HMIP-DRSI1*)
 
 * homematicip_cloud.weather
   * Weather Sensor – basic (*HmIP-SWO-B*)
@@ -310,8 +313,10 @@ It's not possible to detect a key press event on these devices at the moment.
   * Wall-mount Remote Control for brand switches - 2x buttons (*HmIP-BRC2*)
   * Motion Detector for 55mm frames - indoor (HmIP-SMI55)(Push button)
   * Wall-mount Remote Control - 2x buttons (*HmIP-WRC2*)
+  * Wall-mount Remote Control - flat - 2x buttons (*HmIP-WRCC2*)
   * Wall-mount Remote Control - 6x buttons (*HmIP-WRC6*)
   * Key Ring Remote Control - 4x buttons (*HmIP-KRC4*)
   * Key Ring Remote Control - alarm  (*HmIP-KRCA*)
   * Wall-mount Remote Control – flat (*HmIP-WRCC2*)
   * Rotary Button (*HmIP-WRCR*)
+  * 

--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -319,4 +319,3 @@ It's not possible to detect a key press event on these devices at the moment.
   * Key Ring Remote Control - alarm  (*HmIP-KRCA*)
   * Wall-mount Remote Control – flat (*HmIP-WRCC2*)
   * Rotary Button (*HmIP-WRCR*)
-  * 


### PR DESCRIPTION
## Proposed change
add devices
- HMIP-DRSI1 (Switch Actuator for DIN rail mount – 1x channel)
- HMIP-SRD (Rain Sensor)
- HMIP-WRCC2 (Wall-mount Remote Control – flat)



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45475
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
