### PR TITLE
Docs for Hangouts integration: Chrome no longer seems to show oauth_code cookie

### DIFF
--- a/source/_integrations/hangouts.markdown
+++ b/source/_integrations/hangouts.markdown
@@ -34,7 +34,9 @@ Once the code is obtained fill in the form with your email, password and the aut
 2. Log into your Google account normally.
 3. You should be redirected to a loading screen. Copy the `oauth_code` cookie value set by this page and paste it here.
 
-To obtain the `oauth_code` cookie value using Chrome or Firefox, follow the steps below:
+To obtain the `oauth_code` cookie value, follow the steps below:
+
+*Note:* If the `oauth_code` cookie is not showing in Chrome, try in Firefox.
 
 * Press F12 to open developer tools.
 * Select the "Application" (Chrome) or "Storage" (Firefox) tab.

--- a/source/_integrations/hangouts.markdown
+++ b/source/_integrations/hangouts.markdown
@@ -36,7 +36,7 @@ Once the code is obtained fill in the form with your email, password and the aut
 
 To obtain the `oauth_code` cookie value, follow the steps below:
 
-*Note:* If the `oauth_code` cookie is not showing in Chrome, try in Firefox.
+*Note:* If the `oauth_code` cookie is not showing in Chrome, try Firefox.
 
 * Press F12 to open developer tools.
 * Select the "Application" (Chrome) or "Storage" (Firefox) tab.


### PR DESCRIPTION
It still works in Firefox, but Chrome doesn't seem to need/show that cookie any longer.

## Proposed change
* Add an additional note to the docs to advise users try Firefox instead of Chrome if they experience issues.. Something has changed in Chrome in the last ~6 months and it no longer seems to show the `oauth_code` cookie.

## Type of change
* Additional note to advise users to try Firefox if they cannot see the cookie in Chrome

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
