### PR TITLE
Add sensor example for brother printer integration

### DIFF
--- a/source/_integrations/brother.markdown
+++ b/source/_integrations/brother.markdown
@@ -29,7 +29,43 @@ Some very old Brother printers use different data format and these models are no
 
 ## Configuring the printer
 
-To set SNMP, navigate to the printer's web interface (for example: `http://192.168.5.6`) and turn it on under Network / Protocol / SNMP.
+To enable SNMP, navigate to the printer's web interface (for example: `http://192.168.5.6`) and turn it on under Network / Protocol / SNMP.
 For some Brother devices, `SNMPv3 read-write access and v1/v2c read-only access` is the option required (under advanced settings).
 
 ![SNMP settings on Brother Printer web interface](/images/integrations/brother/brother-printer-webui.png)
+
+## Sensor Example
+
+You can configure Home Assistant to alert you when the printer jams or runs out of paper as follows.  First, add the following to `configuration.yaml` under the `binary_sensor:` section (replace `sensor.hl_l2340d_status` with the actual name of your sensor):
+```yaml
+  - platform: template
+    sensors:
+      laser_out_of_paper:
+        value_template: "{{ is_state('sensor.hl_l2340d_status', 'no paper') }}"
+        friendly_name: 'Laser Printer Out of Paper'
+  - platform: template
+    sensors:
+      laser_paper_jam:
+        value_template: "{{ is_state('sensor.hl_l2340d_status', 'paper jam') }}"
+        friendly_name: 'Laser Printer Paper Jam'
+```
+Then, add this under the `alert:` section:
+```yaml
+  laser_out_of_paper:
+    name: Laser Printer is Out of Paper
+    done_message: Laser Printer Has Paper
+    entity_id: binary_sensor.laser_out_of_paper
+    can_acknowledge: true
+    notifiers:
+      - my_phone_notify
+  laser_paper_jam:
+    name: Laser Printer has a Paper Jam
+    done_message: Laser Printer Paper Jam Cleared
+    entity_id: binary_sensor.laser_paper_jam
+    can_acknowledge: true
+    notifiers:
+      - my_phone_notify
+```
+The above will send an alert for paper jam or out of paper whenever the condition is detected, assuming you have the Home Assistant app configured on your phone so that alerts can be sent directly to it. If you don't use the Home Assistant app, you will need to set up a different notifier.
+
+Change `my_phone_notify` to the actual notifier you are using.

--- a/source/_integrations/brother.markdown
+++ b/source/_integrations/brother.markdown
@@ -37,6 +37,9 @@ For some Brother devices, `SNMPv3 read-write access and v1/v2c read-only access`
 ## Sensor Example
 
 You can configure Home Assistant to alert you when the printer jams or runs out of paper as follows.  First, add the following to `configuration.yaml` under the `binary_sensor:` section (replace `sensor.hl_l2340d_status` with the actual name of your sensor):
+
+{% raw %}
+
 ```yaml
   - platform: template
     sensors:
@@ -49,7 +52,11 @@ You can configure Home Assistant to alert you when the printer jams or runs out 
         value_template: "{{ is_state('sensor.hl_l2340d_status', 'paper jam') }}"
         friendly_name: 'Laser Printer Paper Jam'
 ```
+
+{% endraw %}
+
 Then, add this under the `alert:` section:
+
 ```yaml
   laser_out_of_paper:
     name: Laser Printer is Out of Paper
@@ -66,6 +73,7 @@ Then, add this under the `alert:` section:
     notifiers:
       - my_phone_notify
 ```
+
 The above will send an alert for paper jam or out of paper whenever the condition is detected, assuming you have the Home Assistant app configured on your phone so that alerts can be sent directly to it. If you don't use the Home Assistant app, you will need to set up a different notifier.
 
 Change `my_phone_notify` to the actual notifier you are using.


### PR DESCRIPTION
Actual examples of how to use the sensors for this integration are tough to find, so I added one that I figured out.  It would be nice to find a list of valid states for the brother printer integration, but I suspect that is largely determined by which printer you are actually using.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds a complete example of how to use the status sensor to do something useful: alert you when the printer jams or runs out of paper.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
