### PR TITLE
Add SiteSage Emonitor integration

### DIFF
--- a/source/_integrations/emonitor.markdown
+++ b/source/_integrations/emonitor.markdown
@@ -1,7 +1,7 @@
 ---
 title: "SiteSage Emonitor"
 description: "Instructions on how to integrate a SiteSage Emonitor within Home Assistant."
-ha_release: "2021.4"
+ha_release: "2021.5"
 ha_category:
     - Sensor
 ha_iot_class: "Local Polling"

--- a/source/_integrations/emonitor.markdown
+++ b/source/_integrations/emonitor.markdown
@@ -1,0 +1,19 @@
+---
+title: "SiteSage Emonitor"
+description: "Instructions on how to integrate a SiteSage Emonitor within Home Assistant."
+ha_release: "2021.4"
+ha_category:
+    - Sensor
+ha_iot_class: "Local Polling"
+ha_config_flow: true
+ha_dhcp: true
+ha_codeowners:
+  - '@bdraco'
+ha_domain: emonitor
+ha_platforms:
+    - sensor
+---
+
+The SiteSage Emonitor allows local power monitoring on a per circuit basis via an [Emonitor](https://powerhousedynamics.com/solutions/sitesage/) device.
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The SiteSage Emonitor allows local power monitoring on a per circuit basis via an [Emonitor](https://powerhousedynamics.com/solutions/sitesage/) device.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48310
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2365
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
