### PR TITLE
Update zeroconf to explain how auto detection works

### DIFF
--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -30,7 +30,7 @@ zeroconf:
   type: map
   keys:
    default_interface:
-     description: `zeroconf` will attempt to detect the best value based on available routing information. For systems that require broadcasting mDNS on all interfaces, change this option to `false` if `zeroconf` does not function.
+     description: By default, `zeroconf` will attempt to detect the best value based on available routing information. For systems that require broadcasting mDNS on all interfaces, change this option to `false` if `zeroconf` does not function.
      required: false
      type: boolean
      default: true

--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -43,7 +43,7 @@ zeroconf:
 
 ## `default_interface` auto detection
 
-If the `default_interface` is not set, the value is not auto detected based on the system routing next hop for mdns broadcast address (`224.0.0.251`).
+If the `default_interface` is not set, the value is not auto detected based on the system routing next hop for the mdns broadcast address (`224.0.0.251`).
 
 If the next hop cannot be detected or is a loopback address, zeroconf will broadcast on all interfaces. If the next hop is a non-loopback address, zeroconf will only broadcast on the default interface.
 

--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -43,9 +43,9 @@ zeroconf:
 
 ## `default_interface` auto detection
 
-If the `default_interface` is not set, the value is auto detected based on the system routing next hop for the mDNS broadcast address (`224.0.0.251`).
+If the `default_interface` is unset, the value is auto-detected based on the system routing next hop for the mDNS broadcast address (`224.0.0.251`).
 
-If the next hop cannot be detected or is a loopback address, zeroconf will broadcast on all interfaces. If the next hop is a non-loopback address, zeroconf will only broadcast on the default interface.
+If the next-hop cannot be detected or is a loopback address, `zeroconf` will broadcast on all interfaces. If the next hop is a non-loopback address, `zeroconf` will only broadcast on the default interface.
 
 Setting the `default_interface` to `true` or `false` will override the auto detection.
 

--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -43,7 +43,7 @@ zeroconf:
 
 ## `default_interface` auto detection
 
-If the `default_interface` is not set, the value is not auto detected based on the system routing next hop for the mdns broadcast address (`224.0.0.251`).
+If the `default_interface` is not set, the value is auto detected based on the system routing next hop for the mdns broadcast address (`224.0.0.251`).
 
 If the next hop cannot be detected or is a loopback address, zeroconf will broadcast on all interfaces. If the next hop is a non-loopback address, zeroconf will only broadcast on the default interface.
 

--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -30,7 +30,7 @@ zeroconf:
   type: map
   keys:
    default_interface:
-     description: By default, `zeroconf` will broadcast on the default interface. For systems that require broadcasting `mdns` on all interfaces, change this option to `false` if `zeroconf` does not function.
+     description: `zeroconf` will attempt to detect the best value based on available routing information. For systems that require broadcasting `mdns` on all interfaces, change this option to `false` if `zeroconf` does not function.
      required: false
      type: boolean
      default: true
@@ -40,3 +40,12 @@ zeroconf:
      type: boolean
      default: true
 {% endconfiguration %}
+
+## `default_interface` auto detection
+
+If the `default_interface` is not set, the value is not auto detected based on the system routing next hop for mdns broadcast address (`224.0.0.251`).
+
+If the next hop cannot be detected or is a loopback address, zeroconf will broadcast on all interfaces. If the next hop is a non-loopback address, zeroconf will only broadcast on the default interface.
+
+Setting the `default_interface` to `true` or `false` will override the auto detection.
+

--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -30,7 +30,7 @@ zeroconf:
   type: map
   keys:
    default_interface:
-     description: `zeroconf` will attempt to detect the best value based on available routing information. For systems that require broadcasting `mdns` on all interfaces, change this option to `false` if `zeroconf` does not function.
+     description: `zeroconf` will attempt to detect the best value based on available routing information. For systems that require broadcasting mDNS on all interfaces, change this option to `false` if `zeroconf` does not function.
      required: false
      type: boolean
      default: true

--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -43,7 +43,7 @@ zeroconf:
 
 ## `default_interface` auto detection
 
-If the `default_interface` is not set, the value is auto detected based on the system routing next hop for the mdns broadcast address (`224.0.0.251`).
+If the `default_interface` is not set, the value is auto detected based on the system routing next hop for the mDNS broadcast address (`224.0.0.251`).
 
 If the next hop cannot be detected or is a loopback address, zeroconf will broadcast on all interfaces. If the next hop is a non-loopback address, zeroconf will only broadcast on the default interface.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update zeroconf to explain how auto detection works

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/49529
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
