### PR TITLE
Fix MQTT Light Breaking Change details header

### DIFF
--- a/source/_posts/2021-04-07-release-20214.markdown
+++ b/source/_posts/2021-04-07-release-20214.markdown
@@ -694,7 +694,7 @@ to adjust them to match this change.
 
 {% enddetails %}
 
-{% details "MQTT" %}
+{% details "MQTT Fan" %}
 
 The [fan entity model](https://developers.home-assistant.io/docs/core/entity/fan/)
 has been changed. This impacts the way the MQTT Fan supports speeds and the
@@ -802,7 +802,7 @@ safely removed from your YAML configuration.
 
 {% enddetails %}
 
-{% details "SolarEdge" %}
+{% details "MQTT Light" %}
 
 MQTT JSON light now supports `color_mode` which should be used together with
 `supported_color_modes` to signal the light's features.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The breaking change for `MQTT Light` was listed under a duplicate `SolarEdge` header. Fixed that and change the `MQTT` above to `MQTT Fan` for clarity. 

Side question: Should the doc links for the two MQTT breaking changes go to the relative integrations (fan and light) instead of the top level MQTT docs?

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
