### PR TITLE
Update mqtt.markdown

### DIFF
--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -45,10 +45,10 @@ Manual configuration is required when connecting to a broker over TLS.
 ```yaml
 # Example configuration.yaml entry for connecting over TLS without host name verification
 mqtt:
-  certificate: PATH_TO_CA.crt
-  broker: IP_ADDRESS_BROKER
-  port: PORT_BROKER
-  username: MQTT_USERNAME
+  certificate: "PATH_TO_CA.crt"
+  broker: "IP_ADDRESS_BROKER"
+  port: 8883
+  username: "MQTT_USERNAME"
   password: !secret MQTT_PASSWORD
   tls_insecure: true
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -43,7 +43,7 @@ mqtt:
 Manual configuration is required when connecting to a broker over TLS.
 
 ```yaml
-# Example configuration.yaml entry for connecting over TLS without host name verification
+# Example configuration.yaml entry
 mqtt:
   certificate: "PATH_TO_CA.crt"
   broker: "IP_ADDRESS_BROKER"

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -39,7 +39,8 @@ To connect to your [own MQTT broker](/docs/mqtt/broker#run-your-own):
 mqtt:
   broker: IP_ADDRESS_BROKER
 ```
-Manual configuration is required when conencting to a broker over TLS.
+
+Manual configuration is required when connecting to a broker over TLS.
 
 ```yaml
 # Example configuration.yaml entry for connecting over TLS without host name verification

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -39,6 +39,19 @@ To connect to your [own MQTT broker](/docs/mqtt/broker#run-your-own):
 mqtt:
   broker: IP_ADDRESS_BROKER
 ```
+Manual configuration is required when conencting to a broker over TLS.
+
+```yaml
+# Example configuration.yaml entry for connecting over TLS without host name verification
+mqtt:
+  certificate: PATH_TO_CA.crt
+  broker: IP_ADDRESS_BROKER
+  port: PORT_BROKER
+  username: MQTT_USERNAME
+  password: !secret MQTT_PASSWORD
+  tls_insecure: true
+
+```
 
 ## Additional features
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -50,7 +50,6 @@ mqtt:
   port: 8883
   username: "MQTT_USERNAME"
   password: !secret MQTT_PASSWORD
-  tls_insecure: true
 
 ```
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -50,7 +50,6 @@ mqtt:
   port: 8883
   username: "MQTT_USERNAME"
   password: !secret MQTT_PASSWORD
-
 ```
 
 ## Additional features


### PR DESCRIPTION
When I followed the instructions it made it seem like I can configure host/port with GUI and then add the TLS options via configuration file and that did not work. When there is any GUI configuration the mqtt configuration in the yaml file is ignored. This is not obvious, hopefully the proposed addition to help documentation will be useful.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
