### PR TITLE
Detail learned_code event on Broadlink remote

### DIFF
--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -153,6 +153,18 @@ When the LED blinks for the first time, press the button you want to learn. Then
 
 The learned codes are stored in `/configuration/.storage/` in a JSON file called `broadlink_remote_MACADDRESS_codes`. You can open this file with a text editor and copy the codes to set up [custom IR/RF switches](#Setting%20up%20custom%20IR/RF%20switches) or to send them as [base64 codes](#Sending%20a%20base64%20code), but beware: the files in the .storage folder _should never be edited manually_.
 
+#### Learned codes event
+
+When codes have been learned, an event of type `remote_event` is sent. The data passed in the event contains:
+
+| Data attribute | Optional | Description | Example |
+| ---------------------- | -------- | ----------- | --------|
+| `device_id` | no | The ID of the Broadlink device the `learn` command was sent to. | 780fh7632287
+| `type` | no | The event type. Will always be `learned_code`. | learned_code
+| `command` | no | The command sent to be learnt. | heat_cool_medium_horizontal_18
+| `code` | yes | The code learned by the Broadlink device. |
+| `error` | yes | If an error occurs, this will contain the error message. | No infrared code received within 30 seconds
+
 ### Sending commands
 
 After learning IR and RF codes with the `remote.learn_command` service, you can use `remote.send_command` to send them. You can also use this service to send base64 codes taken from elsewhere.

--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -153,16 +153,23 @@ When the LED blinks for the first time, press the button you want to learn. Then
 
 The learned codes are stored in `/configuration/.storage/` in a JSON file called `broadlink_remote_MACADDRESS_codes`. You can open this file with a text editor and copy the codes to set up [custom IR/RF switches](#Setting%20up%20custom%20IR/RF%20switches) or to send them as [base64 codes](#Sending%20a%20base64%20code), but beware: the files in the .storage folder _should never be edited manually_.
 
-#### Learned codes event
+#### Learned codes events
 
 When codes have been learned, an event of type `remote_learned_command` is sent. The data passed in the event contains:
 
 | Data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
 | `device_id` | no | The ID of the Broadlink device the `learn` command was sent to. | 780fh7632287
+| `command` | no | The command sent to be learnt. May not be included depending on error. | heat_cool_medium_horizontal_18
+| `code` | no | The code learned by the Broadlink device. |
+
+If the learning fails, a `remote_learned_command_failed` event is sent.
+
+| Data attribute | Optional | Description | Example |
+| ---------------------- | -------- | ----------- | --------|
+| `device_id` | no | The ID of the Broadlink device the `learn` command was sent to. | 780fh7632287
 | `command` | yes | The command sent to be learnt. May not be included depending on error. | heat_cool_medium_horizontal_18
-| `code` | yes | The code learned by the Broadlink device. |
-| `error` | yes | If an error occurs, this will contain the error message. | No infrared code received within 30 seconds
+| `error` | no | The error message. | No infrared code received within 30 seconds
 
 ### Sending commands
 

--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -155,13 +155,12 @@ The learned codes are stored in `/configuration/.storage/` in a JSON file called
 
 #### Learned codes event
 
-When codes have been learned, an event of type `remote_event` is sent. The data passed in the event contains:
+When codes have been learned, an event of type `remote_learned_command` is sent. The data passed in the event contains:
 
 | Data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
 | `device_id` | no | The ID of the Broadlink device the `learn` command was sent to. | 780fh7632287
-| `type` | no | The event type. Will always be `learned_code`. | learned_code
-| `command` | no | The command sent to be learnt. | heat_cool_medium_horizontal_18
+| `command` | yes | The command sent to be learnt. May not be included depending on error. | heat_cool_medium_horizontal_18
 | `code` | yes | The code learned by the Broadlink device. |
 | `error` | yes | If an error occurs, this will contain the error message. | No infrared code received within 30 seconds
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adding documentation for new feature added to the Broadlink component to send event when a code is learned by the remote.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/46645
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
