### PR TITLE
Update binary sensor names

### DIFF
--- a/source/_integrations/hydrawise.markdown
+++ b/source/_integrations/hydrawise.markdown
@@ -66,10 +66,10 @@ monitored_conditions:
   type: list
   default: All binary sensors are enabled.
   keys:
-    is_watering:
+    watering:
       description: The binary sensor is `on` when the zone is actively watering.
-    status:
-      description: This will indicate `on` when there is a connection to the Hydrawise cloud. It is not an indication of whether the irrigation controller hardware is online.
+    my_controller_status:
+      description: This will indicate `on` when there is a connection to the Hydrawise cloud. It is not an indication of whether the irrigation controller hardware is online. Only a single status sensor is created.
 {% endconfiguration %}
 
 <div class='note warning'>


### PR DESCRIPTION
Change the name of the binary sensor suffix from 'is_watering' to 'watering'.  'Status' sensor is now 'my_controller_status'

## Proposed change

Updating the names of generated sensors.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

No additional information, naked pull request.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
