### PR TITLE
Simplify picotts instructions - it is now preinstalled

### DIFF
--- a/source/_integrations/picotts.markdown
+++ b/source/_integrations/picotts.markdown
@@ -10,17 +10,8 @@ ha_platforms:
   - tts
 ---
 
-The `picotts` text-to-speech platform uses offline pico Text-to-Speech engine to read a text with natural sounding voices.
-This requires to install the pico TTS library on the system, typically on Debian just do `sudo apt-get install libttspico-utils`
-On some Raspbian release, this package is missing but you can just copy the arm deb package from Debian.
-
-On Debian Buster, the package is missing, use the following commands to install it:
-
-```bash
-wget http://ftp.us.debian.org/debian/pool/non-free/s/svox/libttspico0_1.0+git20130326-9_armhf.deb
-wget http://ftp.us.debian.org/debian/pool/non-free/s/svox/libttspico-utils_1.0+git20130326-9_armhf.deb
-sudo apt-get install -f ./libttspico0_1.0+git20130326-9_armhf.deb ./libttspico-utils_1.0+git20130326-9_armhf.deb
-```
+The `picotts` text-to-speech platform uses [Pico TTS library](https://github.com/naggety/picotts) to read out text with natural sounding voices.
+Pico TTS is a powerful open-source engine that runs locally (cloudless) so it can work even without an internet connection.
 
 ## Configuration
 
@@ -50,3 +41,15 @@ tts:
   - platform: picotts
     language: "fr-FR"
 ```
+
+## Manual library installation
+
+If you need to manually install the pico TTS library on your system, typically on Debian just do `sudo apt-get install libttspico-utils`
+On some Raspbian release, this package is missing but you can just copy the arm deb package from Debian.
+
+On Debian Buster, the package is missing, use the following commands to install it:
+
+```bash
+wget http://ftp.us.debian.org/debian/pool/non-free/s/svox/libttspico0_1.0+git20130326-9_armhf.deb
+wget http://ftp.us.debian.org/debian/pool/non-free/s/svox/libttspico-utils_1.0+git20130326-9_armhf.deb
+sudo apt-get install -f ./libttspico0_1.0+git20130326-9_armhf.deb ./libttspico-utils_1.0+git20130326-9_armhf.deb

--- a/source/_integrations/picotts.markdown
+++ b/source/_integrations/picotts.markdown
@@ -41,15 +41,3 @@ tts:
   - platform: picotts
     language: "fr-FR"
 ```
-
-## Manual library installation
-
-If you need to manually install the pico TTS library on your system, typically on Debian just do `sudo apt-get install libttspico-utils`
-On some Raspbian release, this package is missing but you can just copy the arm deb package from Debian.
-
-On Debian Buster, the package is missing, use the following commands to install it:
-
-```bash
-wget http://ftp.us.debian.org/debian/pool/non-free/s/svox/libttspico0_1.0+git20130326-9_armhf.deb
-wget http://ftp.us.debian.org/debian/pool/non-free/s/svox/libttspico-utils_1.0+git20130326-9_armhf.deb
-sudo apt-get install -f ./libttspico0_1.0+git20130326-9_armhf.deb ./libttspico-utils_1.0+git20130326-9_armhf.deb


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

`picotts` instructions were prompting users to install the library. It now comes preinstalled (https://github.com/home-assistant/docker/pull/142)

- Moved manual installation to the bottom of the page
- Completed the introduction sentence (it was left hanging)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/docker/pull/142
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
