### PR TITLE
Wrong type on birth_message and will_message

### DIFF
--- a/source/_docs/mqtt/birth_will.markdown
+++ b/source/_docs/mqtt/birth_will.markdown
@@ -25,7 +25,7 @@ mqtt:
 birth_message:
   description: Birth Message. Set to the empty dict, `{}`, to disable publishing a birth message.
   required: false
-  type: list
+  type: map
   keys:
     topic:
       description: The MQTT topic to publish the message.
@@ -50,7 +50,7 @@ birth_message:
 will_message:
   description: Will Message. Set to the empty dict, `{}`, to disable publishing a will message.
   required: false
-  type: list
+  type: map
   keys:
     topic:
       description: The MQTT topic to publish the message.


### PR DESCRIPTION
Felt wrong since the variable is named birth_message not birth_message*s*

Not fluent in Python, but checked the code around here: 
https://github.com/home-assistant/core/blob/0e068a5f394e4cddde918d7f1cd4343000e4f002/homeassistant/components/mqtt/__init__.py#L847

And it didn't look to me like it handled lists


Tried it and it doesn't work, throws error
This config

```
mqtt:
  birth_message:
    - topic: 'hass/status'
      payload: 'online'
    - topic: 'homeassistant/status' 
      payload: 'online'
  will_message:
    - topic: 'hass/status'
      payload: 'offline'
    - topic: 'homeassistant/status' 
      payload: 'offline'
```

Gave this error:


```
Logger: homeassistant.components.hassio
Source: components/hassio/__init__.py:420
Integration: Hass.io (documentation, issues)
First occurred: 9:44:55 AM (2 occurrences)
Last logged: 9:48:29 AM

    Invalid config for [mqtt]: expected a dictionary for dictionary value @ data['mqtt']['birth_message']. Got [OrderedDict([('topic', 'hass/status'), ('payload', 'maaan')]), OrderedDict([('topic', 'homeassistant/status'), ('payload', 'maaan-boy')])] expected a dictionary for dictionary value @ data['mqtt']['will_message']. Got [OrderedDict([('topic', 'hass/status'), ('payload', 'womaaan')]), OrderedDict([('topic', 'homeassistant/status'), ('payload', 'womaaan-girl')])]. (See /config/configuration.yaml, line 6).
    Invalid config for [mqtt]: expected a dictionary for dictionary value @ data['mqtt']['birth_message']. Got [OrderedDict([('topic', 'hass/status'), ('payload', 'online')]), OrderedDict([('topic', 'homeassistant/status'), ('payload', 'online')])] expected a dictionary for dictionary value @ data['mqtt']['will_message']. Got [OrderedDict([('topic', 'hass/status'), ('payload', 'offline')]), OrderedDict([('topic', 'homeassistant/status'), ('payload', 'offline')])]. (See /config/configuration.yaml, line 6).
```

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
