### PR TITLE
Document MAX! Cube shared and exclusive modes

### DIFF
--- a/source/_integrations/maxcube.markdown
+++ b/source/_integrations/maxcube.markdown
@@ -21,6 +21,8 @@ Limitations:
 
 - Configuring weekly schedules is not possible.
 - Implementation is based on the reverse engineered [MAX! protocol](https://github.com/Bouni/max-cube-protocol).
+- MAX! Cube is locked in exclusive mode and you cannot use any other software to access the cube unless manually shared. See configuration options to enable shared mode.
+
 
 Supported Devices:
 
@@ -62,6 +64,11 @@ maxcube:
     required: false
     type: integer
     default: 62910
+  shared:
+    description: Allows to share the MAX! Cube with other software. The MAX! Cube hardware is not designed to run in this mode; [factory resets has been reported while operating in shared mode](https://github.com/hackercowboy/python-maxcube-api/issues/12). 
+    required: false
+    type: boolean
+    default: False
   scan_interval:
     description: The update interval in seconds
     required: false


### PR DESCRIPTION
maxcube integration now uses exclusive mode to mitigate a firmware bug in the hardware. Document it and a new option to revert to previous behaviour.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documentation for https://github.com/home-assistant/core/pull/45506

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45506
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
