### PR TITLE
Add newly supported bulbs for tplink

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -59,7 +59,7 @@ Plugs are type `switch` when autodiscovery has been disabled.
 
 ### Bulbs
 
-Other bulbs may also work, but with limited color temperatures.  If you find a bulb isn't reaching the full color temperature boundaries, submit a bug report.
+Other bulbs may also work, but with limited color temperatures. If you find a bulb isn't reaching the full-color temperature boundaries, submit a bug report.
 
 - LB100
 - LB110

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -59,6 +59,8 @@ Plugs are type `switch` when autodiscovery has been disabled.
 
 ### Bulbs
 
+Other bulbs may also work, but with limited color temperatures.  If you find a bulb isn't reaching the full color temperature boundaries, submit a bug report.
+
 - LB100
 - LB110
 - LB120
@@ -66,7 +68,10 @@ Plugs are type `switch` when autodiscovery has been disabled.
 - LB230
 - KL110
 - KL120
+- KL125
 - KL130
+- KB130
+- KL430
 
 ## Configuration
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The `tplink` integration previously had rigid requirements for which bulbs could be supported.  The underlying libraries for it had to be updated to add any bulb.  Add the definition of some new bulbs, and also allow unknown bulbs to operate in safe ranges rather than causing crashes.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48235
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/45675

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
