### PR TITLE
[iOS] Fix `/ios/beta` link universal link handling

### DIFF
--- a/source/.well-known/apple-app-site-association
+++ b/source/.well-known/apple-app-site-association
@@ -5,54 +5,54 @@
       {
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant.dev",
         "paths": [
-          "/ios/*",
           "NOT /ios/beta",
           "NOT /ios/beta/*",
+          "/ios/*",
           "/tag/*"
         ]
       },
       {
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant.beta",
         "paths": [
-          "/ios/*",
           "NOT /ios/beta",
           "NOT /ios/beta/*",
+          "/ios/*",
           "/tag/*"
         ]
       },
       {
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant",
         "paths": [
-          "/ios/*",
           "NOT /ios/beta",
           "NOT /ios/beta/*",
+          "/ios/*",
           "/tag/*"
         ]
       },
       {
         "appID": "QMQYCKL255.io.robbie.HomeAssistant.dev",
         "paths": [
-          "/ios/*",
           "NOT /ios/beta",
           "NOT /ios/beta/*",
+          "/ios/*",
           "/tag/*"
         ]
       },
       {
         "appID": "QMQYCKL255.io.robbie.HomeAssistant.beta",
         "paths": [
-          "/ios/*",
           "NOT /ios/beta",
           "NOT /ios/beta/*",
+          "/ios/*",
           "/tag/*"
         ]
       },
       {
         "appID": "QMQYCKL255.io.robbie.HomeAssistant",
         "paths": [
-          "/ios/*",
           "NOT /ios/beta",
           "NOT /ios/beta/*",
+          "/ios/*",
           "/tag/*"
         ]
       }


### PR DESCRIPTION
## Proposed change
Fixes incorrectly opening the app for the `/ios/beta` short link, which is suppose to open the TestFlight link. I did these in the wrong order in #14220 -- according to [Apple's docs](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html): 
> Because the system evaluates each path in the paths array in the order it is specified—and stops evaluating when a positive or negative match is found—you should specify high priority paths before low priority paths.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
