### PR TITLE
Fix format of Tracker Discovery example

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -422,7 +422,7 @@ Setting up a device tracker:
   "state_topic": "homeassistant/device_tracker/paulus/state",
   "payload_home": "home",
   "payload_not_home": "not_home",
-  "source_type": "bluetooth",
+  "source_type": "bluetooth"
  }
 ```
 
@@ -438,6 +438,6 @@ If the device supports gps co-ordinates then they can be sent to Home Assistant 
 {
   "latitude": 32.87336,
   "longitude": -117.22743,
-  "gps_accuracy": 1.2,
+  "gps_accuracy": 1.2
  }
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The current documentation contains incorrectly formatted JSON examples in the MQTT Discovery documentation for the `device_tracker` component. The fix required removal of two commas. Addresses feedback provided in this [comment](https://github.com/home-assistant/home-assistant.io/pull/16288#issuecomment-773608509).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
