### PR TITLE
Add config flow documentation for nuki

### DIFF
--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -8,13 +8,17 @@ ha_iot_class: Local Polling
 ha_codeowners:
   - '@pschmitt'
   - '@pvizeli'
+  - '@pree'
 ha_domain: nuki
 ---
 
 The `nuki` platform allows you to control [Nuki Smart Locks](https://nuki.io/en/smart-lock/) via either a [software bridge](https://play.google.com/store/apps/details?id=io.nuki.bridge) or a [physical bridge](https://nuki.io/en/bridge/).
 
 To add a Nuki bridge to your installation, you need to enable developer mode on your bridge and define a port and an access token. This can be achieved using the [Android app](https://play.google.com/store/apps/details?id=io.nuki) or [iPhone app](https://apps.apple.com/app/nuki-smart-lock/id1044998081). Go to manage my devices, and select the bridge. Within the bridge configuration turn on the HTTP API and check the details in the screen. Please note that the API token should be 6-20 characters long, even though the app allows you to set a longer one.
-Then add the following to your `configuration.yaml` file:
+
+Once you have the token set, to add `Nuki` to your installation, go to **Configuration** >> **Integrations** in the UI, click the button with `+` sign and from the list of integrations select **Nuki**.
+
+Alternatively, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -18,32 +18,6 @@ To add a Nuki bridge to your installation, you need to enable developer mode on 
 
 Once you have the token set, to add `Nuki` to your installation, go to **Configuration** >> **Integrations** in the UI, click the button with `+` sign and from the list of integrations select **Nuki**.
 
-Alternatively, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-lock:
-  - platform: nuki
-    host: 192.168.1.120
-    token: fe2345ef
-```
-
-{% configuration %}
-host:
-  description: The IP or hostname of the Nuki bridge.
-  required: true
-  type: string
-port:
-  description: The port on which the Nuki bridge is listening on.
-  required: false
-  default: 8080
-  type: integer
-token:
-  description: The token that was defined when setting up the bridge.
-  required: true
-  type: string
-{% endconfiguration %}
-
 ## Services
 
 ### Service `lock_n_go`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Added information about config_flow into the documentation. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45664
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
