### PR TITLE
Note motion sensor states are not re-triggered

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -100,5 +100,9 @@ and `off`, the group state will be `on` or `off`.
 It is possible to create a group that the system cannot calculate a group state.
 Groups with entities from unsupported domains will always have an unknown state.
 
+Devices like motion sensors that re-trigger their state change periodically will not be
+bubbled up to the group. For automations with timeouts that need to re-trigger, like motion
+sensor lights, instead create multiple triggers in the automation.
+
 These groups can still be in templates with the `expand()` directive, called using the
 `homeassistant.turn_on` and `homeassistant.turn_off` services, etc.


### PR DESCRIPTION
## Proposed change

Some devices update their status periodically, such as motion sensors re-detecting motion. Relying on that behaviour is a common pattern in automations, and group entities eating those changes can be confusing.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
