### PR TITLE
Update default profile behaviour in light.turn_on

### DIFF
--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -27,7 +27,7 @@ The `.default` suffix should be added to the entity identifier of each light to 
 
 <div class='note'>
 
-If a light entity is in the `on` state, the default profile will only be applied if it is called in the service call data attribute `profile`, like any other named profile.
+If a light entity is in the `on` state, the default profile brightness and will only be applied if it is called in the service call data attribute `profile`, like any other named profile. The transition attribute will be applied for all `light.turn_on`, `light.toggle` and `light.turn_off` service calls, unless specified otherwise in the service call data.
 
 </div>
 

--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -25,6 +25,12 @@ The field transition is optional and can be omitted.
 
 The `.default` suffix should be added to the entity identifier of each light to define a default value, e.g., for `light.ceiling_2` the `profile` field is `light.ceiling_2.default`. To define a default for all lights, the identifier `group.all_lights.default` can be used. Individual settings always supercede the `all_lights` default setting.
 
+<div class='note'>
+
+If a light entity is in the `on` state, the default profile will only be applied if it is called in the service call data attribute `profile`, like any other named profile.
+
+</div>
+
 ### Service `light.turn_on`
 
 Turns one light on or multiple lights on using [groups](/integrations/group/).
@@ -88,6 +94,11 @@ automation:
         brightness: 130
         rgb_color: [255,0,0]
 ```
+<div class='note'>
+
+If no data is sent, and a default profile exists, the default profile will be applied.
+
+</div>
 
 ### Service `light.turn_off`
 


### PR DESCRIPTION
## Proposed change
Remove confusion and document the behaviour of applying the default profile for the light.turn_on service call.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.
Note: This is adding missing documentation for a breaking change in functionality that has been confusing users. Should not be applied until the next branch.
## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/49376

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].
