### PR TITLE
Add subdevice lightbulb support

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -255,6 +255,14 @@ These subdevices are fully implemented in HomeAssistant:
 | -------------------------------- | ----------------------- | --------------- | ------------------------------------------------ |
 | Weather sensor                   | lumi.sensor_ht          | WSDCGQ01LM      | readout `temperature` and `humidity`             |
 | Weather sensor                   | lumi.weather.v1         | WSDCGQ11LM      | readout `temperature`, `humidity` and `pressure` |
+| Smart bulb E27                   | lumi.light.aqcn02       | ZNLDP12LM       | on/off, brightness, color temperature            |
+| IKEA smart bulb E27 white        | ikea.light.led1545g12   | LED1545G12      | on/off, brightness, color temperature            |
+| IKEA smart bulb E27 white        | ikea.light.led1546g12   | LED1546G12      | on/off, brightness, color temperature            |
+| IKEA smart bulb E12 white        | ikea.light.led1536g5    | LED1536G5       | on/off, brightness, color temperature            |
+| IKEA smart bulb GU10 white       | ikea.light.led1537r6    | LED1537R6       | on/off, brightness, color temperature            |
+| IKEA smart bulb E27 white        | ikea.light.led1623g12   | LED1623G12      | on/off, brightness, color temperature            |
+| IKEA smart bulb GU10 white       | ikea.light.led1650r5    | LED1650R5       | on/off, brightness, color temperature            |
+| IKEA smart bulb E12 white        | ikea.light.led1649c5    | LED1649C5       | on/off, brightness, color temperature            |
 
 ### Recognized subdevices (not yet implemented)
 
@@ -301,14 +309,6 @@ These subdevices are recognized by the python-miio code but are still being work
 | Door lock S2                     | lumi.lock.acn02         | ZNMS12LM        |
 | Door lock S2 pro                 | lumi.lock.acn03         | ZNMS13LM        |
 | Vima cylinder lock               | lumi.lock.v1            | A6121           |
-| Smart bulb E27                   | lumi.light.aqcn02       | ZNLDP12LM       |
-| IKEA smart bulb E27 white        | ikea.light.led1545g12   | LED1545G12      |
-| IKEA smart bulb E27 white        | ikea.light.led1546g12   | LED1546G12      |
-| IKEA smart bulb E12 white        | ikea.light.led1536g5    | LED1536G5       |
-| IKEA smart bulb GU10 white       | ikea.light.led1537r6    | LED1537R6       |
-| IKEA smart bulb E27 white        | ikea.light.led1623g12   | LED1623G12      |
-| IKEA smart bulb GU10 white       | ikea.light.led1650r5    | LED1650R5       |
-| IKEA smart bulb E12 white        | ikea.light.led1649c5    | LED1649C5       |
 | Thermostat S2                    | lumi.airrtc.tcpecn02    | KTWKQ03ES       |
 
 ## Xiaomi device tracker (Xiaomi Mi WiFi Repeater 2)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add support for all zigbee lightbulbs connected to a xiaomi gateway:

- lumi.light.aqcn02
- ikea.light.led1545g12
- ikea.light.led1546g12
- ikea.light.led1536g5
- ikea.light.led1537r6
- ikea.light.led1623g12
- ikea.light.led1650r5
- ikea.light.led1649c5



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/46660
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
