### PR TITLE
Enhance QNap configuration value documentation with more hints

### DIFF
--- a/source/_integrations/qnap.markdown
+++ b/source/_integrations/qnap.markdown
@@ -35,7 +35,7 @@ sensor:
 
 {% configuration %}
 host:
-  description: The IP address of the QNAP NAS to monitor.
+  description: The IP address of the QNAP NAS to monitor, i.e., `192.168.8.12`.
   required: true
   type: string
 port:
@@ -44,12 +44,12 @@ port:
   default: 8080
   type: integer
 ssl:
-  description: Whether to connect via `https`.
+  description: Whether to connect via `https`. You might need to configure `port` (i.e., `443`) and `verify_ssl` (i.e., `false`) accordingly.
   required: false
   default: false
   type: boolean
 verify_ssl:
-  description: Whether SSL certificates should be validated.
+  description: Whether SSL certificates should be validated. Set to `false` if you use the default, self-signed QNap certificate.
   required: false
   default: true
   type: boolean
@@ -59,7 +59,7 @@ timeout:
   default: 10
   type: integer
 username:
-  description: An user to connect to the QNAP NAS.
+  description: An administration user to connect to the QNAP NAS. This user must be a member of the _administration_ group.
   required: true
   type: string
 password:
@@ -118,9 +118,9 @@ monitored_conditions:
       description: Displays the used space of the volume as a percentage (creates a new entry for each volume).
 {% endconfiguration %}
 
-### Self-signed certificates
+### SSL and Self-signed certificates
 
-If your QNAP device uses self-signed certificates, set the `verify_ssl` option to `false`.
+If your QNAP device uses self-signed certificates, set the `verify_ssl` option to `false`. If you configured your device to accept SSL-only connections, please also check that you set `port` accordingly, or you might get an `SSL: WRONG_VERSION_NUMBER` error.
 
 ### QNAP device support
 


### PR DESCRIPTION
## Proposed change
Add a few more documentation hints for the QNap integration to avoid the configuration pitfalls I stepped into.

I was already writing bug reports until I realized my configuration errors.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
