### PR TITLE
Clarifying how attributes are set

### DIFF
--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -67,6 +67,10 @@ queries:
       type: template
 {% endconfiguration %}
 
+There is no explicit configuration required for attributes. The integration will set all additional columns returned by the query as attributes. 
+
+Note that in all cases only the first row returned will be used.
+
 ## Examples
 
 In this section, you find some real-life examples of how to use this sensor.


### PR DESCRIPTION
See #17443 for more details.

## Proposed change
<!-- 
I couldn't understand from the docs how attributes come into play without reading the code (which every user will not be able to do). I think if the docs can just state that additional columns returned by the query will be set as attributes – and that only row one gets used – it should be good.
-->

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
The integration's maintainer confirmed that my understanding is correct.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: #17443 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
