### PR TITLE
Enquote username/password in evohome example

### DIFF
--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -33,8 +33,8 @@ To set up this integration, add the following to your `configuration.yaml` file:
 ```yaml
 # Example configuration.yaml entry
 evohome:
-  username: YOUR_USERNAME
-  password: YOUR_PASSWORD
+  username: "YOUR_USERNAME"
+  password: "YOUR_PASSWORD"
 ```
 
 {% configuration %}
@@ -64,8 +64,8 @@ This is an IoT cloud-polling integration and the recommended minimum `scan_inter
 
 TCC systems are implemented as a _location_, which consist of 1-12 _zones_ and, optionally, a DHW controller:
 
- - The system location (e.g., a house) is used for operating modes such as home, away, economy, etc.
- - Heating zones (e.g., rooms) are used for the target temperature.
+- The system location (e.g., a house) is used for operating modes such as home, away, economy, etc.
+- Heating zones (e.g., rooms) are used for the target temperature.
 
 ### Evohome
 
@@ -113,7 +113,7 @@ In the Home Assistant schema, all this is done via a combination of `HVAC_MODE` 
 
 ## Service Calls
 
-This integration provides its own service calls to expose the full functionality of TCC systems beyond the limitations of Home Assistant's standardised schema. Mostly, this relates to specifying the duration of mode changes, after which time the entities revert to **Auto** or **FollowSchedule** (for locations and zones, respectively).
+This integration provides its own service calls to expose the full functionality of TCC systems beyond the limitations of Home Assistant's standardized schema. Mostly, this relates to specifying the duration of mode changes, after which time the entities revert to **Auto** or **FollowSchedule** (for locations and zones, respectively).
 
 It is recommended to use the native service calls (e.g., `evohome.set_system_mode`) instead of Home Assistant's generic equivalents (e.g., `climate.set_hvac_mode`) whenever possible. However, it may be necessary to use the generic service calls for integration with 3rd party systems such as Amazon Alexa or Google Home.
 
@@ -159,7 +159,7 @@ This service call will set the `setpoint` of a zone, as identified by its `entit
 - action:
     - service: evohome.set_zone_override
       target:
-        entity_id: climate.loungeroom\
+        entity_id: climate.loungeroom
       data:
         setpoint: 10
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Feedback on that the example should have enquoted values. Which is matching our new YAML standards.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: #16797

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
