### PR TITLE
Add feedback block to all pages

### DIFF
--- a/plugins/environment_variables.rb
+++ b/plugins/environment_variables.rb
@@ -1,17 +1,33 @@
 module Jekyll
   class EnvironmentVariablesGenerator < Generator
     def generate(site)
+
       # https://www.netlify.com/docs/continuous-deployment/#build-environment-variables
-      repo_url = ENV['REPOSITORY_URL'] || 'https://github.com/home-assistant/home-assistant.io'
+      repository_url = ENV['REPOSITORY_URL'] || 'https://github.com/home-assistant/home-assistant.io'
 
       # Rewrite urls if repo url is the ssh format.
-      if repo_url.start_with? 'git@github.com:'
-        repo_url = repo_url.sub 'git@github.com:', 'https://github.com/'
+      if repository_url.start_with? 'git@github.com:'
+        repository_url = repository_url.sub 'git@github.com:', 'https://github.com/'
       end
 
-      # These values will be available as {{ site.NLY_REPOSITORY_URL }}
-      site.config['NLY_REPOSITORY_URL'] = repo_url
-      site.config['NLY_HEAD'] = ENV['HEAD'] || 'current'
+      # Figure out deployment URL
+      url = site.config['url']
+      if ENV['context'].eql?('production')
+        url = ENV['URL'] || url
+      elsif ENV['context'].eql?('branch-deploy')
+        url = ENV['DEPLOY_URL'] || url
+      end
+      url = url.chomp('/')
+
+      # These values will be available as {{ site.netlify.* }}
+      site.config['netlify'] = {
+        'repository_url' => repository_url,
+        'branch' => ENV['BRANCH'] || 'current',
+        'commit' => ENV['COMMIT_REF'] || '',
+        'head' => ENV['HEAD'] || 'current',
+        'url' => url,
+        'pull_request' => ENV['PULL_REQUEST'].eql?('true'),
+      }
     end
   end
 end

--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -47,6 +47,10 @@ $primary-color: #049cdb;
     padding-right: 5px;
     padding-left: 5px;
   }
+
+  .feedback {
+    margin-bottom: 32px;
+  }
 }
 
 .hero {

--- a/source/_includes/asides/cookbook_navigation.html
+++ b/source/_includes/asides/cookbook_navigation.html
@@ -1,27 +1,26 @@
 <section class="aside-module grid__item one-whole lap-one-half">
-  {% include edit_github.html %}
   {% assign cookbook = site.cookbook | sort_natural: 'title' %}
 
-  <div class='section'>
-    <a href='/cookbook'>Back to the cookbook</a>
+  <div class="section">
+    <a href="/cookbook">Back to the cookbook</a>
   </div>
 
-  <div class='section'>
+  <div class="section">
     <h1 class="title delta">{{page.ha_category}}</h1>
-    <ul class='divided'>
-      {% for recipe in cookbook %}
-        {% if recipe.ha_category == page.ha_category %}
-          <li>
-            {% if recipe.url == page.url %}
-              {{recipe.title}}
-            {% elsif recipe.ha_external_link %}
-              <a href='{{recipe.ha_external_link}}'>{{recipe.title}} <i class="icon-external-link"></i></a>
-            {% else %}
-              <a href='{{recipe.url}}'>{{recipe.title}}</a>
-            {% endif %}
-          </li>
+    <ul class="divided">
+      {% for recipe in cookbook %} {% if recipe.ha_category == page.ha_category
+      %}
+      <li>
+        {% if recipe.url == page.url %} {{recipe.title}} {% elsif
+        recipe.ha_external_link %}
+        <a href="{{recipe.ha_external_link}}"
+          >{{recipe.title}} <i class="icon-external-link"></i
+        ></a>
+        {% else %}
+        <a href="{{recipe.url}}">{{recipe.title}}</a>
         {% endif %}
-      {% endfor %}
+      </li>
+      {% endif %} {% endfor %}
     </ul>
   </div>
 </section>

--- a/source/_includes/asides/getting_started_navigation.html
+++ b/source/_includes/asides/getting_started_navigation.html
@@ -1,15 +1,21 @@
 <section class="aside-module grid__item one-whole lap-one-half">
-  {% include edit_github.html %}
-
-  <div class='section'>
+  <div class="section">
     <h1 class="title delta">Getting Started</h1>
-    <ul class='divided sidebar-menu'>
-      <li>{% active_link /getting-started/ Installation %}
-        <li>{% active_link /getting-started/onboarding/ Onboarding %}</li>
-        <li>{% active_link /getting-started/automation/ Automation %}</li>
-        <li>{% active_link /getting-started/presence-detection/ Presence detection %}</li>
-        <li>{% active_link /getting-started/join-the-community/ Join the community %}</li>
-        <li>{% active_link /getting-started/configuration/ Advanced Configuration %}</li>
+    <ul class="divided sidebar-menu">
+      <li>{% active_link /getting-started/ Installation %}</li>
+      <li>{% active_link /getting-started/onboarding/ Onboarding %}</li>
+      <li>{% active_link /getting-started/automation/ Automation %}</li>
+      <li>
+        {% active_link /getting-started/presence-detection/ Presence detection
+        %}
+      </li>
+      <li>
+        {% active_link /getting-started/join-the-community/ Join the community
+        %}
+      </li>
+      <li>
+        {% active_link /getting-started/configuration/ Advanced Configuration %}
+      </li>
     </ul>
   </div>
 </section>

--- a/source/_includes/asides/help_navigation.html
+++ b/source/_includes/asides/help_navigation.html
@@ -1,21 +1,20 @@
 <section class="aside-module grid__item one-whole lap-one-half">
-  {% include edit_github.html %}
-
   <div class="section">
     <h1 class="title delta">&nbsp;</h1>
     <ul class="divided sidebar-menu">
+      <li>{% active_link /help/ Help %}</li>
       <li>
-        {% active_link /help/ Help %}
-      </li>
-      <li>
-        <a href="https://developers.home-assistant.io">Developer documentation
+        <a href="https://developers.home-assistant.io"
+          >Developer documentation
           <i class="icon-external-link"></i>
         </a>
       </li>
       <li>
         Governance
         <ul>
-          <li>{% active_link /developers/cla/ Contributor License Agreement %}</li>
+          <li>
+            {% active_link /developers/cla/ Contributor License Agreement %}
+          </li>
           <li>{% active_link /privacy/ Privacy Policy %}</li>
           <li>{% active_link /tos/ Terms of Service %}</li>
           <li>{% active_link /code_of_conduct/ Code of Conduct %}</li>

--- a/source/_includes/asides/lovelace_navigation.html
+++ b/source/_includes/asides/lovelace_navigation.html
@@ -1,5 +1,4 @@
 <section class="aside-module grid__item one-whole lap-one-half">
-  <!-- {% include edit_github.html %} -->
   {% assign cards = site.lovelace | sort_natural: 'title' %}
 
   <div class="section">
@@ -19,7 +18,9 @@
       <li>{% active_link /lovelace/badges/ Badges %}</li>
       <li>{% active_link /lovelace/actions/ Actions %}</li>
       <li>
-        <a href="https://developers.home-assistant.io/docs/frontend/custom-ui/lovelace-custom-card.html">Developing Custom Cards
+        <a
+          href="https://developers.home-assistant.io/docs/frontend/custom-ui/lovelace-custom-card.html"
+          >Developing Custom Cards
           <i class="icon-external-link"></i>
         </a>
       </li>
@@ -30,7 +31,7 @@
     <h1 class="title delta">Cards</h1>
     <ul class="divided sidebar-menu">
       {% for card in cards %}
-        <li>{% active_link {{card.url}} {{card.sidebar_label}} %}</li>
+      <li>{% active_link {{card.url}} {{card.sidebar_label}} %}</li>
       {% endfor %}
     </ul>
   </div>

--- a/source/_includes/edit_github.html
+++ b/source/_includes/edit_github.html
@@ -1,4 +1,21 @@
-{% assign url_parts = page.url | split: '/' %}
 {% if page.hide_github_edit != true %}
-<div class='edit-github'><a target="_blank" rel="noopener noreferrer" href='{{ site.NLY_REPOSITORY_URL }}/tree/{{ site.NLY_HEAD }}/source/{{ page.path }}'>Edit this page on GitHub</a></div>
+<div class="material-card text">
+  <b>Help us to improve our documentation</b><br />
+  Suggest an edit to this page, or provide/view feedback for this page.
+  <div class="links">
+    <a
+      href="{{ site.netlify.repository_url }}/tree/{{ site.netlify.head }}/source/{{ page.path }}"
+      ><i class="icon-edit" /> Edit</a
+    >
+    <a
+      href="{{ site.netlify.repository_url }}/issues/new?template=feedback.yml&url={{ site.netlify.url | url_encode }}{{ page.url | url_encode }}&version={{ site.current_major_version }}.{{
+        site.current_minor_version }}.{{ site.current_patch_version }}&labels={{ site.netlify.branch }}"
+      ><i class="icon-comment" /> Provide feedback</a
+    >
+    <a
+      href="{{ site.netlify.repository_url }}/issues?utf8=%E2%9C%93&q=%22{{ site.netlify.url | url_encode }}{{ page.url | url_encode }}%22&in=body"
+      ><i class="icon-comments" /> View pending feedback</a
+    >
+  </div>
+</div>
 {% endif %}

--- a/source/_includes/edit_github.html
+++ b/source/_includes/edit_github.html
@@ -1,5 +1,5 @@
 {% if page.hide_github_edit != true %}
-<div class="material-card text">
+<div class="material-card text feedback">
   <b>Help us to improve our documentation</b><br />
   Suggest an edit to this page, or provide/view feedback for this page.
   <div class="links">

--- a/source/_layouts/page.html
+++ b/source/_layouts/page.html
@@ -3,24 +3,16 @@ layout: default
 ---
 
 <article class="page">
-  {% assign url_parts = page.url | split: '/' %}
-  {% if url_parts[1] != 'components' and
-        url_parts[1] != 'cookbook' and
-        url_parts[1] != 'developers' and
-        url_parts[1] != 'help' and
-        url_parts[1] != 'getting-started' %}
-    {% include edit_github.html %}
-  {% endif %}
-
   {% if page.title and page.show_title != false %}
   <header>
     <h1 class="title indent">
-      {% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}
+      {% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title
+      }}{% endif %}
     </h1>
   </header>
-  <hr class="divider">
+  <hr class="divider" />
   {% endif %}
-
   {{ content }}
-
+  
+  {% include edit_github.html %}
 </article>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds a feedback block to every page of our website, inviting people to suggests edits, provide feedback or view feedback on the current page they are looking at.

![image](https://user-images.githubusercontent.com/195327/107418484-00fe0780-6b17-11eb-840f-ef4a5d08d412.png)


Future steps:
- A bot that labels created feedback issues with the integration labels
- Code owners mentioning for integration pages
- "View feedback"-button based on labels (now based on URL until the above is resolved).

PS: Some formatting changes done by Prettier 🤷 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
