### PR TITLE
New modbus switch.

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -709,27 +709,28 @@ switches:
     verify:
       description: read from modbus device to verify switch.
       required: false
-      type: structure
-    verify/address:
-      description: address to read from. 
-      required: false
-      default: write address
-      type: integer
-    verify/inpu_type:
-      description: type of adddress (holding/coil/discrete/input)
-      required: false
-      default: write_type
-      type: integer
-    verify/state_on:
-      description: value when switch is on.
-      required: false
-      default: same as command_on
-      type: integer
-    verify/state_off:
-      description: value when switch is off.
-      required: false
-      default: same as command_off
-      type: integer
+      type: map
+      keys:
+        address:
+          description: address to read from. 
+          required: false
+          default: write address
+          type: integer
+        input_type:
+          description: type of adddress (holding/coil/discrete/input)
+          required: false
+          default: write_type
+          type: integer
+        state_on:
+          description: value when switch is on.
+          required: false
+          default: same as command_on
+          type: integer
+        state_off:
+          description: value when switch is off.
+          required: false
+          default: same as command_off
+          type: integer
 {% endconfiguration %}
 
 #### Full example

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -644,22 +644,27 @@ To use your Modbus switches in your installation, add the following to your `con
 ```yaml
 # Example configuration.yaml entry
 modbus:
-  - name: hub1
-    type: tcp
+  - type: tcp
     host: IP_ADDRESS
     port: 502
     switches:
       - name: Switch1
         address: 13
-        input_type: coil
+        write_type: coil
       - name: Switch2
         slave: 2
         address: 14
-        input_type: coil
+        write_type: coil
+        verify:
       - name: Register1
         address: 11
         command_on: 1
         command_off: 0
+        verify:
+            input_type: holding
+            address: 127
+            state_on: 25
+            state_off: 1
 ```
 
 {% configuration %}
@@ -674,14 +679,16 @@ switches:
       type: integer
     command_on:
       description: Value to write to turn on the switch.
-      required: true
+      required: false
+      default: 0x01
       type: integer
     command_off:
       description: Value to write to turn off the switch.
-      required: true
+      required: false
+      default: 0x00
       type: integer
-    input_type:
-      description: type of adddress (holding/input/coil)
+    write_type:
+      description: type of adddress (holding/coil)
       required: false
       default: holding
       type: integer
@@ -696,33 +703,38 @@ switches:
       default: 15
     slave:
       description: The number of the slave (can be omitted for tcp and udp Modbus).
-      required: true
+      required: false
       type: integer
-    state_on:
-      description: Register value when switch is on.
+      default: 0
+    verify:
+      description: read from modbus device to verify switch.
+      required: false
+      type: structure
+    verify/address:
+      description: address to read from. 
+      required: false
+      default: write address
+      type: integer
+    verify/inpu_type:
+      description: type of adddress (holding/coil/discrete/input)
+      required: false
+      default: write_type
+      type: integer
+    verify/state_on:
+      description: value when switch is on.
       required: false
       default: same as command_on
       type: integer
-    state_off:
-      description: Register value when switch is off.
+    verify/state_off:
+      description: value when switch is off.
       required: false
       default: same as command_off
       type: integer
-    verify_register:
-      description: Register to readback.
-      required: false
-      default: same as register
-      type: string
-    verify_state:
-      description: Define if is possible to readback the status of the switch.
-      required: false
-      default: true
-      type: boolean
 {% endconfiguration %}
 
 #### Full example
 
-Example switches, for which the state is polled from Modbus every 15 seconds (default).
+Example switches, for which the state is not polled.
 
 ```yaml
 modbus:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation of the redesigned modbus switch.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
https://github.com/home-assistant/core/pull/49386
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
fixes #44082

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
