### PR TITLE
Allow users to set device class for universal media player

### DIFF
--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -42,6 +42,7 @@ media_player:
     attributes:
       is_volume_muted: ENTITY_ID|ATTRIBUTE
       state: ENTITY_ID|ATTRIBUTE
+    device_class: tv
 ```
 
 {% configuration %}
@@ -63,6 +64,10 @@ commands:
   type: string
 attributes:
   description: "Attributes that can be overwritten. Possible entries are `is_volume_muted`, `state`, `source`, `source_list` and `volume_level`. The values should be an entity ID and state attribute separated by a pipe character (|). If the entity ID's state should be used, then only the entity id should be provided."
+  required: false
+  type: string
+device_class:
+  description: The device class that this entity represents. Can be `tv`, `speaker`, or `receiver`.
   required: false
   type: string
 {% endconfiguration %}
@@ -273,6 +278,7 @@ media_player:
         data:
           entity_id: remote.alexander_down_guest
           activity: "{{ source }}"
+    device_class: tv
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
Some users need to be able to set a device class on a universal media player entity so it can be used correctly in e.g. HomeKit. Added support in the linked PR, this PR updates the docs



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/46550
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
