### PR TITLE
Update Litter-Robot documentation for switches and sensors

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -26,13 +26,12 @@ There is currently support for the following device types within Home Assistant:
 
 The following entities are created for this component:
 
-| Entity        | Domain   | Description                                                                                     |
-| ------------- | -------- | ----------------------------------------------------------------------------------------------- |
-| Litter Box    | `vacuum` | Main entity that represents a Litter-Robot unit.                                                |
-| Night Light   | `switch` | When turned on, automatically turns on the night light in darker settings.                      |
-| Panel Lockout | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings.                |
-| Sleep Mode    | `switch` | When turned on, prevents automatic clean cycles for 8 hours on a daily basis from the time set. |
-| Waste Drawer  | `sensor` | Displays the current waste level gauge.                                                         |
+| Entity        | Domain   | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| Litter Box    | `vacuum` | Main entity that represents a Litter-Robot unit.                                 |
+| Night Light   | `switch` | When turned on, automatically turns on the night light in darker settings.       |
+| Panel Lockout | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
+| Waste Drawer  | `sensor` | Displays the current waste level gauge.                                          |
 
 All of the entities above are grouped together and identified by a single device.
 
@@ -46,16 +45,11 @@ Some entities have attributes in addition to the default ones that are available
 | ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | clean_cycle_wait_time_minutes | integer | Current wait time, in minutes, between when your cat uses the Litter-Robot and when the unit cycles automatically.                                                 |
 | is_sleeping                   | boolean | Whether or not the unit is currently in sleep mode.                                                                                                                |
+| sleep_mode_start_time         | string  | When sleep mode is enabled, displays the time the unit will enter sleep mode in the format `%H:%M:%S`, otherwise `None`.                                           |
+| sleep_mode_end_time           | string  | When sleep mode is enabled, displays the time the unit will exit sleep mode in the format `%H:%M:%S`, otherwise `None`.                                            |
 | power_status                  | string  | Current power status of the unit. `AC` indicates normal power, `DC` indicates battery backup and `NC` indicates that the unit is not connected and/or powered off. |
 | unit_status_code              | string  | The [unit status code](https://github.com/natekspencer/pylitterbot/blob/main/pylitterbot/robot.py#L21) associated with the current status of the vacuum.           |
 | last_seen                     | string  | UTC datetime the unit last reported its status.                                                                                                                    |
-
-### Sleep Mode `switch` entity (when enabled)
-
-| Attribute  | Type   | Definition                                                    |
-| ---------- | ------ | ------------------------------------------------------------- |
-| start_time | string | Time the unit will enter sleep mode in the format `%H:%M:%S`. |
-| end_time   | string | Time the unit will exit sleep mode in the format `%H:%M:%S`.  |
 
 ### Waste Drawer `sensor` entity
 

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -26,15 +26,22 @@ There is currently support for the following device types within Home Assistant:
 
 The following entities are created for this component:
 
-| Entity     | Domain   |
-| ---------- | -------- |
-| Litter Box | `vacuum` |
+| Entity        | Domain   | Description                                                                                     |
+| ------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| Litter Box    | `vacuum` | Main entity that represents a Litter-Robot unit.                                                |
+| Night Light   | `switch` | When turned on, automatically turns on the night light in darker settings.                      |
+| Panel Lockout | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings.                |
+| Sleep Mode    | `switch` | When turned on, prevents automatic clean cycles for 8 hours on a daily basis from the time set. |
+| Waste Drawer  | `sensor` | Displays the current waste level gauge.                                                         |
 
 All of the entities above are grouped together and identified by a single device.
 
 ## Attributes
 
-The following additional attributes are available on the `vacuum` component:
+Some entities have attributes in addition to the default ones that are available for that platform. They are listed below.
+
+### Litter Box `vacuum` entity
+
 | Attribute                     | Type    | Definition                                                                                                                                                         |
 | ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | clean_cycle_wait_time_minutes | integer | Current wait time, in minutes, between when your cat uses the Litter-Robot and when the unit cycles automatically.                                                 |
@@ -42,6 +49,21 @@ The following additional attributes are available on the `vacuum` component:
 | power_status                  | string  | Current power status of the unit. `AC` indicates normal power, `DC` indicates battery backup and `NC` indicates that the unit is not connected and/or powered off. |
 | unit_status_code              | string  | The [unit status code](https://github.com/natekspencer/pylitterbot/blob/main/pylitterbot/robot.py#L21) associated with the current status of the vacuum.           |
 | last_seen                     | string  | UTC datetime the unit last reported its status.                                                                                                                    |
+
+### Sleep Mode `switch` entity (when enabled)
+
+| Attribute  | Type   | Definition                                                    |
+| ---------- | ------ | ------------------------------------------------------------- |
+| start_time | string | Time the unit will enter sleep mode in the format `%H:%M:%S`. |
+| end_time   | string | Time the unit will exit sleep mode in the format `%H:%M:%S`.  |
+
+### Waste Drawer `sensor` entity
+
+| Attribute                | Type    | Definition                                                               |
+| ------------------------ | ------- | ------------------------------------------------------------------------ |
+| cycle_count              | integer | Number of clean cycles performed since last reset.                       |
+| cycle_capacity           | integer | Number of clean cycles before unit is full.                              |
+| cycles_after_drawer_full | integer | Number of clean cycles performed since drawer full status was indicated. |
 
 ## Commands
 

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -26,12 +26,12 @@ There is currently support for the following device types within Home Assistant:
 
 The following entities are created for this component:
 
-| Entity        | Domain   | Description                                                                      |
-| ------------- | -------- | -------------------------------------------------------------------------------- |
-| Litter Box    | `vacuum` | Main entity that represents a Litter-Robot unit.                                 |
-| Night Light   | `switch` | When turned on, automatically turns on the night light in darker settings.       |
-| Panel Lockout | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
-| Waste Drawer  | `sensor` | Displays the current waste level gauge.                                          |
+| Entity           | Domain   | Description                                                                      |
+| ---------------- | -------- | -------------------------------------------------------------------------------- |
+| Litter Box       | `vacuum` | Main entity that represents a Litter-Robot unit.                                 |
+| Night Light Mode | `switch` | When turned on, automatically turns on the night light in darker settings.       |
+| Panel Lockout    | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
+| Waste Drawer     | `sensor` | Displays the current waste level gauge.                                          |
 
 All of the entities above are grouped together and identified by a single device.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updates the Litter-Robot documentation for switches and sensors.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/46942
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
