### PR TITLE
Add reboot_gateway service to Velux

### DIFF
--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -65,7 +65,7 @@ There are some rules for packages that will be merged:
     input_boolean:
       my_input:
     ```
-3. Any integration that is not a platform [2], or dictionaries with Entity ID keys [3] can only be merged if its keys, except those for lists, are solely defined once.
+3. Any integration that is not a platform [1], or dictionaries with Entity ID keys [2] can only be merged if its keys, except those for lists, are solely defined once.
 
 <div class='note tip'>
 Components inside packages can only specify platform entries using configuration style 1, where all the platforms are grouped under the integration name.

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -266,9 +266,11 @@ docker-compose restart
 To update your docker-compose image to the latest version and restart:
 
 ```bash
-docker-compose pull
-docker-compose up -d --build homeassistant
+docker-compose pull homeassistant
+docker-compose up -d
 ```
+
+Note: the above will fetch the latest matching image for the `homeassistant` service only. To fetch all matching images for all services defined in the same `docker-compose.yaml` file, omit the service name from the first command.
 
 ## Exposing Devices
 

--- a/source/_docs/mqtt/birth_will.markdown
+++ b/source/_docs/mqtt/birth_will.markdown
@@ -25,7 +25,7 @@ mqtt:
 birth_message:
   description: Birth Message. Set to the empty dict, `{}`, to disable publishing a birth message.
   required: false
-  type: list
+  type: map
   keys:
     topic:
       description: The MQTT topic to publish the message.
@@ -50,7 +50,7 @@ birth_message:
 will_message:
   description: Will Message. Set to the empty dict, `{}`, to disable publishing a will message.
   required: false
-  type: list
+  type: map
   keys:
     topic:
       description: The MQTT topic to publish the message.

--- a/source/_integrations/aftership.markdown
+++ b/source/_integrations/aftership.markdown
@@ -8,7 +8,7 @@ ha_iot_class: Cloud Polling
 ha_domain: aftership
 ---
 
-The `aftership` platform allows one to track deliveries by [AfterShip](https://www.aftership.com), a service that supports 490+ couriers worldwide. There is a 'Forever Free' tier which allows tracking of up to 50 packages per month. There are various paid-for tiers after that.
+The `aftership` platform allows one to track deliveries by [AfterShip](https://www.aftership.com), a service that supports 490+ couriers worldwide. To use the tracking API functionality, the Essentials plan is required. This plan includes 100 shipments per month. There are various paid-for tiers after that.
 
 The sensor value shows the number of packages that are not in `Delivered` state. As attributes are the number of packages per status.
 
@@ -17,7 +17,7 @@ The sensor value shows the number of packages that are not in `Delivered` state.
 To use this sensor, you need an [AfterShip Account](https://accounts.aftership.com/register) and set up an API Key. To set up an API Key go to [AfterShip API](https://admin.aftership.com/settings/api-keys) page, and copy existing key or generate a new one.
 
 <div class='note info'>
-AfterShip recently started requiring having a credit card on file even if you are only using the free plan. That does not change the functionality of the platform, just something to be aware of.
+AfterShip recently removed the tracking API functionality from the Forever Free plan. The tracking API functionality requires at least the Essentials plan.
 </div>
 
 ## Configuration

--- a/source/_integrations/bmp280.markdown
+++ b/source/_integrations/bmp280.markdown
@@ -24,7 +24,7 @@ To use a BMP280 sensor in your installation, you have to enable I2C on your host
 ```yaml
 sensor:
   - platform: bmp280
-  - i2c_address: 0x77
+    i2c_address: 0x77
 ```
 
 {% configuration %}

--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -24,7 +24,7 @@ switch:
 
 {% configuration %}
 mac:
-  description: The device MAC address with lower-case letters.
+  description: The device MAC address with upper-case letters.
   required: true
   type: string
 name:

--- a/source/_integrations/usgs_earthquakes_feed.markdown
+++ b/source/_integrations/usgs_earthquakes_feed.markdown
@@ -118,3 +118,15 @@ geo_location:
     latitude: 35.899722
     longitude: -120.432778
 ```
+## Card Example
+
+Assuming you configure this service using `feed_type: past_week_all_earthquakes`, you can create a corresponding map card in the Lovelace UI with the following card:
+```yaml
+type: map
+name: Earthquakes
+geo_location_sources:
+  - usgs_earthquakes_feed
+entities:
+  - zone.home
+title: Nearby Earthquakes Last Week
+```

--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -42,6 +42,29 @@ password:
   type: string
 {% endconfiguration %}
 
+## Services
+
+### Service `velux.reboot_gateway`
+
+Reboots the configured KLF 200 Gateway.
+
+There is a problem with the KLF 200 gateway where the connection cannot be established after a restart of Home Assistant, only a manual power off and on fixes this.
+As a workaround, you can use an automation to force a restart of the KLF 200 before exiting Home Assistant, like this:
+```yaml
+automation:
+  alias: KLF reboot on hass stop event
+  description: ''
+  trigger:
+    - event_data: {}
+      event_type: homeassistant_stop
+      platform: event
+  condition: []
+  action:
+    - data: {}
+      service: velux.reboot_gateway
+  mode: single
+```
+
 ## Velux Active (KIX 300)
 
 The Velux Active (KIX 300) set is not supported by this integration. To integrate Velux Active (KIX 300) with Home Assistant, you can use the [HomeKit Controller](/integrations/homekit_controller) integration and get full control over your windows, curtains, covers, the air quality sensor KLA 300, etc.

--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -50,6 +50,7 @@ Reboots the configured KLF 200 Gateway.
 
 There is a problem with the KLF 200 gateway where the connection cannot be established after a restart of Home Assistant, only a manual power off and on fixes this.
 As a workaround, you can use an automation to force a restart of the KLF 200 before exiting Home Assistant, like this:
+
 ```yaml
 automation:
   alias: KLF reboot on hass stop event


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation for reboot_gateway service added to velux integration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  [https://github.com/home-assistant/core/pull/43198](url)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
