### PR TITLE
[Xiaomi Miio] Add example for vacuum segment clean with repetition

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1411,7 +1411,7 @@ automation:
         segments: 1
 ```
 
-Single-segment with repetition:
+The original app for Xiaomi vacuum has a nice feature of room cleaning with repetition, you can achieve the same result with repeating segments:
 
 ```yaml
 automation:

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1411,7 +1411,7 @@ automation:
         segments: 1
 ```
 
-Single segment with repetition:
+Single-segment with repetition:
 
 ```yaml
 automation:
@@ -1419,7 +1419,6 @@ automation:
     trigger:
     - event: start
       platform: homeassistant
-    condition: []
     action:
     - service: xiaomi_miio.vacuum_clean_segment
       target:

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1417,14 +1417,14 @@ The original app for Xiaomi vacuum has a nice feature of room cleaning with repe
 automation:
   - alias: "Vacuum kitchen"
     trigger:
-    - event: start
-      platform: homeassistant
+      - event: start
+        platform: homeassistant
     action:
-    - service: xiaomi_miio.vacuum_clean_segment
-      target:
-        entity_id: vacuum.xiaomi_vacuum
-      data:
-        segments: [1, 1]
+      - service: xiaomi_miio.vacuum_clean_segment
+        target:
+          entity_id: vacuum.xiaomi_vacuum
+        data:
+          segments: [1, 1]
 ```
 
 ### Attributes

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1411,6 +1411,23 @@ automation:
         segments: 1
 ```
 
+Single segment with repetition:
+
+```yaml
+automation:
+  - alias: "Vacuum kitchen"
+    trigger:
+    - event: start
+      platform: homeassistant
+    condition: []
+    action:
+    - service: xiaomi_miio.vacuum_clean_segment
+      target:
+        entity_id: vacuum.xiaomi_vacuum
+      data:
+        segments: [1, 1]
+```
+
 ### Attributes
 
 In addition to [all of the attributes provided by the `vacuum` component](/integrations/vacuum/#attributes),


### PR DESCRIPTION
## Proposed change

Original App for xiaomi vacuum has nice feature of room cleaning with repetition. Despite the fact that the protocol does not support repetition for segment cleaning ([proof](https://github.com/rytilahti/python-miio/blob/dfda13edb8bcfd844b2e1f2d7d7374a9a0709ac6/miio/vacuum.py#L685-L691)) user can use a special workaround with repetition of segment id. I think it's a very useful example of integration usage, so it should be somewhere in the documentation about service.
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
