### PR TITLE
Update using_blueprints.markdown

### DIFF
--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -45,6 +45,6 @@ The Home Assistant Community forums have a specific tag for blueprints. This tag
 
 [blueprint-forums]: /get-blueprints
 
-## Split Config
+## Troubleshooting missing automations
 
-When creating automations using the GUI, they are written to `automations.yaml` even if you have a [split config](/docs/configuration/splitting_configuration/#example-combine-include_dir_merge_list-with-automationsyaml). Make sure you are correctly including the base `automations.yaml` file.
+Some users may find that when creating automations using the blueprints, they appear to be created but never show in the automations page. When creating automations using the GUI, they are written to `automations.yaml` even if you have a [split configuration](/docs/configuration/splitting_configuration/#example-combine-include_dir_merge_list-with-automationsyaml). Make sure you are correctly including the base `automations.yaml` file to ensure they are loaded.

--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -44,3 +44,7 @@ The Home Assistant Community forums have a specific tag for blueprints. This tag
 [Visit the Home Assistant forums][blueprint-forums]
 
 [blueprint-forums]: /get-blueprints
+
+## Split Config
+
+When creating automations using the GUI, they are written to `automations.yaml` even if you have a [split config](/docs/configuration/splitting_configuration/#example-combine-include_dir_merge_list-with-automationsyaml). Make sure you are correctly including the base `automations.yaml` file.

--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -47,4 +47,4 @@ The Home Assistant Community forums have a specific tag for blueprints. This tag
 
 ## Troubleshooting missing automations
 
-When creating automations using blueprints, you may find they appear to be created but never show in the automations page. When creating automations using the GUI, they are written to `automations.yaml`; make sure you have `automation: !include automations.yaml` in `configuration.yaml`.
+When you're creating automations using blueprints and they don't appear in the UI, make sure that you add back `automation: !include automations.yaml` from the default configuration to your `configuration.yaml`.

--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -47,4 +47,4 @@ The Home Assistant Community forums have a specific tag for blueprints. This tag
 
 ## Troubleshooting missing automations
 
-When creating automations using blueprints, you may find they appear to be created but never show in the automations page. When creating automations using the GUI, they are written to `automations.yaml` make sure you have `automation: !include automations.yaml` in `configuration.yaml`.
+When creating automations using blueprints, you may find they appear to be created but never show in the automations page. When creating automations using the GUI, they are written to `automations.yaml`; make sure you have `automation: !include automations.yaml` in `configuration.yaml`.

--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -47,4 +47,4 @@ The Home Assistant Community forums have a specific tag for blueprints. This tag
 
 ## Troubleshooting missing automations
 
-Some users may find that when creating automations using the blueprints, they appear to be created but never show in the automations page. When creating automations using the GUI, they are written to `automations.yaml` even if you have a [split configuration](/docs/configuration/splitting_configuration/#example-combine-include_dir_merge_list-with-automationsyaml). Make sure you are correctly including the base `automations.yaml` file to ensure they are loaded.
+When creating automations using blueprints, you may find they appear to be created but never show in the automations page. When creating automations using the GUI, they are written to `automations.yaml` even if you have a [split configuration](/docs/configuration/splitting_configuration/#example-combine-include_dir_merge_list-with-automationsyaml). Make sure you are correctly including the base `automations.yaml` file to ensure they are loaded.

--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -47,4 +47,4 @@ The Home Assistant Community forums have a specific tag for blueprints. This tag
 
 ## Troubleshooting missing automations
 
-When creating automations using blueprints, you may find they appear to be created but never show in the automations page. When creating automations using the GUI, they are written to `automations.yaml` even if you have a [split configuration](/docs/configuration/splitting_configuration/#example-combine-include_dir_merge_list-with-automationsyaml). Make sure you are correctly including the base `automations.yaml` file to ensure they are loaded.
+When creating automations using blueprints, you may find they appear to be created but never show in the automations page. When creating automations using the GUI, they are written to `automations.yaml` make sure you have `automation: !include automations.yaml` in `configuration.yaml`.


### PR DESCRIPTION
as per https://github.com/home-assistant/home-assistant.io/issues/16623

## Proposed change
adds missing warning about split config



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue:  https://github.com/home-assistant/home-assistant.io/issues/16623

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
