### PR TITLE
Tweaks to Media Source documentation

### DIFF
--- a/source/_integrations/media_source.markdown
+++ b/source/_integrations/media_source.markdown
@@ -13,7 +13,11 @@ ha_quality_scale: internal
 
 The Media Source integration platform allows integrations to expose media for
 use inside Home Assistant through the Media Browser panel or through supported
-media players like Google Cast. This integration is configured automatically
+media players like Google Cast.
+
+## Configuration
+
+This integration is configured automatically
 through `default_config` or if another integration implements a media source.
 
 If your configuration does not contain any of the above, you can add the below
@@ -27,7 +31,7 @@ media_source:
 ## Local Media
 
 By default, the integration looks for media in a specified folder.
-If other `media_dirs` are not declared you need to use `/media/local` path for 
+If other `media_dirs` are not declared you need to use `/media/local` path for
 example in companion app notification.
 
 For Home Assistant OS, Supervised and Container users, this folder is by default
@@ -58,23 +62,37 @@ homeassistant:
     recording: /mnt/recordings
 ```
 
+Please note, that the folder must be accessible locally. Home Assistant
+cannot connect to external or remote network shares using this configuration
+option.
+
 ## Playing media from a Media Source
 
-To play media from a media source via a service call, use the uri scheme `media-source://media_source/<media_dir>/<path>`.
-Default `media_dir`is `local`.
+To play media from a media source via a service call, use the uri
+scheme `media-source://media_source/<media_dir>/<path>`.
+Default `media_dir` is `local`.
 
 <div class="note">
-Web browsers and Google Cast media players have very limited video container and codec support. The Media Source integration does not do any transcoding of media, meaning media files must be natively supported by your media player or web browser (for playing in the frontend). If a video file is not supported by your media player or web browser it will fail to play. Please check the documentation of your media player or web browser for lists of supported video formats.
+Web browsers and Google Cast media players have very limited video container
+and codec support. The Media Source integration does not do any transcoding of
+media, meaning media files must be natively supported by your media player or
+web browser (for playing in the frontend).
+
+If a video file is not supported by
+your media player or web browser it will fail to play. Please check the
+documentation of your media player or web browser for lists
+of supported video formats.
 </div>
 
 Example:
+
 ```yaml
 service: media_player.play_media
 target:
   entity_id: media_player.living_room_tv
 data:
-  media_content_type: video/mp4
-  media_content_id: media-source://media_source/local/videos/favourites/Epic Sax Guy 10 Hours.mp4
+  media_content_type: "video/mp4"
+  media_content_id: "media-source://media_source/local/videos/favourites/Epic Sax Guy 10 Hours.mp4"
 ```
 
 [basic-configuration]: /docs/configuration/basic/#media_dirs


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Some small tweaks to the media source documentation. Main addition is to make clear that Home Assistant cannot add external/network mounts.

fixes #16504

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: closes #16504

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
