### PR TITLE
Add note about breaking changes to zwave_js section of release notes

### DIFF
--- a/source/_posts/2021-04-07-release-20214.markdown
+++ b/source/_posts/2021-04-07-release-20214.markdown
@@ -137,11 +137,7 @@ Furthermore two new services are introduced:
 - `zwave_js.bulk_set_partial_config_parameters`
 - `zwave_js.set_value`
 
-<div class='note'>
-There are breaking changes in the Z-Wave JS integration that could affect
-your existing automations. Be sure to read the
-[breaking changes](#breaking-changes) section for more info.
-</div>
+There are breaking changes in the Z-Wave JS integration that could affect your existing automations. Be sure to read the [breaking changes](#breaking-changes) section for more info.
 
 TODO:
 - Add more text to this

--- a/source/_posts/2021-04-07-release-20214.markdown
+++ b/source/_posts/2021-04-07-release-20214.markdown
@@ -137,6 +137,12 @@ Furthermore two new services are introduced:
 - `zwave_js.bulk_set_partial_config_parameters`
 - `zwave_js.set_value`
 
+<div class='note'>
+There are breaking changes in the Z-Wave JS integration that could affect
+your existing automations. Be sure to read the
+[breaking changes](#breaking-changes) section for more info.
+</div>
+
 TODO:
 - Add more text to this
 - Add screenshot


### PR DESCRIPTION
## Proposed change
Beta users are missing the breaking changes section for `zwave_js` so I added a note to hopefully prevent duplicate no-op issues from getting created.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
