### PR TITLE
Remove confusing line from History docs

### DIFF
--- a/source/_integrations/history.markdown
+++ b/source/_integrations/history.markdown
@@ -164,15 +164,15 @@ The following characters can be used in entity globs:
 The history is stored in a SQLite database `home-assistant_v2.db` within your
 configuration directory unless the `recorder` integration is set up differently.
 
- - events table is all events except `time_changed` that happened while recorder integration was running.
- - states table contains all the `new_state` values of `state_changed` events.
- - Inside the states table you have:
-   - `entity_id`: the entity_id of the entity
-   - `state`: the state of the entity
-   - `attributes`: JSON of the state attributes
-   - `last_changed`: timestamp last time the state has changed. A state_changed event can happen when just attributes change.
-   - `last_updated`: timestamp anything has changed (state, attributes)
-   - `created`: timestamp this entry was inserted into the database
+- events table is all events except `time_changed` that happened while recorder integration was running.
+- states table contains all the `new_state` values of `state_changed` events.
+- Inside the states table you have:
+  - `entity_id`: the entity_id of the entity
+  - `state`: the state of the entity
+  - `attributes`: JSON of the state attributes
+  - `last_changed`: timestamp last time the state has changed.
+  - `last_updated`: timestamp anything has changed (state, attributes)
+  - `created`: timestamp this entry was inserted into the database
 
 When the `history` integration queries the states table it only selects states
 where the state has changed: `WHERE last_changed=last_updated`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Removes a confusing line from the history integration documentation.

Details on this:
<https://github.com/home-assistant/core/blob/73c6728e98e2e853afa9bd80b3a689c2d56e49e3/homeassistant/core.py#L864-L865>


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #17031

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
