### PR TITLE
generic camera : example of secured access

### DIFF
--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -139,3 +139,19 @@ camera:
     still_image_url: http://194.218.96.92/jpg/image.jpg
     stream_source: rtsp://194.218.96.92:554
 ```
+
+### Secured access to the camera
+
+To access a camera that requires secured access for still image or live stream (an HIK in my case).
+
+```yaml
+camera: 
+  - platform: generic
+    still_image_url: http://192.168.1.100/ISAPI/Streaming/Channels/101/picture
+    stream_source: rtsp://[LOGIN]:[PASS]@192.168.1.100:554/Streaming/Channels/102
+    name: My Camera
+    verify_ssl: false
+    username: [LOGIN]
+    password: [PASS]
+    authentication: digest
+```

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -147,11 +147,11 @@ To access a camera that requires secured access for still image or live stream (
 ```yaml
 camera: 
   - platform: generic
-    still_image_url: http://192.168.1.100/ISAPI/Streaming/Channels/101/picture
-    stream_source: rtsp://[LOGIN]:[PASS]@192.168.1.100:554/Streaming/Channels/102
-    name: My Camera
+    still_image_url: "http://192.168.1.100/ISAPI/Streaming/Channels/101/picture"
+    stream_source: "rtsp://USERNAME:PASSWORD@192.168.1.100:554/Streaming/Channels/102"
+    name: "My Camera"
     verify_ssl: false
-    username: [LOGIN]
-    password: [PASS]
+    username: "USERNAME"
+    password: "PASSWORD"
     authentication: digest
 ```


### PR DESCRIPTION
Addition of an example with a camera that requires secured access, an HIK camera in my case.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
An example of correct secured access : I had to go to the source code to understand how to configure this because still image requires auth parameters and rtsp requires inlined auth.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
