### PR TITLE
Add API requirement to Etherscan markdown

### DIFF
--- a/source/_integrations/etherscan.markdown
+++ b/source/_integrations/etherscan.markdown
@@ -13,6 +13,12 @@ ha_platforms:
 
 The `Etherscan` sensor platform displays Ether and ERC-20 token balances from [Etherscan.io](https://etherscan.io).
 
+##Setup
+
+A free Etherscan.io API key is required. To create an API key, you will need to register an account and follow the steps on the [Etherscan.io API introduction page](https://etherscan.io/apis).
+
+##Configuration
+
 To add the Etherscan sensor to your installation, specify an Ethereum address to watch in the `configuration.yaml` file. You can also optionally provide a token name to retrieve and ERC-20 token balance. If no token is provided then the balance retrieved will be in ETH. You can also optionally provide the token contract address in case the token name is not found.
 
 ```yaml
@@ -20,18 +26,25 @@ To add the Etherscan sensor to your installation, specify an Ethereum address to
 sensor:
   - platform: etherscan
     address: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
+    api_key: G1I9XSQJMJLDLG72FJ7MKKWDP24BVYLDQ1
   - platform: etherscan
     address: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
     token: OMG
+    api_key: G1I9XSQJMJLDLG72FJ7MKKWDP24BVYLDQ1
   - platform: etherscan
     address: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
     token_address: "0xef68e7c694f40c8202821edf525de3782458639f"
     token: LRC
+    api_key: G1I9XSQJMJLDLG72FJ7MKKWDP24BVYLDQ1
 ```
 
 {% configuration %}
 address:
   description: Ethereum wallet address to watch.
+  required: true
+  type: string
+api_key:
+  description: Etherscan.io API key
   required: true
   type: string
 name:


### PR DESCRIPTION
## Proposed change
This change adds documentation to cover the setup of an Etherscan.io account and API key which is required for use of the API.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/49981
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
