### PR TITLE
Updated Onkyo documentation in line with code changes

### DIFF
--- a/source/_integrations/onkyo.markdown
+++ b/source/_integrations/onkyo.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate Onkyo and some Pioneer receivers i
 ha_category:
   - Media Player
 ha_release: 0.17
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ha_domain: onkyo
 ---
 
@@ -26,26 +26,26 @@ media_player:
       pc: "HTPC"
 ```
 
- If your receiver has second or third zone’s available, they are displayed as additional media players with the same functionality as the main zone.
+ If your receiver has second or third zones available, they are displayed as additional media players with the same functionality as the main zone.
 
 {% configuration %}
 host:
   description: IP address of the device. Example:`192.168.1.2`. If not specified, the platform will load any discovered receivers.
   required: false
   type: string
+port:
+  description: The port of the receiver.
+  default: 60128
+  required: false
+  type: integer
 name:
   description: Name of the device. (*Required if host is specified*)
   required: false
   type: string
 max_volume:
-  description: Maximum volume as a percentage. Often the maximum volume of the receiver is far too loud. Setting this will set Home Assistant's 100% volume to be this setting on the amp. i.e., if you set this to 50% when you set Home Assistant to be 100% then your receiver will be set to 50% of it's maximum volume.
-  required: false
-  default: 100
-  type: integer
-receiver_max_volume:
   description: The maximum volume of the receiver. For older Onkyo receivers this was 80, newer Onkyo receivers use 200.
   required: false
-  default: 80
+  default: 90
   type: integer
 sources:
   description: A list of mappings from source to source name. Valid sources can be found below. A default list will be used if no source mapping is specified.
@@ -85,15 +85,15 @@ List of source names:
 If your source is not listed above, and you want to figure out how to format that source name so you can map its entry, you can use the `onkyo-eiscp` Python module to discover the exact naming needed. First, change your receiver's source to the one that you need to define, and then run:
 
 ```bash
-onkyo --host 192.168.0.100 source=query
+eiscp_monitor --host 192.168.0.100 source=query
 ```
 
 To find your receivers max volume use the onkyo-eiscp Python module set the receiver to its maximum volume
 (don't do this whilst playing something!) and run:
 
 ```bash
-onkyo --host 192.168.0.100 volume=query
-unknown-model: master-volume = 191
+eiscp_monitor --host 192.168.0.100 volume=query
+main | master-volume: 191
 ```
 
 ### Service `onkyo_select_hdmi_output`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I opened a PR on the Onkyo component as follow up on [this PR](https://github.com/home-assistant/core/pull/33694/).
The documentation changes are largely the same as this PR: #12699 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48640
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
