### PR TITLE
added another choose example

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -613,8 +613,7 @@ automation:
 
 More `choose` can be used together. This is the case of an IF-IF. 
 The following example shows how a single automation can control entities that aren't related to each other but have in common the same trigger.
-When the sun goes below the horizon; the `porch` and `garden` lights must turn on. If someone is watching the tv in the living room, there is a high chance that someone is in that room, therefore the living room lights have to turn on too. Same concept applies for the `studio` room.
-
+When the sun goes below the horizon, the `porch` and `garden` lights must turn on. If someone is watching the TV in the living room, there is a high chance that someone is in that room, therefore the living room lights have to turn on too. Same concept applies for the `studio` room.
 
 {% raw %}
 

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -617,52 +617,51 @@ More `choose` can be used together. This is the case of an IF-IF.
 
 ```yaml
 automation:
-- alias: "Turn lights on when the sun gets dim and if some room is occupied"
-  trigger:
-    platform: numeric_state
-    entity_id: sun.sun
-    value_template: '{{ state.attributes.elevation }}'
-    below: 4
-  condition: []
-  action:
-  - service: light.turn_on
-    data:
-      brightness: 255
-      color_temp: 366
-      transition: 200
-    entity_id:
-      - light.porch
-      - light.garden
-  - choose:
-    - conditions:
-      - condition: state
-        entity_id: input_boolean.livingroom_tv
-        state: 'on'
-      - condition: state
-        entity_id: light.livingroom
-        state: 'off'
-      sequence:
-      - service: light.turn_on
-        data:
-          brightness: 255
-          color_temp: 366
-          transition: 200
-          entity_id: light.livingroom
-  - choose:
-    - conditions:
-      - condition: state
-        entity_id: input_boolean.studio_pc
-        state: 'on'
-      - condition: state
-        entity_id: light.studio
-        state: 'off'
-      sequence:
-      - service: light.turn_on
-        data:
-          brightness: 255
-          color_temp: 366
-          transition: 200
-          entity_id: light.studio
+  - alias: "Turn lights on when the sun gets dim and if some room is occupied"
+      trigger:
+        - platform: numeric_state
+          entity_id: sun.sun
+          value_template: "{{ state.attributes.elevation }}"
+          below: 4
+      action:
+        - service: light.turn_on
+          data:
+            brightness: 255
+            color_temp: 366
+          target:
+            entity_id:
+              - light.porch
+              - light.garden
+        - choose:
+            - conditions:
+                - condition: state
+                  entity_id: binary_sensor.livingroom_tv
+                  state: on
+                - condition: state
+                  entity_id: light.livingroom
+                  state: off
+              sequence:
+                - service: light.turn_on
+                  data:
+                    brightness: 255
+                    color_temp: 366
+                  target:
+                    entity_id: light.livingroom
+        - choose:
+            - conditions:
+                - condition: state
+                  entity_id: binary_sensor.studio_pc
+                  state: on
+                - condition: state
+                  entity_id: light.studio
+                  state: off
+              sequence:
+                - service: light.turn_on
+                  data:
+                    brightness: 255
+                    color_temp: 366
+                  target:
+                    entity_id: light.studio
 ```
 
 {% endraw %}

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -611,11 +611,15 @@ automation:
 {% endraw %}
 
 
-More `choose` can be used together. This is the case of an IF-IF.
+More `choose` can be used together. This is the case of an IF-IF. 
+The following example shows how a single automation can control entities that aren't related to each other but have in common the same trigger.
+When the sun goes below the horizon; the `porch` and `garden` lights must turn on. If someone is watching the tv in the living room, there is a high chance that someone is in that room, therefore the living room lights have to turn on too. Same concept applies for the `studio` room.
+
 
 {% raw %}
 
 ```yaml
+# Example with "if" and "if"
 automation:
   - alias: "Turn lights on when the sun gets dim and if some room is occupied"
       trigger:
@@ -624,6 +628,7 @@ automation:
           value_template: "{{ state.attributes.elevation }}"
           below: 4
       action:
+        # This must always apply
         - service: light.turn_on
           data:
             brightness: 255
@@ -632,14 +637,12 @@ automation:
             entity_id:
               - light.porch
               - light.garden
+        # IF a entity is ON
         - choose:
             - conditions:
                 - condition: state
                   entity_id: binary_sensor.livingroom_tv
                   state: on
-                - condition: state
-                  entity_id: light.livingroom
-                  state: off
               sequence:
                 - service: light.turn_on
                   data:
@@ -647,14 +650,12 @@ automation:
                     color_temp: 366
                   target:
                     entity_id: light.livingroom
+         # IF another entity not related to the previous, is ON
         - choose:
             - conditions:
                 - condition: state
                   entity_id: binary_sensor.studio_pc
                   state: on
-                - condition: state
-                  entity_id: light.studio
-                  state: off
               sequence:
                 - service: light.turn_on
                   data:

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -656,7 +656,7 @@ automation:
             - conditions:
                 - condition: state
                   entity_id: binary_sensor.studio_pc
-                  state: on
+                  state: "on"
               sequence:
                 - service: light.turn_on
                   data:

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -643,7 +643,7 @@ automation:
             - conditions:
                 - condition: state
                   entity_id: binary_sensor.livingroom_tv
-                  state: on
+                  state: "on"
               sequence:
                 - service: light.turn_on
                   data:

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -610,6 +610,63 @@ automation:
 
 {% endraw %}
 
+
+More `choose` can be used together. This is the case of an IF-IF.
+
+{% raw %}
+
+```yaml
+automation:
+- alias: "Turn lights on when the sun gets dim and if some room is occupied"
+  trigger:
+    platform: numeric_state
+    entity_id: sun.sun
+    value_template: '{{ state.attributes.elevation }}'
+    below: 4
+  condition: []
+  action:
+  - service: light.turn_on
+    data:
+      brightness: 255
+      color_temp: 366
+      transition: 200
+    entity_id:
+      - light.porch
+      - light.garden
+  - choose:
+    - conditions:
+      - condition: state
+        entity_id: input_boolean.livingroom_tv
+        state: 'on'
+      - condition: state
+        entity_id: light.livingroom
+        state: 'off'
+      sequence:
+      - service: light.turn_on
+        data:
+          brightness: 255
+          color_temp: 366
+          transition: 200
+          entity_id: light.livingroom
+  - choose:
+    - conditions:
+      - condition: state
+        entity_id: input_boolean.studio_pc
+        state: 'on'
+      - condition: state
+        entity_id: light.studio
+        state: 'off'
+      sequence:
+      - service: light.turn_on
+        data:
+          brightness: 255
+          color_temp: 366
+          transition: 200
+          entity_id: light.studio
+```
+
+{% endraw %}
+
 [Script component]: /integrations/script/
 [automations]: /getting-started/automation-action/
 [Alexa/Amazon Echo]: /integrations/alexa/

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -626,7 +626,7 @@ automation:
       trigger:
         - platform: numeric_state
           entity_id: sun.sun
-          value_template: "{{ state.attributes.elevation }}"
+          attribute: elevation
           below: 4
       action:
         # This must always apply

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -611,9 +611,11 @@ automation:
 {% endraw %}
 
 
-More `choose` can be used together. This is the case of an IF-IF. 
+More `choose` can be used together. This is the case of an IF-IF.
+
 The following example shows how a single automation can control entities that aren't related to each other but have in common the same trigger.
-When the sun goes below the horizon, the `porch` and `garden` lights must turn on. If someone is watching the TV in the living room, there is a high chance that someone is in that room, therefore the living room lights have to turn on too. Same concept applies for the `studio` room.
+
+When the sun goes below the horizon, the `porch` and `garden` lights must turn on. If someone is watching the TV in the living room, there is a high chance that someone is in that room, therefore the living room lights have to turn on too. The same concept applies to the `studio` room.
 
 {% raw %}
 


### PR DESCRIPTION
more choose can be used together for creating extended conditions which do not depend from each others

## Proposed change
I added an example that shows how more `choose` can be used within the same automation or script.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
