### PR TITLE
Remove roon join and unjoin services 

### DIFF
--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -15,16 +15,11 @@ The Roon integration allows you to control [RoonLabs](https://roonlabs.com/) mus
 
 This integration uses Roon Core, a Roon application that runs on a machine on your network. Via Roon Core, Home Assistant can control all the Roon music players on your network.
 
-To integrate with Roon, you need to provide Home Assistant with the Hostname or IP address of the machine that runs your Roon Core, and then authorize Home Assistant in the Roon application.
-
-If you use an IP address, please assign a static IP address to the machine that runs Roon Core. This ensures that it won't change IP addresses, so you won't have to change the configuration in Home Assistant if it reboots and changes IP address. See your router's manual for details on how to set this up.
-
 ## Configuration
 
-You need the Hostname or IP address of the machine that runs your Roon Core. This might be a machine name (which can be followed by `.local`, e.g., `myserver.local`) or can be an IP address.
-
 1. From the Home Assistant front-end, navigate to **Configuration** then **Integrations**. Under **Set up a new integration** locate 'Roon' and click **Configure**.
-2. Enter the `Hostname` or `IP address` for the Roon Core machine and click **Submit**.
+2. Hoe Assistant will then try find your Roon Core - if it is successful it will display `Authorize HomeAssistant in Roon` and you can skip to 3
+2. If your Roon Core is not automatically found you can enter the `Hostname` or `IP address` for the Roon Core machine when requested and click **Submit**.
 3. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to **Settings** and then **Extensions**, there you will see an entry for Home Assistant with a button next to it. Click **Enable**.
 4. Roon core will then provide Home Assistant with the details of your media players.
 5. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.
@@ -42,24 +37,6 @@ Roon uses a path based on the roon browser hierarchy to specify which media to p
 | `media_content_type`   |       no | Only `music` is suppported  |
 
  For example to play the album Harvest by Neil Young you should set `media_content_id` to `Library/Artists/Neil Young/Harvest` and to play BBC Radio 4 you would set `media_content_id` to `My Live Radio/BBC Radio 4`
-
-### Service `roon.join`
-
-Group players together.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | ID of the player that will be the master of the group.
-| `join_ids` | no | id(s) of the players that will join the master.
-
-### Service `roon.unjoin`
-
-Remove players from a group.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | ID of the player that is the master of the group.
-| `unlink_name` | yes | id(s) of the players that will be unjoined from the group. If not specified, all players will be unjoined from the master.
 
 ### Service `roon.transfer`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR updates the roon documentation to remove the roon specific services that will be replaced  by use of the media_payer based services.

It also revises the documentation about installation since Roon now supports discovery (I must have missed this when I added that feature)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/49667
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
