### PR TITLE
Don't refer to deprecated Hyperion effect names

### DIFF
--- a/source/_integrations/hyperion.markdown
+++ b/source/_integrations/hyperion.markdown
@@ -46,10 +46,10 @@ added/removed from Home Assistant.
 The effect list is dynamically pulled from the Hyperion server. The following
 extra effects will be available:
 
-- BOBLIGHTSERVER: Use a Boblight-Server configured in Hyperion.
-- GRABBER: Use a 'Platform Capture' grabber that is configured in Hyperion.
-- V4L: Use a 'USB Capture' V4L device that is configured in Hyperion.
-- Solid: Use a solid color only.
+- 'Boblight Server': Use a 'Boblight Server' configured in Hyperion.
+- 'Platform Capture': Use a 'Platform Capture' grabber that is configured in Hyperion.
+- 'USB Capture': Use a 'USB Capture' device that is configured in Hyperion.
+- 'Solid': Use a solid color only.
 
 ## Advanced Entities
 
@@ -114,7 +114,7 @@ To have the lights playing an effect when pausing, idle or turn off a media play
         effect: "Full color mood blobs"
 ```
 
-To capture the screen when playing something on a media_player you can use this example:
+To capture the screen on a USB capture device, when playing something on a media_player, you can use this example:
 
 ```yaml
 - alias: "Set hyperion when playback starts"
@@ -127,5 +127,5 @@ To capture the screen when playing something on a media_player you can use this 
       target:
         entity_id: light.hyperion
       data:
-        effect: V4L
+        effect: "USB Capture"
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update documentation to no longer refer to deprecated Hyperion effect names.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45763
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
