### PR TITLE
Add note about tested hardware in NAD documentation

### DIFF
--- a/source/_integrations/nad.markdown
+++ b/source/_integrations/nad.markdown
@@ -10,6 +10,11 @@ ha_domain: nad
 
 The `nad` platform allows you to control a [NAD receiver](https://nadelectronics.com/) through RS232, TCP and Telnet from Home Assistant.
 
+Please note that the RS232 interface is only tested with the NAD T748v2, but is should work with more NAD receivers.
+The Telnet interface is only tested with the NAD T787.
+
+## Configuration
+
 To add an NAD receiver to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -18,12 +23,13 @@ media_player:
   - platform: nad
     serial_port: /dev/ttyUSB0
 ```
+
 ```yaml
 # Example configuration.yaml entry for TCP configuration
 media_player:
   - platform: nad
     type: TCP
-    host: IP_ADDRESS
+    host: "IP_ADDRESS"
 ```
 
 {% configuration %}
@@ -89,7 +95,7 @@ A full configuration example could look like this:
 media_player:
   - platform: nad
     serial_port: /dev/ttyUSB0
-    name: NAD Receiver
+    name: "NAD Receiver"
     min_volume: -60
     max_volume: -20
     sources:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds a small note about supported/known hardware in the NAD documentation.
It is based on the note from the upstream library used.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: closes #16725

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
