### PR TITLE
Add information about CoIoT and unicast to Shelly integration docs

### DIFF
--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -31,6 +31,7 @@ Integrate [Shelly devices](https://shelly.cloud) into Home Assistant.
 ## Shelly device configuration
 
 Shelly devices use the `CoIoT` protocol to communicate with integration. For Shelly firmware 1.10.0 or newer, `CoIoT` must be enabled in the device settings. Navigate to local IP address of your Shelly device, **Internet & Security** >> **ADVANCED - DEVELOPER SETTINGS** and check the box **Enable CoIoT**.
+
 We recommend using `unicast` for communication. To enable this, enter the local IP address of the Home Assistant server and port 5683 into the **CoIoT peer** field and push **SAVE** button. This is mandatory for Shelly Motion.
 
 <div class="note">

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -32,7 +32,7 @@ Integrate [Shelly devices](https://shelly.cloud) into Home Assistant.
 
 Shelly devices use the `CoIoT` protocol to communicate with integration. For Shelly firmware 1.10.0 or newer, `CoIoT` must be enabled in the device settings. Navigate to local IP address of your Shelly device, **Internet & Security** >> **ADVANCED - DEVELOPER SETTINGS** and check the box **Enable CoIoT**.
 
-We recommend using `unicast` for communication. To enable this, enter the local IP address of the Home Assistant server and port 5683 into the **CoIoT peer** field and push **SAVE** button. This is mandatory for Shelly Motion. After changing the **CoIoT peer**, the Shelly device needs to be manually restarted.
+We recommend using `unicast` for communication. To enable this, enter the local IP address of the Home Assistant server and port `5683` into the **CoIoT peer** field and push **SAVE** button. This is mandatory for Shelly Motion. After changing the **CoIoT peer**, the Shelly device needs to be manually restarted.
 
 <div class="note">
 Integration is communicating directly with the device; cloud connection is not needed.

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -30,7 +30,7 @@ Integrate [Shelly devices](https://shelly.cloud) into Home Assistant.
 
 ## Shelly device configuration
 
-Shelly devices use the `CoIoT` protocol to communicate with integration. For Shelly firmware 1.10.0 or newer, `CoIoT` must be enabled in the device settings. Navigate to local IP address of your Shelly device, **Internet & Security** >> **ADVANCED - DEVELOPER SETTINGS** and check the box **Enable CoIoT**.
+Shelly devices use the `CoIoT` protocol to communicate with integration. For Shelly firmware 1.10.0 or newer, `CoIoT` must be enabled in the device settings. Navigate to the local IP address of your Shelly device, **Internet & Security** >> **ADVANCED - DEVELOPER SETTINGS** and check the box **Enable CoIoT**.
 
 We recommend using `unicast` for communication. To enable this, enter the local IP address of the Home Assistant server and port `5683` into the **CoIoT peer** field and push **SAVE** button. This is mandatory for Shelly Motion with firmware 1.1.0 or newer. After changing the **CoIoT peer**, the Shelly device needs to be manually restarted.
 

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -32,7 +32,7 @@ Integrate [Shelly devices](https://shelly.cloud) into Home Assistant.
 
 Shelly devices use the `CoIoT` protocol to communicate with integration. For Shelly firmware 1.10.0 or newer, `CoIoT` must be enabled in the device settings. Navigate to local IP address of your Shelly device, **Internet & Security** >> **ADVANCED - DEVELOPER SETTINGS** and check the box **Enable CoIoT**.
 
-We recommend using `unicast` for communication. To enable this, enter the local IP address of the Home Assistant server and port 5683 into the **CoIoT peer** field and push **SAVE** button. This is mandatory for Shelly Motion.
+We recommend using `unicast` for communication. To enable this, enter the local IP address of the Home Assistant server and port 5683 into the **CoIoT peer** field and push **SAVE** button. This is mandatory for Shelly Motion. After changing the **CoIoT peer**, the Shelly device needs to be manually restarted.
 
 <div class="note">
 Integration is communicating directly with the device; cloud connection is not needed.

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -32,7 +32,7 @@ Integrate [Shelly devices](https://shelly.cloud) into Home Assistant.
 
 Shelly devices use the `CoIoT` protocol to communicate with integration. For Shelly firmware 1.10.0 or newer, `CoIoT` must be enabled in the device settings. Navigate to local IP address of your Shelly device, **Internet & Security** >> **ADVANCED - DEVELOPER SETTINGS** and check the box **Enable CoIoT**.
 
-We recommend using `unicast` for communication. To enable this, enter the local IP address of the Home Assistant server and port `5683` into the **CoIoT peer** field and push **SAVE** button. This is mandatory for Shelly Motion. After changing the **CoIoT peer**, the Shelly device needs to be manually restarted.
+We recommend using `unicast` for communication. To enable this, enter the local IP address of the Home Assistant server and port `5683` into the **CoIoT peer** field and push **SAVE** button. This is mandatory for Shelly Motion with firmware 1.1.0 or newer. After changing the **CoIoT peer**, the Shelly device needs to be manually restarted.
 
 <div class="note">
 Integration is communicating directly with the device; cloud connection is not needed.

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -28,6 +28,11 @@ ha_platforms:
 
 Integrate [Shelly devices](https://shelly.cloud) into Home Assistant.
 
+## Shelly device configuration
+
+Shelly devices use the `CoIoT` protocol to communicate with integration. For Shelly firmware 1.10.0 or newer, `CoIoT` must be enabled in the device settings. Navigate to local IP address of your Shelly device, **Internet & Security** >> **ADVANCED - DEVELOPER SETTINGS** and check the box **Enable CoIoT**.
+We recommend using `unicast` for communication. To enable this, enter the local IP address of the Home Assistant server and port 5683 into the **CoIoT peer** field and push **SAVE** button. This is mandatory for Shelly Motion.
+
 <div class="note">
 Integration is communicating directly with the device; cloud connection is not needed.
 </div>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds information about `CoIoT` and `unicast` configuration for Shelly devices with firmware 1.10.0 or later.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
