### PR TITLE
Remove the `name` variable from Amazon Polly documentation

### DIFF
--- a/source/_integrations/amazon_polly.markdown
+++ b/source/_integrations/amazon_polly.markdown
@@ -49,10 +49,6 @@ region_name:
   required: false
   type: [string, list]
   default: us-east-1
-name:
-  description: "Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`."
-  required: false
-  type: string
 text_type:
   description: "Specify wherever to use text (default) or ssml markup by default."
   required: false


### PR DESCRIPTION
The variable `name` does not exist in the Amazon Polly integration and should be removed from the documentation.

## Proposed change

Remoove the unused variable from the documentation page for the  Amazon Polly integration.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: [`17345`](https://github.com/home-assistant/home-assistant.io/issues/17345)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
