### PR TITLE
Add documentation for zwave_js.bulk_set_partial_config_parameters service

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -72,6 +72,7 @@ This service will update a configuration parameter. To update multiple partial p
 Let's use parameter 31 for [this device](https://devices.zwave-js.io/?jumpTo=0x000c:0x0203:0x0001:0.0) as an example to show examples of different ways that the `LED 1 Blink Status (bottom)` partial parameter can be set. Note that in places where we are using different values for the same key, the different values are interchangeable across the examples. We can, for instance, use `1` or `Blink` interchangeably for the `value` in all of the examples.
 
 Example 1:
+
 ```yaml
 service: zwave_js.set_config_parameter
 target:
@@ -83,6 +84,7 @@ data:
 ```
 
 Example 2:
+
 ```yaml
 service: zwave_js.set_config_parameter
 target:
@@ -94,6 +96,7 @@ data:
 ```
 
 Example 3:
+
 ```yaml
 service: zwave_js.set_config_parameter
 target:

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -117,7 +117,9 @@ This service will bulk set multiple partial configuration parameters. Be warned 
 
 #### Examples of bulk setting partial parameter values
 
-Let's use parameter 21 for [this device](https://devices.zwave-js.io/?jumpTo=0x031e:0x000a:0x0001:0.0) as an example to show how partial parameters can be bulk set. In this case, we want to set 0xff to 127, 0x7f00 to 10, and 0x8000 to 1 (or the raw value of 4735). Note that when using the dictionary format (examples 2 and 3) to map the partial parameter to values, the cached values for the missing partial parameters will be used. So in this case, the service would use the cached value for partial parameters 0xff0000, 0x3f000000, and 0x40000000. If you send the raw integer value, it is assumed that you have calculated the full value, so in example 1, partial parameters 0xff0000, 0x3f000000, and 0x40000000 would all be set to 0.
+Let's use parameter 21 for [this device](https://devices.zwave-js.io/?jumpTo=0x031e:0x000a:0x0001:0.0) as an example to show how partial parameters can be bulk set. In this case, we want to set `0xff` to `127`, `0x7f00` to `10`, and `0x8000` to `1` (or the raw value of `4735`). Note that when using the dictionary format (examples 2 and 3) to map the partial parameter to values, the cached values for the missing partial parameters will be used.
+
+So in this case, the service would use the cached value for partial parameters `0xff0000`, `0x3f000000`, and `0x40000000`. If you send the raw integer value, it is assumed that you have calculated the full value, so in example 1, partial parameters `0xff0000`, `0x3f000000`, and `0x40000000` would all be set to `0`.
 
 Example 1:
 ```yaml

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -122,6 +122,7 @@ Let's use parameter 21 for [this device](https://devices.zwave-js.io/?jumpTo=0x0
 So in this case, the service would use the cached value for partial parameters `0xff0000`, `0x3f000000`, and `0x40000000`. If you send the raw integer value, it is assumed that you have calculated the full value, so in example 1, partial parameters `0xff0000`, `0x3f000000`, and `0x40000000` would all be set to `0`.
 
 Example 1:
+
 ```yaml
 service: zwave_js.bulk_set_partial_config_parameters
 target:

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -117,9 +117,13 @@ This service will bulk set multiple partial configuration parameters. Be warned 
 
 #### Examples of bulk setting partial parameter values
 
-Let's use parameter 21 for [this device](https://devices.zwave-js.io/?jumpTo=0x031e:0x000a:0x0001:0.0) as an example to show how partial parameters can be bulk set. In this case, we want to set `0xff` to `127`, `0x7f00` to `10`, and `0x8000` to `1` (or the raw value of `4735`). Note that when using the dictionary format (examples 2 and 3) to map the partial parameter to values, the cached values for the missing partial parameters will be used.
+Let's use parameter 21 for [this device](https://devices.zwave-js.io/?jumpTo=0x031e:0x000a:0x0001:0.0) as an example to show how partial parameters can be bulk set. In this case, we want to set `0xff` to `127`, `0x7f00` to `10`, and `0x8000` to `1` (or the raw value of `4735`). 
 
-So in this case, the service would use the cached value for partial parameters `0xff0000`, `0x3f000000`, and `0x40000000`. If you send the raw integer value, it is assumed that you have calculated the full value, so in example 1, partial parameters `0xff0000`, `0x3f000000`, and `0x40000000` would all be set to `0`.
+<div class='note'>
+
+When using the dictionary format to map the partial parameter to values, the cached values for the missing partial parameters will be used. So in examples 2 and 3, the service would use the cached value for partial parameters `0xff0000`, `0x3f000000`, and `0x40000000` because new values haven't been specified. If you send the raw integer value, it is assumed that you have calculated the full value, so in example 1, partial parameters `0xff0000`, `0x3f000000`, and `0x40000000` would all be set to `0`.
+
+</div>
 
 Example 1:
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -137,6 +137,7 @@ data:
 ```
 
 Example 2:
+
 ```yaml
 service: zwave_js.bulk_set_partial_config_parameters
 target:

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -57,7 +57,7 @@ Advanced users: Make sure that the server started successfully by inspecting the
 
 ### Service `zwave_js.set_config_parameter`
 
-This service will update a configuration parameter. At this time, it is not possible to update multiple partial parameters in a single call, but we hope to add support for that in the future.
+This service will update a configuration parameter. To update multiple partial parameters in a single call, use the `zwave_js.bulk_set_partial_config_parameters` service.
 
 | Service Data Attribute 	| Required  	| Description                                                                                                                               	|
 |------------------------	|-----------	|-------------------------------------------------------------------------------------------------------------------------------------------	|
@@ -102,6 +102,57 @@ data:
   entity_id: switch.fan
   parameter: "LED 1 Blink Status (bottom)"
   value: "Blink"
+```
+
+### Service `zwave_js.bulk_set_partial_config_parameters`
+
+This service will bulk set multiple partial configuration parameters. Be warned that correctly using this service requires an advanced knowledge of Z-Wave to use correctly.
+
+| Service Data Attribute 	| Required  	| Description                                                                                                                               	|
+|------------------------	|-----------	|-------------------------------------------------------------------------------------------------------------------------------------------	|
+| `entity_id`            	| no        	| Entity (or list of entities) to set the configuration parameter on. At least one `entity_id` or `device_id` must be provided.                       	|
+| `device_id`            	| no        	| ID of device to set the configuration parameter on. At least one `entity_id` or `device_id` must be provided.                                                	|
+| `parameter`            	| yes       	| The parameter number or the name of the property. The name of the property is case sensitive.                                             	|
+| `value`                	| yes       	| Either the raw integer value that you want to set for the entire parameter, or a dictionary where the keys are the bitmasks (in integer or hex form) and the values are the value you want to set on each partial. Note that when using a dictionary, and bitmasks that are not provided will be set to their currently cached values.                       	|
+
+#### Examples of bulk setting partial parameter values
+
+Let's use parameter 21 for [this device](https://devices.zwave-js.io/?jumpTo=0x031e:0x000a:0x0001:0.0) as an example to show how partial parameters can be bulk set. In this case, we want to set 0xff to 127, 0x7f00 to 10, and 0x8000 to 1 (or the raw value of 4735). Note that when using the dictionary format (examples 2 and 3) to map the partial parameter to values, the cached values for the missing partial parameters will be used. So in this case, the service would use the cached value for partial parameters 0xff0000, 0x3f000000, and 0x40000000. If you send the raw integer value, it is assumed that you have calculated the full value, so in example 1, partial parameters 0xff0000, 0x3f000000, and 0x40000000 would all be set to 0.
+
+Example 1:
+```yaml
+service: zwave_js.bulk_set_partial_config_parameters
+target:
+  entity_id: switch.fan
+data:
+  parameter: 21
+  value: 4735
+```
+
+Example 2:
+```yaml
+service: zwave_js.bulk_set_partial_config_parameters
+target:
+  entity_id: switch.fan
+data:
+  parameter: 21
+  value:
+    0xff: 127
+    0x7f00: 10
+    0x8000: 1
+```
+
+Example 3:
+```yaml
+service: zwave_js.bulk_set_partial_config_parameters
+target:
+  entity_id: switch.fan
+data:
+  parameter: 21
+  value:
+    255: 127
+    32512: 10
+    32768: 1
 ```
 
 ### Service `zwave_js.refresh_value`

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -106,7 +106,7 @@ data:
 
 ### Service `zwave_js.bulk_set_partial_config_parameters`
 
-This service will bulk set multiple partial configuration parameters. Be warned that correctly using this service requires an advanced knowledge of Z-Wave to use correctly.
+This service will bulk set multiple partial configuration parameters. Be warned that correctly using this service requires advanced knowledge of Z-Wave to use correctly.
 
 | Service Data Attribute 	| Required  	| Description                                                                                                                               	|
 |------------------------	|-----------	|-------------------------------------------------------------------------------------------------------------------------------------------	|

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -150,6 +150,7 @@ data:
 ```
 
 Example 3:
+
 ```yaml
 service: zwave_js.bulk_set_partial_config_parameters
 target:


### PR DESCRIPTION
## Proposed change
Documenting the new service. Edits welcome, this is an advanced use service and documenting it is hard.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48306
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
