### PR TITLE
Update documentation for the light integration

### DIFF
--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -13,13 +13,15 @@ This integration allows you to track and control various light bulbs. Read the i
 
 ### Default turn-on values
 
-To set the default color, brightness and transition values when the light is turned on, create a custom `light_profiles.csv`, normally located in the default config folder where you find `configuration.yaml`. 
-The `light_profiles.csv` has to have a header, which is skipped when [the file is read](https://github.com/home-assistant/core/blob/7c783dc1b45ca63f071da9d3fc97d85b1b7039b7/homeassistant/components/light/__init__.py#L318).
-The format of the header is
-```
+To set the default color, brightness and transition values when the light is turned on, create a custom `light_profiles.csv`, normally located in the default configuration folder where you find `configuration.yaml`. 
+
+The `light_profiles.csv` has to have a header. The format of the header is:
+
+```txt
 profile,color_x,color_y,brightness,transition
 ```
-The field transition is optional and can be omitted, [see here for reference](https://github.com/home-assistant/core/blob/7c783dc1b45ca63f071da9d3fc97d85b1b7039b7/homeassistant/components/light/__init__.py#L324-328)
+
+The field transition is optional and can be omitted.
 
 The `.default` suffix should be added to the entity identifier of each light to define a default value, e.g., for `light.ceiling_2` the `profile` field is `light.ceiling_2.default`. To define a default for all lights, the identifier `group.all_lights.default` can be used. Individual settings always supercede the `all_lights` default setting.
 

--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -13,9 +13,15 @@ This integration allows you to track and control various light bulbs. Read the i
 
 ### Default turn-on values
 
-To set the default color, brightness and transition values when the light is turned on, create a custom `light_profiles.csv` (as described below in the `profile` attribute of `light.turn_on`).
+To set the default color, brightness and transition values when the light is turned on, create a custom `light_profiles.csv`, normally located in the default config folder where you find `configuration.yaml`. 
+The `light_profiles.csv` has to have a header, which is skipped when [the file is read](https://github.com/home-assistant/core/blob/7c783dc1b45ca63f071da9d3fc97d85b1b7039b7/homeassistant/components/light/__init__.py#L318).
+The format of the header is
+```
+profile,color_x,color_y,brightness,transition
+```
+The field transition is optional and can be omitted, [see here for reference](https://github.com/home-assistant/core/blob/7c783dc1b45ca63f071da9d3fc97d85b1b7039b7/homeassistant/components/light/__init__.py#L324-328)
 
-The `.default` suffix should be added to the entity identifier of each light to define a default value, e.g., for `light.ceiling_2` the `id` field is `light.ceiling_2.default`. To define a default for all lights, the identifier `group.all_lights.default` can be used. Individual settings always supercede the `all_lights` default setting.
+The `.default` suffix should be added to the entity identifier of each light to define a default value, e.g., for `light.ceiling_2` the `profile` field is `light.ceiling_2.default`. To define a default for all lights, the identifier `group.all_lights.default` can be used. Individual settings always supercede the `all_lights` default setting.
 
 ### Service `light.turn_on`
 


### PR DESCRIPTION
The instructions about default turn-on values were not clear.

## Proposed change
Updated information about default turn-on values



## Type of change
- [X] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- This PR fixes or closes issue: fixes #16566

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - [X] I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
