### PR TITLE
Update device-specific.markdown

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -214,7 +214,7 @@ For Inovelli LZW30-SN and LZW31-SN switches with a third button for configuratio
 
 Once this is complete, `zwave.scene_activated` events will fire according to which button press you perform. For information on what button press corresponds to what scene_id and scene_data in the event, see [Inovelli Knowledge Base > How To: Setting Up Scenes In Home Assistant](https://support.inovelli.com/portal/en/kb/articles/how-to-setting-up-scenes-in-home-assistant).
 
-### Zooz Scene Capable On/Off and Dimmer Wall Switches (Zen21v3 & Zen22v2 - Firmware 3.0+, Zen26 & Zen27 - Firmware 2.0+, Zen30 Double Switch, Zen34 Remote Switch)
+### Zooz Scene Capable On/Off and Dimmer Wall Switches (Zen21v3 & Zen22v2 - Firmware 3.0+, Zen26 & Zen27 - Firmware 2.0+, Zen30 Double Switch, Zen32 Scene Controller, Zen34 Remote Switch)
 
 Many Zooz switches that have been sold do not have the latest firmwares. Contact Zooz to obtain the over the air firmware update instructions and new user manual for the switches.
 
@@ -746,11 +746,146 @@ Zen30 (Double Switch):
   </Value>
 </CommandClass>
 ```
+Zen32 Scene Controller:
+
+```xml
+<CommandClass id="112">
+  <Value type="list" genre="config" index="1" label="LED indicator mode for relay" size="1" min="0" max="3" value="0">
+    <Help></Help>
+    <Item label="LED on when relay off, LED off when relay on" value="0"/>
+    <Item label="LED on when relay on, LED off when relay off" value="1"/>
+    <Item label="LED always off" value="2"/>
+    <Item label="LED always on" value="3"/>
+  </Value>
+  <Value type="list" genre="config" index="2" label="LED indicator mode for Button 1" size="1" min="0" max="3" value="0">
+    <Help></Help>
+    <Item label="LED on when dimmer off, LED off when dimmer on" value="0"/>
+    <Item label="LED on when dimmer on, LED off when dimmer off" value="1"/>
+    <Item label="LED always off" value="2"/>
+    <Item label="LED always on" value="3"/>
+  </Value>
+  <Value type="list" genre="config" index="3" label="LED indicator mode for Button 2" size="1" min="0" max="3" value="0">
+    <Help></Help>
+    <Item label="LED on when dimmer off, LED off when dimmer on" value="0"/>
+    <Item label="LED on when dimmer on, LED off when dimmer off" value="1"/>
+    <Item label="LED always off" value="2"/>
+    <Item label="LED always on" value="3"/>
+  </Value>
+  <Value type="list" genre="config" index="4" label="LED indicator mode for Button 3" size="1" min="0" max="3" value="0">
+    <Help></Help>
+    <Item label="LED on when dimmer off, LED off when dimmer on" value="0"/>
+    <Item label="LED on when dimmer on, LED off when dimmer off" value="1"/>
+    <Item label="LED always off" value="2"/>
+    <Item label="LED always on" value="3"/>
+  </Value>
+  <Value type="list" genre="config" index="5" label="LED indicator mode for Button 4" size="1" min="0" max="3" value="0">
+    <Help></Help>
+    <Item label="LED on when dimmer off, LED off when dimmer on" value="0"/>
+    <Item label="LED on when dimmer on, LED off when dimmer off" value="1"/>
+    <Item label="LED always off" value="2"/>
+    <Item label="LED always on" value="3"/>
+  </Value>
+  <Value type="list" genre="config" index="6" label="LED indicator color for relay" size="1" min="0" max="3" value="0">
+    <Help></Help>
+    <Item label="white" value="0"/>
+    <Item label="blue" value="1"/>
+    <Item label="green" value="2"/>
+    <Item label="red" value="3"/>
+  </Value>
+  <Value type="list" genre="config" index="7" label="LED indicator color for Button 1" size="1" min="0" max="3" value="0">
+    <Help></Help>
+    <Item label="white" value="0"/>
+    <Item label="blue" value="1"/>
+    <Item label="green" value="2"/>
+    <Item label="red" value="3"/>
+  </Value>
+  <Value type="list" genre="config" index="8" label="LED indicator color for Button 2" size="1" min="0" max="3" value="0">
+    <Help></Help>
+    <Item label="white" value="0"/>
+    <Item label="blue" value="1"/>
+    <Item label="green" value="2"/>
+    <Item label="red" value="3"/>
+  </Value>
+  <Value type="list" genre="config" index="9" label="LED indicator color for Button 3" size="1" min="0" max="3" value="0">
+    <Help></Help>
+    <Item label="white" value="0"/>
+    <Item label="blue" value="1"/>
+    <Item label="green" value="2"/>
+    <Item label="red" value="3"/>
+  </Value>
+  <Value type="list" genre="config" index="10" label="LED indicator color for Button 4" size="1" min="0" max="3" value="0">
+    <Help></Help>
+    <Item label="white" value="0"/>
+    <Item label="blue" value="1"/>
+    <Item label="green" value="2"/>
+    <Item label="red" value="3"/>
+  </Value>
+  <Value type="list" genre="config" index="11" label="LED indicator brightness for relay" size="1" min="0" max="2" value="0">
+    <Help></Help>
+    <Item label="bright (100%)" value="0"/>
+    <Item label="medium (60%)" value="1"/>
+    <Item label="low (30%)" value="2"/>
+  </Value>
+  <Value type="list" genre="config" index="12" label="LED indicator brightness for Button 1" size="1" min="0" max="2" value="0">
+    <Help></Help>
+    <Item label="bright (100%)" value="0"/>
+    <Item label="medium (60%)" value="1"/>
+    <Item label="low (30%)" value="2"/>
+  </Value>
+  <Value type="list" genre="config" index="13" label="LED indicator brightness for Button 2" size="1" min="0" max="2" value="0">
+    <Help></Help>
+    <Item label="bright (100%)" value="0"/>
+    <Item label="medium (60%)" value="1"/>
+    <Item label="low (30%)" value="2"/>
+  </Value>
+  <Value type="list" genre="config" index="14" label="LED indicator brightness for Button 3" size="1" min="0" max="2" value="0">
+    <Help></Help>
+    <Item label="bright (100%)" value="0"/>
+    <Item label="medium (60%)" value="1"/>
+    <Item label="low (30%)" value="2"/>
+  </Value>
+  <Value type="list" genre="config" index="15" label="LED indicator brightness for Button 4" size="1" min="0" max="2" value="0">
+    <Help></Help>
+    <Item label="bright (100%)" value="0"/>
+    <Item label="medium (60%)" value="1"/>
+    <Item label="low (30%)" value="2"/>
+  </Value>
+  <Value type="int" genre="config" index="16" label="Auto turn-off timer for relay" size="4" min="0" max="65535" value="0" units="minutes">
+     <Help>Set the time (in minutes) after which you want the switch to automatically turn off once it has been turned on.</Help>
+  </Value>
+  <Value type="int" genre="config" index="17" label="Auto turn-on timer for relay" size="4" min="0" max="65535" value="0" units="minutes">
+    <Help>Set the time (in minutes) after which you want the switch to automatically turn on once it has been turned off.</Help>
+  </Value>
+  <Value type="list" genre="config" index="18" label="State after power failure" size="1" min="0" max="2" value="0">
+    <Help></Help>
+    <Item label="Relay and buttons remember and restore last state" value="0"/>
+    <Item label="Relay and buttons forced to off after power failure" value="1"/>
+    <Item label="Relay and buttons forced to on after power failure" value="2"/>
+  </Value>
+  <Value type="list" genre="config" index="19" label="Disable / enable control on the relay" size="1" min="0" max="2" value="1">
+    <Help></Help>
+    <Item label="Disable local / physical control (from the button), enable Z-Wave control" value="0"/>
+    <Item label="Enable local / physical control (from the button), enable Z-Wave control" value="1"/>
+    <Item label="Disable local / physical control (from the button), disable Z-Wave control" value="2"/>
+  </Value>
+  <Value type="list" genre="config" index="20" label="Relay behavior with disabled local / Z-Wave control" size="1" min="0" max="1" value="1">
+    <Help></Help>
+    <Item label="report on/off status when button is pressed and change LED indicator status if Parameter 19 is set to value 0 or 2" value="0"/>
+    <Item label="DON’T report on/off status when button is pressed and DON’T change LED indicator status if Parameter 19 is set to value 0 or 2 (but the relay will always send central scene command)" value="1"/>
+  </Value>
+  <Value type="list" genre="config" index="21" label="3-way switch type" size="1" min="0" max="1" value="0">
+    <Help>Choose the type of 3-way switch you want to use with this switch in a 3-way set-up.</Help>
+    <Item label="regular mechanical 3-way on/off switch, use the connected 3-way switch to turn the light on or off (default)" value="0"/>
+    <Item label="momentary switch, click once to change status (light on or off)" value="1"/>
+  </Value>
+</CommandClass>
+```
+
 Zen34 Remote Switch:
 
 ```xml
 <CommandClass id="112">
-  <Value type="list" index="1" genre="config" label="LED indicator mode" units="" min="0" max="3" value="1" size="1">
+ <Value type="list" index="1" genre="config" label="LED indicator mode" units="" min="0" max="3" value="1" size="1">
      <Help>Choose the LED indicator mode for your Remote Switch</Help>
         <Item label="LED always off" value="0" />
         <Item label="LED on when button is pressed to indicate scene activation or association command" value="1" />
@@ -799,6 +934,21 @@ For the Zooz Zen30 Double Switch, you'll need to add the `COMMAND_CLASS_CENTRAL_
   <Value type="int" genre="user" instance="1" index="1" label="Bottom Button Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
   <Value type="int" genre="user" instance="1" index="2" label="Top Button Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
   <Value type="int" genre="user" instance="1" index="3" label="Relay Button Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
+</CommandClass>
+```
+
+For the Zooz Zen32 Scene Controller, you'll need to add the `COMMAND_CLASS_CENTRAL_SCENE` for each node in your `zwcfg` file with the following:
+
+```xml
+<CommandClass id="91" name="COMMAND_CLASS_CENTRAL_SCENE" version="1" request_flags="4" innif="true" scenecount="0">
+  <Instance index="1" />
+  <Value type="int" genre="system" instance="1" index="0" label="Scene Count" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="2" />
+  <Value type="int" genre="user" instance="1" index="1" label="Top Button Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
+  <Value type="int" genre="user" instance="1" index="2" label="Small Button 1 Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
+  <Value type="int" genre="user" instance="1" index="3" label="Small Button 2 Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
+  <Value type="int" genre="user" instance="1" index="4" label="Small Button 3 Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
+  <Value type="int" genre="user" instance="1" index="5" label="Small Button 4 Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
+</CommandClass>
 </CommandClass>
 ```
 


### PR DESCRIPTION
Add entries for Zooz ZEN32 Scene Controller (advanced parameters and central scene)

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
Added necessary details for using a Zooz ZEN32 Scene Controller with legacy OZW 1.4
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
