### PR TITLE
Ensure continuous mode is not used

### DIFF
--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -33,7 +33,7 @@ This platform has been tested and is confirmed to be working with the iRobot Roo
 
 <div class='note'>
 
-The Roomba's MQTT server only allows a single connection. Enabling continuous mode will force the App to connect via the cloud to your Roomba. [More info here](https://github.com/NickWaterton/Roomba980-Python#firmware-2xx-notes)
+The Roomba's MQTT server only allows a single connection. If another smart home platform uses continues mode, Home Assistant will not be able to connect to your Roomba. Enabling continuous mode in Home Assistant will force the App to connect via the cloud to your Roomba. [More info here](https://github.com/NickWaterton/Roomba980-Python#firmware-2xx-notes)
 
 </div>
 
@@ -58,5 +58,11 @@ docker exec -it CONTAINER_NAME_OR_ID python -c 'import roombapy.entry_points; ro
 <div class='note'>
   
 The command to retrieve the credentials does not need any additional software to be installed because it uses the built-in [roombapy](https://github.com/pschmitt/roombapy) package and [password](https://github.com/pschmitt/roombapy/blob/1.6.1/roomba/entry_points.py#L20) function deployed with Home Assistant.
+
+</div>
+
+<div class='note'>
+  
+If the password cannot be retrieved, another smart home system may be using continuous mode. Ensure no other systems use your Roomba and try again. 
 
 </div>


### PR DESCRIPTION
I had a Homey with Roomba integration running which caused the automatic integration and manual retrieval of the password to fail. Disabling the Homey app allowed Home assistant to complete the setup flawlessly.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
