### PR TITLE
Document zwave_js_value_updated event

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -313,7 +313,9 @@ Value Notification example:
 
 ### Value updated events
 
-Due to some devices not following the Z-Wave spec, there are scenarios where a device will send a value update but a state change won't be detected in Home Assistant. To address the gap, the `zwave_js_value_updated` event can be listened to to capture any value updates that are received by an entity. This event is **enabled on a per device basis.** The following devices currently support this event:
+Due to some devices not following the Z-Wave spec, there are scenarios where a device will send a value update but a state change won't be detected in Home Assistant. To address the gap, the `zwave_js_value_updated` event can be listened to to capture any value updates that are received by an affected entity. This event is **enabled on a per device and entity platform basis**, and the entities will have `assumed_state` set to `true`. This change will affect how the UI for these entities look; if you'd like the UI to match other entities of the same type where `assumed_state` is not set to `true`, you can override the setting via [entity customization](/docs/configuration/customizing-devices/#assumed_state).
+
+The following devices currently support this event:
 
 - Vision Security ZL7432 In Wall Dual Relay Switch
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -313,11 +313,13 @@ Value Notification example:
 
 ### Value updated events
 
-Due to some devices not following the Z-Wave spec, there are scenarios where a device will send a value update but a state change won't be detected in Home Assistant. To address the gap, the `zwave_js_value_updated` event can be listened to to capture any value updates that are received by an affected entity. This event is **enabled on a per device and entity platform basis**, and the entities will have `assumed_state` set to `true`. This change will affect how the UI for these entities look; if you'd like the UI to match other entities of the same type where `assumed_state` is not set to `true`, you can override the setting via [entity customization](/docs/configuration/customizing-devices/#assumed_state).
+Due to some devices not following the Z-Wave spec, there are scenarios where a device will send a value update but a state change won't be detected in Home Assistant. To address the gap, the `zwave_js_value_updated` event can be listened to to capture any value updates that are received by an affected entity. This event is **enabled on a per device and per entity domain basis**, and the entities will have `assumed_state` set to `true`. This change will affect how the UI for these entities look; if you'd like the UI to match other entities of the same type where `assumed_state` is not set to `true`, you can override the setting via [entity customization](/docs/configuration/customizing-devices/#assumed_state).
 
 The following devices currently support this event:
 
-- Vision Security ZL7432 In Wall Dual Relay Switch
+| Make            	| Model                            	| Entity Domain 	|
+|-----------------	|----------------------------------	|---------------	|
+| Vision Security 	| ZL7432 In Wall Dual Relay Switch 	| `switch`      	|
 
 Value Updated example:
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -341,6 +341,19 @@ Value Updated example:
 }
 ```
 
+This event can be used to trigger a refresh of values when the new state needs to be retrieved. Here's an example automation:
+```
+trigger:
+  platform: event
+  event_type: zwave_js_value_updated
+  event_data:
+    entity_id: switch.in_wall_dual_relay_switch
+action:
+  - service: zwave_js.refresh_value
+    target:
+      entity_id: switch.in_wall_dual_relay_switch_2, switch.in_wall_dual_relay_switch_3
+```
+
 ## Current Limitations
 
 As this integration is still in the early stages there are some important limitations to be aware of.

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -286,7 +286,7 @@ These are notification events fired by devices using the Entry Control command c
 }
 ```
 
-## Scene events (Value Notification)
+### Scene events (Value Notification)
 
 Value Notifications are used for stateless values, like `Central Scenes` and `Scene Activation`. These events fire with the `zwave_js_value_notification` event type.
 
@@ -307,6 +307,32 @@ Value Notification example:
     "property_key": "001",
     "property_key_name": "001",
     "value": "KeyPressed",
+    "value_raw": 0
+}
+```
+
+### Value updated events
+
+Due to some devices not following the Z-Wave spec, there are scenarios where a device will send a value update but a state change won't be detected in Home Assistant. To address the gap, the `zwave_js_value_updated` event can be listened to to capture any value updates that are received by an entity. This event is **enabled on a per device basis.** The following devices currently support this event:
+
+- Vision Security ZL7432 In Wall Dual Relay Switch
+
+Value Updated example:
+
+```json
+{
+    "node_id": 4,
+    "home_id": "974823419",
+    "device_id": "ad8098fe80980974",
+    "entity_id": "switch.in_wall_dual_relay_switch",
+    "command_class": 37,
+    "command_class_name": "Switch Binary",
+    "endpoint": 0,
+    "property": "currentValue",
+    "property_name": "currentValue",
+    "property_key": null,
+    "property_key_name": null,
+    "value": 0,
     "value_raw": 0
 }
 ```

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -342,7 +342,8 @@ Value Updated example:
 ```
 
 This event can be used to trigger a refresh of values when the new state needs to be retrieved. Here's an example automation:
-```
+
+```yaml
 trigger:
   platform: event
   event_type: zwave_js_value_updated


### PR DESCRIPTION
## Proposed change
There is at least one device that does not properly follow the Z-Wave spec. The end result is that HA doesn't see state changes in cases where it should because of the way that the device is advertising its state updates. This new event will be enabled on a per device basis to capture those state transitions.

Context:
- https://github.com/zwave-js/node-zwave-js/pull/2387
- https://github.com/home-assistant/core/pull/49510




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/49510
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/zwave-js/node-zwave-js/pull/2387

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
