### PR TITLE
Describe how to use WeMo long press event triggers

### DIFF
--- a/source/_integrations/wemo.markdown
+++ b/source/_integrations/wemo.markdown
@@ -126,16 +126,17 @@ The following is an example implementation of an automation:
 ```yaml
 # Example automation
 - id: long_press_living_room
-  alias: Toggle amplifier power
+  alias: "Toggle amplifier power"
   trigger:
-  - platform: event
-    event_type: wemo_subscription_event
-    event_data:
-      type: LongPress
-      entity_id: Living Room
+    - platform: event
+      event_type: wemo_subscription_event
+      event_data:
+        type: LongPress
+        entity_id: Living Room
   action:
-  - service: media_player.toggle
-    entity_id: media_player.amplifier
+    - service: media_player.toggle
+      target:
+        entity_id: media_player.amplifier
 ```
 
 A `device` automation can also be used through the automation editor. Look for the `Wemo button was pressed for 2 seconds` trigger for the dimmer or light switch device.

--- a/source/_integrations/wemo.markdown
+++ b/source/_integrations/wemo.markdown
@@ -117,7 +117,7 @@ There are several services which can be used for automations and control of the 
 
 ## Long Press Events and Triggers
 
-For WeMo Light Switches and Dimmers, pressing the button on the device for two seconds will activate a long press event. The long press can can trigger an automation
+For WeMo Light Switches and Dimmers, pressing the button on the device for two seconds will activate a long press event. The long press can trigger an automation
 either by using an `event` trigger or a `device` trigger. For an `event` trigger the `event_type` will be `wemo_subscription_event`. The event data will have a `type` parameter
 set to the value `LongPress` and a `name` parameter indicating the dimmer or light switch that was triggered.
 

--- a/source/_integrations/wemo.markdown
+++ b/source/_integrations/wemo.markdown
@@ -117,7 +117,7 @@ There are several services which can be used for automations and control of the 
 
 ## Long Press Events and Triggers
 
-For WeMo Light Switches and Dimmers, pressing the button on the device for two seconds will activate a long press event. The long press can trigger an automation
+For WeMo Light Switches and Dimmers, pressing the button on the device for two seconds will activate a long press event. The long-press can trigger an automation
 either by using an `event` trigger or a `device` trigger. For an `event` trigger the `event_type` will be `wemo_subscription_event`. The event data will have a `type` parameter
 set to the value `LongPress` and a `name` parameter indicating the dimmer or light switch that was triggered.
 

--- a/source/_integrations/wemo.markdown
+++ b/source/_integrations/wemo.markdown
@@ -114,3 +114,30 @@ There are several services which can be used for automations and control of the 
 | `turn_on` | Calling this service will turn the humidifier on and set the speed to the last used speed (defaults to medium, entity_id is required).
 | `wemo.set_humidity` | Calling this service will set the desired relative humidity setting on the device (entity_id is a required list of 1 or more entities to set humidity on, and target_humidity is a required float value between 0 and 100 (this value will be rounded down and mapped to one of the valid desired humidity settings of 45, 50, 55, 60, or 100 that are supported by the WeMo humidifier)).
 | `wemo.reset_filter_life` | Calling this service will reset the humdifier's filter life back to 100% (entity_id is a required list of 1 or more entities to reset the filter life on). Call this service when you change the filter on your humidifier.
+
+## Long Press Events and Triggers
+
+For WeMo Light Switches and Dimmers, pressing the button on the device for two seconds will activate a long press event. The long press can can trigger an automation
+either by using an `event` trigger or a `device` trigger. For an `event` trigger the `event_type` will be `wemo_event`. The event data will have a `type` parameter
+set to the value `long_press` and a `entity_id` parameter indicating the dimmer or light switch that was triggered.
+
+The following is an example implementation of an automation:
+
+```yaml
+# Example automation
+- id: long_press_living_room
+  alias: Toggle amplifier power
+  trigger:
+  - platform: event
+    event_type: wemo_event
+    event_data:
+      type: long_press
+      entity_id: light.living_room
+  action:
+  - service: media_player.toggle
+    entity_id: media_player.amplifier
+```
+
+A `device` automation can also be used through the automation editor. Look for the `Wemo button was pressed for 2 seconds` trigger for the dimmer or light switch device.
+
+Note: Due to the way that long press events are received by Home Assistant, modifying any of the Rules through the WeMo app can cause long press events to stop working until Home Assistant is restarted. Home Assistant modifies the local device's rules database to enable long press event support. This local modification is not synchronized with the cloud service. Any rule changes from the cloud service (via the app) will likely overwrite the local changes made by Home Assistant.

--- a/source/_integrations/wemo.markdown
+++ b/source/_integrations/wemo.markdown
@@ -118,8 +118,8 @@ There are several services which can be used for automations and control of the 
 ## Long Press Events and Triggers
 
 For WeMo Light Switches and Dimmers, pressing the button on the device for two seconds will activate a long press event. The long press can can trigger an automation
-either by using an `event` trigger or a `device` trigger. For an `event` trigger the `event_type` will be `wemo_event`. The event data will have a `type` parameter
-set to the value `long_press` and a `entity_id` parameter indicating the dimmer or light switch that was triggered.
+either by using an `event` trigger or a `device` trigger. For an `event` trigger the `event_type` will be `wemo_subscription_event`. The event data will have a `type` parameter
+set to the value `LongPress` and a `name` parameter indicating the dimmer or light switch that was triggered.
 
 The following is an example implementation of an automation:
 
@@ -129,10 +129,10 @@ The following is an example implementation of an automation:
   alias: Toggle amplifier power
   trigger:
   - platform: event
-    event_type: wemo_event
+    event_type: wemo_subscription_event
     event_data:
-      type: long_press
-      entity_id: light.living_room
+      type: LongPress
+      entity_id: Living Room
   action:
   - service: media_player.toggle
     entity_id: media_player.amplifier

--- a/source/_integrations/wemo.markdown
+++ b/source/_integrations/wemo.markdown
@@ -128,11 +128,11 @@ The following is an example implementation of an automation:
 - id: long_press_living_room
   alias: "Toggle amplifier power"
   trigger:
-    - platform: event
-      event_type: wemo_subscription_event
-      event_data:
-        type: LongPress
-        entity_id: Living Room
+  - platform: event
+    event_type: wemo_subscription_event
+    event_data:
+      type: LongPress
+      name: Living Room
   action:
     - service: media_player.toggle
       target:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Describe how to use WeMo long press event triggers

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45503

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
