### PR TITLE
Add Denon AVR-S650H to denonavr integration documentation

### DIFF
--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -48,6 +48,7 @@ Known supported devices:
 - Denon AVR-3312
 - Denon AVR-3313CI
 - Denon AVR-4810
+- Denon AVR-S650H
 - Denon AVR-S710W
 - Denon AVR-S720W
 - Denon AVR-S750H


### PR DESCRIPTION
## Proposed change

The Denon AVR-S650H works fine with the current `denonavr` integration.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
