### PR TITLE
rflink: Add hint about which configuration file is used

### DIFF
--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -108,6 +108,7 @@ In order to have your devices discovered automatically, you need to add the foll
 When pressing the button on the physical remote, RFLink detects the signal and the device should be added automatically to Home Assistant.
 
 ```yaml
+# Example configuration.yaml entry
 light:
   - platform: rflink
     automatic_add: true
@@ -159,6 +160,7 @@ If you find a device is recognized differently, with different protocols or the 
 For debugging purposes or context when investigating issues you can enable debug logging for RFLink with the following configuration snippet:
 
 ```yaml
+# Example configuration.yaml entry
 logger:
   default: error
   logs:


### PR DESCRIPTION
## Proposed change
This adds the same ``# Example configuration.yaml entry`` line that is used in other code blocks to the two code clocks that are missing it.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: -
- Link to parent pull request in the Brands repository: -
- This PR fixes or closes issue: https://github.com/home-assistant/home-assistant.io/issues/16354

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
