### PR TITLE
Update cover template documentation to check state before calling

### DIFF
--- a/source/_integrations/cover.template.markdown
+++ b/source/_integrations/cover.template.markdown
@@ -145,7 +145,8 @@ In this section you will find some real-life examples of how to use this cover.
 ### Garage Door
 
 This example converts a garage door with a controllable switch and position
-sensor into a cover.
+sensor into a cover.  The condition check is optional, but suggested if you
+use the same switch to open and close the garage.
 
 {% raw %}
 
@@ -158,13 +159,21 @@ cover:
         friendly_name: "Garage Door"
         position_template: "{{ states('sensor.garage_door') }}"
         open_cover:
-          service: switch.turn_on
-          target:
-            entity_id: switch.garage_door
+          - condition:
+            condition: state
+            entity_id: sensor.garage_door
+            state: 'off'
+          - service: switch.turn_on
+            target:
+              entity_id: switch.garage_door
         close_cover:
-          service: switch.turn_off
-          target:
-            entity_id: switch.garage_door
+          - condition:
+            condition: state
+            entity_id: sensor.garage_door
+            state: 'on'
+          - service: switch.turn_off
+            target:
+              entity_id: switch.garage_door
         stop_cover:
           service: switch.turn_on
           target:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This prevents Google Assistant from opening a door without security
via the "close" command.

See https://github.com/home-assistant/core/pull/47054
and https://github.com/home-assistant/core/pull/46088 for more info.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

I'm not sure whether to put on current or next.  It seems the file name changed so it doesn't cleanly apply.  I'm fine with it just going into next, but I don't think it makes sense to update twice.
