### PR TITLE
Add documentation for telegram_bot bearer_token authentication

### DIFF
--- a/source/_integrations/telegram_bot.markdown
+++ b/source/_integrations/telegram_bot.markdown
@@ -43,9 +43,9 @@ Send a photo.
 | `url`                     |       no | Remote path to an image. |
 | `file`                    |       no | Local path to an image.  |
 | `caption`                 |      yes | The title of the image. |
-| `username`                |      yes | Username for a URL which requires HTTP basic authentication. |
-| `password`                |      yes | Password for a URL which requires HTTP basic authentication. |
-| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
+| `username`                |      yes | Username for a URL which requires HTTP authentication. |
+| `password`                |      yes | Password (or bearer token) for a URL which require HTTP authentication. |
+| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication, or `bearer_token` for OAuth 2.0 bearer token authentication. Defaults to `basic`.  |
 | `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `parse_mode`              |      yes | Parser for the message text: `markdownv2`, `html` or `markdown`. |
 | `disable_notification`     |      yes | True/false for send the message silently. iOS users and web users will not receive a notification, Android users will receive a notification with no sound. Defaults to False. |
@@ -64,9 +64,9 @@ Send a video.
 | `url`                     |       no | Remote path to a video. |
 | `file`                    |       no | Local path to a video.  |
 | `caption`                 |      yes | The title of the video. |
-| `username`                |      yes | Username for a URL which requires HTTP basic authentication. |
-| `password`                |      yes | Password for a URL which requires HTTP basic authentication. |
-| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
+| `username`                |      yes | Username for a URL which requires HTTP authentication. |
+| `password`                |      yes | Password (or bearer token) for a URL which require HTTP authentication. |
+| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication, or `bearer_token` for OAuth 2.0 bearer token authentication. Defaults to `basic`.  |
 | `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `parse_mode`              |      yes | Parser for the message text: `markdownv2`, `html` or `markdown`. |
 | `disable_notification`    |      yes | True/false to send the message silently. iOS users and web users will not receive a notification. Android users will receive a notification with no sound. Defaults to False. |
@@ -84,9 +84,9 @@ Send an animation.
 | `url`                     |       no | Remote path to a GIF or H.264/MPEG-4 AVC video without sound. |
 | `file`                    |       no | Local path to a GIF or H.264/MPEG-4 AVC video without sound.  |
 | `caption`                 |      yes | The title of the animation. |
-| `username`                |      yes | Username for a URL which requires HTTP basic authentication. |
-| `password`                |      yes | Password for a URL which requires HTTP basic authentication. |
-| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
+| `username`                |      yes | Username for a URL which requires HTTP authentication. |
+| `password`                |      yes | Password (or bearer token) for a URL which require HTTP authentication. |
+| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication, or `bearer_token` for OAuth 2.0 bearer token authentication. Defaults to `basic`.  |
 | `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `parse_mode`              |      yes | Parser for the message text: `markdownv2`, `html` or `markdown`. |
 | `disable_notification`    |      yes | True/false to send the message silently. iOS users and web users will not receive a notification. Android users will receive a notification with no sound. Defaults to False. |
@@ -105,9 +105,9 @@ Send a voice message.
 | `url`                     |       no | Remote path to a voice message. |
 | `file`                    |       no | Local path to a voice message.  |
 | `caption`                 |      yes | The title of the voice message. |
-| `username`                |      yes | Username for a URL which requires HTTP basic authentication. |
-| `password`                |      yes | Password for a URL which requires HTTP basic authentication. |
-| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
+| `username`                |      yes | Username for a URL which requires HTTP authentication. |
+| `password`                |      yes | Password (or bearer token) for a URL which require HTTP authentication. |
+| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication, or `bearer_token` for OAuth 2.0 bearer token authentication. Defaults to `basic`.  |
 | `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `disable_notification`    |      yes | True/false to send the message silently. iOS users and web users will not receive a notification. Android users will receive a notification with no sound. Defaults to False. |
 | `verify_ssl`              |      yes | True/false for checking the SSL certificate of the server for HTTPS URLs. Defaults to True. |
@@ -124,9 +124,9 @@ Send a sticker.
 |---------------------------|----------|--------------------------------------------------|
 | `url`                     |       no | Remote path to a static .webp or animated .tgs sticker. |
 | `file`                    |       no | Local path to a static .webp or animated .tgs sticker.  |
-| `username`                |      yes | Username for a URL which requires HTTP basic authentication. |
-| `password`                |      yes | Password for a URL which requires HTTP basic authentication. |
-| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
+| `username`                |      yes | Username for a URL which requires HTTP authentication. |
+| `password`                |      yes | Password (or bearer token) for a URL which require HTTP authentication. |
+| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication, or `bearer_token` for OAuth 2.0 bearer token authentication. Defaults to `basic`.  |
 | `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `disable_notification`     |      yes | True/false for send the message silently. iOS users and web users will not receive a notification, Android users will receive a notification with no sound. Defaults to False. |
 | `verify_ssl`              |      yes | True/false for checking the SSL certificate of the server for HTTPS URLs. Defaults to True. |
@@ -144,9 +144,9 @@ Send a document.
 | `url`                     |       no | Remote path to a document. |
 | `file`                    |       no | Local path to a document.  |
 | `caption`                 |      yes | The title of the document. |
-| `username`                |      yes | Username for a URL which requires HTTP basic authentication. |
-| `password`                |      yes | Password for a URL which requires HTTP basic authentication. |
-| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
+| `username`                |      yes | Username for a URL which requires HTTP authentication. |
+| `password`                |      yes | Password (or bearer token) for a URL which require HTTP authentication. |
+| `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication, or `bearer_token` for OAuth 2.0 bearer token authentication. Defaults to `basic`.  |
 | `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `parse_mode`              |      yes | Parser for the message text: `markdownv2`, `html` or `markdown`. |
 | `disable_notification`    |      yes | True/false for send the message silently. iOS users and web users will not receive a notification, Android users will receive a notification with no sound. Defaults to False. |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for bearer token authentication in telegram bot


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/46567
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
