### PR TITLE
Add documentation for advanced Hyperion entities

### DIFF
--- a/source/_integrations/hyperion.markdown
+++ b/source/_integrations/hyperion.markdown
@@ -61,6 +61,27 @@ extra effects will be available:
 - V4L: Use a 'USB Capture' V4L device that is configured in Hyperion.
 - Solid: Use a solid color only.
 
+## Advanced Entities
+
+The Hyperion integration comes with a series of disabled-by-default entities for
+advanced usecases. These entities expose 'raw' underlying Hyperion API components for
+improved extensibility and interoperability which are particularly useful in cases where
+there are multiple Hyperion server clients (of which Home Assistant is one).
+
+Provided advanced entities:
+
+- `light.[instance]_priority`: A "priority" light that acts exclusively on a given
+  Hyperion priority. Only color/effects (and not components) are available in this light.
+  Turning this light off will set a black color at this given priority rather than
+  turning the light off in absolute terms.
+- `switch.[instance]_component_[component]`: A switch to turn on/off the relevant
+  underlying Hyperion component as shown on the Hyperion server `Remote Control` page
+  under `Component Control`. This allows fine grained control over sources (e.g. `USB Capture`) and
+  Hyperion functionality (e.g. `Blackbar Detection`).
+
+These entities may be enabled by visiting the `Integrations` page, choosing the relevant
+entity and toggling `Enable entity`, followed by `Update`.
+
 ## Examples
 
 To start Hyperion with an effect, use the following automation:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the recently merged https://github.com/home-assistant/core/pull/45410 that adds advanced Hyperion entities.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45410
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
