### PR TITLE
 add ssl support to tcp integration

### DIFF
--- a/source/_integrations/tcp.markdown
+++ b/source/_integrations/tcp.markdown
@@ -67,6 +67,16 @@ buffer_size:
   required: false
   default: "`1024`"
   type: integer
+ssl:
+  description: If `true`, use SSL/TLS.
+  required: false
+  default: false
+  type: boolean
+verify_ssl:
+  description: Set this to `false` if the server is using a self-signed certificate.
+  required: false
+  default: true
+  type: boolean
 {% endconfiguration %}
 
 ### Examples
@@ -193,4 +203,14 @@ timeout:
   required: false
   type: integer
   default: 10
+ssl:
+  description: If `true`, use SSL/TLS.
+  required: false
+  default: false
+  type: boolean
+verify_ssl:
+  description: Set this to `false` if the server is using a self-signed certificate.
+  required: false
+  default: true
+  type: boolean
 {% endconfiguration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documentation update to reflect the SSL support added in https://github.com/home-assistant/core/pull/48060



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48060
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
