### PR TITLE
Update netio.markdown

### DIFF
--- a/source/_integrations/netio.markdown
+++ b/source/_integrations/netio.markdown
@@ -10,7 +10,7 @@ ha_platforms:
   - switch
 ---
 
-The `netio` switch platform allows you to control your [Netio](https://www.netio-products.com/en/overview/) Netio4, Netio4 All, and Netio 230B. These are smart outlets controllable through Ethernet and/or Wi-Fi that reports consumptions (Netio4all).
+The `netio` switch platform allows you to control your [Netio](https://www.netio-products.com/en/overview/) Netio4, Netio4 All, and Netio 230B. These are smart outlets controllable through Ethernet and/or Wi-Fi that reports consumptions (Netio4all).  This integration requires Telnet to be enabled on the Netio device.
 
 To use Netio devices in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_integrations/netio.markdown
+++ b/source/_integrations/netio.markdown
@@ -10,7 +10,7 @@ ha_platforms:
   - switch
 ---
 
-The `netio` switch platform allows you to control your [Netio](https://www.netio-products.com/en/overview/) Netio4, Netio4 All, and Netio 230B. These are smart outlets controllable through Ethernet and/or Wi-Fi that reports consumptions (Netio4all).  This integration requires Telnet to be enabled on the Netio device.
+The `netio` switch platform allows you to control your [Netio](https://www.netio-products.com/en/overview/) Netio4, Netio4 All, and Netio 230B. These are smart outlets controllable through Ethernet and/or Wi-Fi that reports consumptions (Netio4all). This integration requires Telnet to be enabled on the Netio device.
 
 To use Netio devices in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION


## Proposed change
<!-- 
  I just tried configuring my NetIO device and it wasn't clear that this integration uses Telnet for integration.  Telnet is disabled on 
  the device by default.  The device supports many integration types and I had to figure out via the error logs why I couldn't get 
  the device going.  Suggest adding the  documentation update to mention Telnet so it is clear to potential users.  
  Also it isn't clear what the <host> variable in the Lua script example refers to (I still haven't figured it out).  Suggest update doc 
  to clarify.    
  
-->



## Type of change
<!--
    Documentation update only.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
