### PR TITLE
Add config flow to Verisure

### DIFF
--- a/source/_integrations/verisure.markdown
+++ b/source/_integrations/verisure.markdown
@@ -21,6 +21,8 @@ ha_platforms:
   - lock
   - sensor
   - switch
+ha_config_flow: true
+ha_dhcp: true
 ---
 
 Home Assistant has support to integrate your [Verisure](https://www.verisure.com/) devices.
@@ -34,75 +36,7 @@ There is currently support for the following device types within Home Assistant:
 - Lock
 - Binary Sensor (Door & Window)
 
-## Configuration
-
-To integrate Verisure with Home Assistant, add the following section to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-verisure:
-  username: USERNAME
-  password: PASSWORD
-```
-
-{% configuration %}
-username:
-  description: The username to Verisure mypages.
-  required: true
-  type: string
-password:
-  description: The password to Verisure mypages.
-  required: true
-  type: string
-alarm:
-  description: Set to `true` to show alarm, `false` to disable.
-  required: false
-  type: boolean
-  default: true
-hygrometers:
-  description: Set to `true` to show hygrometers, `false` to disable.
-  required: false
-  type: boolean
-  default: true
-smartplugs:
-  description: Set to `true` to show smartplugs, `false` to disable.
-  required: false
-  type: boolean
-  default: true
-locks:
-  description: Set to `true` to show locks, `false` to disable.
-  required: false
-  type: boolean
-  default: true
-default_lock_code:
-  description: Code that will be used to lock or unlock, if none is supplied.
-  required: false
-  type: string
-thermometers:
-  description: Set to `true` to show thermometers, `false` to disable.
-  required: false
-  type: boolean
-  default: true
-mouse:
-  description: Set to `true` to show mouse detectors, `false` to disable.
-  required: false
-  type: boolean
-  default: true
-door_window:
-  description: Set to `true` to show doors and windows, `false` to disable.
-  required: false
-  type: boolean
-  default: true
-code_digits:
-  description: Number of digits in PIN code.
-  required: false
-  type: integer
-  default: 4
-giid:
-  description: The GIID of your installation (If you have more then one alarm system). To find the GIID for your systems run `python verisure.py` EMAIL PASSWORD installations'.
-  required: false
-  type: string
-{% endconfiguration %}
+{% include integrations/config_flow.md %}
 
 ## Alarm Control Panel
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds the new configuration flow for Verisure to the Home Assistant documentation.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/47880
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
