### PR TITLE
Grant permissions with groups

### DIFF
--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -86,13 +86,15 @@ nodes:
       type: list
 {% endconfiguration %}
 
-Example with multiple VMs and no containers:
+Example with multiple VMs, no containers, self-signed certificate and pve realm for the user setup described below:
 
 ```yaml
 proxmoxve:
   - host: IP_ADDRESS
     username: USERNAME
     password: PASSWORD
+    verify_ssl: false
+    realm: pve
     nodes:
       - node: NODE_NAME
         vms:
@@ -110,38 +112,39 @@ The created sensor will be called `binary_sensor.NODE_NAME_VMNAME_running`.
 
 To be able to retrieve the status of VMs and containers, the user used to connect must minimally have the `VM.Audit` privilege. Below is a guide to how to configure a new user with the minimum required permissions.
 
-### Create Home Assistant Role
+### Create Home Assistant Group
 
-Before creating the user, we need to create a permissions role for the user.
+Before creating the user, we need to create a group for the user.
+Privileges can be either applied to Groups or Roles.
 
 1. Click `Datacenter`
-2. Open `Permissions` and click `Roles`
-3. Click the `Create` button above all the existing roles
-4. name the new role (e.g.,  "home-assistant")
-5. Click the arrow next to privileges and select `VM.Audit` in the dropdown
-6. Click `Create`
+2. Open `Permissions` and click `Groups`
+3. Click the `Create` button above all the existing groups
+4. Name the new group (e.g.,  "HomeAssistant")
+5. Click `Create`
+
+### Add Group Permissions to all Assets
+
+For the group to access the VMs we need to grant it the auditor role
+
+1. Click `Datacenter`
+2. Click `Permissions`
+3. Open `Add` and click `Group Permission`
+4. Select "/" for the path
+5. Select your Home Assistant group (`HomeAssistant`)
+6. Select the Auditor role (`PVEAuditor`)
+7. Make sure `Propagate` is checked
 
 ### Create Home Assistant User
 
-Creating a dedicated user for Home Assistant, limited to only the role just created is the most secure method. These instructions use the `pve` realm for the user. This allows a connection, but ensures that the user is not authenticated for SSH connections. If you use the `pve` realm, just be sure to add `realm: pve` to your configuration.
+Creating a dedicated user for Home Assistant, limited to only to the access just created is the most secure method. These instructions use the `pve` realm for the user. This allows a connection, but ensures that the user is not authenticated for SSH connections. If you use the `pve` realm, just be sure to add `realm: pve` to your configuration.
 
 1. Click `Datacenter`
 2. Open `Permissions` and click `Users`
 3. Click `Add`
 4. Enter a username (e.g., "hass")
 5. Set the realm to "Proxmox VE authentication server"
- Enter a secure password (it can be complex as you will only need to copy/paste it into your Home Assistant configuration)
-6. Ensure `Enabled` is checked and `Expire` is set to "never"
-7. Click `Add`
-
-### Add User Permissions to Assets
-
-To apply the user and role just created, we need to give it permissions
-
-1. Click `Datacenter`
-2. Click `Permissions`
-3. Open `Add` and click `User Permission`
-4. Select "/" for the path
-5. Select your Home Assistant user (`hass`)
-6. Select the Home Assistant role (`home-assistant`)
-7. Make sure `Propagate` is checked
+6. Enter a secure password (it can be complex as you will only need to copy/paste it into your Home Assistant configuration)
+7. Select the group just created earlier (`HomeAssistant`) to grant access to Proxmox
+8. Ensure `Enabled` is checked and `Expire` is set to "never"
+9. Click `Add`


### PR DESCRIPTION
1. Not creating a new role when there is no benefit (it uses the existing auditor role)
2. Grant permission with groups instead of roles. It is best practice to grant roles to groups instead of users directly for ease of management and scalability.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
