### PR TITLE
Update reference to location of edit link for documentation

### DIFF
--- a/source/_faq/missing-documentation.markdown
+++ b/source/_faq/missing-documentation.markdown
@@ -4,6 +4,6 @@ description: "The documentation is missing or outdated"
 ha_category: Documentation
 ---
 
-Home Assistant is a FAST moving open source project. This means occasionally the official documentation will not be 100% current or complete. Since this is an open source volunteer project, we would encourage anyone who finds gaps in the documentation to click the `edit this page on Github` link in the top right and submit any corrections/enhancements they may find useful. A step-by-step guide on how to contribute to the documentation can be found [here](https://community.home-assistant.io/t/editing-the-documentation-and-creating-a-pull-request-on-github/9573).
+Home Assistant is a FAST moving open source project. This means occasionally the official documentation will not be 100% current or complete. Since this is an open source volunteer project, we would encourage anyone who finds gaps in the documentation to click the `EDIT` link at the bottom and submit any corrections/enhancements they may find useful. A step-by-step guide on how to contribute to the documentation can be found [here](https://community.home-assistant.io/t/editing-the-documentation-and-creating-a-pull-request-on-github/9573).
 
 In the absence of information, many users find it beneficial to look at other people's configurations to find examples of what they want to accomplish in their own configurations. The easiest way to find these configurations is through this [GitHub search](https://github.com/search?q=topic%3Ahome-assistant-config&type=Repositories).


### PR DESCRIPTION
The link to edit the documentation has moved to the bottom of the documentation pages.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The current location of the link is nonexistent and has moved down. I have not checked with which commit this happened.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
