### PR TITLE
Add examples for new template variable `transition` in `light.template` documentation

### DIFF
--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -31,12 +31,17 @@ light:
         color_template: "({{states('input_number.h_input') | int}}, {{states('input_number.s_input') | int}})"
         turn_on:
           service: script.theater_lights_on
+          data: 
+            transition: "{{ transition | float}}"
         turn_off:
           service: script.theater_lights_off
+          data: 
+            transition: "{{ transition | float}}"
         set_level:
           service: script.theater_lights_level
           data:
             brightness: "{{ brightness }}"
+            transition: "{{ transition | float}}"
         set_temperature:
           service: input_number.set_value
           data:


### PR DESCRIPTION
## Proposed change
Update code sample for `light.template` to demonstrate use of new `transition` parameter.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/48255
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
