### PR TITLE
Add additional weblink attributes

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -139,12 +139,12 @@ name:
 format:
   required: false
   description: "How the attribute value should be formatted. Currently only supported for timestamp attributes. Valid values are: `relative`, `total`, `date`, `time` and `datetime`."
-  type: string  
+  type: string
 {% endconfiguration %}
 
 ### Button
 
-Row with an (optional) icon, label and a single text button at the end of the row that can trigger a defined action. 
+Row with an (optional) icon, label and a single text button at the end of the row that can trigger a defined action.
 
 {% configuration %}
 type:
@@ -356,6 +356,16 @@ icon:
   description: "Icon to display (e.g., `mdi:home`)."
   type: string
   default: "`mdi:link`"
+new_tab:
+  required: false
+  description: Open link in new tab. If link is external URL or a download link, this will automatically be true. Use if internal URL should be opened in new tab.
+  type: boolean
+  default: false
+download:
+  required: false
+  description: Is link a download?
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 ## Examples
@@ -433,7 +443,7 @@ entities:
     conditions:
       - entity: sun.sun
         state: above_horizon
-    row: 
+    row:
       entity: sun.sun
       type: attribute
       attribute: azimuth


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add additional lovelace -> `entities` card -> `weblink` attributes.

Depending on if / when the parent PR is merged, this might need to go into `current` / `rc` instead of `next`.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/8295
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
