### PR TITLE
Add docs for new siren platform

### DIFF
--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -1,0 +1,99 @@
+---
+title: Siren
+description: Instructions on how to set up siren devices within Home Assistant.
+ha_category:
+  - Siren
+ha_release: '2021.5'
+ha_domain: siren
+ha_quality_scale: internal
+ha_codeowners:
+  - '@home-assistant/core'
+  - '@raman325'
+ha_iot_class:
+---
+
+The `siren` integration is built for the controlling and monitoring of siren/chime devices.
+
+## Services
+
+### siren services
+
+Available services: `siren.set_active_tone`, `siren.set_volume_level`, `siren.turn_on`, `siren.turn_off`, `siren.toggle`
+
+<div class='note'>
+
+Not all siren services may be available for your platform. Be sure to check the available services Home Assistant has enabled by checking the Services page in the [Developer Tools](/docs/tools/dev-tools/).
+
+</div>
+
+### Service `siren.set_active_tone`
+
+Set active tone for the siren device. This service is only available if the device supports different tones. The list of available tones depend on the device itself.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of siren devices to control.
+| `tone` | no  | New activee tone.
+
+#### Automation example
+
+```yaml
+automation:
+  trigger:
+    platform: time
+    at: "07:15:00"
+  action:
+    - service: siren.set_active_tone
+      target:
+        entity_id: siren.doorbell
+      data:
+        tone: "doorbell"
+```
+
+### Service `siren.set_volume_level`
+
+Set volume level of the siren device
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of siren devices to control.
+| `volume_level` | no  | New volume level for siren device
+
+#### Automation example
+
+```yaml
+automation:
+  trigger:
+    platform: time
+    at: "07:15:00"
+  action:
+    - service: siren.set_volume_level
+      target:
+        entity_id: siren.doorbell
+      data:
+        humidity: 0.5
+```
+
+### Service `siren.turn_on`
+
+Turn the siren device on.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of siren devices to control.
+
+### Service `siren.turn_off`
+
+Turn the siren device off.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of siren devices to control.
+
+### Service `siren.toggle`
+
+Toggle the siren device on/off.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of siren devices to control.

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -18,61 +18,13 @@ The `siren` integration is built for the controlling and monitoring of siren/chi
 
 ### siren services
 
-Available services: `siren.set_active_tone`, `siren.set_volume_level`, `siren.turn_on`, `siren.turn_off`, `siren.toggle`
+Available services: `siren.turn_on`, `siren.turn_off`, `siren.toggle`
 
 <div class='note'>
 
 Not all siren services may be available for your platform. Be sure to check the available services Home Assistant has enabled by checking the Services page in the [Developer Tools](/docs/tools/dev-tools/).
 
 </div>
-
-### Service `siren.set_active_tone`
-
-Set active tone for the siren device. This service is only available if the device supports different tones. The list of available tones depend on the device itself.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of siren devices to control.
-| `tone` | no  | New activee tone.
-
-#### Automation example
-
-```yaml
-automation:
-  trigger:
-    platform: time
-    at: "07:15:00"
-  action:
-    - service: siren.set_active_tone
-      target:
-        entity_id: siren.doorbell
-      data:
-        tone: "doorbell"
-```
-
-### Service `siren.set_volume_level`
-
-Set volume level of the siren device
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of siren devices to control.
-| `volume_level` | no  | New volume level for siren device
-
-#### Automation example
-
-```yaml
-automation:
-  trigger:
-    platform: time
-    at: "07:15:00"
-  action:
-    - service: siren.set_volume_level
-      target:
-        entity_id: siren.doorbell
-      data:
-        humidity: 0.5
-```
 
 ### Service `siren.turn_on`
 

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -14,17 +14,13 @@ ha_iot_class:
 
 The Siren integration is built for the controlling and monitoring of siren/chime devices.
 
+Siren entities are created automatically by integrations that support them.
+
 ## Services
 
 ### siren services
 
 Available services: `siren.turn_on`, `siren.turn_off`, `siren.toggle`
-
-<div class='note'>
-
-Not all siren services may be available for your device. Be sure to check the available services Home Assistant has enabled by checking the Services page in the [Developer Tools](/docs/tools/dev-tools/).
-
-</div>
 
 ### Service `siren.turn_on`
 

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -28,24 +28,24 @@ Not all siren services may be available for your platform. Be sure to check the 
 
 ### Service `siren.turn_on`
 
-Turn the siren device on.
+Turn the siren on.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of siren devices to control.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of sirens to control.
 
 ### Service `siren.turn_off`
 
-Turn the siren device off.
+Turn the siren off.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of siren devices to control.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of sirens to control.
 
 ### Service `siren.toggle`
 
-Toggle the siren device on/off.
+Toggle the siren on/off.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of siren devices to control.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of sirens to control.

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -34,13 +34,13 @@ Turn the siren on.
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of sirens to control.
 
-There are three optional input parameters that can be passed into the service call, each gated by a supported feature flag. If the corresponding flag isn't set when a given input parameter is provided in the service call, it will be filtered out from the service call by the base platform before being passed to the integration.
+There are three optional input parameters that can be passed into the service call depending on whether or not your device supports them. Check the device's integration documentation for more details.
 
-| Parameter Name 	| Data Validation                       	| Supported Feature Flag 	|
-|----------------	|---------------------------------------	|------------------------	|
-| `tone`         	| `vol.Any(vol.Coerce(int), cv.string)` 	| `SUPPORT_TONES`        	|
-| `duration`     	| `cv.positive_int`                     	| `SUPPORT_DURATIONS`    	|
-| `volume_level` 	| `cv.small_float`                      	| `SUPPORT_VOLUME_SET`   	|
+| Parameter Name  | Input Type
+|---------------- |-------------------------
+| `tone`          | `string` or `integer`
+| `duration`      | `integer`
+| `volume_level`  | `float` between 0 and 1
 
 ### Service `siren.turn_off`
 

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -3,7 +3,7 @@ title: Siren
 description: Instructions on how to set up siren devices within Home Assistant.
 ha_category:
   - Siren
-ha_release: '2021.5'
+ha_release: '2021.8'
 ha_domain: siren
 ha_quality_scale: internal
 ha_codeowners:

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -34,6 +34,14 @@ Turn the siren on.
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of sirens to control.
 
+There are three optional input parameters that can be passed into the service call, each gated by a supported feature flag. If the corresponding flag isn't set when a given input parameter is provided in the service call, it will be filtered out from the service call by the base platform before being passed to the integration.
+
+| Parameter Name 	| Data Validation                       	| Supported Feature Flag 	|
+|----------------	|---------------------------------------	|------------------------	|
+| `tone`         	| `vol.Any(vol.Coerce(int), cv.string)` 	| `SUPPORT_TONES`        	|
+| `duration`     	| `cv.positive_int`                     	| `SUPPORT_DURATIONS`    	|
+| `volume_level` 	| `cv.small_float`                      	| `SUPPORT_VOLUME_SET`   	|
+
 ### Service `siren.turn_off`
 
 Turn the siren off.

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -22,7 +22,7 @@ Available services: `siren.turn_on`, `siren.turn_off`, `siren.toggle`
 
 <div class='note'>
 
-Not all siren services may be available for your platform. Be sure to check the available services Home Assistant has enabled by checking the Services page in the [Developer Tools](/docs/tools/dev-tools/).
+Not all siren services may be available for your device. Be sure to check the available services Home Assistant has enabled by checking the Services page in the [Developer Tools](/docs/tools/dev-tools/).
 
 </div>
 

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -12,7 +12,7 @@ ha_codeowners:
 ha_iot_class:
 ---
 
-The `siren` integration is built for the controlling and monitoring of siren/chime devices.
+The Siren integration is built for the controlling and monitoring of siren/chime devices.
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
Adding a new siren platform as discussed in https://github.com/home-assistant/architecture/issues/375

Dev docs update: https://github.com/home-assistant/developers.home-assistant/pull/865



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48309
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2364
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
