### PR TITLE
Add new services to the profiler

### DIFF
--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -111,7 +111,7 @@ An example is below:
 
 ### Service `profiler.log_event_loop_scheduled`
 
-Log what is scheduled in the event loop. This can be helpful in in tracking down integrations that do not stop listeners on stop or do not have sufficient locking to avoid scheduling updates before the previous update finished.
+Log what is scheduled in the event loop. This can be helpful in tracking down integrations that do not stop listeners when Home Assistant stops or do not have sufficient locking to avoid scheduling updates before the previous update is finished.
 
 Each upcoming scheduled item is logged similar to the below example:
 

--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -76,7 +76,7 @@ When `start_log_objects` highlights the growth of a collection of objects in mem
 
 ### Service `profiler.log_thread_frames`
 
-To help discover run away threads, why the executor is overloaded, or other threading problem, the current frames for each running thread will be logged when this service is called.
+To help discover run away threads, why the executor is overloaded, or other threading problems, the current frames for each running thread will be logged when this service is called.
 
 An example is below:
 
@@ -116,4 +116,3 @@ Log what is scheduled in the event loop. This can be helpful in in tracking down
 Each upcoming scheduled item is logged similar to the below example:
 
 `[homeassistant.components.profiler] Scheduled: <TimerHandle when=1528307.1818668307 async_track_point_in_utc_time.<locals>.run_action(<Job HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.screenlogic.ScreenlogicDataUpdateCoordinator object at 0x7f985d896d30>>>) at /usr/src/homeassistant/homeassistant/helpers/event.py:1175>`
-

--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -73,3 +73,12 @@ Stop logging the growth of objects in memory.
 | `type` | no | The type of object to dump to the log.
 
 When `start_log_objects` highlights the growth of a collection of objects in memory, this service can help investigate. The `repr` of each object that matches `type` will be logged.
+
+### Service `profiler.log_thread_frames`
+
+Log the current frames for all threads.
+
+### Service `profiler.log_event_loop_scheduled`
+
+Log what is scheduled in the event loop.
+

--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -111,7 +111,7 @@ An example is below:
 
 ### Service `profiler.log_event_loop_scheduled`
 
-Log what is scheduled in the event loop.
+Log what is scheduled in the event loop. This can be helpful in in tracking down integrations that do not stop listeners on stop or do not have sufficient locking to avoid scheduling updates before the previous update finished.
 
 Each upcoming scheduled item is logged similar to the below example:
 

--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -76,9 +76,44 @@ When `start_log_objects` highlights the growth of a collection of objects in mem
 
 ### Service `profiler.log_thread_frames`
 
-Log the current frames for all threads.
+To help discover run away threads, why the executor is overloaded, or other threading problem, the current frames for each running thread will be logged when this service is called.
+
+An example is below:
+
+```txt
+[homeassistant.components.profiler] Thread [SyncWorker_6]: File "/usr/local/lib/python3.8/threading.py", line 890, in _bootstrap
+    self._bootstrap_inner()
+  File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
+    self.run()
+  File "/usr/local/lib/python3.8/threading.py", line 870, in run
+    self._target(*self._args, **self._kwargs)
+  File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 80, in _worker
+    work_item.run()
+  File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
+    result = self.fn(*self.args, **self.kwargs)
+  File "/usr/src/homeassistant/homeassistant/components/samsungtv/media_player.py", line 139, in update
+    self._state = STATE_ON if self._bridge.is_on() else STATE_OFF
+  File "/usr/src/homeassistant/homeassistant/components/samsungtv/bridge.py", line 72, in is_on
+    return self._get_remote() is not None
+  File "/usr/src/homeassistant/homeassistant/components/samsungtv/bridge.py", line 274, in _get_remote
+    self._remote.open()
+  File "/usr/local/lib/python3.8/site-packages/samsungtvws/remote.py", line 146, in open
+    self.connection = websocket.create_connection(
+  File "/usr/local/lib/python3.8/site-packages/websocket/_core.py", line 511, in create_connection
+    websock.connect(url, **options)
+  File "/usr/local/lib/python3.8/site-packages/websocket/_core.py", line 219, in connect
+    self.sock, addrs = connect(url, self.sock_opt, proxy_info(**options),
+  File "/usr/local/lib/python3.8/site-packages/websocket/_http.py", line 120, in connect
+    sock = _open_socket(addrinfo_list, options.sockopt, options.timeout)
+  File "/usr/local/lib/python3.8/site-packages/websocket/_http.py", line 170, in _open_socket
+    sock.connect(address)
+```
 
 ### Service `profiler.log_event_loop_scheduled`
 
 Log what is scheduled in the event loop.
+
+Each upcoming scheduled item is logged similar to the below example:
+
+`[homeassistant.components.profiler] Scheduled: <TimerHandle when=1528307.1818668307 async_track_point_in_utc_time.<locals>.run_action(<Job HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.screenlogic.ScreenlogicDataUpdateCoordinator object at 0x7f985d896d30>>>) at /usr/src/homeassistant/homeassistant/helpers/event.py:1175>`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add new services to the profiler

- log_thread_frames - To help discover run away threads, why the executor is overloaded, or other threading problem, the current frames for each running thread will be logged when this service is called.

- log_event_loop_scheduled - This can be helpful in in tracking down integrations that do not stop listeners on stop or do not have sufficient locking to avoid scheduling updates before the previous update finished.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/49327
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
