### PR TITLE
Add docs for HomePilot integration

### DIFF
--- a/source/_integrations/homepilot.markdown
+++ b/source/_integrations/homepilot.markdown
@@ -1,0 +1,26 @@
+---
+title: "Rademacher HomePilot"
+description: "Instructions for connecting Rademacher HomePilot devices."
+ha_release: "0.38"
+ha_category: Cover
+ha_iot_class: "Local Polling"
+ha_config_flow: true
+ha_codeowners:
+  - '@nico0302'
+ha_domain: homepilot
+---
+
+The [Rademacher HomePilot](https://www.rademacher.de/smart-home/produkte/homepilot) integration allows you to connect your Rademacher HomePilot Hub or Smart2Smart Bridge with Home Assistant.
+The [pyhomepilot libary](https://github.com/Nico0302/pyhomepilot) is used for communicating.
+
+Support is currently limited to automatic blinds.
+
+### Setup
+
+Menu: *Configuration* -> *Integrations*
+
+Fill the form:
+
+* The ip-address or hostname of the **host**
+* Optional a **password** if you configured it in your hosts settings (recommended)
+

--- a/source/_integrations/homepilot.markdown
+++ b/source/_integrations/homepilot.markdown
@@ -15,14 +15,4 @@ The [pyhomepilot library](https://github.com/Nico0302/pyhomepilot) is used for c
 
 Support is currently limited to automatic blinds.
 
-## Configuration
-
-To add the Rademacher HomePilot integration to your installation:
-
-- Go to the Integrations menu: **Configuration** >> **Integrations** in the UI.
-- Click the button with the `+` sign at the bottom right of the screen.
-- Select **Rademacher HomePilot** from the list of integrations.
-- Fill in the IP address or hostname of your Rademacher Hub or Bridge under **Host**.
-- If you protected your Rademacher Hub or Bridge with a password you should also enter it.
-- Click on **SUBMIT** to complete the setup.
-
+{% include integrations/config_flow.md %}

--- a/source/_integrations/homepilot.markdown
+++ b/source/_integrations/homepilot.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Rademacher HomePilot"
 description: "Instructions for connecting Rademacher HomePilot devices."
-ha_release: "0.38"
+ha_release: "2021.3"
 ha_category: Cover
 ha_iot_class: "Local Polling"
 ha_config_flow: true

--- a/source/_integrations/homepilot.markdown
+++ b/source/_integrations/homepilot.markdown
@@ -11,7 +11,7 @@ ha_domain: homepilot
 ---
 
 The [Rademacher HomePilot](https://www.rademacher.de/smart-home/produkte/homepilot) integration allows you to connect your Rademacher HomePilot Hub or Smart2Smart Bridge with Home Assistant.
-The [pyhomepilot libary](https://github.com/Nico0302/pyhomepilot) is used for communication.
+The [pyhomepilot library](https://github.com/Nico0302/pyhomepilot) is used for communicating.
 
 Support is currently limited to automatic blinds.
 

--- a/source/_integrations/homepilot.markdown
+++ b/source/_integrations/homepilot.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Rademacher HomePilot"
 description: "Instructions for connecting Rademacher HomePilot devices."
-ha_release: "2021.3"
+ha_release: "2021.5"
 ha_category: Cover
 ha_iot_class: "Local Polling"
 ha_config_flow: true
@@ -22,7 +22,7 @@ To add the Rademacher HomePilot integration to your installation:
 - Go to the Integrations menu: **Configuration** >> **Integrations** in the UI.
 - Click the button with the `+` sign at the bottom right of the screen.
 - Select **Rademacher HomePilot** from the list of integrations.
-- Fill in the IP adress or hostname of your Rademacher Hub or Bridge under **Host**.
+- Fill in the IP address or hostname of your Rademacher Hub or Bridge under **Host**.
 - If you protected your Rademacher Hub or Bridge with a password you should also enter it.
 - Click on **SUBMIT** to complete the setup.
 

--- a/source/_integrations/homepilot.markdown
+++ b/source/_integrations/homepilot.markdown
@@ -11,7 +11,7 @@ ha_domain: homepilot
 ---
 
 The [Rademacher HomePilot](https://www.rademacher.de/smart-home/produkte/homepilot) integration allows you to connect your Rademacher HomePilot Hub or Smart2Smart Bridge with Home Assistant.
-The [pyhomepilot libary](https://github.com/Nico0302/pyhomepilot) is used for communicating.
+The [pyhomepilot libary](https://github.com/Nico0302/pyhomepilot) is used for communication.
 
 Support is currently limited to automatic blinds.
 

--- a/source/_integrations/homepilot.markdown
+++ b/source/_integrations/homepilot.markdown
@@ -11,7 +11,6 @@ ha_domain: homepilot
 ---
 
 The [Rademacher HomePilot](https://www.rademacher.de/smart-home/produkte/homepilot) integration allows you to connect your Rademacher HomePilot Hub or Smart2Smart Bridge with Home Assistant.
-The [pyhomepilot library](https://github.com/Nico0302/pyhomepilot) is used for communicating.
 
 Support is currently limited to automatic blinds.
 

--- a/source/_integrations/homepilot.markdown
+++ b/source/_integrations/homepilot.markdown
@@ -15,12 +15,14 @@ The [pyhomepilot libary](https://github.com/Nico0302/pyhomepilot) is used for co
 
 Support is currently limited to automatic blinds.
 
-### Setup
+## Configuration
 
-Menu: *Configuration* -> *Integrations*
+To add the Rademacher HomePilot integration to your installation:
 
-Fill the form:
-
-* The ip-address or hostname of the **host**
-* Optional a **password** if you configured it in your hosts settings (recommended)
+- Go to the Integrations menu: **Configuration** >> **Integrations** in the UI.
+- Click the button with the `+` sign at the bottom right of the screen.
+- Select **Rademacher HomePilot** from the list of integrations.
+- Fill in the IP adress or hostname of your Rademacher Hub or Bridge under **Host**.
+- If you protected your Rademacher Hub or Bridge with a password you should also enter it.
+- Click on **SUBMIT** to complete the setup.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This pull request adds the documentation for a new integration supporting [Rademacher HomePilot](https://www.rademacher.de/smart-home/produkte/homepilot) devices.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48648
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2244
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
