### PR TITLE
Remove redundant conversion for TP-Link template entities

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -162,23 +162,23 @@ sensor:
     sensors:
       my_tp_switch_amps:
         friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Current"
-        value_template: "{{ state_attr('switch.my_tp_switch','current_a') | float }}"
+        value_template: "{{ state_attr('switch.my_tp_switch','current_a') }}"
         unit_of_measurement: "A"
       my_tp_switch_watts:
         friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Current Consumption"
-        value_template: "{{ state_attr('switch.my_tp_switch','current_power_w') | float }}"
+        value_template: "{{ state_attr('switch.my_tp_switch','current_power_w') }}"
         unit_of_measurement: "W"
       my_tp_switch_total_kwh:
         friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Total Consumption"
-        value_template: "{{ state_attr('switch.my_tp_switch','total_energy_kwh') | float }}"
+        value_template: "{{ state_attr('switch.my_tp_switch','total_energy_kwh') }}"
         unit_of_measurement: "kWh"
       my_tp_switch_volts:
         friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Voltage"
-        value_template: "{{ state_attr('switch.my_tp_switch','voltage') | float }}"
+        value_template: "{{ state_attr('switch.my_tp_switch','voltage') }}"
         unit_of_measurement: "V"
       my_tp_switch_today_kwh:
         friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Today's Consumption"
-        value_template: "{{ state_attr('switch.my_tp_switch','today_energy_kwh') | float }}"
+        value_template: "{{ state_attr('switch.my_tp_switch','today_energy_kwh') }}"
         unit_of_measurement: "kWh"
 ```
 


### PR DESCRIPTION
## Proposed change

Since the attributes after https://github.com/home-assistant/core/pull/48828 are now anyway returned as `float`, there is no need anymore to explicitly convert them in the templates.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48828
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
