### PR TITLE
Add service ota_update to shelly integration

### DIFF
--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -123,12 +123,15 @@ Not all devices support all input events. You can check on [Shelly API Reference
 
 ### Service `shelly.ota_update`
 
-Triggers an over-the-air update for selected Shelly device(s). At least one of `area_id` or `device_id` has to be provided. This could be easily done via the target selector on UI.
+Triggers an over-the-air update for selected Shelly device(s). At least one of `area_id` or `device_id` has to be provided. This could be easily done via the target selector on UI. If both `url`and `beta` parameter are set, still ota update from specified `url` is triggered, because it is more specific.
 
-  | Service data attribute | Required | Type | Description |
-  | ---------------------- | -------- | ---- | ----------- |
-  | `area_id` | no | `list` | Area or list of areas to trigger OTA update (_only Shelly devices will be touched_) |
-  | `device_id` | no | `list` | Device or list of devices to trigger OTA update |
+  | Service data attribute | Required | Type | Default | Description |
+  | ---------------------- | -------- | ---- | ------- | ----------- |
+  | `area_id` | no | `list` || Area or list of areas to trigger OTA update (_only Shelly devices will be touched_) |
+  | `device_id` | no | `list` || Device or list of devices to trigger OTA update |
+  | `url` | no | `bool` || Run firmware update from specified URL |
+  | `beta` | no | `bool` | `false` | Run firmware update from beta URL (*if available*) |
+  | `force` | no | `bool` | `false` | Allows downgrade from beta-version to latest release-version and reinstall of current release-version |
 
 ## Known issues and limitations
 

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -119,6 +119,17 @@ Not all devices support all input events. You can check on [Shelly API Reference
 
 </div>
 
+## Services
+
+### Service `shelly.ota_update`
+
+Triggers an over-the-air update for selected Shelly device(s). At least one of `area_id` or `device_id` has to be provided. This could be easily done via the target selector on UI.
+
+  | Service data attribute | Required | Type | Description |
+  | ---------------------- | -------- | ---- | ----------- |
+  | `area_id` | no | `list` | Area or list of areas to trigger OTA update (_only Shelly devices will be touched_) |
+  | `device_id` | no | `list` | Device or list of devices to trigger OTA update |
+
 ## Known issues and limitations
 
 - Only supports firmware 1.8 and later


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds a new service `ota_update` to the shelly integration, which is intended to trigger OTA updates to a single or multiple devices at the same time.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#48448
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
