### PR TITLE
Improve example and explain speed_range for mqtt fan

### DIFF
--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -217,12 +217,12 @@ retain:
   type: boolean
   default: true
 speed_range_min:
-  description: The minimum of numeric output range (`off` not included, so `speed_range_min` - 1 represents 0%).
+  description: The minimum of numeric output range (`off` not included, so `speed_range_min` - 1 represents 0%). The number of speeds within the speed_range / 100 will determine the `percentage_step`.
   required: false
   type: integer
   default: 1
 speed_range_max:
-  description: The maximum of numeric output range (representing 100%).
+  description: The maximum of numeric output range (representing 100%). The number of speeds within the speed_range / 100 will determine the `percentage_step`.
   required: false
   type: integer
   default: 100
@@ -253,6 +253,7 @@ In this section you find some real-life examples of how to use this fan.
 ### Full configuration
 
 The example below shows a full configuration for a MQTT fan using percentage and preset modes.
+There are 10 speeds within the speed range, so  `percentage_step` = 100 / 10 steps = 10.0 %.
 
 ```yaml
 # Example using percentage based speeds with preset modes configuration.yaml
@@ -279,10 +280,10 @@ fan:
     payload_oscillation_on: "true"
     payload_oscillation_off: "false"
     speed_range_min: 1
-    speed_range_max: 100
+    speed_range_max: 10
 ```
 
-{% raw %}}
+{% raw %}
 
 This example demonstrates how to use command templates with JSON output.
 

--- a/source/_integrations/fan.template.markdown
+++ b/source/_integrations/fan.template.markdown
@@ -54,7 +54,7 @@ fan:
         preset_modes:
           - 'auto'
           - 'smart'
-          - 'woosh'
+          - 'whoosh'
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Improve example and explain the relation between `speed_range` and `percentage_step`. Remove typo's.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48951
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/48802

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
