### PR TITLE
Add documentation for logger regex filters

### DIFF
--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -122,7 +122,7 @@ Possible log severity levels, listed in order from most severe to least severe, 
 
 Service-specific Regular Expression filters for logs. A message is omitted if it matches the Regular Expression.
 
-An example config might look like this:
+An example configuration might look like this:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -88,6 +88,14 @@ where **namespace** is the *<component_namespace>* currently logging.
       '&lt;component_namespace&gt;':
         description: Logger namespace of the component. See [log_level](#log-levels).
         type: string
+  filters:
+    description: Regular Expression logging filters.
+    required: false
+    type: map
+    keys:
+      '&lt;component_namespace&gt;':
+        description: Logger namespace of the component and a list of Regular Expressions. See [Log Filters](#log-filters).
+        type: list
 {% endconfiguration %}
 
 In the example, do note the difference between 'glances_api' and 'homeassistant.components.glances' namespaces,
@@ -109,6 +117,26 @@ Possible log severity levels, listed in order from most severe to least severe, 
 - info
 - debug
 - notset
+
+### Log Filters
+
+Service-specific Regular Expression filters for logs. A message is omitted if it matches the Regular Expression.
+
+An example config might look like this:
+
+```yaml
+# Example configuration.yaml entry
+logger:
+  default: info
+  logs:
+    custom_components.my_integration: critical
+  filters:
+    custom_component.my_integartion:
+      - "HTTP 429" # Filter all HTTP 429 errors
+      - "Request to .*unreliable.com.* Timed Out"
+    homeassistant.components.nws:
+      - "^Error handling request$"
+```
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
Adds documentation for logger filters implemented in https://github.com/home-assistant/core/pull/48439



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48439
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
