### PR TITLE
Add ScreenLogic set_color_mode service information

### DIFF
--- a/source/_integrations/screenlogic.markdown
+++ b/source/_integrations/screenlogic.markdown
@@ -21,7 +21,7 @@ ha_platforms:
   - switch
 ---
 
-The Pentair ScreenLogic integration allows you to integrate your Pentair Intellitouch or EasyTouch pool controller with Home Assistant via the [Pentair ScreenLogic](https://www.pentair.com/en-us/products/residential/pool-spa-equipment/pool-automation/screenlogic2_interfaceforintellitouchandeasytouchautomationsystems.html) gateway.
+The Pentair ScreenLogic integration allows you to integrate your Pentair IntelliTouch or EasyTouch pool controller with Home Assistant via the [Pentair ScreenLogic](https://www.pentair.com/en-us/products/residential/pool-spa-equipment/pool-automation/screenlogic2_interfaceforintellitouchandeasytouchautomationsystems.html) gateway.
 
 {% include integrations/config_flow.md %}
 
@@ -30,3 +30,43 @@ The Pentair ScreenLogic integration allows you to integrate your Pentair Intelli
 ScreenLogic options are set via **Configuration** -> **Integrations** -> **Pentair ScreenLogic** -> **Options**.
 
 * Seconds between scans - How many seconds between each polling of the ScreenLogic gateway.
+
+## Services
+
+### `screenlogic.set_color_mode`
+
+Sets the operation of any connected color-capable lights.
+
+| Service data attribute | Optional | Description                                                         |
+| ---------------------- | -------- | ------------------------------------------------------------------- |
+| `device_id`            | no       | The `device_id` of the ScreenLogic Gateway to set to color mode on. |
+| `color_mode`           | no       | The color mode to set. Valid values are listed below.               |
+
+## Reference
+
+### Color Modes
+
+| color_mode   | Name         | Description                                                                                               |
+| ------------ | ------------ | --------------------------------------------------------------------------------------------------------- |
+| `all_off`    | All Off      | Turns all light circuits off.                                                                             |
+| `all_on`     | All On       | Turns all light circuits on to their last mode.                                                           |
+| `color_set`  | Color Set    | Sets light circuits to their pre-set colors as set in the pool controller.                                |
+| `color_sync` | Color Sync   | Synchronize all IntelliBrite, SAm, SAL, or FIBERworks color changing lights and synchronize their colors. |
+| `color_swim` | Color Swim   | Cycles through white, magenta, blue and green colors. (Emulates Pentair SAm color changing light.)        |
+| `party`      | Party        | Rapid color changing building the energy and excitement.                                                  |
+| `romance`    | Romance      | Slow color transitions creating a mesmerizing and calming effect.                                         |
+| `caribbean`  | Caribbean    | Transitions between a variety of blues and greens.                                                        |
+| `american`   | American     | Patriotic red, white and blue transition.                                                                 |
+| `sunset`     | Sunset       | Dramatic transitions of orange, red and magenta tones.                                                    |
+| `royal`      | Royal        | Richer, deeper, color tones.                                                                              |
+| `save`       | Save Color   | Save the exact colors that are being displayed.                                                           |
+| `recall`     | Recall Color | Recall the saved colors.                                                                                  |
+| `blue`       | Blue         | Fixed color: Blue                                                                                         |
+| `green`      | Green        | Fixed color: Green                                                                                        |
+| `red`        | Red          | Fixed color: Red                                                                                          |
+| `white`      | White        | Fixed color: White                                                                                        |
+| `magenta`    | Magenta      | Fixed color: Magenta                                                                                      |
+| `thumper`    | Thumper      | Toggles the solenoid thumper on MagicStream laminars.                                                     |
+| `next_mode`  | Next Mode    | Cycle to the next color mode.                                                                             |
+| `reset`      | Reset        | Reset light modes.                                                                                        |
+| `hold`       | Hold         | Hold light transitions.                                                                                   |

--- a/source/_integrations/screenlogic.markdown
+++ b/source/_integrations/screenlogic.markdown
@@ -37,10 +37,10 @@ ScreenLogic options are set via **Configuration** -> **Integrations** -> **Penta
 
 Sets the operation of any connected color-capable lights.
 
-| Service data attribute | Optional | Description                                                         |
-| ---------------------- | -------- | ------------------------------------------------------------------- |
-| `device_id`            | no       | The `device_id` of the ScreenLogic Gateway to set to color mode on. |
-| `color_mode`           | no       | The color mode to set. Valid values are listed below.               |
+| Service data attribute | Optional | Description                                                                                                                                                  |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `target`               | no       | An `area` containing the ScreenLogic device, the ScreenLogic `device` itself, or any `entity` from the ScreenLogic device you wish to set the color mode on. |
+| `color_mode`           | no       | The color mode to set. Valid values are listed below.                                                                                                        |
 
 ## Reference
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add set_color_mode service information, along with reference for all valid color modes.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/49366
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
