### PR TITLE
Remove YAML optionals from Sighthound config example

### DIFF
--- a/source/_integrations/sighthound.markdown
+++ b/source/_integrations/sighthound.markdown
@@ -12,7 +12,7 @@ ha_domain: sighthound
 
 Detect people in camera images using [Sighthound Cloud](https://www.sighthound.com/products/cloud). The Sighthound Developer tier (free for non-commercial use) allows 5000 images to be processed per month. If you need more processing per month you will need to sign up for a production account (i.e., a Basic or Pro account).
 
-This integration adds an image processing entity where the state of the entity is the number of people detected in an image. For each person detected, an `sighthound.person_detected` event is fired. The event data includes the entity_id of the image processing entity firing the event, and the bounding box around the detected person. 
+This integration adds an image processing entity where the state of the entity is the number of people detected in an image. For each person detected, an `sighthound.person_detected` event is fired. The event data includes the entity_id of the image processing entity firing the event, and the bounding box around the detected person.
 
 If `save_file_folder` is configured, on each new detection of a person, an annotated image with the name `sighthound_{camera_name}_latest.jpg` is saved in the configured folder if it doesn't already exist, and overwritten if it does exist. The saved image shows the bounding box around detected people and can be displayed on the Home Assistant front end using a [Local File](/integrations/local_file/) camera, and used in notifications. If `save_timestamped_file` is configured as `true`, then the annotated image is saved with a file name that includes the time of detection.
 
@@ -26,9 +26,7 @@ To enable this platform in your installation, add the following to your `configu
 # Example configuration.yaml entry
 image_processing:
   - platform: sighthound
-    api_key: some_key
-    save_file_folder: /my_dir/
-    save_timestamped_file: True
+    api_key: "MY_API_KEY"
     source:
       - entity_id: camera.my_cam
 ```
@@ -49,7 +47,7 @@ save_file_folder:
 save_timestamped_file:
   description: Save the processed image with the time of detection in the filename. Requires save_file_folder to be configured.
   required: false
-  type: string
+  type: boolean
 source:
   description: The list of image sources.
   required: true

--- a/source/_integrations/sighthound.markdown
+++ b/source/_integrations/sighthound.markdown
@@ -47,6 +47,7 @@ save_file_folder:
 save_timestamped_file:
   description: Save the processed image with the time of detection in the filename. Requires save_file_folder to be configured.
   required: false
+  default: false
   type: boolean
 source:
   description: The list of image sources.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Removes optional configuration keys from the initial example, additionally, corrects a type in the configuration block.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/core#47256

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
