### PR TITLE
Correct internal quality scale labels to improve analytics

### DIFF
--- a/source/_integrations/air_quality.markdown
+++ b/source/_integrations/air_quality.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to add air quality sensors with Home Assistant
 ha_release: 0.85
 ha_iot_class:
 ha_domain: air_quality
+ha_quality_scale: internal
 ---
 
 The `air_quality` gather information about the air quality and pollution details.

--- a/source/_integrations/command_line.markdown
+++ b/source/_integrations/command_line.markdown
@@ -7,7 +7,6 @@ ha_category:
 ha_release: 0.12
 ha_iot_class: Local Polling
 ha_domain: command_line
-ha_quality_scale: internal
 ha_platforms:
   - binary_sensor
   - cover

--- a/source/_integrations/geo_location.markdown
+++ b/source/_integrations/geo_location.markdown
@@ -6,6 +6,7 @@ ha_category:
 logo: geo_location.png
 ha_release: 0.78
 ha_domain: geo_location
+ha_quality_scale: internal
 ha_iot_class:
 ---
 

--- a/source/_integrations/local_ip.markdown
+++ b/source/_integrations/local_ip.markdown
@@ -9,7 +9,6 @@ ha_config_flow: true
 ha_codeowners:
   - '@issacg'
 ha_domain: local_ip
-ha_quality_scale: internal
 ha_platforms:
   - sensor
 ---

--- a/source/_integrations/stt.markdown
+++ b/source/_integrations/stt.markdown
@@ -6,6 +6,7 @@ ha_codeowners:
   - '@pvizeli'
 ha_domain: stt
 ha_iot_class:
+ha_quality_scale: internal
 ---
 
 Speech-to-Text (STT) allows you to stream speech data to the STT API and get text back.

--- a/source/_integrations/webhook.markdown
+++ b/source/_integrations/webhook.markdown
@@ -2,6 +2,7 @@
 ha_release: 0.8
 title: Webhook
 ha_domain: webhook
+ha_quality_scale: internal
 ha_iot_class:
 ---
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Processes some of the data in: <https://github.com/home-assistant/core/pull/48947>.
Adding this to the current branch, so it will show up in the analytics asap.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
