### PR TITLE
Move additional automation reading in getting started

### DIFF
--- a/source/getting-started/automation.markdown
+++ b/source/getting-started/automation.markdown
@@ -43,10 +43,14 @@ A new automation with the action set up to turn on the lights.
 
 Click the orange button to save the automation. Now wait till it's 30 minutes until the sun sets and see your automation magic!
 
-Further reading on automations:
+{% include getting-started/next_step.html step="Presence detection" link="/getting-started/presence-detection/" %}
+
+If after completing this getting started, you are interested in reading more
+about automations, we recommend the following page.
 
 - [Triggers](/docs/automation/trigger/)
 - [Conditions](/docs/automation/condition/)
 - [Actions](/docs/automation/action/)
 
-{% include getting-started/next_step.html step="Presence detection" link="/getting-started/presence-detection/" %}
+Please note, these pages require a bit more experience with Home Assistant
+than you probably have at this point of this tutorial.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR moves the additional reading on automations out of the tutorial flow.
It also adds an additional note to it.

Based on feedback received in #17034


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #17034

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
