### PR TITLE
Update SIMPLISAFE_EVENT results and automation usage.

### DIFF
--- a/source/_integrations/simplisafe.markdown
+++ b/source/_integrations/simplisafe.markdown
@@ -142,7 +142,7 @@ To build an automation using one of these, use `SIMPLISAFE_EVENT`
 as an event trigger, with `last_event_type` as the `event_data`.
 For example, the following will trigger when the doorbell rings:
 
-```
+```yaml
 trigger:
   - platform: event
     event_type: SIMPLISAFE_EVENT

--- a/source/_integrations/simplisafe.markdown
+++ b/source/_integrations/simplisafe.markdown
@@ -105,29 +105,50 @@ following keys:
 * `system_id`: the system ID to which the event belongs
 * `timestamp`: the UTC datetime at which the event was received
 
-For example, when the system is armed by "remote" means (via the web app, etc.), a
+For example, when someone rings the doorbell, a
 `SIMPLISAFE_EVENT` event will fire with the following event data:
 
 ```python
 {
-    "changed_by": "",
-    "event_type": "armed_home",
-    "info": "System Armed (Home) by Remote Management",
-    "sensor_name": "",
-    "sensor_serial": "",
-    "sensor_type": "remote",
-    "system_id": 123456,
-    "timestamp": datetime.datetime(2020, 2, 13, 23, 1, 13, tzinfo=<UTC>),
+    "event_type": "SIMPLISAFE_EVENT",
+    "data": {
+        "last_event_changed_by": "",
+        "last_event_type": "doorbell_detected",
+        "last_event_info": "Someone is at your \"Front Door\"",
+        "last_event_sensor_name": "Front Door",
+        "last_event_sensor_serial": "",
+        "last_event_sensor_type": "doorbell",
+        "system_id": [systemid],
+        "last_event_timestamp": "2021-01-28T22:01:32+00:00"
+    },
+    "origin": "LOCAL",
+    "time_fired": "2021-01-28T22:01:37.478539+00:00",
+    "context": {
+        "id": "[id]",
+        "parent_id": null,
+        "user_id": null
+    }
 }
 ```
 
-`event_type`, being one of the key fields automations might be built from, can have the
-following values:
+`last_event_type` can have the following values:
 
 * `camera_motion_detected`
 * `doorbell_detected`
 * `entry_detected`
 * `motion_detected`
+
+To build an automation using one of these, use `SIMPLISAFE_EVENT`
+as an event trigger, with `last_event_type` as the `event_data`.
+For example, the following will trigger when the doorbell rings:
+
+```
+trigger:
+  - platform: event
+    event_type: SIMPLISAFE_EVENT
+    event_data:
+        last_event_type: doorbell_detected
+```
 
 ### `SIMPLISAFE_NOTIFICATION`
 


### PR DESCRIPTION
The original documentation shows SIMPLISAFE_EVENT being an event_type and also serving an event_type as a subset. The current simplipy version has an event_type of SIMPLISAFE_EVENT, and the event_data returned is almost all prefaced with "last_". Since this document deals with v2 and v3, it's possible the original documentation displays what a v2 system will show. If that's the case, we should include both sets of event data with a header describing which goes with which Simplisafe version.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
