### PR TITLE
Clarify how to reboot Roomba to generate auto-discovery

### DIFF
--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -27,7 +27,7 @@ The `roomba` integration allows you to control your [iRobot Roomba](https://www.
 
 <div class='note'>
   
-This platform has been tested and is confirmed to be working with the iRobot Roomba s9+, Roomba 980, Roomba 960, Roomba 890, and Braava jet m6 models, but should also work fine with any Wi-Fi enabled Roomba or Braava like the 690.  For auto discovery you will need to initate a Roomba reboot. For example, by holding the clean button for upto 20 seconds on an i7 or 980 . [More info here](https://homesupport.irobot.com/app/answers/detail/a_id/9087/~/rebooting-or-resetting-your-robot)
+This integration has been tested and confirmed to be working with the iRobot Roomba s9+, Roomba 980, Roomba 960, Roomba 890, and Braava jet m6 models, but should also work fine with any Wi-Fi enabled Roomba or Braava like the 690. For auto-discovery, you will need to initiate a Roomba reboot. For example, by holding the clean button for up to 20 seconds on an i7 or 980. [More information about rebooting your robot](https://homesupport.irobot.com/app/answers/detail/a_id/9087/~/rebooting-or-resetting-your-robot).
 
 </div>
 

--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -27,7 +27,7 @@ The `roomba` integration allows you to control your [iRobot Roomba](https://www.
 
 <div class='note'>
   
-This platform has been tested and is confirmed to be working with the iRobot Roomba s9+, Roomba 980, Roomba 960, Roomba 890, and Braava jet m6 models, but should also work fine with any Wi-Fi enabled Roomba or Braava like the 690.  For auto discovery you will need to initate a roomba reboot. For example, by holding the clean button for upto 20 seconds on an i7 or 980 . [More info here](https://homesupport.irobot.com/app/answers/detail/a_id/9087/~/rebooting-or-resetting-your-robot)
+This platform has been tested and is confirmed to be working with the iRobot Roomba s9+, Roomba 980, Roomba 960, Roomba 890, and Braava jet m6 models, but should also work fine with any Wi-Fi enabled Roomba or Braava like the 690.  For auto discovery you will need to initate a Roomba reboot. For example, by holding the clean button for upto 20 seconds on an i7 or 980 . [More info here](https://homesupport.irobot.com/app/answers/detail/a_id/9087/~/rebooting-or-resetting-your-robot)
 
 </div>
 

--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -26,7 +26,9 @@ The `roomba` integration allows you to control your [iRobot Roomba](https://www.
 </p>
 
 <div class='note'>
-This platform has been tested and is confirmed to be working with the iRobot Roomba s9+, Roomba 980, Roomba 960, Roomba 890, and Braava jet m6 models, but should also work fine with any Wi-Fi enabled Roomba or Braava like the 690.
+  
+This platform has been tested and is confirmed to be working with the iRobot Roomba s9+, Roomba 980, Roomba 960, Roomba 890, and Braava jet m6 models, but should also work fine with any Wi-Fi enabled Roomba or Braava like the 690.  For auto discovery you will need to initate a roomba reboot. For example, by holding the clean button for upto 20 seconds on an i7 or 980 . [More info here](https://homesupport.irobot.com/app/answers/detail/a_id/9087/~/rebooting-or-resetting-your-robot)
+
 </div>
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Without this key piece of info most people will never experience DHCP auto discovery of their roomba.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/47696
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
