### PR TITLE
Add Hive boost off

### DIFF
--- a/source/_integrations/hive.markdown
+++ b/source/_integrations/hive.markdown
@@ -39,9 +39,9 @@ Menu: *Configuration* > *Integrations* > *Select your new integration* > *Press 
   
 ## Services
 
-### Service `hive.boost_heating`
+### Service `hive.boost_heating_on`
 
-You can use the service `hive.boost_heating` to set your heating to boost for a period of time at a certain target temperature". Individual TRVs can also be boosted in the same way, using this service.
+You can use the service `hive.boost_heating_on` to set your heating to boost for a period of time at a certain target temperature". Individual TRVs can also be boosted in the same way, using this service.
 
 | Service data attribute | Optional | Description                                                            |
 | ---------------------- | -------- | ---------------------------------------------------------------------- |
@@ -56,12 +56,32 @@ Examples:
 script:
   boost_heating:
     sequence:
-      - service: hive.boost_heating
+      - service: hive.boost_heating_on
         target:
           entity_id: "climate.heating"
         data:
           time_period: "01:30:00"
           temperature: "20.5"
+```
+
+### Service `hive.boost_heating_off`
+
+You can use the service `hive.boost_heating_off` to set your heating to boost for a period of time at a certain target temperature". Individual TRVs can also be boosted in the same way, using this service.
+
+| Service data attribute | Optional | Description                                    |
+| ---------------------- | -------- | ---------------------------------------------- |
+| `entity_id`            | no       | String, Name of entity e.g., `climate.heating` |
+
+Examples:
+
+```yaml
+# Example script to boost heating, boost period and target temperature specified.
+script:
+  boost_heating:
+    sequence:
+      - service: hive.boost_heating_off
+        target:
+          entity_id: "climate.heating"
 ```
 
 ### Service `hive.boost_hot_water`
@@ -143,7 +163,6 @@ The `hive` switch platform integrates your Hive plugs into Home Assistant, enabl
 The platform supports the following Hive products:
 
 - Hive Active Plug
-- Hive Heat on Demand
 
 ### Water Heater
 

--- a/source/_integrations/hive.markdown
+++ b/source/_integrations/hive.markdown
@@ -164,6 +164,7 @@ The `hive` switch platform integrates your Hive plugs into Home Assistant, enabl
 The platform supports the following Hive products:
 
 - Hive Active Plug
+- Hive Heat on Demand
 
 ### Water Heater
 

--- a/source/_integrations/hive.markdown
+++ b/source/_integrations/hive.markdown
@@ -40,9 +40,9 @@ Menu: *Configuration* > *Integrations* > *Select your new integration* > *Press 
   
 ## Services
 
-### Service `hive.boost_heating`
+### Service `hive.boost_heating_on`
 
-You can use the service `hive.boost_heating` to set your heating to boost for a period of time at a certain target temperature". Individual TRVs can also be boosted in the same way, using this service.
+You can use the service `hive.boost_heating_on` to set your heating to boost for a period of time at a certain target temperature". Individual TRVs can also be boosted in the same way, using this service.
 
 | Service data attribute | Optional | Description                                                            |
 | ---------------------- | -------- | ---------------------------------------------------------------------- |
@@ -57,12 +57,32 @@ Examples:
 script:
   boost_heating:
     sequence:
-      - service: hive.boost_heating
+      - service: hive.boost_heating_on
         target:
           entity_id: "climate.heating"
         data:
           time_period: "01:30:00"
           temperature: "20.5"
+```
+
+### Service `hive.boost_heating_off`
+
+You can use the service `hive.boost_heating_off` to set your heating to boost for a period of time at a certain target temperature". Individual TRVs can also be boosted in the same way, using this service.
+
+| Service data attribute | Optional | Description                                    |
+| ---------------------- | -------- | ---------------------------------------------- |
+| `entity_id`            | no       | String, Name of entity e.g., `climate.heating` |
+
+Examples:
+
+```yaml
+# Example script to boost heating, boost period and target temperature specified.
+script:
+  boost_heating:
+    sequence:
+      - service: hive.boost_heating_off
+        target:
+          entity_id: "climate.heating"
 ```
 
 ### Service `hive.boost_hot_water`
@@ -144,7 +164,6 @@ The `hive` switch platform integrates your Hive plugs into Home Assistant, enabl
 The platform supports the following Hive products:
 
 - Hive Active Plug
-- Hive Heat on Demand
 
 ### Water Heater
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add a new service for switching the hive boost off and restoring the old state.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48701
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
