### PR TITLE
Update zwave_js.bulk_set_partial_config_parameters description

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -115,8 +115,8 @@ This service will bulk set multiple partial configuration parameters. Be warned 
 |------------------------	|-----------	|-------------------------------------------------------------------------------------------------------------------------------------------	|
 | `entity_id`            	| no        	| Entity (or list of entities) to set the configuration parameter on. At least one `entity_id` or `device_id` must be provided.                       	|
 | `device_id`            	| no        	| ID of device to set the configuration parameter on. At least one `entity_id` or `device_id` must be provided.                                                	|
-| `parameter`            	| yes       	| The parameter number or the name of the property. The name of the property is case sensitive.                                             	|
-| `value`                	| yes       	| Either the raw integer value that you want to set for the entire parameter, or a dictionary where the keys are the bitmasks (in integer or hex form) and the values are the value you want to set on each partial. Note that when using a dictionary, and bitmasks that are not provided will be set to their currently cached values.                       	|
+| `parameter`            	| yes       	| The parameter number of the property. The name of the property is case sensitive.                                             	|
+| `value`                	| yes       	| Either the raw integer value that you want to set for the entire parameter, or a dictionary where the keys are either the bitmasks (in integer or hex form) or the partial parameter name and the values are the value you want to set on each partial (either the integer value or a named state when applicable). Note that when using a dictionary, and bitmasks that are not provided will be set to their currently cached values.                       	|
 
 #### Examples of bulk setting partial parameter values
 
@@ -124,7 +124,7 @@ Let's use parameter 21 for [this device](https://devices.zwave-js.io/?jumpTo=0x0
 
 <div class='note'>
 
-When using the dictionary format to map the partial parameter to values, the cached values for the missing partial parameters will be used. So in examples 2 and 3, the service would use the cached value for partial parameters `0xff0000`, `0x3f000000`, and `0x40000000` because new values haven't been specified. If you send the raw integer value, it is assumed that you have calculated the full value, so in example 1, partial parameters `0xff0000`, `0x3f000000`, and `0x40000000` would all be set to `0`.
+When using the dictionary format to map the partial parameter to values, the cached values for the missing partial parameters will be used. So in examples 2, 3, 4, and 5, the service would use the cached value for partial parameters `0xff0000`, `0x3f000000`, and `0x40000000` because new values haven't been specified. If you send the raw integer value, it is assumed that you have calculated the full value, so in example 1, partial parameters `0xff0000`, `0x3f000000`, and `0x40000000` would all be set to `0`.
 
 </div>
 
@@ -165,6 +165,34 @@ data:
     255: 127
     32512: 10
     32768: 1
+```
+
+Example 4:
+
+```yaml
+service: zwave_js.bulk_set_partial_config_parameters
+target:
+  entity_id: switch.fan
+data:
+  parameter: 21
+  value:
+    255: 127
+    32512: 10
+    32768: "Fine"
+```
+
+Example 5:
+
+```yaml
+service: zwave_js.bulk_set_partial_config_parameters
+target:
+  entity_id: switch.fan
+data:
+  parameter: 21
+  value:
+    "Quick Strip Effect: Hue Color Wheel / Color Temp": 127
+    "Quick Strip Effect Intensity": 10
+    "Quick Strip Effect Intensity Scale": "Fine"
 ```
 
 ### Service `zwave_js.refresh_value`


### PR DESCRIPTION
## Proposed change
With the linked dependency bump, we added new possibilities to the service schema, so updating the docs accordingly. I also found an unintended bug that is fixed in the linked PR (and documentation updated as well).



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/49445
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
