### PR TITLE
Quick howto to flash Hue devices via OTA folder.

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -191,7 +191,7 @@ Note that the `otau_directory` setting is optional and can be used for any firmw
 ```yaml
 service: zha.issue_zigbee_cluster_command
 data:
-  ieee: 'xx:xx:xx:xx:xx:xx:xx:xx'
+  ieee: "xx:xx:xx:xx:xx:xx:xx:xx"
   endpoint_id: 11
   cluster_id: 25
   cluster_type: out

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -186,7 +186,23 @@ zha:
 
 You can choose if the IKEA or LEDVANCE provider should be set to enabled (`true`) or disabled (`false`) individually. After the OTA firmware upgrades are finished, you can set these to `false` again if you do not want ZHA to automatically download and perform OTA firmware upgrades in the future.
 
-Note that the `otau_directory` setting is optional and can be used for any firmware files you have downloaded yourself.
+Note that the `otau_directory` setting is optional and can be used for any firmware files you have downloaded yourself, for any device type and manufacturer. For example, Philips Hue firmwares manually downloaded from [here](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/OTA-Image-Types---Firmware-versions) and/or [here](https://github.com/Koenkk/zigbee-OTA/blob/a02a4cb33f7c46b4d2916805bfcad582124ec975/index.json) added to the `otau_directory` can be flashed, although a manual `zha.issue_zigbee_cluster_command` command currently (as of 2021.3.3) must be issued against the IEEE of the Philips Hue device under Developer Tools->Services, e.g.:
+
+```
+service: zha.issue_zigbee_cluster_command
+data:
+  ieee: 'xx:xx:xx:xx:xx:xx:xx:xx'
+  endpoint_id: 11
+  cluster_id: 25
+  cluster_type: out
+  command: 0
+  command_type: client
+  args:
+    - 0
+    - 100
+```
+
+Note: `cluster_id: 25` may also be `cluster_id: 0x0019`. The two are synonymous. 
 
 ### Defining Zigbee channel to use
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -188,7 +188,7 @@ You can choose if the IKEA or LEDVANCE provider should be set to enabled (`true`
 
 Note that the `otau_directory` setting is optional and can be used for any firmware files you have downloaded yourself, for any device type and manufacturer. For example, Philips Hue firmwares manually downloaded from [here](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/OTA-Image-Types---Firmware-versions) and/or [here](https://github.com/Koenkk/zigbee-OTA/blob/a02a4cb33f7c46b4d2916805bfcad582124ec975/index.json) added to the `otau_directory` can be flashed, although a manual `zha.issue_zigbee_cluster_command` command currently (as of 2021.3.3) must be issued against the IEEE of the Philips Hue device under Developer Tools->Services, e.g.:
 
-```
+```yaml
 service: zha.issue_zigbee_cluster_command
 data:
   ieee: 'xx:xx:xx:xx:xx:xx:xx:xx'


### PR DESCRIPTION
Quick howto to flash Hue devices via OTA folder (ZHA). Clarify that other OEMs are possible, and people can throw out their Hue bridges. 

I followed the "edit" link on the doc webpage, so I assume the current branch of `current` is OK. 

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][]. ( I believe so )

[standards]: https://developers.home-assistant.io/docs/documenting/standards
