### PR TITLE
Fix broken link in Tahoma documentation

### DIFF
--- a/source/_integrations/tahoma.markdown
+++ b/source/_integrations/tahoma.markdown
@@ -22,7 +22,7 @@ ha_platforms:
   - switch
 ---
 
-The `Tahoma` integration platform is used as an interface to the [tahomalink.com](https://www.tahomalink.com) website. It adds covers, scenes and a sun sensor from the Tahoma platform.
+The Tahoma integration is used as an interface to the [tahomalink.com](https://www.tahomalink.com) website. It adds covers, scenes and a sun sensor from the Tahoma platform.
 
 There is currently support for the following device types within Home Assistant:
 
@@ -40,9 +40,12 @@ To use your Tahoma devices in your installation, add the following to your `conf
 ```yaml
 # Example configuration.yaml entry
 tahoma:
-  username: YOUR_USERNAME
-  password: YOUR_PASSWORD
-  exclude: [BridgeHUEComponent, HueLampHUEComponent, PodComponent]
+  username: "YOUR_USERNAME"
+  password: "YOUR_PASSWORD"
+  exclude: 
+    - "BridgeHUEComponent"
+    - "HueLampHUEComponent"
+    - "PodComponent"
 ```
 
 {% configuration %}
@@ -60,4 +63,4 @@ exclude:
   type: list
 {% endconfiguration %}
 
-This also works with the Somfy Connexoon. Check [here](https://somfyhouse.freshdesk.com/nl/support/solutions/articles/14000058145-wat-is-het-verschil-tussen-de-tahoma-en-de-connexoon-) for the differences between the bridges.
+This also works with the Somfy Connexoon. Check [here](https://www.somfy.nl/keuzehulp/verschillen-tahoma-en-connexoon) for the differences between the bridges.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

- Fixes a broken link at the bottom of the page. The page was moved.
- Some small styling tweaks/adjustments

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #17188

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
