### PR TITLE
Make clear that dlib platform are only available on Core

### DIFF
--- a/source/_integrations/dlib_face_detect.markdown
+++ b/source/_integrations/dlib_face_detect.markdown
@@ -12,7 +12,11 @@ The `dlib_face_detect` image processing platform allows you to use the [Dlib](ht
 
 This can be used to trigger an automation rule. Further info is on the [integration](/integrations/image_processing/) page.
 
-### Configuration Home Assistant
+<div class='note'>
+This integration is only available on Home Assistant Core installation types. Unfortunately, it cannot be used with Home Assistant OS, Supervised or Container.
+</div>
+
+## Configuration
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/dlib_face_identify.markdown
+++ b/source/_integrations/dlib_face_identify.markdown
@@ -12,7 +12,11 @@ The `dlib_face_identify` image processing platform allows you to use the [Dlib](
 
 For using the result inside an automation rule, take a look at the [integration](/integrations/image_processing/) page.
 
-### Configuration Home Assistant
+<div class='note'>
+This integration is only available on Home Assistant Core installation types. Unfortunately, it cannot be used with Home Assistant OS, Supervised or Container.
+</div>
+
+## Configuration
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

PR to make clear that the `dlib` integrations are only available on Home Assistant Core installation types.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #17102

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
