### PR TITLE
Clean up Speedtest.net integration documentation

### DIFF
--- a/source/_integrations/speedtestdotnet.markdown
+++ b/source/_integrations/speedtestdotnet.markdown
@@ -15,38 +15,28 @@ ha_platforms:
   - sensor
 ---
 
-The `speedtestdotnet` integration uses the [Speedtest.net](https://speedtest.net/) web service to measure network bandwidth performance.
+The Speedtest.net integration uses the [Speedtest.net](https://speedtest.net/) web service to measure network bandwidth performance.
 
-By default, a speed test will be run every hour. The user can change the update frequency in the configuration by defining the `scan_interval` for a speed test to run.
+
+{% include integrations/config_flow.md %}
 
 Most Speedtest.net servers require TCP port 8080 outbound to function. Without this port open you may experience significant delays or no results at all. See note on their [help page](https://www.speedtest.net/help).
 
-{% include integrations/config_flow.md %}
+By default, a speed test will be run every hour. You can update frequency in the integration configuration.
 
 ## Integration Sensors
 
 The following sensors are added by the integration:
 
 sensors:
-  - Ping sensor: Reaction time in ms of your connection (how fast you get a response after you’ve sent out a request).
-  - Download sensor: The download speed (Mbit/s).
-  - Upload sensor: The upload speed (Mbit/s).
+
+- Ping sensor: Reaction time in ms of your connection (how fast you get a response after you’ve sent out a request).
+- Download sensor: The download speed (Mbit/s).
+- Upload sensor: The upload speed (Mbit/s).
   
-### Time period dictionary example
-
-```yaml
-scan_interval:
-  # At least one of these must be specified:
-  days: 0
-  hours: 0
-  minutes: 3
-  seconds: 30
-  milliseconds: 0
-```
-
 ### Service
 
-Once loaded, the `speedtestdotnet` integration will expose a service (`speedtestdotnet.speedtest`) that can be called to run a Speedtest.net speed test on demand. This service takes no parameters. This can be useful if you have enabled manual mode.
+Once loaded, the integration will expose a service (`speedtestdotnet.speedtest`) that can be called to run a Speedtest.net speed test on demand. This service takes no parameters. This can be useful when auto update has been disabled in the integration options.
 
 ```yaml
 action:
@@ -59,18 +49,6 @@ Please be aware of the potential [inconsistencies](https://github.com/sivel/spee
 ## Examples
 
 In this section you will find some real-life examples of how to use this component.
-
-### Run periodically
-
-Every half hour of every day:
-
-```yaml
-# Example configuration.yaml entry
-speedtestdotnet:
-  scan_interval:
-    minutes: 30
-```
-
 ### Using as a trigger in an automation
 
 {% raw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Cleans up the speedtest.net integration documentation. It is not configured via the UI, and there are still references to things like `scan_interval`, which doesn't apply anymore.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
