### PR TITLE
Add link from using blueprint to creating blueprint

### DIFF
--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -45,6 +45,13 @@ The Home Assistant Community forums have a specific tag for blueprints. This tag
 
 [blueprint-forums]: /get-blueprints
 
+## Creating new blueprints
+
+Using blueprints is nice and easy, but what if you could create that one missing
+blueprint that our community definitely needs?
+
+Learn more about blueprint by [reading our tutorial on creating a blueprint](//docs/blueprint/tutorial/).
+
 ## Troubleshooting missing automations
 
 When you're creating automations using blueprints and they don't appear in the UI, make sure that you add back `automation: !include automations.yaml` from the default configuration to your `configuration.yaml`.

--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -50,7 +50,7 @@ The Home Assistant Community forums have a specific tag for blueprints. This tag
 Using blueprints is nice and easy, but what if you could create that one missing
 blueprint that our community definitely needs?
 
-Learn more about blueprint by [reading our tutorial on creating a blueprint](//docs/blueprint/tutorial/).
+Learn more about blueprint by [reading our tutorial on creating a blueprint](/docs/blueprint/tutorial/).
 
 ## Troubleshooting missing automations
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds a small chapter to the using blueprint docs, to the blueprint creation tutorial.
As suggested by #16552

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: closes #16552

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
