### PR TITLE
add missing description

### DIFF
--- a/source/_integrations/fan.template.markdown
+++ b/source/_integrations/fan.template.markdown
@@ -110,6 +110,10 @@ fan:
         description: Defines an action to run when the fan is given a speed percentage command.
         required: false
         type: action
+      set_preset_mode:
+        description: Defines an action to run when the fan is given a preset command.
+        required: false
+        type: action
       set_oscillating:
         description: Defines an action to run when the fan is given an osc state command.
         required: false


### PR DESCRIPTION
`set_preset_mode` is defined in the example but not in the variable description.

## Proposed change
adding missing description



## Type of change
adding variables description

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
none

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
