### PR TITLE
Add documentation for binary sensors in Syncthru integration

### DIFF
--- a/source/_integrations/syncthru.markdown
+++ b/source/_integrations/syncthru.markdown
@@ -12,6 +12,7 @@ ha_domain: syncthru
 ha_ssdp: true
 ha_platforms:
   - sensor
+  - binary_sensor
 ---
 
 The Samsung SyncThru Printer platform allows you to read current data from your local Samsung printer.
@@ -20,13 +21,11 @@ It usually provides information about the device's state, the left amount of ink
 
 The following information is displayed in separate sensors, if it is available:
 
+ - Whether the printer is online
+ - Whether the printer is in an error state
  - Black, cyan, magenta and yellow toner fill level
  - Black, cyan, magenta and yellow drum state
  - First to fifth paper input tray state
  - First to sixth paper output tray state
 
 {% include integrations/config_flow.md %}
-
-<div class="note warning">
-Note that this component or parts thereof may not work if the language of your printer is not configured to be English.
-</div>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
adds binary sensors

also remove outdated warning about english configuration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/48114
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
