### PR TITLE
Mention Social Blade integration removal in 2021.4 release notes

### DIFF
--- a/source/_posts/2021-04-07-release-20214.markdown
+++ b/source/_posts/2021-04-07-release-20214.markdown
@@ -844,6 +844,8 @@ The following integrations are no longer available as of this release:
 
 - **Griddy** has been removed, Ercot shut down Griddy after the massive power
   mess in Texas in mid February. ([@bdraco] - [#47218])
+- **Social Blade** has been removed as it was broken and violated ADR-004 
+  which prohibits integrations that rely on web scraping. ([@frenck] - [#48677])
 
 ## All changes
 
@@ -2171,6 +2173,7 @@ The following integrations are no longer available as of this release:
 [#48647]: https://github.com/home-assistant/core/pull/48647
 [#48660]: https://github.com/home-assistant/core/pull/48660
 [#48667]: https://github.com/home-assistant/core/pull/48667
+[#48677]: https://github.com/home-assistant/core/pull/48677
 [#48682]: https://github.com/home-assistant/core/pull/48682
 [#48691]: https://github.com/home-assistant/core/pull/48691
 [#48710]: https://github.com/home-assistant/core/pull/48710


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This integration was removed just 3 days ago and I think it was forgot to added to release notes.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48677
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2383
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
