### PR TITLE
Adjust wording and add ha_platforms in Litter-Robot documentation

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -2,7 +2,7 @@
 title: Litter-Robot
 description: Instructions on how to integrate a Litter-Robot Wi-Fi-enabled, automatic, self-cleaning litter box to Home Assistant.
 ha_category:
-  - Vacuum
+  - Pets
 ha_iot_class: Cloud Polling
 ha_release: 2021.3
 ha_config_flow: true
@@ -16,15 +16,13 @@ The Litter-Robot integration allows you to control and monitor your Wi-Fi-enable
 
 You will need a Litter-Robot account as well as a Wi-Fi-enabled Litter-Robot unit that has already been associated with your account.
 
-There is currently support for the following device types within Home Assistant:
-
-- Vacuum (this is the representation of your Litter-Robot litter box)
+The Feeder-Robot is not currently supported by this integration.
 
 {% include integrations/config_flow.md %}
 
 ## Entities
 
-The following entities are created for this component:
+The following entities are created for this component and identified by a single device per Litter-Robot unit:
 
 | Entity           | Domain   | Description                                                                      |
 | ---------------- | -------- | -------------------------------------------------------------------------------- |
@@ -33,15 +31,13 @@ The following entities are created for this component:
 | Panel Lockout    | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
 | Waste Drawer     | `sensor` | Displays the current waste level gauge.                                          |
 
-All of the entities above are grouped together and identified by a single device.
-
-## Attributes
+## Additional Attributes
 
 Some entities have attributes in addition to the default ones that are available for that platform. They are listed below.
 
 ### Litter Box `vacuum` entity
 
-| Attribute                     | Type    | Definition                                                                                                                                                         |
+| Attribute                     | Type    | Description                                                                                                                                                        |
 | ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | clean_cycle_wait_time_minutes | integer | Current wait time, in minutes, between when your cat uses the Litter-Robot and when the unit cycles automatically.                                                 |
 | is_sleeping                   | boolean | Whether or not the unit is currently in sleep mode.                                                                                                                |
@@ -53,7 +49,7 @@ Some entities have attributes in addition to the default ones that are available
 
 ### Waste Drawer `sensor` entity
 
-| Attribute                | Type    | Definition                                                               |
+| Attribute                | Type    | Description                                                              |
 | ------------------------ | ------- | ------------------------------------------------------------------------ |
 | cycle_count              | integer | Number of clean cycles performed since last reset.                       |
 | cycle_capacity           | integer | Number of clean cycles before unit is full.                              |
@@ -61,7 +57,7 @@ Some entities have attributes in addition to the default ones that are available
 
 ## Commands
 
-In addition to the entities that are created above, some commands are utilized for additional functionality that is available in the Litter-Robot companion app.
+Commands are utilized for additional functionality that is available in the Litter-Robot companion app. The following are currently available:
 
 ### reset_waste_drawer
 

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -2,7 +2,7 @@
 title: Litter-Robot
 description: Instructions on how to integrate a Litter-Robot Wi-Fi-enabled, automatic, self-cleaning litter box to Home Assistant.
 ha_category:
-  - Pets
+  - Vacuum
 ha_iot_class: Cloud Polling
 ha_release: 2021.3
 ha_config_flow: true
@@ -10,6 +10,10 @@ ha_quality_scale: gold
 ha_codeowners:
   - '@natekspencer'
 ha_domain: litterrobot
+ha_platforms:
+  - sensor
+  - switch
+  - vacuum
 ---
 
 The Litter-Robot integration allows you to control and monitor your Wi-Fi-enabled, automatic, self-cleaning litter box for cats.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adjust wording in Litter-Robot documentation and add ha_platforms.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/46942
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
