### PR TITLE
Fix error in mystrom documentation

### DIFF
--- a/source/_integrations/mystrom.markdown
+++ b/source/_integrations/mystrom.markdown
@@ -178,7 +178,7 @@ switch:
 
 {% configuration %}
 host:
-  description: "The IP address of your myStrom switch, e.g., `http://192.168.1.32`."
+  description: "The IP address of your myStrom switch, e.g., `192.168.1.32`."
   required: true
   type: string
 name:


### PR DESCRIPTION

## Proposed change

The `host` attribute must be the *IP*, not the URL of the switch. If one supplies the URL one is presented with a very helpful "no route to mystrom plug" message.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

It's a fix to docs. There's not a lot of additional information :)

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
