### PR TITLE
Add documentation for Litter-Robot integration

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate a Litter-Robot WiFi-enabled, autom
 ha_category:
   - Vacuum
 ha_iot_class: Cloud Polling
-ha_release: 2021.2
+ha_release: 2021.3
 ha_config_flow: true
 ha_quality_scale: gold
 ha_codeowners:
@@ -35,9 +35,9 @@ This integration can be configured via the UI:
 
 The following entities are created for this component:
 
-| Entity     | Domain   | Attributes                                                                   |
-| ---------- | -------- | ---------------------------------------------------------------------------- |
-| Litter Box | `vacuum` | clean cycle wait time minutes<br/>is sleeping<br/>power status<br/>last seen |
+| Entity     | Domain   | Attributes                                                                                        |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------- |
+| Litter Box | `vacuum` | clean cycle wait time minutes<br/>is sleeping<br/>power status<br/>unit status code<br/>last seen |
 
 All of the entities above are grouped together and identified by a single device.
 

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -6,6 +6,7 @@ ha_category:
 ha_iot_class: Cloud Polling
 ha_release: 2021.2
 ha_config_flow: true
+ha_quality_scale: gold
 ha_codeowners:
   - '@natekspencer'
 ha_domain: litterrobot

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -1,0 +1,110 @@
+---
+title: Litter-Robot
+description: Instructions on how to integrate a Litter-Robot WiFi-enabled, automatic, self-cleaning litter box to Home Assistant.
+ha_category:
+  - Vacuum
+ha_iot_class: Cloud Polling
+ha_release: 2021.2
+ha_config_flow: true
+ha_codeowners:
+  - '@natekspencer'
+ha_domain: litterrobot
+---
+
+The Litter-Robot integration allows you to control and monitor your WiFi-enabled, automatic, self-cleaning litter box for cats.
+
+You will need a Litter-Robot account as well as a Wi-Fi enabled Litter-Robot unit that has already been associated with your account.
+
+There is currently support for the following device types within Home Assistant:
+
+- Vacuum (this is the representation of your Litter-Robot litter box)
+
+## Configuration
+
+This integration can be configured via the UI:
+
+1. Go to **Configuration**->**Integrations**
+2. Click **+ ADD INTEGRATION** to setup a new integration
+3. Search for **Litter-Robot** and click on it
+4. Enter your _username_ and _password_ and click **SUBMIT**.
+5. Upon successful login, you will have the opportunity to select the area that your Litter-Robot is located.
+6. Click the **Finish** button.
+
+## Entities
+
+The following entities are created for this component:
+
+| Entity     | Domain   | Attributes                                                                   |
+| ---------- | -------- | ---------------------------------------------------------------------------- |
+| Litter Box | `vacuum` | clean cycle wait time minutes<br/>is sleeping<br/>power status<br/>last seen |
+
+All of the entities above are grouped together and identified by a single device.
+
+## Services
+
+In addition to the entities that are created above, some services that are built-in to the vacuum domain are utilized for additional functionality that is available in the Litter-Robot companion app.
+
+Replace `<entity_id>` in any of the below snippets with the appropriate value of your Litter-Robot vacuum entity.
+
+### vacuum.turn_off
+
+Supports turning off your Litter-Robot. If the unit is currently cycling, it will interrupt the cycle and stop the bonnet where it is at the time the command is received.
+
+```yaml
+service: vacuum.turn_off
+entity_id: <entity_id>
+```
+
+### vacuum.turn_on
+
+Supports turning on your Litter-Robot, initiating a clean cycle.
+
+```yaml
+service: vacuum.turn_on
+entity_id: <entity_id>
+```
+
+### vacuum.send_command
+
+#### reset_waste_drawer
+
+Resets the waste drawer gauge on the Litter-Robot.
+
+```yaml
+service: vacuum.send_command
+data:
+  entity_id: <entity_id>
+  command: reset_waste_drawer
+```
+
+Alternatively, you can create a script using the snippet below that can then be reused across Home Assistant.
+
+```yaml
+alias: Reset Waste Drawer
+sequence:
+  - service: vacuum.send_command
+    data:
+      entity_id: <entity_id>
+      command: reset_waste_drawer
+mode: single
+icon: 'mdi:refresh'
+```
+
+#### set_sleep_mode
+
+Enables (with sleep time param) or disables sleep mode on the Litter-Robot.
+
+| Param      | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                              |
+| ---------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| enabled    | bool   | true to enable, false to disable                                                                                                                                                                                                                                                                                                                                                                         |
+| sleep_time | string | time at which the unit will enter sleep mode and prevent an automatic clean cycle for 8 hours. This param uses the 24-hour format string `%H:%M:%S`, with seconds being optional, and is based on the timezone configured for your Home Assistant installation. As such, `10:30:00` would indicate 10:30 am, whereas `22:30:00` would indicate 10:30 pm. Required if the param `enabled` is set to true. |
+
+```yaml
+service: vacuum.send_command
+data:
+  entity_id: <entity_id>
+  command: set_sleep_mode
+  params:
+    enabled: true
+    sleep_time: '22:30:00'
+```

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -53,8 +53,9 @@ Resets the waste drawer gauge on the Litter-Robot. This will reset the cycle cou
 
 ```yaml
 service: vacuum.send_command
-data:
+target:
   entity_id: vacuum.litter_robot_litter_box
+data:
   command: reset_waste_drawer
 ```
 
@@ -71,8 +72,9 @@ Example of setting the sleep mode to begin at 10:30 PM.
 
 ```yaml
 service: vacuum.send_command
-data:
+target:
   entity_id: vacuum.litter_robot_litter_box
+data:
   command: set_sleep_mode
   params:
     enabled: true

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -1,6 +1,6 @@
 ---
 title: Litter-Robot
-description: Instructions on how to integrate a Litter-Robot WiFi-enabled, automatic, self-cleaning litter box to Home Assistant.
+description: Instructions on how to integrate a Litter-Robot Wi-Fi-enabled, automatic, self-cleaning litter box to Home Assistant.
 ha_category:
   - Vacuum
 ha_iot_class: Cloud Polling
@@ -12,7 +12,7 @@ ha_codeowners:
 ha_domain: litterrobot
 ---
 
-The Litter-Robot integration allows you to control and monitor your WiFi-enabled, automatic, self-cleaning litter box for cats.
+The Litter-Robot integration allows you to control and monitor your Wi-Fi-enabled, automatic, self-cleaning litter box for cats.
 
 You will need a Litter-Robot account as well as a Wi-Fi-enabled Litter-Robot unit that has already been associated with your account.
 
@@ -26,77 +26,55 @@ There is currently support for the following device types within Home Assistant:
 
 The following entities are created for this component:
 
-| Entity     | Domain   | Attributes                                                                                        |
-| ---------- | -------- | ------------------------------------------------------------------------------------------------- |
-| Litter Box | `vacuum` | clean cycle wait time minutes<br/>is sleeping<br/>power status<br/>unit status code<br/>last seen |
+| Entity     | Domain   |
+| ---------- | -------- |
+| Litter Box | `vacuum` |
 
 All of the entities above are grouped together and identified by a single device.
 
-## Services
+## Attributes
 
-In addition to the entities that are created above, some services that are built-in to the vacuum domain are utilized for additional functionality that is available in the Litter-Robot companion app.
+The following additional attributes are available on the `vacuum` component:
+| Attribute                     | Type    | Definition                                                                                                                                                         |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| clean_cycle_wait_time_minutes | integer | Current wait time, in minutes, between when your cat uses the Litter-Robot and when the unit cycles automatically.                                                 |
+| is_sleeping                   | boolean | Whether or not the unit is currently in sleep mode.                                                                                                                |
+| power_status                  | string  | Current power status of the unit. `AC` indicates normal power, `DC` indicates battery backup and `NC` indicates that the unit is not connected and/or powered off. |
+| unit_status_code              | string  | The [unit status code](https://github.com/natekspencer/pylitterbot/blob/main/pylitterbot/robot.py#L21) associated with the current status of the vacuum.           |
+| last_seen                     | string  | UTC datetime the unit last reported its status.                                                                                                                    |
 
-Replace `<entity_id>` in any of the below snippets with the appropriate value of your Litter-Robot vacuum entity.
+## Commands
 
-### vacuum.turn_off
+In addition to the entities that are created above, some commands are utilized for additional functionality that is available in the Litter-Robot companion app.
 
-Supports turning off your Litter-Robot. If the unit is currently cycling, it will interrupt the cycle and stop the bonnet where it is at the time the command is received.
+### reset_waste_drawer
 
-```yaml
-service: vacuum.turn_off
-entity_id: <entity_id>
-```
-
-### vacuum.turn_on
-
-Supports turning on your Litter-Robot, initiating a clean cycle.
-
-```yaml
-service: vacuum.turn_on
-entity_id: <entity_id>
-```
-
-### vacuum.send_command
-
-#### reset_waste_drawer
-
-Resets the waste drawer gauge on the Litter-Robot.
+Resets the waste drawer gauge on the Litter-Robot. This will reset the cycle count returned by the Litter-Robot API to `0`.
 
 ```yaml
 service: vacuum.send_command
 data:
-  entity_id: <entity_id>
+  entity_id: vacuum.litter_robot_litter_box
   command: reset_waste_drawer
 ```
 
-Alternatively, you can create a script using the snippet below that can then be reused across Home Assistant.
+### set_sleep_mode
 
-```yaml
-alias: Reset Waste Drawer
-sequence:
-  - service: vacuum.send_command
-    data:
-      entity_id: <entity_id>
-      command: reset_waste_drawer
-mode: single
-icon: 'mdi:refresh'
-```
+Enables (with `sleep_time` param) or disables sleep mode on the Litter-Robot.
 
-#### set_sleep_mode
+| Param      | Type   | Required                                        | Description                                                                                                                                                                                                                                                                                                                                              |
+| ---------- | ------ | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| enabled    | bool   | yes                                             | Set to true to enable and false to disable.                                                                                                                                                                                                                                                                                                              |
+| sleep_time | string | Required if the param `enabled` is set to true. | Time at which the unit will enter sleep mode and prevent an automatic clean cycle for 8 hours. This param uses the 24-hour format string `%H:%M:%S`, with seconds being optional, and is based on the timezone configured for your Home Assistant installation. As such, `10:30:00` would indicate 10:30 AM, whereas `22:30:00` would indicate 10:30 PM. |
 
-Enables (with sleep time param) or disables sleep mode on the Litter-Robot.
-
-| Param      | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                              |
-| ---------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| enabled    | bool   | true to enable, false to disable                                                                                                                                                                                                                                                                                                                                                                         |
-| sleep_time | string | time at which the unit will enter sleep mode and prevent an automatic clean cycle for 8 hours. This param uses the 24-hour format string `%H:%M:%S`, with seconds being optional, and is based on the timezone configured for your Home Assistant installation. As such, `10:30:00` would indicate 10:30 am, whereas `22:30:00` would indicate 10:30 pm. Required if the param `enabled` is set to true. |
+Example of setting the sleep mode to begin at 10:30 PM.
 
 ```yaml
 service: vacuum.send_command
 data:
-  entity_id: <entity_id>
+  entity_id: vacuum.litter_robot_litter_box
   command: set_sleep_mode
   params:
     enabled: true
-    sleep_time: '22:30:00'
+    sleep_time: "22:30:00"
 ```

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -14,22 +14,13 @@ ha_domain: litterrobot
 
 The Litter-Robot integration allows you to control and monitor your WiFi-enabled, automatic, self-cleaning litter box for cats.
 
-You will need a Litter-Robot account as well as a Wi-Fi enabled Litter-Robot unit that has already been associated with your account.
+You will need a Litter-Robot account as well as a Wi-Fi-enabled Litter-Robot unit that has already been associated with your account.
 
 There is currently support for the following device types within Home Assistant:
 
 - Vacuum (this is the representation of your Litter-Robot litter box)
 
-## Configuration
-
-This integration can be configured via the UI:
-
-1. Go to **Configuration**->**Integrations**
-2. Click **+ ADD INTEGRATION** to setup a new integration
-3. Search for **Litter-Robot** and click on it
-4. Enter your _username_ and _password_ and click **SUBMIT**.
-5. Upon successful login, you will have the opportunity to select the area that your Litter-Robot is located.
-6. Click the **Finish** button.
+{% include integrations/config_flow.md %}
 
 ## Entities
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for new Litter-Robot core integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/45886
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2228
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
