### PR TITLE
KNX read service

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -231,26 +231,26 @@ address:
 # Example automation to update a cover position after 10 seconds of movement initiation
 automation:
   - trigger:
-      platform: event
-      event_type: knx_event
-      event_data:
-        destination: 0/4/20 # Cover move trigger
+      - platform: event
+        event_type: knx_event
+        event_data:
+          destination: "0/4/20" # Cover move trigger
     action:
       - delay: 0:0:10
       - service: knx.read
         data: 
-          address: 0/4/21 # Cover position address
+          address: "0/4/21" # Cover position address
 
   - trigger:
-      platform: homeassistant
-      event: start
+      - platform: homeassistant
+        event: start
     action:
       - service: knx.event_register # register the group address to trigger a knx_event
         data:
-          address: 0/4/20 # Cover move trigger
+          address: "0/4/20" # Cover move trigger
       - service: knx.read
         data:
-          address: 0/4/21 # Cover position address
+          address: "0/4/21" # Cover position address
 ```
 
 ### Register Event

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -212,7 +212,20 @@ type:
 
 ### Read
 
-You can also use the `homeassistant.update_entity` service call to issue GroupValueRead requests for all `*state_address` of a device.
+You can use the `homeassistant.update_entity` service call to issue GroupValueRead requests for all `*state_address` of an entity.
+To manually send GroupValueRead requests use the `knx.read` service. The response can be used from `knx_event` and will be processed in KNX entities.
+
+```txt
+Domain: knx
+Service: read
+Service Data: {"address": "1/0/15"}
+```
+
+{% configuration %}
+address:
+  description: Group address(es) to send read request to. Lists will read multiple group addresses.
+  type: [string, list]
+{% endconfiguration %}
 
 ### Register Event
 

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -228,16 +228,29 @@ address:
 {% endconfiguration %}
 
 ```yaml
-# Example automation to read a group address on Home Assistant start up
+# Example automation to update a cover position after 10 seconds of movement initiation
 automation:
-  trigger:
-    platform: homeassistant
-    event: start
-  action:
-    service: knx.read
-    data:
-      address: 1/2/3
-# Please note that this is done by default for every *_state_address of entities (see `sync_state` attribute)
+  - trigger:
+      platform: event
+      event_type: knx_event
+      event_data:
+        destination: 0/4/20 # Cover move trigger
+    action:
+      - delay: 0:0:10
+      - service: knx.read
+        data: 
+          address: 0/4/21 # Cover position address
+
+  - trigger:
+      platform: homeassistant
+      event: start
+    action:
+      - service: knx.event_register # register the group address to trigger a knx_event
+        data:
+          address: 0/4/20 # Cover move trigger
+      - service: knx.read
+        data:
+          address: 0/4/21 # Cover position address
 ```
 
 ### Register Event

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -247,7 +247,7 @@ automation:
       - platform: homeassistant
         event: start
     action:
-      # register the group address to trigger a knx_event
+      # Register the group address to trigger a knx_event
       - service: knx.event_register
         data:
           # Cover move trigger

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -234,23 +234,28 @@ automation:
       - platform: event
         event_type: knx_event
         event_data:
-          destination: "0/4/20" # Cover move trigger
+          # Cover move trigger
+          destination: "0/4/20"
     action:
       - delay: 0:0:10
       - service: knx.read
-        data: 
-          address: "0/4/21" # Cover position address
+        data:
+          # Cover position address
+          address: "0/4/21"
 
   - trigger:
       - platform: homeassistant
         event: start
     action:
-      - service: knx.event_register # register the group address to trigger a knx_event
+      # register the group address to trigger a knx_event
+      - service: knx.event_register
         data:
-          address: "0/4/20" # Cover move trigger
+          # Cover move trigger
+          address: "0/4/20"
       - service: knx.read
         data:
-          address: "0/4/21" # Cover position address
+          # Cover position address
+          address: "0/4/21"
 ```
 
 ### Register Event

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -227,6 +227,19 @@ address:
   type: [string, list]
 {% endconfiguration %}
 
+```yaml
+# Example automation to read a group address on Home Assistant start up
+automation:
+  trigger:
+    platform: homeassistant
+    event: start
+  action:
+    service: knx.read
+    data:
+      address: 1/2/3
+# Please note that this is done by default for every *_state_address of entities (see `sync_state` attribute)
+```
+
 ### Register Event
 
 The `knx.event_register` service can be used to register (or unregister) group addresses to fire `knx_event` Events. Events for group addresses matching the `event_filter` attribute in `configuration.yaml` can not be unregistered. See [knx_event](#events)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for `knx.read` service.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/46670
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
