### PR TITLE
Add documentation for rtorrent switch

### DIFF
--- a/source/_integrations/rtorrent.markdown
+++ b/source/_integrations/rtorrent.markdown
@@ -8,7 +8,24 @@ ha_iot_class: Local Polling
 ha_domain: rtorrent
 ha_platforms:
   - sensor
+  - switch
 ---
+
+There is currently support for the following device types within Home Assistant:
+
+- [Sensor](#sensor)
+- [Switch](#switch)
+
+<div class="note">
+This integration requires the rTorrent XML-RPC API exposed on an HTTP interface.
+Note that for security reasons, simply using the SCGI interface (default `localhost:5000`) of rTorrent won't work.
+
+The [official reference](https://github.com/rakshasa/rtorrent/wiki/RPC-Setup-XMLRPC) describes how to set up that HTTP interface.
+
+Alternatively, the [arch-rtorrentvpn](https://github.com/binhex/arch-rtorrentvpn) container can be used with `url` set to `http://admin:rutorrent@127.0.0.1:9080/RPC2`.
+</div>
+
+## Sensor
 
 The `rtorrent` platform allows you to monitor your downloads with [rTorrent](https://rakshasa.github.io/rtorrent/) from within Home Assistant and setup automations based on the information.
 
@@ -30,12 +47,6 @@ sensor:
       - 'downloading_torrents'
       - 'active_torrents'
 ```
-
-This sensor requires the rTorrent XML-RPC API exposed on an HTTP interface.
-Note that for security reasons, simply using the SCGI interface (default `localhost:5000`) of rTorrent won't work.
-The [official reference](https://github.com/rakshasa/rtorrent/wiki/RPC-Setup-XMLRPC) describes how to set up that HTTP interface.
-
-Alternatively, the [arch-rtorrentvpn](https://github.com/binhex/arch-rtorrentvpn) container can be used with `url` set to `http://admin:rutorrent@127.0.0.1:9080/RPC2`.
 
 {% configuration %}
 url:
@@ -69,4 +80,28 @@ monitored_variables:
       description: The number of torrents that are leeching.
     active_torrents:
       description: The number of torrents that are actively ( measurable speed ) leeching, seeding or both.
+{% endconfiguration %}
+
+## Switch
+
+The `rtorrent` switch platform allows you to control your [rTorrent](https://rakshasa.github.io/rtorrent/) client from within Home Assistant. The platform enables you switch all your active torrents in pause, and then unpause them all.
+
+To add this switch to your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: rtorrent
+    url: "http://<user>:<password>@<host>:<port>/RPC2"
+```
+
+{% configuration %}
+url:
+  description: The URL to the HTTP endpoint of the rTorrent XML-RPC API.
+  required: true
+  type: string
+name:
+  description: The name to use when displaying this rTorrent switch.
+  required: false
+  type: string
 {% endconfiguration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds documentation of the rtorrent switch documentation.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/49379
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
