### PR TITLE
Update generic.markdown section about the `rtsp_transport` option added recently

### DIFF
--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -71,6 +71,10 @@ verify_ssl:
   required: false
   default: true
   type: boolean
+rtsp_transport:
+  description: "Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`."
+  required: false
+  type: string
 {% endconfiguration %}
 
 <p class='img'>


### PR DESCRIPTION
## Proposed change

Add the `rtsp_transport`  to generic camera documentation


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/46623


## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
