### PR TITLE
Add 'set_switch_override' text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,18 @@ Setting up to contribute to documentation and the process for submitting pull re
 
 ## Site preview
 
-In order to make the preview available on [http://127.0.0.1:4000](http://127.0.0.1:4000), use the following [bundler](
+In order to make the preview available on `http://127.0.0.1:4000`, use the following [bundler](
 https://bundler.io/
 ) command:
 
 ```bash
 bundle exec rake preview
+```
+
+If the preview is not running on your local machine, pass the IP of the target machine from where it should be served as a parameter, i.e. to access on `http://192.168.0.123:4000`:
+
+```bash
+bundle exec rake preview[192.168.0.123]
 ```
 
 ## Speeding up site generation

--- a/source/_docs/installation/troubleshooting.markdown
+++ b/source/_docs/installation/troubleshooting.markdown
@@ -43,3 +43,22 @@ For `iptables` systems (was the default for older distributions):
 iptables -I INPUT -p tcp --dport 8123 -j ACCEPT
 iptables-save > /etc/network/iptables.rules  # your rules may be saved elsewhere
 ```
+
+### System freezes
+
+On small systems (such as a Pi2), not directly sypported by binaries (Python Wheels) you may run out of memory.
+Upon the first run or after an upgrade, Home Assistant uses a lot of resources to (re)compile all the integrations. 
+If you run out of memory and/or swap memory, your system will freeze.
+Increasing swap memory can help:
+
+```bash
+sudo dphys-swapfile swapoff
+sudo nano /etc/dphys-swapfile
+```
+
+Modify the line the sets the swapfile size. Set it equal to your memory or double your current setting: `CONF_SWAPSIZE = 925` then:
+
+```bash
+sudo dphys-swapfile swapon
+sudo systemctl restart dphys-swapfile.service
+```

--- a/source/_integrations/geniushub.markdown
+++ b/source/_integrations/geniushub.markdown
@@ -10,7 +10,7 @@ ha_category:
 ha_release: 0.92
 ha_iot_class: Local Polling
 ha_codeowners:
-  - '@zxdavb'
+  - "@zxdavb"
 ha_domain: geniushub
 ---
 
@@ -30,32 +30,35 @@ Each zone controlled by your Genius Hub will be exposed as either a:
 
 Currently, there is no support for altering zone schedules, although entities can be switched to/from geniushub modes that utilize schedules.
 
-There are limitations due to the differences between the Genius Hub and Home Assistant schemas (e.g.,  HA has no **Footprint** mode) - use the service handlers, below, for this functionality.
+There are limitations due to the differences between the Genius Hub and Home Assistant schemas (e.g., HA has no **Footprint** mode) - use the service handlers, below, for this functionality.
 
 ### Service Handlers
 
-Home Assistant is obligated to place restrictions upon integrations such as **geniushub** to maintain compatibility with other ecosystems (e.g.,  Google Home) and so not all of the **geniushub** functionality is available via the web UI. Some of this missing functionality is exposed via integration-specific service handlers:
- - `set_zone_override`: change the zone's setpoint _for a specified duration_ (up to 24h), and
- - `set_zone_mode`: change the zone's mode to one of `off`, `timer` or (if supported by the zone) `footprint`
+Home Assistant is obligated to place restrictions upon integrations such as **geniushub** to maintain compatibility with other ecosystems (e.g., Google Home) and so not all of the **geniushub** functionality is available via the web UI. Some of this missing functionality is exposed via integration-specific service handlers:
+
+- `set_switch_override`: change the switches on time _for a specified duration_ (up to 24h),
+- `set_zone_override`: change the zone's setpoint _for a specified duration_ (up to 24h), and
+- `set_zone_mode`: change the zone's mode to one of `off`, `timer` or (if supported by the zone) `footprint`
 
 ### Climate and Water Heater Entities
 
-Climate and Water Heater entities will report their current temperature, setpoint and mode; other properties (e.g.,  occupied state) are available via their state attributes (see examples below). The Genius Hub mode will be reported as/set to:
+Climate and Water Heater entities will report their current temperature, setpoint and mode; other properties (e.g., occupied state) are available via their state attributes (see examples below). The Genius Hub mode will be reported as/set to:
 
-GH mode | HA Operation | HA Preset
-:---: | :---: | :---:
-**Off** | Off | N/A
-**Timer** | Heat | None
-**Override** | Heat | Boost
-**Footprint** | Heat | Activity
+|    GH mode    | HA Operation | HA Preset |
+| :-----------: | :----------: | :-------: |
+|    **Off**    |     Off      |    N/A    |
+|   **Timer**   |     Heat     |   None    |
+| **Override**  |     Heat     |   Boost   |
+| **Footprint** |     Heat     | Activity  |
 
 **Footprint** mode is only available to **Radiator** zones that have room sensors.
 
 ### Switch Entities
 
-Switch entities will report back their state; other properties are available via their state attributes. Currently, HA switches do not have modes/presets, so the Home Assistant `state` will be *reported* as:
+Switch entities will report back their state; other properties are available via their state attributes. Currently, HA switches do not have modes/presets, so the Home Assistant `state` will be _reported_ as:
+
 - `On` for **Override** \ **On**, and
-- `Off` otherwise (NB: the zone could still be 'on', e.g.,  with **Timer** mode)
+- `Off` otherwise (NB: the zone could still be 'on', e.g., with **Timer** mode)
 
 Note: if you turn a Switch entity `Off` via Home Assistant's web UI, it will revert to **Timer** mode - this may not be the behavior you are expecting.
 
@@ -85,12 +88,12 @@ Each such entity has a state attribute that will contain a list of any such issu
     entity_id: sensor.geniushub_errors
     above: 0
   action:
-  - service: notify.pushbullet_notifier
-    data:
-      title: "Genius Hub has errors"
-      message: >-
-        Genius Hub has the following {{ states('sensor.geniushub_errors') }} errors:
-        {{ state_attr('sensor.geniushub_errors', 'error_list') }}
+    - service: notify.pushbullet_notifier
+      data:
+        title: "Genius Hub has errors"
+        message: >-
+          Genius Hub has the following {{ states('sensor.geniushub_errors') }} errors:
+          {{ state_attr('sensor.geniushub_errors', 'error_list') }}
 ```
 
 {% endraw %}
@@ -105,12 +108,12 @@ This alert may be useful to see if the CH is being turned on whilst you're on a 
     platform: state
     entity_id: binary_sensor.dual_channel_receiver_2_1
   action:
-  - service: notify.pushbullet_notifier
-    data:
-      title: "Warning: CH State Change!"
-      message: >-
-        {{ trigger.to_state.attributes.friendly_name }} has changed
-        from {{ trigger.from_state.state }} to {{ trigger.to_state.state }}.
+    - service: notify.pushbullet_notifier
+      data:
+        title: "Warning: CH State Change!"
+        message: >-
+          {{ trigger.to_state.attributes.friendly_name }} has changed
+          from {{ trigger.from_state.state }} to {{ trigger.to_state.state }}.
 ```
 
 {% endraw %}
@@ -197,7 +200,7 @@ This option is recommended only if Option 1 does not work. The MAC address shoul
 # Example configuration.yaml entry, using a Hub Token
 geniushub:
   token: GENIUS_HUB_TOKEN
-  mac : GENIUS_HUB_MAC
+  mac: GENIUS_HUB_MAC
 ```
 
 ```yaml
@@ -210,25 +213,25 @@ geniushub:
 
 {% configuration %}
 token:
-  description: The Hub Token of the Genius Hub.
-  required: true
-  type: string
+description: The Hub Token of the Genius Hub.
+required: true
+type: string
 mac:
-  description: The MAC address of the Hub's ethernet port.
-  required: false
-  type: string
+description: The MAC address of the Hub's ethernet port.
+required: false
+type: string
 host:
-  description: The hostname/IP address of the Genius Hub.
-  required: true
-  type: string
+description: The hostname/IP address of the Genius Hub.
+required: true
+type: string
 username:
-  description: Your Genius Hub username.
-  required: false
-  type: string
+description: Your Genius Hub username.
+required: false
+type: string
 password:
-  description: Your Genius Hub password.
-  required: false
-  type: string
+description: Your Genius Hub password.
+required: false
+type: string
 {% endconfiguration %}
 
 Note: `username` and `password` are only required when `host` is used (instead of `token`).

--- a/source/_integrations/geniushub.markdown
+++ b/source/_integrations/geniushub.markdown
@@ -10,7 +10,7 @@ ha_category:
 ha_release: 0.92
 ha_iot_class: Local Polling
 ha_codeowners:
-  - "@zxdavb"
+  - '@zxdavb'
 ha_domain: geniushub
 ---
 
@@ -30,11 +30,11 @@ Each zone controlled by your Genius Hub will be exposed as either a:
 
 Currently, there is no support for altering zone schedules, although entities can be switched to/from geniushub modes that utilize schedules.
 
-There are limitations due to the differences between the Genius Hub and Home Assistant schemas (e.g., HA has no **Footprint** mode) - use the service handlers, below, for this functionality.
+There are limitations due to the differences between the Genius Hub and Home Assistant schemas (e.g.,  HA has no **Footprint** mode) - use the service handlers, below, for this functionality.
 
 ### Service Handlers
 
-Home Assistant is obligated to place restrictions upon integrations such as **geniushub** to maintain compatibility with other ecosystems (e.g., Google Home) and so not all of the **geniushub** functionality is available via the web UI. Some of this missing functionality is exposed via integration-specific service handlers:
+Home Assistant is obligated to place restrictions upon integrations such as **geniushub** to maintain compatibility with other ecosystems (e.g.,  Google Home) and so not all of the **geniushub** functionality is available via the web UI. Some of this missing functionality is exposed via integration-specific service handlers:
 
 - `set_switch_override`: change the switches on time _for a specified duration_ (up to 24h),
 - `set_zone_override`: change the zone's setpoint _for a specified duration_ (up to 24h), and
@@ -42,23 +42,23 @@ Home Assistant is obligated to place restrictions upon integrations such as **ge
 
 ### Climate and Water Heater Entities
 
-Climate and Water Heater entities will report their current temperature, setpoint and mode; other properties (e.g., occupied state) are available via their state attributes (see examples below). The Genius Hub mode will be reported as/set to:
+Climate and Water Heater entities will report their current temperature, setpoint and mode; other properties (e.g.,  occupied state) are available via their state attributes (see examples below). The Genius Hub mode will be reported as/set to:
 
-|    GH mode    | HA Operation | HA Preset |
-| :-----------: | :----------: | :-------: |
-|    **Off**    |     Off      |    N/A    |
-|   **Timer**   |     Heat     |   None    |
-| **Override**  |     Heat     |   Boost   |
-| **Footprint** |     Heat     | Activity  |
+GH mode | HA Operation | HA Preset
+:---: | :---: | :---:
+**Off** | Off | N/A
+**Timer** | Heat | None
+**Override** | Heat | Boost
+**Footprint** | Heat | Activity
 
 **Footprint** mode is only available to **Radiator** zones that have room sensors.
 
 ### Switch Entities
 
-Switch entities will report back their state; other properties are available via their state attributes. Currently, HA switches do not have modes/presets, so the Home Assistant `state` will be _reported_ as:
+Switch entities will report back their state; other properties are available via their state attributes. Currently, HA switches do not have modes/presets, so the Home Assistant `state` will be *reported* as:
 
 - `On` for **Override** \ **On**, and
-- `Off` otherwise (NB: the zone could still be 'on', e.g., with **Timer** mode)
+- `Off` otherwise (NB: the zone could still be 'on', e.g.,  with **Timer** mode)
 
 Note: if you turn a Switch entity `Off` via Home Assistant's web UI, it will revert to **Timer** mode - this may not be the behavior you are expecting.
 
@@ -88,12 +88,12 @@ Each such entity has a state attribute that will contain a list of any such issu
     entity_id: sensor.geniushub_errors
     above: 0
   action:
-    - service: notify.pushbullet_notifier
-      data:
-        title: "Genius Hub has errors"
-        message: >-
-          Genius Hub has the following {{ states('sensor.geniushub_errors') }} errors:
-          {{ state_attr('sensor.geniushub_errors', 'error_list') }}
+  - service: notify.pushbullet_notifier
+    data:
+      title: "Genius Hub has errors"
+      message: >-
+        Genius Hub has the following {{ states('sensor.geniushub_errors') }} errors:
+        {{ state_attr('sensor.geniushub_errors', 'error_list') }}
 ```
 
 {% endraw %}
@@ -108,12 +108,12 @@ This alert may be useful to see if the CH is being turned on whilst you're on a 
     platform: state
     entity_id: binary_sensor.dual_channel_receiver_2_1
   action:
-    - service: notify.pushbullet_notifier
-      data:
-        title: "Warning: CH State Change!"
-        message: >-
-          {{ trigger.to_state.attributes.friendly_name }} has changed
-          from {{ trigger.from_state.state }} to {{ trigger.to_state.state }}.
+  - service: notify.pushbullet_notifier
+    data:
+      title: "Warning: CH State Change!"
+      message: >-
+        {{ trigger.to_state.attributes.friendly_name }} has changed
+        from {{ trigger.from_state.state }} to {{ trigger.to_state.state }}.
 ```
 
 {% endraw %}
@@ -200,7 +200,7 @@ This option is recommended only if Option 1 does not work. The MAC address shoul
 # Example configuration.yaml entry, using a Hub Token
 geniushub:
   token: GENIUS_HUB_TOKEN
-  mac: GENIUS_HUB_MAC
+  mac : GENIUS_HUB_MAC
 ```
 
 ```yaml
@@ -213,25 +213,25 @@ geniushub:
 
 {% configuration %}
 token:
-description: The Hub Token of the Genius Hub.
-required: true
-type: string
+  description: The Hub Token of the Genius Hub.
+  required: true
+  type: string
 mac:
-description: The MAC address of the Hub's ethernet port.
-required: false
-type: string
+  description: The MAC address of the Hub's ethernet port.
+  required: false
+  type: string
 host:
-description: The hostname/IP address of the Genius Hub.
-required: true
-type: string
+  description: The hostname/IP address of the Genius Hub.
+  required: true
+  type: string
 username:
-description: Your Genius Hub username.
-required: false
-type: string
+  description: Your Genius Hub username.
+  required: false
+  type: string
 password:
-description: Your Genius Hub password.
-required: false
-type: string
+  description: Your Genius Hub password.
+  required: false
+  type: string
 {% endconfiguration %}
 
 Note: `username` and `password` are only required when `host` is used (instead of `token`).


### PR DESCRIPTION
## Proposed change
<!-- 
    Provide new service to override the duration 'on' time for a genius hub switch.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    The new service `geniushub.set_switch_override` is a non-breaking change and provides additional functionality.
-->

- [Link to parent pull request in the codebase: ](https://github.com/home-assistant/core/pull/45558)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.

- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
