### PR TITLE
Sync docs with dev codebase, fixing missing platforms

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -8,6 +8,8 @@ ha_iot_class: Local Polling
 ha_codeowners:
   - '@JeffLIrion'
 ha_domain: androidtv
+ha_platforms:
+  - media_player
 ---
 
 The `androidtv` platform allows you to control an Android TV device or [Amazon Fire TV](https://www.amazon.com/b/?node=8521791011) device.

--- a/source/_integrations/anthemav.markdown
+++ b/source/_integrations/anthemav.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_iot_class: Local Push
 ha_release: 0.37
 ha_domain: anthemav
+ha_platforms:
+  - media_player
 ---
 
 Both [Anthem]'s current and last generation of A/V Receivers and Processors support IP-based, network control. This Home Assistant platform adds proper "local push" support for any of these receivers on your network.

--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -13,6 +13,7 @@ ha_codeowners:
 ha_config_flow: true
 ha_zeroconf: true
 ha_platforms:
+  - media_player
   - remote
 ---
 

--- a/source/_integrations/aquostv.markdown
+++ b/source/_integrations/aquostv.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.35
 ha_iot_class: Local Polling
 ha_domain: aquostv
+ha_platforms:
+  - media_player
 ---
 
 The `aquostv` platform allows you to control a [Sharp Aquos TV](http://www.sharp-world.com/aquos/en/index.html).

--- a/source/_integrations/arcam_fmj.markdown
+++ b/source/_integrations/arcam_fmj.markdown
@@ -9,6 +9,8 @@ ha_codeowners:
   - '@elupus'
 ha_domain: arcam_fmj
 ha_ssdp: true
+ha_platforms:
+  - media_player
 ---
 
 The `arcam_fmj` integration allows you to control [Arcam FMJ Receivers](https://www.arcam.co.uk/range/fmj.htm) from Home Assistant.

--- a/source/_integrations/blackbird.markdown
+++ b/source/_integrations/blackbird.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.68
 ha_iot_class: Local Polling
 ha_domain: blackbird
+ha_platforms:
+  - media_player
 ---
 
 The `blackbird` platform allows you to control [Monoprice Blackbird Matrix Switch](https://www.monoprice.com/product?p_id=21819) using a serial connection.

--- a/source/_integrations/bluesound.markdown
+++ b/source/_integrations/bluesound.markdown
@@ -7,6 +7,8 @@ ha_category:
 ha_release: 0.51
 ha_iot_class: Local Polling
 ha_domain: bluesound
+ha_platforms:
+  - media_player
 ---
 
 The `bluesound` platform allows you to control your [Bluesound](https://www.bluesound.com/) HiFi wireless speakers and audio integrations from Home Assistant.

--- a/source/_integrations/braviatv.markdown
+++ b/source/_integrations/braviatv.markdown
@@ -9,6 +9,8 @@ ha_codeowners:
   - '@bieniu'
 ha_domain: braviatv
 ha_config_flow: true
+ha_platforms:
+  - media_player
 ---
 
 The `braviatv` platform allows you to control a [Sony Bravia TV](https://www.sony.com/).

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -11,6 +11,8 @@ ha_domain: cast
 ha_codeowners:
   - '@emontnemery'
 ha_zeroconf: true
+ha_platforms:
+  - media_player
 ---
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/channels.markdown
+++ b/source/_integrations/channels.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.65
 ha_iot_class: Local Polling
 ha_domain: channels
+ha_platforms:
+  - media_player
 ---
 
 The Channels platform allows you to control [Channels](https://getchannels.com/) from Home Assistant. Play, pause, seek, or skip commercials on an instance of Channels that is running on your network.

--- a/source/_integrations/clementine.markdown
+++ b/source/_integrations/clementine.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.39
 ha_iot_class: Local Polling
 ha_domain: clementine
+ha_platforms:
+  - media_player
 ---
 
 The `clementine` platform allows you to control a [Clementine Music Player](https://www.clementine-player.org).

--- a/source/_integrations/cmus.markdown
+++ b/source/_integrations/cmus.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: 0.23
 ha_domain: cmus
+ha_platforms:
+  - media_player
 ---
 
 The `cmus` platform allows you to control a [cmus](https://cmus.github.io/) music player on a remote or local machine from Home Assistant.

--- a/source/_integrations/config.markdown
+++ b/source/_integrations/config.markdown
@@ -8,6 +8,8 @@ ha_quality_scale: internal
 ha_codeowners:
   - '@home-assistant/core'
 ha_domain: config
+ha_platforms:
+  - scene
 ---
 
 The `config` integration is designed to display panels in the frontend to configure and manage parts of Home Assistant.

--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -28,6 +28,7 @@ ha_platforms:
   - fan
   - light
   - lock
+  - scene
   - sensor
   - switch
 ---

--- a/source/_integrations/demo.markdown
+++ b/source/_integrations/demo.markdown
@@ -19,9 +19,12 @@ ha_platforms:
   - cover
   - device_tracker
   - fan
+  - humidifier
   - light
   - lock
+  - media_player
   - notify
+  - number
   - remote
   - sensor
   - stt

--- a/source/_integrations/denon.markdown
+++ b/source/_integrations/denon.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: 0.7.2
 ha_domain: denon
+ha_platforms:
+  - media_player
 ---
 
 The `denon` platform allows you to control a [Denon Network Receiver](https://www.denon.com/category/homecinema/avreceiver) from Home Assistant. It might be that your device is supported by the [Denon AVR] platform.

--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -11,6 +11,8 @@ ha_codeowners:
   - '@starkillerOG'
 ha_config_flow: true
 ha_ssdp: true
+ha_platforms:
+  - media_player
 ---
 
 The `denonavr` platform allows you to control [Denon Network Receivers](https://www.denon.com/en-gb/shop/networkmusicsystem/ceolpiccolon4) from Home Assistant. It might be that your device is supported by the [Denon] platform.

--- a/source/_integrations/directv.markdown
+++ b/source/_integrations/directv.markdown
@@ -13,6 +13,7 @@ ha_codeowners:
 ha_quality_scale: gold
 ha_ssdp: true
 ha_platforms:
+  - media_player
   - remote
 ---
 

--- a/source/_integrations/dlna_dmr.markdown
+++ b/source/_integrations/dlna_dmr.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.76
 ha_iot_class: Local Push
 ha_domain: dlna_dmr
+ha_platforms:
+  - media_player
 ---
 
 The `dlna_dmr` platform allows you to control a [DLNA Digital Media Renderer](https://www.dlna.org/), such as DLNA enabled TVs or radios.

--- a/source/_integrations/dunehd.markdown
+++ b/source/_integrations/dunehd.markdown
@@ -9,6 +9,8 @@ ha_domain: dunehd
 ha_config_flow: true
 ha_codeowners:
   - '@bieniu'
+ha_platforms:
+  - media_player
 ---
 
 The `Dune HD` integration allows you to control a [Dune HD media player](https://dune-hd.com/eng/products/full_hd_media_players) from Home Assistant. Support is based on the official [IP protocol](https://dune-hd.com/support/ip_control/dune_ip_control_overview.txt) published by Dune.

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -18,6 +18,7 @@ ha_domain: ecobee
 ha_platforms:
   - binary_sensor
   - climate
+  - humidifier
   - notify
   - sensor
   - weather

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -20,6 +20,7 @@ ha_platforms:
   - alarm_control_panel
   - climate
   - light
+  - scene
   - sensor
   - switch
 ---

--- a/source/_integrations/emby.markdown
+++ b/source/_integrations/emby.markdown
@@ -8,6 +8,8 @@ ha_iot_class: Local Push
 ha_codeowners:
   - '@mezz64'
 ha_domain: emby
+ha_platforms:
+  - media_player
 ---
 
 The `emby` platform allows you to control a [Emby](https://emby.media/) multimedia system from Home Assistant.

--- a/source/_integrations/enigma2.markdown
+++ b/source/_integrations/enigma2.markdown
@@ -9,6 +9,8 @@ ha_iot_class: Local Polling
 ha_codeowners:
   - '@fbradyirl'
 ha_domain: enigma2
+ha_platforms:
+  - media_player
 ---
 
 The `enigma2` platform allows you to control a Linux based set-top box which is running [Enigma2](https://github.com/oe-alliance/oe-alliance-enigma2) with the OpenWebif plugin installed.

--- a/source/_integrations/epson.markdown
+++ b/source/_integrations/epson.markdown
@@ -9,6 +9,8 @@ ha_domain: epson
 ha_codeowners:
   - '@pszafer'
 ha_config_flow: true
+ha_platforms:
+  - media_player
 ---
 
 The `epson` platform allows you to control a Epson projector from Home Assistant.

--- a/source/_integrations/fibaro.markdown
+++ b/source/_integrations/fibaro.markdown
@@ -20,6 +20,7 @@ ha_platforms:
   - cover
   - light
   - lock
+  - scene
   - sensor
   - switch
 ---

--- a/source/_integrations/forked_daapd.markdown
+++ b/source/_integrations/forked_daapd.markdown
@@ -10,6 +10,8 @@ ha_codeowners:
   - '@uvjustin'
 ha_config_flow: true
 ha_zeroconf: true
+ha_platforms:
+  - media_player
 ---
 
 The `forked_daapd` integration allows you to control your [forked-daapd](http://ejurgensen.github.io/forked-daapd/) server from Home Assistant. This integration can control the forked-daapd outputs (zones) with limited playback control (play/pause, previous/next track) and media info support. Playlist manipulation is not supported.

--- a/source/_integrations/frontier_silicon.markdown
+++ b/source/_integrations/frontier_silicon.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_iot_class: Local Push
 ha_release: '0.40'
 ha_domain: frontier_silicon
+ha_platforms:
+  - media_player
 ---
 
 This integration provides support for Internet Radios based on the [Frontier Silicon chipset]. Some of the manufacturers which offer products based on these chips include: Hama, Medion, Slivercrest, Auna, Technisat, Revo, Pinnel, etc. These devices will be usually controlled by the [UNDOK] app.

--- a/source/_integrations/gpmdp.markdown
+++ b/source/_integrations/gpmdp.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: '0.20'
 ha_domain: gpmdp
+ha_platforms:
+  - media_player
 ---
 
 The `gpmdp` media player platform allows you to control a [GPMDP](https://www.googleplaymusicdesktopplayer.com/) instance running on a computer from Home Assistant.

--- a/source/_integrations/gstreamer.markdown
+++ b/source/_integrations/gstreamer.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.39
 ha_iot_class: Local Push
 ha_domain: gstreamer
+ha_platforms:
+  - media_player
 ---
 
 The `gstreamer` platform allows you to play audio via a [gstreamer](https://gstreamer.freedesktop.org/) pipeline. Practically, this means you can play audio directly on the computer running Home Assistant. It is particularly suited for playing TTS. Advanced users can specify a pipeline to transform the audio stream and/or redirect it elsewhere.

--- a/source/_integrations/harman_kardon_avr.markdown
+++ b/source/_integrations/harman_kardon_avr.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: 0.85
 ha_domain: harman_kardon_avr
+ha_platforms:
+  - media_player
 ---
 
 The `harman_kardon_avr` platform allows you to control Harman Kardon Network Receivers from Home Assistant.

--- a/source/_integrations/hdmi_cec.markdown
+++ b/source/_integrations/hdmi_cec.markdown
@@ -7,6 +7,7 @@ ha_release: 0.23
 ha_iot_class: Local Push
 ha_domain: hdmi_cec
 ha_platforms:
+  - media_player
   - switch
 ---
 

--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -10,6 +10,8 @@ ha_codeowners:
   - '@andrewsayre'
 ha_domain: heos
 ha_ssdp: true
+ha_platforms:
+  - media_player
 ---
 
 The HEOS integration adds support for [HEOS](https://www.denon.com/en-gb/shop/amplifiersmrs/heosavr) capable products, such as speakers, amps, and receivers (Denon and Marantz) into Home Assistant. Features currently include:

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -8,6 +8,8 @@ ha_quality_scale: internal
 ha_codeowners:
   - '@home-assistant/core'
 ha_domain: homeassistant
+ha_platforms:
+  - scene
 ---
 
 The Home Assistant integration provides generic implementations like the generic `homeassistant.turn_on`.

--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -29,8 +29,10 @@ ha_platforms:
   - climate
   - cover
   - fan
+  - humidifier
   - light
   - lock
+  - media_player
   - sensor
   - switch
 ---

--- a/source/_integrations/horizon.markdown
+++ b/source/_integrations/horizon.markdown
@@ -7,6 +7,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: 0.72
 ha_domain: horizon
+ha_platforms:
+  - media_player
 ---
 
 The `horizon` integration allows you to control a [Unitymedia](https://www.unitymedia.de) Horizon HD Recorder from Home Assistant.

--- a/source/_integrations/hunterdouglas_powerview.markdown
+++ b/source/_integrations/hunterdouglas_powerview.markdown
@@ -14,6 +14,7 @@ ha_codeowners:
 ha_homekit: true
 ha_platforms:
   - cover
+  - scene
   - sensor
 ---
 

--- a/source/_integrations/itunes.markdown
+++ b/source/_integrations/itunes.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.7.3
 ha_iot_class: Local Polling
 ha_domain: itunes
+ha_platforms:
+  - media_player
 ---
 
 The `itunes` media player platform allows you to control [iTunes](https://apple.com/itunes/) from Home Assistant. It uses a 3rd party server that you run on your Mac called [itunes-api](https://github.com/maddox/itunes-api). Play, pause or skip songs remotely on iTunes running on your Mac.

--- a/source/_integrations/kef.markdown
+++ b/source/_integrations/kef.markdown
@@ -8,6 +8,8 @@ ha_release: 0.104
 ha_codeowners:
   - '@basnijholt'
 ha_domain: kef
+ha_platforms:
+  - media_player
 ---
 
 The `kef` platform allows you to control the KEF LS50 Wireless and [KEF LSX](https://international.kef.com/products/lsx) speakers from Home Assistant.

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -28,6 +28,7 @@ ha_platforms:
   - fan
   - light
   - notify
+  - scene
   - sensor
   - switch
   - weather

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -13,6 +13,7 @@ ha_domain: kodi
 ha_config_flow: true
 ha_zeroconf: true
 ha_platforms:
+  - media_player
   - notify
 ---
 

--- a/source/_integrations/lcn.markdown
+++ b/source/_integrations/lcn.markdown
@@ -20,6 +20,7 @@ ha_platforms:
   - climate
   - cover
   - light
+  - scene
   - sensor
   - switch
 ---

--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: '0.20'
 ha_domain: lg_netcast
+ha_platforms:
+  - media_player
 ---
 
 The `lg_netcast` platform allows you to control a LG Smart TV running NetCast 3.0 (LG Smart TV models released in 2012) and NetCast 4.0 (LG Smart TV models released in 2013). For the new LG WebOS TV's use the [webostv](/integrations/webostv#media-player) platform.

--- a/source/_integrations/lg_soundbar.markdown
+++ b/source/_integrations/lg_soundbar.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: 0.81
 ha_domain: lg_soundbar
+ha_platforms:
+  - media_player
 ---
 
 The `lg_soundbar` platform allows you to control [LG Soundbars](https://www.lg.com/us/sound-bars) from Home Assistant.

--- a/source/_integrations/lifx_cloud.markdown
+++ b/source/_integrations/lifx_cloud.markdown
@@ -7,6 +7,8 @@ ha_category:
 ha_iot_class: Cloud Push
 ha_release: 0.43
 ha_domain: lifx_cloud
+ha_platforms:
+  - scene
 ---
 
 The `lifx_cloud` scene platform allows you to activate the scenes that LIFX smartphone apps store in the LIFX cloud.

--- a/source/_integrations/litejet.markdown
+++ b/source/_integrations/litejet.markdown
@@ -11,6 +11,7 @@ ha_domain: litejet
 ha_config_flow: true
 ha_platforms:
   - light
+  - scene
   - switch
 ha_codeowners:
   - '@joncar'

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -16,6 +16,7 @@ ha_platforms:
   - binary_sensor
   - cover
   - light
+  - scene
   - switch
 ---
 

--- a/source/_integrations/lutron_caseta.markdown
+++ b/source/_integrations/lutron_caseta.markdown
@@ -24,6 +24,7 @@ ha_platforms:
   - cover
   - fan
   - light
+  - scene
   - switch
 ---
 

--- a/source/_integrations/mediaroom.markdown
+++ b/source/_integrations/mediaroom.markdown
@@ -8,6 +8,8 @@ ha_release: 0.63
 ha_codeowners:
   - '@dgomes'
 ha_domain: mediaroom
+ha_platforms:
+  - media_player
 ---
 
 The `mediaroom` integration allows you to control a [Mediaroom](https://en.wikipedia.org/wiki/Ericsson_Mediaroom) Set-Top Box (STB) from Home Assistant.

--- a/source/_integrations/monoprice.markdown
+++ b/source/_integrations/monoprice.markdown
@@ -10,6 +10,8 @@ ha_codeowners:
   - '@etsinko'
   - '@OnFreund'
 ha_domain: monoprice
+ha_platforms:
+  - media_player
 ---
 
 The `monoprice` platform allows you to control [Monoprice 6-Zone Amplifier](https://www.monoprice.com/product?p_id=10761) using a serial connection.

--- a/source/_integrations/mpchc.markdown
+++ b/source/_integrations/mpchc.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.25
 ha_iot_class: Local Polling
 ha_domain: mpchc
+ha_platforms:
+  - media_player
 ---
 
 The `mpchc` platform allows you to connect a [Media Player Classic Home Cinema](https://mpc-hc.org/) to Home Assistant. It will allow you to see the current playing item, and respond to changes in the player's state.

--- a/source/_integrations/mpd.markdown
+++ b/source/_integrations/mpd.markdown
@@ -8,6 +8,8 @@ ha_iot_class: Local Polling
 ha_codeowners:
   - '@fabaff'
 ha_domain: mpd
+ha_platforms:
+  - media_player
 ---
 
 The `mpd` platform allows you to control a [Music Player Daemon](https://www.musicpd.org/) from Home Assistant. Unfortunately you will not be able to manipulate the playlist (add or delete songs) or add transitions between the songs.

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -18,6 +18,8 @@ ha_platforms:
   - cover
   - fan
   - lock
+  - number
+  - scene
   - sensor
   - switch
 ---

--- a/source/_integrations/nad.markdown
+++ b/source/_integrations/nad.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.36
 ha_iot_class: Local Polling
 ha_domain: nad
+ha_platforms:
+  - media_player
 ---
 
 The `nad` platform allows you to control a [NAD receiver](https://nadelectronics.com/) through RS232, TCP and Telnet from Home Assistant.

--- a/source/_integrations/nexia.markdown
+++ b/source/_integrations/nexia.markdown
@@ -16,6 +16,7 @@ ha_dhcp: true
 ha_platforms:
   - binary_sensor
   - climate
+  - scene
   - sensor
 ---
 

--- a/source/_integrations/onkyo.markdown
+++ b/source/_integrations/onkyo.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.17
 ha_iot_class: Local Polling
 ha_domain: onkyo
+ha_platforms:
+  - media_player
 ---
 
 The `onkyo` platform allows you to control a [Onkyo](https://www.onkyo.com), [Integra](http://www.integrahometheater.com)

--- a/source/_integrations/openhome.markdown
+++ b/source/_integrations/openhome.markdown
@@ -8,6 +8,8 @@ ha_iot_class: Local Polling
 ha_domain: openhome
 ha_codeowners:
   - '@bazwilliams'
+ha_platforms:
+  - media_player
 ---
 
 The `openhome` platform allows you to connect an [Openhome Compliant Renderer](http://openhome.org/) to Home Assistant such as a [Linn Products Ltd](https://www.linn.co.uk) HiFi streamer. It will allow you to control media playback, volume, source and see the current playing item. Openhome devices should be discovered by using the [the discovery component](/integrations/discovery/), their device names are taken from the name of the room configured on the device.

--- a/source/_integrations/panasonic_bluray.markdown
+++ b/source/_integrations/panasonic_bluray.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: 0.83
 ha_domain: panasonic_bluray
+ha_platforms:
+  - media_player
 ---
 
 The `panasonic_bluray` platform allows you to control a Panasonic Blu-Ray player. Note that the device must be on the same subnet as Home Assistant; connections from a different subnet will return an error.

--- a/source/_integrations/panasonic_viera.markdown
+++ b/source/_integrations/panasonic_viera.markdown
@@ -9,6 +9,7 @@ ha_iot_class: Local Polling
 ha_domain: panasonic_viera
 ha_config_flow: true
 ha_platforms:
+  - media_player
   - remote
 ---
 

--- a/source/_integrations/pandora.markdown
+++ b/source/_integrations/pandora.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.22
 ha_iot_class: Local Polling
 ha_domain: pandora
+ha_platforms:
+  - media_player
 ---
 
 If you have a Pandora account, you can control it from Home Assistant with this media player.

--- a/source/_integrations/philips_js.markdown
+++ b/source/_integrations/philips_js.markdown
@@ -11,6 +11,7 @@ ha_codeowners:
 ha_domain: philips_js
 ha_config_flow: true
 ha_platforms:
+  - media_player
   - remote
 ---
 

--- a/source/_integrations/pioneer.markdown
+++ b/source/_integrations/pioneer.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.19
 ha_iot_class: Local Polling
 ha_domain: pioneer
+ha_platforms:
+  - media_player
 ---
 
 The `pioneer` platform allows you to control Pioneer Network Receivers. Please note, however, that the more recent Pioneer models work with [Onkyo](/integrations/onkyo) platform instead.

--- a/source/_integrations/pjlink.markdown
+++ b/source/_integrations/pjlink.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.76
 ha_iot_class: Local Polling
 ha_domain: pjlink
+ha_platforms:
+  - media_player
 ---
 
 The `pjlink` platform allows you to control from Home Assistant, projectors with support for the [PJLink protocol](https://pjlink.jbmia.or.jp/english/index.html).

--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -12,6 +12,7 @@ ha_codeowners:
   - '@jjlawren'
 ha_domain: plex
 ha_platforms:
+  - media_player
   - sensor
 ---
 

--- a/source/_integrations/ps4.markdown
+++ b/source/_integrations/ps4.markdown
@@ -9,6 +9,8 @@ ha_iot_class: Local Polling
 ha_codeowners:
   - '@ktnrg45'
 ha_domain: ps4
+ha_platforms:
+  - media_player
 ---
 
 The `ps4` integration allows you to control a

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -15,6 +15,7 @@ ha_codeowners:
 ha_ssdp: true
 ha_homekit: true
 ha_platforms:
+  - media_player
   - remote
 ---
 

--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -9,6 +9,8 @@ ha_config_flow: true
 ha_codeowners:
   - '@pavoni'
 ha_domain: roon
+ha_platforms:
+  - media_player
 ---
 
 The Roon integration allows you to control [RoonLabs](https://roonlabs.com/) music players from Home Assistant.

--- a/source/_integrations/russound_rio.markdown
+++ b/source/_integrations/russound_rio.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.49
 ha_iot_class: Local Push
 ha_domain: russound_rio
+ha_platforms:
+  - media_player
 ---
 
 The `russound_rio` platform allows you to control Russound devices that make use of the RIO protocol.

--- a/source/_integrations/russound_rnet.markdown
+++ b/source/_integrations/russound_rnet.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.25
 ha_iot_class: Local Polling
 ha_domain: russound_rnet
+ha_platforms:
+  - media_player
 ---
 
 The `russound_rnet` platform allows you to control Russound devices that make use of the RNET protocol.

--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -10,6 +10,8 @@ ha_codeowners:
   - '@escoand'
 ha_domain: samsungtv
 ha_ssdp: true
+ha_platforms:
+  - media_player
 ---
 
 The `samsungtv` platform allows you to control a [Samsung Smart TV](https://www.samsung.com/uk/tvs/all-tvs/).

--- a/source/_integrations/sisyphus.markdown
+++ b/source/_integrations/sisyphus.markdown
@@ -12,6 +12,7 @@ ha_codeowners:
 ha_domain: sisyphus
 ha_platforms:
   - light
+  - media_player
 ---
 
 The [Sisyphus](https://sisyphus-industries.com/) integration for Home Assistant allows you to observe and control your Sisyphus Kinetic Art Table.

--- a/source/_integrations/smartthings.markdown
+++ b/source/_integrations/smartthings.markdown
@@ -26,6 +26,7 @@ ha_platforms:
   - fan
   - light
   - lock
+  - scene
   - sensor
   - switch
 ---

--- a/source/_integrations/snapcast.markdown
+++ b/source/_integrations/snapcast.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.13
 ha_iot_class: Local Polling
 ha_domain: snapcast
+ha_platforms:
+  - media_player
 ---
 
 The `snapcast` platform allows you to control [Snapcast](https://github.com/badaix/snapcast) from Home Assistant.

--- a/source/_integrations/songpal.markdown
+++ b/source/_integrations/songpal.markdown
@@ -12,6 +12,8 @@ ha_codeowners:
   - '@shenxn'
 ha_domain: songpal
 ha_ssdp: true
+ha_platforms:
+  - media_player
 ---
 
 The `songpal` platform allows you to control Sony's Songpal ("[Audio Control API](https://developer.sony.com/develop/audio-control-api/)") compatible devices such as soundbars, AV receivers and wireless speakers from Home Assistant.

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -13,6 +13,8 @@ ha_codeowners:
   - '@cgtobi'
 ha_ssdp: true
 ha_platforms:
+  - binary_sensor
+  - media_player
   - sensor
 ---
 

--- a/source/_integrations/soundtouch.markdown
+++ b/source/_integrations/soundtouch.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.34
 ha_iot_class: Local Polling
 ha_domain: soundtouch
+ha_platforms:
+  - media_player
 ---
 
 The `soundtouch` platform allows you to control your [Bose Soundtouch](https://www.soundtouch.com/) speakers from Home Assistant.

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -11,6 +11,8 @@ ha_codeowners:
   - '@frenck'
 ha_domain: spotify
 ha_zeroconf: true
+ha_platforms:
+  - media_player
 ---
 
 The Spotify media player integration allows you to control [Spotify](https://www.spotify.com/) playback from Home Assistant.

--- a/source/_integrations/squeezebox.markdown
+++ b/source/_integrations/squeezebox.markdown
@@ -10,6 +10,8 @@ ha_codeowners:
   - '@rajlaud'
 ha_config_flow: true
 ha_dhcp: true
+ha_platforms:
+  - media_player
 ---
 
 The Squeezebox integration allows you to control a [Logitech Squeezebox](https://en.wikipedia.org/wiki/Squeezebox_%28network_music_player%29) music player from Home Assistant. This lets you control Squeezebox hardware like the Classic, Transporter, Duet, Boom, Radio and Touch and of software players like [Squeezelite](https://github.com/ralph-irving/squeezelite), [SoftSqueeze](http://softsqueeze.sourceforge.net/), [SqueezePlayer](https://play.google.com/store/apps/details?id=de.bluegaspode.squeezeplayer) and [SqueezeSlave](https://forums.slimdevices.com/showthread.php?93607-ANNOUNCE-Squeezeslave-1-2-released).

--- a/source/_integrations/tahoma.markdown
+++ b/source/_integrations/tahoma.markdown
@@ -18,6 +18,7 @@ ha_platforms:
   - binary_sensor
   - cover
   - lock
+  - scene
   - sensor
   - switch
 ---

--- a/source/_integrations/tuya.markdown
+++ b/source/_integrations/tuya.markdown
@@ -20,6 +20,7 @@ ha_platforms:
   - cover
   - fan
   - light
+  - scene
   - switch
 ha_dhcp: true
 ---

--- a/source/_integrations/ue_smart_radio.markdown
+++ b/source/_integrations/ue_smart_radio.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: '0.60'
 ha_iot_class: Cloud Polling
 ha_domain: ue_smart_radio
+ha_platforms:
+  - media_player
 ---
 
 The `ue_radio` platform allows you to control a [Logitech UE Smart Radio](https://www.uesmartradio.com) from Home Assistant. This lets you control both Logitech UE Smart Radios and Logitech Squeezebox Radios that have been updated with the UE Smart Radio update.

--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -7,6 +7,8 @@ ha_iot_class: Calculated
 ha_release: 0.11
 ha_quality_scale: internal
 ha_domain: universal
+ha_platforms:
+  - media_player
 ---
 
 Universal Media Players combine multiple existing entities in Home Assistant into one media player entity. This is used for creating a single entity that controls an entire media center.

--- a/source/_integrations/upb.markdown
+++ b/source/_integrations/upb.markdown
@@ -12,6 +12,7 @@ ha_codeowners:
 ha_domain: upb
 ha_platforms:
   - light
+  - scene
 ---
 
 The UPB integration allows Home Assistant to connect to a Universal Powerline Bus Powerline Interface Module (UPB PIM) to get status and control UPB devices and UPB links. The UPB PIM may be connected either to a serial port or over TCP. The integration implements the following platforms:

--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -11,6 +11,7 @@ ha_codeowners:
 ha_domain: velux
 ha_platforms:
   - cover
+  - scene
 ---
 
 [Velux](https://www.velux.com/) integration for Home Assistant allows you to connect to a Velux KLF 200 interface, to control [io-homecontrol](http://www.io-homecontrol.com) devices like windows and blinds. The module allows you to start scenes configured within KLF 200.

--- a/source/_integrations/vera.markdown
+++ b/source/_integrations/vera.markdown
@@ -23,6 +23,7 @@ ha_platforms:
   - cover
   - light
   - lock
+  - scene
   - sensor
   - switch
 ---

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -11,6 +11,8 @@ ha_codeowners:
   - '@raman325'
 ha_domain: vizio
 ha_zeroconf: true
+ha_platforms:
+  - media_player
 ---
 
 The `vizio` integration allows you to control [SmartCast](https://www.vizio.com/smartcast-app)-compatible TVs and sound bars (2016+ models).

--- a/source/_integrations/vlc.markdown
+++ b/source/_integrations/vlc.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.35
 ha_iot_class: Local Polling
 ha_domain: vlc
+ha_platforms:
+  - media_player
 ---
 
 The `vlc` platform allows you to control [VLC media player](https://www.videolan.org/vlc/index.html).

--- a/source/_integrations/vlc_telnet.markdown
+++ b/source/_integrations/vlc_telnet.markdown
@@ -9,6 +9,8 @@ ha_codeowners:
   - '@rodripf'
   - '@dmcc'
 ha_domain: vlc_telnet
+ha_platforms:
+  - media_player
 ---
 
 The `vlc_telnet` platform allows you to control a [VLC media player](https://www.videolan.org/vlc/index.html) using the built in telnet interface.

--- a/source/_integrations/volumio.markdown
+++ b/source/_integrations/volumio.markdown
@@ -10,6 +10,8 @@ ha_codeowners:
   - '@OnFreund'
 ha_domain: volumio
 ha_zeroconf: true
+ha_platforms:
+  - media_player
 ---
 
 The `Volumio` platform allows you to control a [Volumio](https://volumio.org/) media player from Home Assistant.

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -10,6 +10,7 @@ ha_codeowners:
   - '@bendavid'
 ha_domain: webostv
 ha_platforms:
+  - media_player
   - notify
 ---
 

--- a/source/_integrations/wink.markdown
+++ b/source/_integrations/wink.markdown
@@ -26,6 +26,7 @@ ha_platforms:
   - fan
   - light
   - lock
+  - scene
   - sensor
   - switch
   - water_heater

--- a/source/_integrations/xbox.markdown
+++ b/source/_integrations/xbox.markdown
@@ -14,6 +14,7 @@ ha_domain: xbox
 ha_config_flow: true
 ha_platforms:
   - binary_sensor
+  - media_player
   - remote
   - sensor
 ---

--- a/source/_integrations/xiaomi_tv.markdown
+++ b/source/_integrations/xiaomi_tv.markdown
@@ -8,6 +8,8 @@ ha_iot_class: Assumed State
 ha_codeowners:
   - '@simse'
 ha_domain: xiaomi_tv
+ha_platforms:
+  - media_player
 ---
 
 The `xiaomi_tv` platform allows you to control a [Xiaomi TV](https://www.mi.com/en/mitv3s/65flat/).

--- a/source/_integrations/yamaha.markdown
+++ b/source/_integrations/yamaha.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_release: 0.16
 ha_iot_class: Local Polling
 ha_domain: yamaha
+ha_platforms:
+  - media_player
 ---
 
 The `yamaha` platform allows you to control [Yamaha Network Receivers](https://usa.yamaha.com/products/audio-visual/av-receivers-amps/rx) from Home Assistant.

--- a/source/_integrations/yamaha_musiccast.markdown
+++ b/source/_integrations/yamaha_musiccast.markdown
@@ -8,6 +8,8 @@ ha_codeowners:
   - '@jalmeroth'
 ha_iot_class: Local Polling
 ha_domain: yamaha_musiccast
+ha_platforms:
+  - media_player
 ---
 
 The `yamaha_musiccast` platform allows you to control [Yamaha MusicCast Receivers](https://usa.yamaha.com/products/audio_visual/musiccast/index.html) from Home Assistant.

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -30,6 +30,7 @@ ha_platforms:
   - fan
   - light
   - lock
+  - number
   - sensor
   - switch
 ha_zeroconf: true

--- a/source/_integrations/ziggo_mediabox_xl.markdown
+++ b/source/_integrations/ziggo_mediabox_xl.markdown
@@ -6,6 +6,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: '0.60'
 ha_domain: ziggo_mediabox_xl
+ha_platforms:
+  - media_player
 ---
 
 The `ziggo_mediabox_xl` integration allows you to control a [Ziggo](https://www.ziggo.nl/) Mediabox XL from Home Assistant.

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -25,6 +25,7 @@ ha_platforms:
   - fan
   - light
   - lock
+  - number
   - sensor
   - switch
 ---


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

@jjlawren Noticed media player was missing in the frontmatter for platforms.
A small check I noticed an issue, this syncs up the docs with the manifests correctly.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
