### PR TITLE
Remove scan_interval warning in PVOutput docs

### DIFF
--- a/source/_integrations/pvoutput.markdown
+++ b/source/_integrations/pvoutput.markdown
@@ -22,7 +22,6 @@ sensor:
   - platform: pvoutput
     system_id: YOUR_SYSTEM_ID
     api_key: YOUR_API_KEY
-    scan_interval: 120
 ```
 
 {% configuration %}
@@ -41,12 +40,6 @@ name:
   type: string
 {% endconfiguration %}
 
-<div class='note warning'>
-
-It's recommended to set `scan_interval:` according to a value greater than 60 seconds. The service only allows 60 requests per hour but the sensor's default is 30 seconds.
-
-</div>
-
 To format the PVoutput sensor it's recommended to use the [template component](/topics/templating/). For example:
 
 {% raw %}
@@ -56,7 +49,6 @@ sensor:
   - platform: pvoutput
     system_id: YOUR_SYSTEM_ID
     api_key: YOUR_API_KEY
-    scan_interval: 150
   - platform: template
     sensors:
       power_consumption:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Removing the warning in PVOutput docs about setting the scan_interval to >60sec, as the default for this sensor is already set at 120sec. So by default, this sensor shouldn't bust API limits and scan_interval should not need to be adjusted.

https://github.com/home-assistant/core/blob/dev/homeassistant/components/pvoutput/sensor.py#L35


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
