### PR TITLE
Mention `target` key for frontend actions

### DIFF
--- a/source/lovelace/actions.markdown
+++ b/source/lovelace/actions.markdown
@@ -56,6 +56,11 @@ tap_action:
       description: "Service data to include (e.g., `entity_id: media_player.bedroom`) when `action` defined as `call-service`"
       type: string
       default: none
+    target:
+      required: false
+      description: "Service target when `action` defined as `call-service`" (see [Service Targets](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/#service-targets))
+      type: list
+      default: none
     confirmation:
       required: false
       description: "Present a confirmation dialog to confirm the action. See `confirmation` object below"
@@ -103,6 +108,11 @@ hold_action:
       description: "Service data to include (e.g., `entity_id: media_player.bedroom`) when `action` defined as `call-service`"
       type: string
       default: none
+    target:
+      required: false
+      description: "Service target when `action` defined as `call-service`" (see [Service Targets](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/#service-targets))
+      type: list
+      default: none
     confirmation:
       required: false
       description: "Present a confirmation dialog to confirm the action. See `confirmation` object below"
@@ -149,6 +159,11 @@ double_tap_action:
       required: false
       description: "Service data to include (e.g., `entity_id: media_player.bedroom`) when `action` defined as `call-service`"
       type: string
+      default: none
+    target:
+      required: false
+      description: "Service target when `action` defined as `call-service`" (see [Service Targets](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/#service-targets))
+      type: list
       default: none
     confirmation:
       required: false

--- a/source/lovelace/actions.markdown
+++ b/source/lovelace/actions.markdown
@@ -58,7 +58,7 @@ tap_action:
       default: none
     target:
       required: false
-      description: "Service target when `action` defined as `call-service`" (see [Service Targets](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/#service-targets))
+      description: "Service target when `action` defined as `call-service` (see [Service Targets](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/#service-targets))"
       type: list
       default: none
     confirmation:
@@ -110,7 +110,7 @@ hold_action:
       default: none
     target:
       required: false
-      description: "Service target when `action` defined as `call-service`" (see [Service Targets](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/#service-targets))
+      description: "Service target when `action` defined as `call-service` (see [Service Targets](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/#service-targets))"
       type: list
       default: none
     confirmation:
@@ -162,7 +162,7 @@ double_tap_action:
       default: none
     target:
       required: false
-      description: "Service target when `action` defined as `call-service`" (see [Service Targets](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/#service-targets))
+      description: "Service target when `action` defined as `call-service` (see [Service Targets](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/#service-targets))"
       type: list
       default: none
     confirmation:


### PR DESCRIPTION
## Proposed change

Not sure if this link to the dev docs is good, but I could not find anything about the targets in the regular docs (only for the blueprint target selector).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
