### PR TITLE
[template/alarm_control_panel] Add explanation for various 'code' usages

### DIFF
--- a/source/_integrations/alarm_control_panel.template.markdown
+++ b/source/_integrations/alarm_control_panel.template.markdown
@@ -45,7 +45,10 @@ alarm_control_panel:
           target:
             entity_id: alarm_control_panel.real_alarm
           data:
+            # assigning a value to 'code' will disregard any input from the UI, suitable for arming without manually entering the code
             code: !secret alarm_code
+            # assigning the correct template to 'code' will use the UI input, suitable for arming only after entering the correct code
+            #code: '{{code}}'
         disarm:
           - condition: state
             entity_id: device_tracker.paulus


### PR DESCRIPTION
## Proposed change

Extra details regarding the usages of the 'code' variable passsed in the alarm/disarm services

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
I spent a couple of hours debugging my local home assistant instance to figure out why the code I am entering in the UI is not taken into account.
Found out that the method `render_complex` called from [service.py](https://github.com/home-assistant/core/blob/a9a9e1f199e936f4528a2c96e7cb09afe27516d1/homeassistant/helpers/service.py#L217) needs the type of `value` to be an instance of `Template` so that the code enterd from the UI saved in `variables` can be [matched](https://github.com/home-assistant/core/blob/a9a9e1f199e936f4528a2c96e7cb09afe27516d1/homeassistant/helpers/template.py#L102)

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
