### PR TITLE
Extend examples on Shell Command documentation

### DIFF
--- a/source/_integrations/shell_command.markdown
+++ b/source/_integrations/shell_command.markdown
@@ -17,6 +17,8 @@ Shell commands aren't allowed for a camel-case naming, please use lowercase nami
 [script]: /integrations/script/
 [automation]: /getting-started/automation/
 
+## Configuration
+
 ```yaml
 # Example configuration.yaml entry
 # Exposes service shell_command.restart_pow
@@ -37,6 +39,28 @@ Any service data passed into the service call to activate the shell command will
 
 `stdout` and `stderr` output from the command are both captured and will be logged by setting the [log level](/integrations/logger/) to debug.
 
+## Examples
+
+### Defining multiple shell commands
+
+You can also define multiple shell commands at once. This is an example
+that defines three different (unrelated) shell commands.
+
+```yaml
+# Example configuration.yaml entry
+shell_command:
+  restart_pow: touch ~/.pow/restart.txt
+  call_remote: curl http://example.com/ping
+  my_script: bash /config/shell/script.sh
+```
+
+### Automation example
+
+This is a an example of an shell command used in conjunction with an input
+helper and an automation.
+
+{% raw %}
+
 ```yaml
 # Apply value of a GUI slider to the shell_command
 automation:
@@ -55,8 +79,8 @@ input_number:
     max: 32
     step: 1
 
-{% raw %}
 shell_command:
   set_ac_to_slider: 'irsend SEND_ONCE DELONGHI AC_{{ states("input_number.ac_temperature") }}_AUTO'
-{% endraw %}
 ```
+
+{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Added an additional example to show how multiple shell commands work.
Created because of feedback received in #17490


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: closes #17490

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
