### PR TITLE
Add picnic integration docs

### DIFF
--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -24,7 +24,7 @@ This integration provides the following sensors. The term delivery and order
 | Name                           | Description                                                                                                                                         |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Completed deliveries           | Number of delivered orders.                                                                                                                     |
-| Total orders                   | Total amount of orders, including cancelled orders, deliveries in progress and completed deliveries.                                                |
+| Total orders                   | Total amount of orders, including canceled orders, deliveries in progress and completed deliveries.                                                |
 | Cart items count               | The amount of different products currently in the cart.                                                                                             |
 | Cart total price               | The total price for products currently in the cart.                                                                                                 |
 | Selected slot start            | Start of the selected delivery slot, `unavailable` if none is selected.                                                                             |

--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -3,7 +3,7 @@ title: Picnic
 description: How to setup and use the Picnic integration in Home Assistant.
 ha_category:
   - Other
-ha_release: 2021.4
+ha_release: 2021.5
 ha_iot_class: Cloud Polling
 ha_config_flow: true
 ha_codeowners:
@@ -19,12 +19,10 @@ The Picnic integration allows one to get information from [Picnic](https://picni
 
 ## Sensors
 
-This integration provides the following sensors. The term delivery and order
+This integration provides the following sensors. Some sensors are disabled by default when adding the integration.
 
 | Name                           | Description                                                                                                                                         |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Completed deliveries           | Number of delivered orders.                                                                                                                     |
-| Total orders                   | Total amount of orders, including canceled orders, deliveries in progress and completed deliveries.                                                |
 | Cart items count               | The amount of different products currently in the cart.                                                                                             |
 | Cart total price               | The total price for products currently in the cart.                                                                                                 |
 | Selected slot start            | Start of the selected delivery slot, `unavailable` if none is selected.                                                                             |

--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -1,0 +1,40 @@
+---
+title: Picnic
+description: How to setup and use the Picnic integration in Home Assistant.
+ha_category:
+  - Other
+ha_release: 2021.4
+ha_iot_class: Cloud Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@corneyl'
+ha_domain: picnic
+ha_platforms:
+  - sensor
+---
+
+The Picnic component allows one te get information from [Picnic](https://picnic.app) about orders, deliveries and cart contents.
+
+{% include integrations/config_flow.md %}
+
+## Sensors
+
+This integration provides the following sensors. The term delivery and order
+
+| Name                           | Description                                                                                                                                         |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Completed deliveries           | Number of delivered orders.                                                                                                                     |
+| Total orders                   | Total amount of orders, including cancelled orders, deliveries in progress and completed deliveries.                                                |
+| Cart items count               | The amount of different products currently in the cart.                                                                                             |
+| Cart total price               | The total price for products currently in the cart.                                                                                                 |
+| Selected slot start            | Start of the selected delivery slot, `unavailable` if none is selected.                                                                             |
+| Selected slot end              | End of the selected delivery slot, `unavailable` if none is selected.                                                                               |
+| Selected slot max order time   | Maximum time it's still possible to place an order for the selected delivery slot, `unavailable` if none is selected.                               |
+| Selected slot min order value  | The minimum order value needed to be able to place an order for the selected delivery window slot, `unavailable` if none is selected.               |
+| Last order slot start          | Start of the last placed order's delivery slot                                                                                                      |
+| Last order slot end            | End of the last placed order's delivery slot                                                                                                        |
+| Last order status              | Status of the last order, either `CURRENT`, `CANCELLED` or `COMPLETED`. Will only transition to `COMPLETED` after the invoice email has been sent.  |
+| Last order ETA start           | Start of the ETA window of the last order, will get more precise if the driver is underway.                                                         |
+| Last order ETA end             | End of the ETA window of the last order.                                                                                                            |
+| Last order delivery time       | The delivery time of the last order, `unavailable` if not yet delivered.                                                                            |
+| Last order total price         | The total price of the last order.                                                                                                                  |

--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -13,7 +13,7 @@ ha_platforms:
   - sensor
 ---
 
-The Picnic component allows one te get information from [Picnic](https://picnic.app) about orders, deliveries and cart contents.
+The Picnic integration allows one to get information from [Picnic](https://picnic.app) about orders, deliveries and cart content.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation of new Picnic integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/47507
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2321
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
