### PR TITLE
Add note that media_source media must be natively supported

### DIFF
--- a/source/_integrations/media_source.markdown
+++ b/source/_integrations/media_source.markdown
@@ -64,7 +64,7 @@ To play media from a media source via a service call, use the uri scheme `media-
 Default `media_dir`is `local`.
 
 <div class="note">
-The Media Source integration does not do any transcoding of media, meaning media files must be natively supported by the web browser (for playing in the frontend) or media player. Web browsers and Google Cast media players typically have very limited video container and codec support. If a video file is not supported by your web browser it will fail to play. Please check the documentation of your web browser or media player.
+Web browsers and Google Cast media players have very limited video container and codec support. The Media Source integration does not do any transcoding of media, meaning media files must be natively supported by your media player or web browser (for playing in the frontend). If a video file is not supported by your media player or web browser it will fail to play. Please check the documentation of your media player or web browser for lists of supported video formats.
 </div>
 
 Example:

--- a/source/_integrations/media_source.markdown
+++ b/source/_integrations/media_source.markdown
@@ -63,6 +63,10 @@ homeassistant:
 To play media from a media source via a service call, use the uri scheme `media-source://media_source/<media_dir>/<path>`.
 Default `media_dir`is `local`.
 
+<div class="note">
+The Media Source integration does not do any transcoding of media, meaning media files must be natively supported by the web browser (for playing in the frontend) or media player. Web browsers and Google Cast media players typically have very limited video container and codec support. If a video file is not supported by your web browser it will fail to play. Please check the documentation of your web browser or media player.
+</div>
+
 Example:
 ```yaml
 service: media_player.play_media


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add note that media_source media must be natively supported because there's no transcoding done by media_source


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
