### PR TITLE
Add multiple actions example to switch template

### DIFF
--- a/source/_integrations/switch.template.markdown
+++ b/source/_integrations/switch.template.markdown
@@ -139,6 +139,38 @@ switch:
 
 {% endraw %}
 
+### Multiple actions for turn_on or turn_off
+
+This example shows multiple service calls for turn_on and turn_off.
+
+{% raw %}
+
+```yaml
+switch:
+  - platform: template
+    switches:
+      copy:
+        value_template: "{{ is_state('switch.source', 'on') }}"
+        turn_on:
+          - service: switch.turn_on
+            target:
+              entity_id: switch.target
+          - service: light.turn_on
+            target:
+              entity_id: light.target
+            data:
+              brightness_pct: 40
+        turn_off:
+          - service: switch.turn_off
+            target:
+              entity_id: switch.target
+          - service: light.turn_off
+            target:
+              entity_id: light.target
+```
+
+{% endraw %}
+
 ### Sensor and Two Switches
 
 This example shows a switch that takes its state from a sensor, and uses two


### PR DESCRIPTION
## Proposed change
There can be multiple service calls for `turn_on` or `turn_off` actions in the switch template. This PR adds an example for this.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
