### PR TITLE
Mqtt cover tilt calculated from position 

### DIFF
--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -227,8 +227,12 @@ tilt_command_topic:
   description: The MQTT topic to publish commands to control the cover tilt.
   required: false
   type: string
+tilt_from_position:
+  description: Calculate the tilt valio from the change of the position and fis versa. This is usefull for venetian blinds, that dont have a topic for the tilt. It takes the value from `tilt_max` as percentage that it takes for a full turn of the slats. It cannot be used together with `tilt_command_topic`.
+  required: false
+  type: boolean
 tilt_max:
-  description: The maximum tilt value
+  description: The maximum tilt value.
   required: false
   type: integer
   default: 100
@@ -414,6 +418,40 @@ cover:
 
 {% endraw %}
 
+### Full configuration using tilt calculated from position
+
+The example below shows a full configuration for a cover using stopped state.
+
+{% raw %}
+
+```yaml
+# Example configuration.yaml entry
+cover:
+  - platform: mqtt
+    name: "MQTT Cover"
+    command_topic: "home-assistant/cover/set"
+    state_topic: "home-assistant/cover/state"
+    position_topic: "home-assistant/cover/position"
+    set_position_topic: "home-assistant/cover/position/set"
+    qos: 1
+    retain: false
+    payload_open:  "open"
+    payload_close: "close"
+    payload_stop:  "stop"
+    state_opening: "open"
+    state_closing: "close"
+    state_stopped: "stop"
+    position_open: 100
+    position_closed: 0
+    tilt_min: 0
+    tilt_max: 6
+    tilt_from_position: True
+    tilt_opened_value: 3
+    tilt_closed_value: 0
+    optimistic: false
+```
+
+{% endraw %}
 To test, you can use the command line tool `mosquitto_pub` shipped with `mosquitto` or the `mosquitto-clients` package to send MQTT messages. This allows you to operate your cover manually:
 
 ```bash

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -228,7 +228,7 @@ tilt_command_topic:
   required: false
   type: string
 tilt_from_position:
-  description: Calculate the tilt valio from the change of the position and fis versa. This is usefull for venetian blinds, that dont have a topic for the tilt. It takes the value from `tilt_max` as percentage that it takes for a full turn of the slats. It cannot be used together with `tilt_command_topic`.
+  description: Calculate the tilt value  from the change of the position and vice versa. This is useful for Venetian blinds, that don't have a topic for the tilt. It takes the value from `tilt_max` as the percentage that it takes for a full turn of the slats. It cannot be used together with `tilt_command_topic`.
   required: false
   type: boolean
 tilt_max:
@@ -420,7 +420,7 @@ cover:
 
 ### Full configuration using tilt calculated from position
 
-The example below shows a full configuration for a cover using stopped state.
+The example below shows a full example how to setup a blind with moveable slats, that does not have a topic for tilt.
 
 {% raw %}
 

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -231,6 +231,7 @@ tilt_from_position:
   description: Calculate the tilt value  from the change of the position and vice versa. This is useful for Venetian blinds, that don't have a topic for the tilt. It takes the value from `tilt_max` as the percentage that it takes for a full turn of the slats. It cannot be used together with `tilt_command_topic`.
   required: false
   type: boolean
+  default: false
 tilt_max:
   description: The maximum tilt value.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I added a new option that the tilt can be calculated from the change of position. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/47860
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
