### PR TITLE
Added TS-228 Device Support

### DIFF
--- a/source/_integrations/qnap.markdown
+++ b/source/_integrations/qnap.markdown
@@ -126,6 +126,7 @@ This integration has been tested on the following devices:
 
 - TS-231P2 (QTS 4.4.2)
 - TS-259 Pro+ (QTS 4.2.6)
+- TS-228 (QTS 4.3.6)
 - TS-410 (QTS 4.2.3)
 - TS-419 (QTS 4.2.3)
 - TS-451 (QTS 4.2.2)


### PR DESCRIPTION
I have tested the integration with my TS-228 and QTS (4.3.6).  Seems like everything is working fine and valid data is pushed to HA

## Proposed change
Extend documentation to show support for TS-228 Devices 



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
