### PR TITLE
Modbus service

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -300,7 +300,7 @@ climates:
 
 | Service | Description |
 | ------- | ----------- |
-| set_temperature | Set Temperature. Requires `value` to be passed in, which is the desired target temperature. `value` should be in the same type as `data_type` |
+| set_temperature (#set-temperature)| Set Temperature. Requires `value` to be passed in, which is the desired target temperature. `value` should be in the same type as `data_type` |
 
 ### Configuring platform cover
 
@@ -760,7 +760,7 @@ modbus:
 
 | Service | Description |
 | ------- | ----------- |
-| write_register | Write register. Requires `hub`, `unit`, `address` and `value` fields. `value` can be either single value or an array |
+| write_register (#write_register)| Write register. Requires `hub`, `unit`, `address` and `value` fields. `value` can be either single value or an array |
 
 Description:
 
@@ -774,7 +774,7 @@ Description:
 
 | Service | Description |
 | ------- | ----------- |
-| write_coil | Write coil. Requires `hub`, `unit`, `address` and `state` fields. `state` can be either single bolean or an array |
+| write_coil (#write_coil)| Write coil. Requires `hub`, `unit`, `address` and `state` fields. `state` can be either single bolean or an array |
 
 Description:
 

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -296,7 +296,9 @@ climates:
       default: C
 {% endconfiguration %}
 
-#### Service `modbus.set-temperature`
+## Services
+
+### Service `modbus.set-temperature`
 
 | Service | Description |
 | ------- | ----------- |

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -296,11 +296,11 @@ climates:
       default: C
 {% endconfiguration %}
 
-#### Services
+#### set-temperature
 
 | Service | Description |
 | ------- | ----------- |
-| set_temperature (#set-temperature)| Set Temperature. Requires `value` to be passed in, which is the desired target temperature. `value` should be in the same type as `data_type` |
+| set_temperature | Set Temperature. Requires `value` to be passed in, which is the desired target temperature. `value` should be in the same type as `data_type` |
 
 ### Configuring platform cover
 
@@ -756,11 +756,11 @@ modbus:
     name: hub2
 ```
 
-### Services
+### write_register
 
 | Service | Description |
 | ------- | ----------- |
-| write_register (#write_register)| Write register. Requires `hub`, `unit`, `address` and `value` fields. `value` can be either single value or an array |
+| write_register | Write register. Requires `hub`, `unit`, `address` and `value` fields. `value` can be either single value or an array |
 
 Description:
 
@@ -771,10 +771,11 @@ Description:
 | address   | Address of the Register (e.g., 138) |
 | value     | A single value or an array of 16-bit values. Single value will call modbus function code 6. Array will call modbus function code 16. Array might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |
 
+### write_coil
 
 | Service | Description |
 | ------- | ----------- |
-| write_coil (#write_coil)| Write coil. Requires `hub`, `unit`, `address` and `state` fields. `state` can be either single bolean or an array |
+| write_coil | Write coil. Requires `hub`, `unit`, `address` and `state` fields. `state` can be either single bolean or an array |
 
 Description:
 

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -758,12 +758,11 @@ modbus:
 
 ### Services
 
-
 | Service | Description |
 | ------- | ----------- |
 | write_register | Write register. Requires `hub`, `unit`, `address` and `value` fields. `value` can be either single value or an array |
 
-#### Service Data Attributes
+Description:
 
 | Attribute | Description |
 | --------- | ----------- |
@@ -771,6 +770,21 @@ modbus:
 | unit      | Slave address (1-255, mostly 255 if you talk to Modbus via TCP) |
 | address   | Address of the Register (e.g., 138) |
 | value     | A single value or an array of 16-bit values. Single value will call modbus function code 6. Array will call modbus function code 16. Array might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |
+
+
+| Service | Description |
+| ------- | ----------- |
+| write_coil | Write coil. Requires `hub`, `unit`, `address` and `state` fields. `state` can be either single bolean or an array |
+
+Description:
+
+| Attribute | Description |
+| --------- | ----------- |
+| hub       | Hub name (defaults to 'default' when omitted) |
+| unit      | Slave address (1-255, mostly 255 if you talk to Modbus via TCP) |
+| address   | Address of the Register (e.g., 138) |
+| state     | A single boolean or an array of booleans. Single boolean will call modbus function code 6. Array will call modbus function code 16.
+..
 
 ## Log warning (v1.0.8 and onwards)
 

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -296,7 +296,7 @@ climates:
       default: C
 {% endconfiguration %}
 
-#### set-temperature
+#### Service `modbus.set-temperature`
 
 | Service | Description |
 | ------- | ----------- |
@@ -756,7 +756,7 @@ modbus:
     name: hub2
 ```
 
-### write_register
+### Service `modbus.write_register`
 
 | Service | Description |
 | ------- | ----------- |
@@ -771,7 +771,7 @@ Description:
 | address   | Address of the Register (e.g., 138) |
 | value     | A single value or an array of 16-bit values. Single value will call modbus function code 6. Array will call modbus function code 16. Array might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |
 
-### write_coil
+### Service `modbus.write_coil`
 
 | Service | Description |
 | ------- | ----------- |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add description of write_coil.

This is added to "next" because "next" contains a new version of the modbus integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
https://github.com/home-assistant/core/pull/48633

- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
