### PR TITLE
Prometheus skip state unknown

### DIFF
--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -64,6 +64,11 @@ override_metric:
   type: string
   description: Metric name to use instead of unit or default metric. This will store all data points in a single metric.
   required: false
+skip_unknown:
+  type: boolean
+  description: Skip metrics that are in STATE_UNKNOWN to prevent exporting values that could be wrong.
+  required: false
+  default: false
 component_config:
   type: string
   required: false
@@ -137,6 +142,7 @@ Advanced configuration example:
 # Advanced configuration.yaml entry
 prometheus:
   namespace: hass
+  skip_unknown: true
   component_config_glob:
     sensor.*_hum:
       override_metric: humidity_percent


### PR DESCRIPTION
## Proposed change
Giving a value of 0 by default can lead to erroneous data being exported.
For example, if a MQTT temperature sensor is in `STATE_UNKNOWN` (which can happen after a HASS restart), a temperature of 0°C will be exported.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/47840

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
