### PR TITLE
Rflink component fix with TCP KEEP ALIVE option

### DIFF
--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -57,6 +57,11 @@ reconnect_interval:
   required: false
   default: 10
   type: integer
+tcp_keepalive_idle_timer:
+  description: Time in seconds to wait since last data packet was seen before a TCP KEEPALIVE is sent. Value of 0 will disable this feature.
+  required: false
+  default: 3600
+  type: integer 
 {% endconfiguration %}
 
 ### Full example
@@ -100,6 +105,7 @@ When re-flashing the Arduino MEGA, disconnect the ESP8266 to avoid programming d
 rflink:
   host: 192.168.0.10
   port: 1234
+  tcp_keepalive_idle_timer: 600
 ```
 
 ### Adding devices Automatically


### PR DESCRIPTION
goes a long with a pending code change in CORE
https://github.com/home-assistant/core/pull/46438

I am still confused if it should be in CURRENT or NEXT: it's a new field avaialble in yaml
which is introduced to fix an issue in current code ....

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/46438
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/41251

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
