### PR TITLE
InComfort: reorder configuration description

### DIFF
--- a/source/_integrations/incomfort.markdown
+++ b/source/_integrations/incomfort.markdown
@@ -34,31 +34,6 @@ In addition, there is a **Sensor** for each of CV pressure, CV temperature, and 
 
 Any room thermostats (there can be 0, 1 or 2) are represented as **Climate** devices. They will report the thermostat's `temperature` (setpoint, target temperature) and `current_temperature` and the setpoint can be changed.
 
-## Automation
-
-To send an alert if the CV pressure is too low or too high, consider the following example:
-
-{% raw %}
-
-```yaml
-- alias: "Low CV Pressure Alert"
-  trigger:
-    platform: numeric_state
-    entity_id: sensor.cv_pressure
-    below: 1.0
-  action:
-  - service: notify.pushbullet_notifier
-    data:
-      title: "Warning: Low CH Pressure"
-      message: >-
-        {{ trigger.to_state.attributes.friendly_name }}
-        is low, {{ trigger.to_state.state }} bar.
-```
-
-{% endraw %}
-
-Other properties are available via each device's attributes.
-
 ## Configuration
 
 To set up this integration, add one of the following to your `configuration.yaml` file:
@@ -101,3 +76,28 @@ password:
   required: inclusive
   type: string
 {% endconfiguration %}
+
+## Automation
+
+To send an alert if the CV pressure is too low or too high, consider the following example:
+
+{% raw %}
+
+```yaml
+- alias: "Low CV Pressure Alert"
+  trigger:
+    platform: numeric_state
+    entity_id: sensor.cv_pressure
+    below: 1.0
+  action:
+  - service: notify.pushbullet_notifier
+    data:
+      title: "Warning: Low CH Pressure"
+      message: >-
+        {{ trigger.to_state.attributes.friendly_name }}
+        is low, {{ trigger.to_state.state }} bar.
+```
+
+{% endraw %}
+
+Other properties are available via each device's attributes.


### PR DESCRIPTION
## Proposed change
<!-- 
-->
The configuration settings were placed at the end of the page, after an automation example. 
For more consistency the configuration is now placed before the automation example.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
