### PR TITLE
Add missing Switch device classes

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -66,12 +66,13 @@ initial_state:
 
 #### Device Class
 
-Device class is currently supported by the following components:
+Device class is currently supported by the following platforms:
 
-* [Binary Sensor](/integrations/binary_sensor/)
-* [Sensor](/integrations/sensor/)
-* [Cover](/integrations/cover/)
-* [Media Player](/integrations/media_player/)
+- [Binary Sensor](/integrations/binary_sensor/)
+- [Cover](/integrations/cover/)
+- [Media Player](/integrations/media_player/)
+- [Sensor](/integrations/sensor/)
+- [Switch](/integrations/switch/)
 
 ### Manual customization
 
@@ -123,7 +124,7 @@ Home Assistant offers a service to reload the core configuration while Home Assi
 
 To reload customizations, navigate to Configuration > Server Controls and then press the "Reload Location & Customizations" button. If you don't see this, enable Advanced Mode on your user profile page first.
 
-Alternatively, you can reload via service call. Navigate to Developer Tools > Services tab, select `homeassistant.reload_core_config` from the dropdown and press the "Call Service" button. 
+Alternatively, you can reload via service call. Navigate to Developer Tools > Services tab, select `homeassistant.reload_core_config` from the dropdown and press the "Call Service" button.
 
 <div class='note warning'>
 New customize information will be applied the next time the state of the entity gets updated.

--- a/source/_integrations/switch.markdown
+++ b/source/_integrations/switch.markdown
@@ -16,6 +16,14 @@ Keeps track which switches are in your environment, their state and allows you t
 - Maintains a state per switch and a combined state `all_switches`.
 - Registers services `switch.turn_on`, `switch.turn_off`, and `switch.toggle` to control switches.
 
+## Device Class
+
+The way these switches are displayed in the frontend can be modified in the [customize section](/docs/configuration/customizing-devices/). The following device classes are supported for switches:
+
+- **None**: Generic switch. This is the default and doesn't need to be set.
+- **outlet**: This switch, switches a power outlet.
+- **switch**: A generic switch.
+
 ## Use the services
 
 In the frontend open the sidebar. At the bottom, under **Developer Tools**, click **Services**. From the Service dropdown menu choose `switch.turn_on` or `switch.turn_off` from the list of available services. In the Entity dropdown menu choose or enter the entity ID you want to work with. This will enter something like the sample below into the **Service Data** field. Now hit **CALL SERVICE**.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Switches currently have 2 devices classes available, however, these aren't documented.
Yet, they show up in the customization UI, raising questions.

This PR adds the device classes for the switch platform to the documentation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #16691

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
