### PR TITLE
Update proxmoxve documentation with port and user instructions

### DIFF
--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -41,7 +41,7 @@ proxmoxve:
 
 {% configuration %}
 host:
-  description: IP address of the Proxmox VE instance.
+  description: IP address of the Proxmox VE instance. Can include port by appending ":<port>".
   required: true
   type: string
 port:
@@ -148,3 +148,5 @@ Creating a dedicated user for Home Assistant, limited to only to the access just
 7. Select the group just created earlier (`HomeAssistant`) to grant access to Proxmox
 8. Ensure `Enabled` is checked and `Expire` is set to "never"
 9. Click `Add`
+
+In your Home Assistant configuration, use `hass@pve` for the username and your chosen password for the password.

--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -41,7 +41,7 @@ proxmoxve:
 
 {% configuration %}
 host:
-  description: IP address of the Proxmox VE instance. Can include port by appending ":<port>".
+  description: IP address of the Proxmox VE instance. Can include port by appending ":\<port\>".
   required: true
   type: string
 port:
@@ -55,7 +55,7 @@ verify_ssl:
   default: true
   type: boolean
 username:
-  description: The username used to authenticate. Can include the realm by appending "@<realm>".
+  description: The username used to authenticate. Can include the realm by appending "@\<realm\>".
   required: true
   type: string
 password:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

* Include port in hostname details
* Explicitly state the config to use for the example user

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: #17392

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
