### PR TITLE
Add note about HomeKit reliability with older home hubs

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -469,7 +469,7 @@ The following home hubs showed strong results when testing with 300 accessories:
 
 The following home hubs showed strong results when testing with 200 accessories:
 
-- Apple TV 4k
+- Apple TV 4k (best results when using ethernet instead of WiFi)
 
 The following home hubs have been reported to have trouble with a large number of accessories:
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -464,9 +464,12 @@ HomeKit relies heavily on your home hub to keep track of Bluetooth devices. Addi
 
 The following home hubs have been tested successfully with a large number of devices (>300):
 
+- HomePod
+- HomePod Mini
+
+The following home hubs have been tested successfully with a large number of devices (>200):
+
 - Apple TV 4k
-- Home Pod
-- Home Pod Mini
 
 The following home hubs have been reported to have trouble with a large number of devices:
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -460,7 +460,7 @@ automation:
 
 ### All or some devices are intermittently unresponsive
 
-HomeKit relies heavily on your home hub to keep track of Bluetooth devices. Additionally, each home hub has to keep track of every HomeKit accessory that you bridge. If you have many accessories, notably cameras or Bluetooth devices, **consider disabling older home hubs**.
+HomeKit relies heavily on your home hub to keep track of Bluetooth devices. Additionally, each home hub has to keep track of every HomeKit accessory that you bridge. If you have many accessories, notably cameras or Bluetooth devices, **consider disabling HomeKit on older home hubs**.
 
 The following home hubs showed strong results when testing with 300 accessories:
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -460,18 +460,18 @@ automation:
 
 ### All or some devices are intermittently unresponsive
 
-HomeKit relies heavily on your home hub to keep track of Bluetooth devices. Additionally, each home hub has to keep track of every HomeKit accessory that you bridge. If you have many accessories or Bluetooth devices, **consider disabling older home hubs**.
+HomeKit relies heavily on your home hub to keep track of Bluetooth devices. Additionally, each home hub has to keep track of every HomeKit accessory that you bridge. If you have many accessories, notably cameras or Bluetooth devices, **consider disabling older home hubs**.
 
-The following home hubs have been tested successfully with a large number of devices (>300):
+The following home hubs showed strong results with at least 300 accessories:
 
 - HomePod
 - HomePod Mini
 
-The following home hubs have been tested successfully with a large number of devices (>200):
+The following home hubs showed strong results with at least 200 accessories:
 
 - Apple TV 4k
 
-The following home hubs have been reported to have trouble with a large number of devices:
+The following home hubs have been reported to have trouble with a large number of accessories:
 
 - Apple TV HD
 - Various iPad models

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -575,17 +575,13 @@ If you have any iOS 12.x devices signed into your iCloud account, media player e
 
 #### Accessories are all listed as not responding
 
-There are reports where the IGMP settings in a router were causing issues with HomeKit. This resulted in a situation where all of the Home Assistant HomeKit accessories stopped responding a few minutes after Home Assistant (re)started. Double check your router's IGPM settings if you experiencing this issue. The default IGMP settings typically work best.
+There are reports where the IGMP settings in a router were causing issues with HomeKit. This resulted in a situation where all of the Home Assistant HomeKit accessories stopped responding a few minutes after Home Assistant (re)started. Double check your router's IGMP settings if you experiencing this issue. The default IGMP settings typically work best.
 
 See [specific entity doesn't work](#specific-entity-doesnt-work)
 
 #### Accessory not responding - after restart or update
 
 See [resetting accessories](#resetting-accessories)
-
-#### Accessory not responding - randomly
-
-Unfortunately, that sometimes happens at the moment. It might help to close the `Home` App and delete it from the cache. Usually, the accessory should get back to responding after a few minutes at most.
 
 #### The linked battery sensor isn't recognized
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -458,6 +458,21 @@ automation:
 
 ## Troubleshooting
 
+### All or some devices are intermittently unresponsive
+
+HomeKit relies heavily on your home hub to keep track of Bluetooth devices. Additionally, each home hub has to keep track of every HomeKit accessory that you bridge. If you have many accessories or Bluetooth devices, **consider disabling older home hubs**.
+
+The following home hubs have been tested successfully with a large number of devices (>300):
+
+- Apple TV 4k
+- Home Pod
+- Home Pod Mini
+
+The following home hubs have been reported to have trouble with a large number of devices:
+
+- Apple TV HD
+- Various iPad models
+
 ### Resetting when created via YAML
 
  1. Delete the `HomeKit` integration in the **{% my integrations %}** screen.

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -462,12 +462,12 @@ automation:
 
 HomeKit relies heavily on your home hub to keep track of Bluetooth devices. Additionally, each home hub has to keep track of every HomeKit accessory that you bridge. If you have many accessories, notably cameras or Bluetooth devices, **consider disabling older home hubs**.
 
-The following home hubs showed strong results with at least 300 accessories:
+The following home hubs showed strong results when testing with 300 accessories:
 
 - HomePod
 - HomePod Mini
 
-The following home hubs showed strong results with at least 200 accessories:
+The following home hubs showed strong results when testing with 200 accessories:
 
 - Apple TV 4k
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add note about HomeKit reliability with older home hubs

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
