### PR TITLE
ProxmoxVE Change realm to username instead of password

### DIFF
--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -55,11 +55,11 @@ verify_ssl:
   default: true
   type: boolean
 username:
-  description: The username used to authenticate.
+  description: The username used to authenticate. Can include the realm by appending "@<realm>"
   required: true
   type: string
 password:
-  description: The password used to authenticate. Can include the realm by appending "@<realm>"
+  description: The password used to authenticate.
   required: true
   type: string
 realm:

--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -55,7 +55,7 @@ verify_ssl:
   default: true
   type: boolean
 username:
-  description: The username used to authenticate. Can include the realm by appending "@<realm>"
+  description: The username used to authenticate. Can include the realm by appending "@<realm>".
   required: true
   type: string
 password:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Change the documentation to be correct and include the realm in the username instead of the password in the documentation. According to [proxmoxer](https://github.com/proxmoxer/proxmoxer#short-usage-information), the python module that the ProxmoxVE integration uses, this should be appended to the username and not the password.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
