### PR TITLE
Add TV channel to google assistant

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -194,19 +194,6 @@ entity_config:
           description: Allows for associating this device to a Room in Google Assistant.
           required: false
           type: string
-        channel_list:
-          description: List of available channels (only for Channel Trait)
-          required: false
-          type: list
-          keys:
-            channel_name:
-              description: Name of the channel
-              required: true
-              type: string
-            channel_number:
-              description: Numeric identifier for the channel
-              required: true
-              type: string
 {% endconfiguration %}
 
 ### Available domains
@@ -264,37 +251,7 @@ Here are the modes that are currently available:
 
 ### TV Channels
 
-The is no TV channel object in Home Assistant. To change channel by name with Google Assistant, you must provide a `channel_list` for your entity.
-
-```yaml
-# Example configuration.yaml entry
-google_assistant:
-  project_id: YOUR_PROJECT_ID
-  service_account: !include SERVICE_ACCOUNT.JSON
-  report_state: true
-  exposed_domains:
-    - media_player
-  entity_config:
-    media_player.living_room_tv:
-      channel_list:
-        - channel_name: "ABC"
-          channel_number: 1
-        - channel_name: "Fox"
-          channel_number: 2
-```
-
-```yaml
-# Example configuration.yaml entry with channel json config
-google_assistant:
-  project_id: YOUR_PROJECT_ID
-  service_account: !include SERVICE_ACCOUNT.JSON
-  report_state: true
-  exposed_domains:
-    - media_player
-  entity_config:
-    media_player.living_room_tv:
-      channel_list: !include GOOGLE_ASSISTANT_CHANNEL_LIST.JSON
-```
+There is no TV channel object in Home Assistant. TV channel can only be changed by number, not by name (for example, `Turn to channel two`).
 
 ### Troubleshooting
 

--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -264,7 +264,7 @@ Here are the modes that are currently available:
 
 ### TV Channels
 
-The is no tv channel object in home-assistant. To change channel by name with Google Assistant, you must provide a `channel_list` for your entity.
+The is no TV channel object in Home Assistant. To change channel by name with Google Assistant, you must provide a `channel_list` for your entity.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -194,6 +194,19 @@ entity_config:
           description: Allows for associating this device to a Room in Google Assistant.
           required: false
           type: string
+        channel_list:
+          description: List of available channels (only for Channel Trait)
+          required: false
+          type: list
+          keys:
+            channel_name:
+              description: Name of the channel
+              required: true
+              type: string
+            channel_number:
+              description: Numeric identifier for the channel
+              required: true
+              type: string
 {% endconfiguration %}
 
 ### Available domains
@@ -248,6 +261,40 @@ Here are the modes that are currently available:
 - fan-only
 - dry
 - eco
+
+### TV Channels
+
+The is no tv channel object in home-assistant. To change channel by name with Google Assistant, you must provide a `channel_list` for your entity.
+
+```yaml
+# Example configuration.yaml entry
+google_assistant:
+  project_id: YOUR_PROJECT_ID
+  service_account: !include SERVICE_ACCOUNT.JSON
+  report_state: true
+  exposed_domains:
+    - media_player
+  entity_config:
+    media_player.living_room_tv:
+      channel_list:
+        - channel_name: "ABC"
+          channel_number: 1
+        - channel_name: "Fox"
+          channel_number: 2
+```
+
+```yaml
+# Example configuration.yaml entry with channel json config
+google_assistant:
+  project_id: YOUR_PROJECT_ID
+  service_account: !include SERVICE_ACCOUNT.JSON
+  report_state: true
+  exposed_domains:
+    - media_player
+  entity_config:
+    media_player.living_room_tv:
+      channel_list: !include GOOGLE_ASSISTANT_CHANNEL_LIST.JSON
+```
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Proposed change

Add [Channel Trait](https://developers.google.com/assistant/smarthome/traits/channel) support to google assistant.
It allow changing channel by number with google assistant :
- `Turn to channel two`

This is no channel object in home assistant, only play_media service with channel media type. So, channel can only be changed by number, not by name.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/49676

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
