### PR TITLE
Update note about Z-Wave deprecation

### DIFF
--- a/source/_docs/z-wave/control-panel.markdown
+++ b/source/_docs/z-wave/control-panel.markdown
@@ -10,7 +10,7 @@ The Z-Wave control panel is available via **Configuration** &rarr; **Integration
 
 <div class='note'>
 
-The current Z-Wave integration will eventually be deprecated and replaced with a [new implementation based on OpenZWave Daemon](https://developers.home-assistant.io/blog/2020/02/04/new-zwave/); it's currently in beta, and you can [try it now](/integrations/ozw/).
+This Z-Wave integration is deprecated and replaced with a [new implementation based on Z-Wave JS](/integrations/zwave_js); it's currently in beta, and you can [try it now](/integrations/zwave_js/).
 
 </div>
 

--- a/source/_integrations/zwave.markdown
+++ b/source/_integrations/zwave.markdown
@@ -29,13 +29,13 @@ ha_platforms:
   - switch
 ---
 
-<p class='note warning'>
+<div class='note warning'>
 
 This integration is deprecated. We recommend using [the Z-Wave JS integration](/integrations/zwave_js).
 
 The Z-Wave integration will no longer receive any updates. It will not be removed unless it becomes incompatible with a future version of Python.
 
-</p>
+</div>
 
 The [Z-Wave](https://www.z-wave.com/) integration for Home Assistant allows you to observe and control connected Z-Wave devices. Please see the [Z-Wave getting started section](/docs/z-wave/) for in-depth documentation on how to use and setup the Z-Wave component.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updated an outdated note on the old z-wave integration.
Feedback from #16602


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: closes #16602

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
