### PR TITLE
Add documentation for Mazda Connected Services integration

### DIFF
--- a/source/_integrations/mazda.markdown
+++ b/source/_integrations/mazda.markdown
@@ -1,0 +1,41 @@
+---
+title: "Mazda Connected Services"
+description: "Instructions on how to integrate your Connected Services capable Mazda vehicle with Home Assistant."
+ha_release: "2021.2.1"
+ha_category:
+  - Car
+  - Sensor
+ha_iot_class: "Cloud Polling"
+ha_quality_scale: platinum
+ha_config_flow: true
+ha_codeowners:
+  - '@bdr99'
+ha_domain: mazda
+---
+
+The Mazda Connected Services integration allows you to retrieve data from a Mazda vehicle. In order to use this integration, you must first register your vehicle using the MyMazda app ([iOS](https://apps.apple.com/us/app/mymazda/id451886367)/[Android](https://play.google.com/store/apps/details?id=com.interrait.mymazda)).
+
+This integration requires an active Mazda Connected Services subscription and a compatible vehicle. The following Mazda vehicles are Mazda Connected Services capable:
+- Mazda3: 2019+
+- CX-30: 2020+
+- CX-9: 2021+
+- CX-5: 2021+
+
+Currently, this integration only provides the Sensor platform. The following sensors are supported:
+- Fuel Percentage Remaining
+- Fuel Distance Remaining
+- Odometer
+- Front Left Tire Pressure
+- Front Right Tire Pressure
+- Rear Left Tire Pressure
+- Rear Right Tire Pressure
+
+## Configuration
+
+To enable the Mazda Connected Services integration, go to **Configuration** > **Integrations** > **Add Integration** > **Mazda Connected Services**.
+
+Enter the same email address and password that you would use to sign into the MyMazda mobile app. Select your region, and click **Submit**.
+
+<div class='note warning'>
+    The MyMazda API only allows one active session at a time. Therefore, if you use the same account with both Home Assistant and the MyMazda mobile app, you may experience issues ("Multiple devices detected" notifications, session expired warnings, etc.) To fix this, you can create a secondary MyMazda account, and share your vehicle with the secondary account. Log into the mobile app using the primary account and select Menu > MyMazda > My Vehicle > Drivers > Manage Drivers > Invite Driver. When finished, log into the secondary account with Home Assistant.
+</div>

--- a/source/_integrations/mazda.markdown
+++ b/source/_integrations/mazda.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Mazda Connected Services"
 description: "Instructions on how to integrate your Connected Services capable Mazda vehicle with Home Assistant."
-ha_release: "2021.2.1"
+ha_release: "2021.3"
 ha_category:
   - Car
   - Sensor
@@ -16,12 +16,14 @@ ha_domain: mazda
 The Mazda Connected Services integration allows you to retrieve data from a Mazda vehicle. In order to use this integration, you must first register your vehicle using the MyMazda app ([iOS](https://apps.apple.com/us/app/mymazda/id451886367)/[Android](https://play.google.com/store/apps/details?id=com.interrait.mymazda)).
 
 This integration requires an active Mazda Connected Services subscription and a compatible vehicle. The following Mazda vehicles are Mazda Connected Services capable:
+
 - Mazda3: 2019+
 - CX-30: 2020+
 - CX-9: 2021+
 - CX-5: 2021+
 
 Currently, this integration only provides the Sensor platform. The following sensors are supported:
+
 - Fuel Percentage Remaining
 - Fuel Distance Remaining
 - Odometer
@@ -37,5 +39,5 @@ To enable the Mazda Connected Services integration, go to **Configuration** > **
 Enter the same email address and password that you would use to sign into the MyMazda mobile app. Select your region, and click **Submit**.
 
 <div class='note warning'>
-    The MyMazda API only allows one active session at a time. Therefore, if you use the same account with both Home Assistant and the MyMazda mobile app, you may experience issues ("Multiple devices detected" notifications, session expired warnings, etc.) To fix this, you can create a secondary MyMazda account, and share your vehicle with the secondary account. Log into the mobile app using the primary account and select Menu > MyMazda > My Vehicle > Drivers > Manage Drivers > Invite Driver. When finished, log into the secondary account with Home Assistant.
+    The MyMazda API only allows one active session at a time. Therefore, if you use the same account with both Home Assistant and the MyMazda mobile app, you may experience issues ("Multiple devices detected" notifications, session expired warnings, etc.) To fix this, you can create a secondary MyMazda account, and share your vehicle with the secondary account. Log in to the mobile app using the primary account and select Menu > MyMazda > My Vehicle > Drivers > Manage Drivers > Invite Driver. When finished, log into the secondary account with Home Assistant.
 </div>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the new Mazda Connected Services integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45768
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2221
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
