### PR TITLE
Update Litter-Robot documentation to reflect new feature support

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -2,7 +2,7 @@
 title: Litter-Robot
 description: Instructions on how to integrate a Litter-Robot Wi-Fi-enabled, automatic, self-cleaning litter box to Home Assistant.
 ha_category:
-  - Pets
+  - Vacuum
 ha_iot_class: Cloud Polling
 ha_release: 2021.3
 ha_config_flow: true

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -2,7 +2,7 @@
 title: Litter-Robot
 description: Instructions on how to integrate a Litter-Robot Wi-Fi-enabled, automatic, self-cleaning litter box to Home Assistant.
 ha_category:
-  - Vacuum
+  - Pets
 ha_iot_class: Cloud Polling
 ha_release: 2021.3
 ha_config_flow: true

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -27,12 +27,14 @@ The Feeder-Robot is not currently supported by this integration.
 
 The following entities are created for this component and identified by a single device per Litter-Robot unit:
 
-| Entity           | Domain   | Description                                                                      |
-| ---------------- | -------- | -------------------------------------------------------------------------------- |
-| Litter Box       | `vacuum` | Main entity that represents a Litter-Robot unit.                                 |
-| Night Light Mode | `switch` | When turned on, automatically turns on the night light in darker settings.       |
-| Panel Lockout    | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
-| Waste Drawer     | `sensor` | Displays the current waste level gauge.                                          |
+| Entity                | Domain   | Description                                                                      |
+| --------------------- | -------- | -------------------------------------------------------------------------------- |
+| Litter Box            | `vacuum` | Main entity that represents a Litter-Robot unit.                                 |
+| Night Light Mode      | `switch` | When turned on, automatically turns on the night light in darker settings.       |
+| Panel Lockout         | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
+| Sleep Mode Start Time | `sensor` | When sleep mode is enabled, displays the current or next sleep mode start time.  |
+| Sleep Mode End Time   | `sensor` | When sleep mode is enabled, displays the current or last sleep mode end time.    |
+| Waste Drawer          | `sensor` | Displays the current waste drawer level.                                         |
 
 ## Additional Attributes
 
@@ -40,23 +42,14 @@ Some entities have attributes in addition to the default ones that are available
 
 ### Litter Box `vacuum` entity
 
-| Attribute                     | Type    | Description                                                                                                                                                        |
-| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| clean_cycle_wait_time_minutes | integer | Current wait time, in minutes, between when your cat uses the Litter-Robot and when the unit cycles automatically.                                                 |
-| is_sleeping                   | boolean | Whether or not the unit is currently in sleep mode.                                                                                                                |
-| sleep_mode_start_time         | string  | When sleep mode is enabled, displays the time the unit will enter sleep mode in the format `%H:%M:%S`, otherwise `None`.                                           |
-| sleep_mode_end_time           | string  | When sleep mode is enabled, displays the time the unit will exit sleep mode in the format `%H:%M:%S`, otherwise `None`.                                            |
-| power_status                  | string  | Current power status of the unit. `AC` indicates normal power, `DC` indicates battery backup and `NC` indicates that the unit is not connected and/or powered off. |
-| unit_status_code              | string  | The [unit status code](https://github.com/natekspencer/pylitterbot/blob/main/pylitterbot/robot.py#L21) associated with the current status of the vacuum.           |
-| last_seen                     | string  | UTC datetime the unit last reported its status.                                                                                                                    |
-
-### Waste Drawer `sensor` entity
-
-| Attribute                | Type    | Description                                                              |
-| ------------------------ | ------- | ------------------------------------------------------------------------ |
-| cycle_count              | integer | Number of clean cycles performed since last reset.                       |
-| cycle_capacity           | integer | Number of clean cycles before unit is full.                              |
-| cycles_after_drawer_full | integer | Number of clean cycles performed since drawer full status was indicated. |
+| Attribute                     | Type    | Description                                                                                                                                                                             |
+| ----------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| clean_cycle_wait_time_minutes | integer | Current wait time, in minutes, between when your cat uses the Litter-Robot and when the unit cycles automatically.                                                                      |
+| is_sleeping                   | boolean | Whether or not the unit is currently in sleep mode.                                                                                                                                     |
+| sleep_mode_enabled            | boolean | Whether or not sleep mode is enabled.                                                                                                                                                   |
+| power_status                  | string  | Current power status of the unit. `AC` indicates normal power, `DC` indicates battery backup and `NC` indicates that the unit is not connected and/or powered off.                      |
+| status_code                   | string  | The [status code](https://github.com/natekspencer/pylitterbot/blob/884944b011f5fea9639b7d21d19fa3f7708e25a7/pylitterbot/enums.py#L44) associated with the current status of the vacuum. |
+| last_seen                     | string  | UTC datetime the unit last reported its status.                                                                                                                                         |
 
 ## Commands
 
@@ -64,7 +57,7 @@ Commands are utilized for additional functionality that is available in the Litt
 
 ### reset_waste_drawer
 
-Resets the waste drawer gauge on the Litter-Robot. This will reset the cycle count returned by the Litter-Robot API to `0`.
+Resets the waste drawer level on the Litter-Robot. This will reset the cycle count returned by the Litter-Robot API to `0` such that the waste drawer entity will report as `0.0 %`.
 
 ```yaml
 service: vacuum.send_command
@@ -78,10 +71,10 @@ data:
 
 Enables (with `sleep_time` param) or disables sleep mode on the Litter-Robot.
 
-| Param      | Type   | Required                                        | Description                                                                                                                                                                                                                                                                                                                                              |
-| ---------- | ------ | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| enabled    | bool   | yes                                             | Set to true to enable and false to disable.                                                                                                                                                                                                                                                                                                              |
-| sleep_time | string | Required if the param `enabled` is set to true. | Time at which the unit will enter sleep mode and prevent an automatic clean cycle for 8 hours. This param uses the 24-hour format string `%H:%M:%S`, with seconds being optional, and is based on the timezone configured for your Home Assistant installation. As such, `10:30:00` would indicate 10:30 AM, whereas `22:30:00` would indicate 10:30 PM. |
+| Param      | Type   | Required | Description                                                                                                                                                                                                                                                                                                                                              |
+| ---------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| enabled    | bool   | yes      | Set to true to enable and false to disable.                                                                                                                                                                                                                                                                                                              |
+| sleep_time | string | no       | Time at which the unit will enter sleep mode and prevent an automatic clean cycle for 8 hours. This param uses the 24-hour format string `%H:%M:%S`, with seconds being optional, and is based on the timezone configured for your Home Assistant installation. As such, `10:30:00` would indicate 10:30 AM, whereas `22:30:00` would indicate 10:30 PM. |
 
 Example of setting the sleep mode to begin at 10:30 PM.
 
@@ -94,4 +87,24 @@ data:
   params:
     enabled: true
     sleep_time: "22:30:00"
+```
+
+### set_wait_time
+
+Sets the wait time, in minutes, between when your cat uses the Litter-Robot and when the unit cycles automatically.
+
+| Param     | Type | Required | Description                 |
+| --------- | ---- | -------- | --------------------------- |
+| wait_time | int  | yes      | Must be one of: 3, 7 or 15. |
+
+Example of setting the wait time to 3 minutes.
+
+```yaml
+service: vacuum.send_command
+target:
+  entity_id: vacuum.litter_robot_litter_box
+data:
+  command: set_wait_time
+  params:
+    wait_time: 3
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updates the Litter-Robot documentation so it reflects new features exposed in the integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48300
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
