### PR TITLE
Remove broken link from ASUSWRT

### DIFF
--- a/source/_integrations/asuswrt.markdown
+++ b/source/_integrations/asuswrt.markdown
@@ -16,7 +16,7 @@ ha_platforms:
   - sensor
 ---
 
-The `asuswrt` integration is the main integration to connect to a [ASUSWRT](https://www.asus.com/ASUSWRT/) based router.
+The ASUSWRT integration can connect Home Assistant to a ASUS router that runs on ASUSWRT firmware.
 
 There is currently support for the following device types within Home Assistant:
 
@@ -57,7 +57,7 @@ It is possible to change some behaviors through the integration options. These c
 - **Dnsmasq**: The location in the router of the dnsmasq.leases files
 - **Require IP**: If devices must have IP (this option is available only for access point mode)
 
-**Note**: if you don't want to automatically track new detected device, disable the integration system option `Enable new added entities` 
+**Note**: if you don't want to automatically track new detected device, disable the integration system option `Enable new added entities`
 
 ## Padavan custom firmware (The rt-n56u project)
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Fixes broken link reported in #16889. Unfortunately, it seems like ASUS no longer has a page on the ASUSWRT firmware.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #16889

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
