### PR TITLE
Add section to warning about WiFi-based Zigbee-to-Serial bridges so it has a direct URL link

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -88,6 +88,8 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
   - [PiZiGate](https://zigate.fr/produit/pizigate-v1-0/)
   - [Wifi ZiGate](https://zigate.fr/produit/zigate-pack-wifi-v1-3/)
 
+#### Warning about WiFi-based Zigbee-to-Serial bridges/gateways
+
 <div class="note warning">
 
 The **EZSP** protocol requires a stable connection to the serial port. With _ITEAD Sonoff ZBBridge_ connecting over the WiFi network

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -88,7 +88,7 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
   - [PiZiGate](https://zigate.fr/produit/pizigate-v1-0/)
   - [Wifi ZiGate](https://zigate.fr/produit/zigate-pack-wifi-v1-3/)
 
-#### Warning about WiFi-based Zigbee-to-Serial bridges/gateways
+#### Warning about Wi-Fi-based Zigbee-to-Serial bridges/gateways
 
 <div class="note warning">
 


### PR DESCRIPTION
## Proposed change

Add a section in the ZHA documentation to the warning about WiFi-based Zigbee-to-Serial bridges/gateways (serial proxy servers/services) in order to make it get a direct URL link that can then be linked-to in the community forum and other support channels, (similar to one can directly link to bellows warning https://github.com/zigpy/bellows#warning-about-zigbee-to-wifi-bridges for the same issue without having to explain that the ZHA integration relies on bellows).

The problems caused by WiFi-based Zigbee-to-Serial bridges/gateways (serial proxy servers/services) is now common in the Home Assistant community forum so that it would be easier to reply to those with URL that is direct link to this warning. Would be good if could simply post a link to https://www.home-assistant.io/integrations/zha/#warning-about-wifi-based-zigbee-to-serial-bridges-gateways instead of only being able to post a link to https://www.home-assistant.io/integrations/zha/#known-working-zigbee-radio-modules and having to instruct them to scroll down to this warning.

Please note that a lot of first time ZHA users are having a bad time with [Sonoff ZBBridge](https://www.digiblur.com/2020/07/how-to-use-sonoff-zigbee-bridge-with.html), most those issues seam to be WiFi related:

https://community.home-assistant.io/t/sonoff-zbbridge-sonoff-zigbee-bridge-from-itead/187346
https://community.home-assistant.io/t/zigbee-errors/292478/
https://community.home-assistant.io/t/sonoff-zbbridge-suddenly-appears-offline-but-is-online-and-working/274296
https://community.home-assistant.io/t/sonoff-zigbee-bridge-lost-devices-when-in-zha-mode/238511
https://community.home-assistant.io/t/moving-from-usb-stick-to-sonoff-bridge-any-issues/276656
https://community.home-assistant.io/t/sonoff-zigbee-bridge-couldnt-start-ezsp/291417
https://community.home-assistant.io/t/diagnose-zigbee-network-issue/261742
https://community.home-assistant.io/t/zha-component-sometimes-falls-off-and-devices-become-unavailable-for-no-apparent-reason/270616
https://community.home-assistant.io/t/experience-with-flashing-tasmota-on-sonoff-zigbee-bridge-devices-is-it-flawless-and-how-do-those-compare-with-aqara-zigbee-sensors/230025/
https://community.home-assistant.io/t/what-is-the-best-zigbee-coordinator-to-be-used-with-zha/271742

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards