### PR TITLE
Link to a more up-to-date list of compatible devices

### DIFF
--- a/source/_integrations/qnap.markdown
+++ b/source/_integrations/qnap.markdown
@@ -122,17 +122,6 @@ monitored_conditions:
 
 If your QNAP device uses self-signed certificates, set the `verify_ssl` option to `false`.
 
-### QNAP device support:
+### QNAP device support
 
-This integration has been tested on the following devices:
-
-- TS-231P2 (QTS 4.4.2)
-- TS-259 Pro+ (QTS 4.2.6)
-- TS-228 (QTS 4.3.6)
-- TS-410 (QTS 4.2.3)
-- TS-419 (QTS 4.2.3)
-- TS-451 (QTS 4.2.2)
-- TS-470 (QTS 4.2.2)
-- TS-639 (QTS 4.2.3)
-
-Other QNAP NAS devices using similar firmware should work fine. For more information about supported devices, or to report issues with your device, please visit the [qnapstats project](https://github.com/colinodell/python-qnapstats#device-support).
+This integration works with most (but not all) QNAP devices.  A complete, up-do-date [list of compatible devices can be found here](https://github.com/colinodell/python-qnapstats#device-support).

--- a/source/_integrations/qnap.markdown
+++ b/source/_integrations/qnap.markdown
@@ -124,4 +124,4 @@ If your QNAP device uses self-signed certificates, set the `verify_ssl` option t
 
 ### QNAP device support
 
-This integration works with most (but not all) QNAP devices.  A complete, up-do-date [list of compatible devices can be found here](https://github.com/colinodell/python-qnapstats#device-support).
+This integration works with most (but not all) QNAP devices. A complete, up-to-date [list of compatible devices can be found here](https://github.com/colinodell/python-qnapstats#device-support).


### PR DESCRIPTION
## Proposed change

A more up-to-date list of compatible QNAP devices can be found on the underlying library's README file.  Instead of maintaining two copies of the list, we can simply link to the library's list instead.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: fixes #16680 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
