### PR TITLE
Add details about unavailable and unknown states for Prometheus

### DIFF
--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -179,3 +179,16 @@ When looking into the metrics on the Prometheus side, there will be:
 - The [client library](https://github.com/prometheus/client_python) provided metrics, which are a bunch of **process_\*** and also a single pseudo-metric **python_info** which contains (not as value but as labels) information about the Python version of the client, i.e., the Home Assistant Python interpreter.
   
 Typically, you will only be interested in the first set of metrics.
+
+## Metrics in unavailable or unknown states
+
+When the Prometheus exporter starts (typically when Home Assistant starts), all non-excluded entities in an unavailable or unknown state are not be exported until they are available again. If the entity goes into state unavailable or unknown again, the value exported will always be the latest known one.
+
+While an entity is in those states, the `entity_available` corresponding metric is set to 0. This metric can be used to filter out values while the entity is unavailable or in an unknown state thanks to a [recording rule](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/).
+
+For example:
+
+```yaml
+- record: known_temperature_c
+  expr: temperature_c unless entity_available == 0
+```

--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -189,6 +189,6 @@ While an entity is in those states, the `entity_available` corresponding metric 
 For example:
 
 ```yaml
-- record: known_temperature_c
-  expr: temperature_c unless entity_available == 0
+- record: "known_temperature_c"
+  expr: "temperature_c unless entity_available == 0"
 ```


### PR DESCRIPTION
## Proposed change
Give Prometheus users more details on how the exporter works regarding
entities in unavailable or unknown states, and give some pointers on
how uncertain values can be filtered out.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/47840
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/35978

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
