### PR TITLE
Fix direct state attribute access in HomeMatic example

### DIFF
--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -55,6 +55,8 @@ If you want to see if a specific device you have is supported, head over to the 
 We automatically detect all devices we currently support and try to generate useful names. If you enable name-resolving, we try to fetch names from Metadata (Homegear), via JSON-RPC or the XML-API you may have installed on your CCU. Since this may fail this is disabled by default.
 You can manually rename the created entities by using Home Assistant's [Customizing](/docs/configuration/customizing-devices/) feature. The Homematic integration is also supported by the [Entity Registry](https://developers.home-assistant.io/docs/en/entity_registry_index.html), which allows you to change the friendly name and the entity ID directly in the Home Assistant UI.
 
+## Configuration
+
 To set up the component, add the following information to your `configuration.yaml` file:
 
 ```yaml
@@ -159,38 +161,38 @@ password:
   type: string
 {% endconfiguration %}
 
-#### Example configuration with multiple protocols and some other options set:
+### Example configuration with multiple protocols and some other options set
 
 ```yaml
 homematic:
   interfaces:
     rf:
       host: 127.0.0.1
-      resolvenames: json
-      username: Admin
-      password: secret
+      resolvenames: "json"
+      username: "Admin"
+      password: "secret"
     wired:
       host: 127.0.0.1
       port: 2000
-      resolvenames: json
-      username: Admin
-      password: secret
+      resolvenames: "json"
+      username: "Admin"
+      password: "secret"
     ip:
       host: 127.0.0.1
       port: 2010
     groups:
       host: 127.0.0.1
       port: 9292
-      resolvenames: json
-      username: Admin
-      password: secret
+      resolvenames: "json"
+      username: "Admin"
+      password: "secret"
       path: /groups
   hosts:
     ccu2:
       host: 127.0.0.1
       port: 2001
-      username: Admin
-      password: secret
+      username: "Admin"
+      password: "secret"
 
 ```
 
@@ -213,7 +215,6 @@ This does *not* affect the entities in Home Assistant. They all use their own co
 ### Reading attributes of entities
 
 Most devices have, besides their state, additional attributes like their battery state or valve position. These can be accessed using templates in automations, or even as their own entities using the [template sensor](/integrations/template) component. Here's an example of a template sensor that exposes the valve position of a thermostat.
-
 
 {% raw %}
 
@@ -239,8 +240,8 @@ The values of variables are polled from the CCU/Homegear in an interval of 30 se
 
 When Homematic devices change their state or some other internal value, the CCU/Homegear sends event messages to Home Assistant. These events are automatically parsed and the entities in Home Assistant are updated. However, you can also manually use these events to trigger automations. Two event-types are available:
 
-- **homematic.keypress**: For devices with buttons, see information below
-- **homematic.impulse**: For impulse sensors
+- `homematic.keypress`: For devices with buttons, see information below
+- `homematic.impulse`: For impulse sensors
 
 #### Devices with buttons
 
@@ -256,7 +257,7 @@ automation:
      platform: event
      event_type: homematic.keypress
      event_data:
-       name: Kitchen Switch
+       name: "Kitchen Switch"
        channel: 1
        param: PRESS_SHORT
    action:
@@ -309,7 +310,7 @@ Simulate a button being pressed:
 action:
   service: homematic.virtualkey
   data:
-    address: BidCoS-RF
+    address: "BidCoS-RF"
     channel: 1
     param: PRESS_LONG
 ```
@@ -321,7 +322,7 @@ Open KeyMatic:
 action:
   service: homematic.virtualkey
   data:
-    address: LEQ1234567
+    address: "LEQ1234567"
     channel: 1
     param: OPEN
 ```
@@ -335,7 +336,7 @@ action:
   target:
     entity_id: homematic.ccu2
   data:
-    name: Variablename
+    name: "Variablename"
     value: true
 ```
 
@@ -351,7 +352,7 @@ Manually turn on a switch actor:
 action:
   service: homematic.set_device_value
   data:
-    address: LEQ1234567
+    address: "LEQ1234567"
     channel: 1
     param: STATE
     value: true
@@ -364,7 +365,7 @@ Manually set temperature on thermostat:
 action:
   service: homematic.set_device_value
   data:
-    address: LEQ1234567
+    address: "LEQ1234567"
     channel: 4
     param: SET_TEMPERATURE
     value: 23.0
@@ -377,7 +378,7 @@ Manually set the active profile on thermostat:
 action:
   service: homematic.set_device_value
   data:
-    address: LEQ1234567
+    address: "LEQ1234567"
     channel: 1
     param: ACTIVE_PROFILE
     value: 1
@@ -392,7 +393,7 @@ action:
   service: homematic.put_paramset
   data:
     interface: wireless
-    address: LEQ1234567
+    address: "LEQ1234567"
     paramset_key: MASTER
     paramset:
       WEEK_PROGRAM_POINTER: 1
@@ -406,7 +407,7 @@ action:
   service: homematic.put_paramset
   data:
     interface: wireless
-    address: LEQ1234567
+    address: "LEQ1234567"
     paramset_key: MASTER
     rx_mode: WAKEUP
     paramset:
@@ -457,7 +458,7 @@ binary_sensor:
           - sensor.office_voltage
           - sensor.time
         value_template: >-
-          {{as_timestamp(now()) - as_timestamp(states.sensor.office_voltage.last_changed) < 600}}
+          {{ as_timestamp(now()) - as_timestamp(state_attr('sensor.office_voltage', 'last_changed')) < 600 }}
 
 automation:
   - alias: "Homematic Reconnect"
@@ -528,7 +529,7 @@ To use this notification platform in your installation, add the following to you
 notify:
   - name: my_hm
     platform: homematic
-    address: NEQXXXXXXX
+    address: "NEQXXXXXXX"
     channel: 2
     param: "SUBMIT"
     value: "1,1,108000,8"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

- Fixes a case of `states.domain.entity.attribute` to use `state_attr()` as it should be
- Some minor cleanup & styling.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #17282

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
