### PR TITLE
Add postgres sql url schema change

### DIFF
--- a/source/_posts/2021-05-05-release-20215.markdown
+++ b/source/_posts/2021-05-05-release-20215.markdown
@@ -636,8 +636,7 @@ recover live. The `db_integrity_check` option has been deprecated.
 
 ([@bdraco] - [#49036] [#49098])
 
-If you are using a postgresql database please verify that your connection url starts with `postgresql://`.
-In case you use still the old url starting with `postgres://`, please replace it with `postgresql://` otherwise you will get an error to setup the recorder.
+If you are using a PostgreSQL database please verify that your connection URL starts with `postgresql://`. In case you use still an old URL starting with `postgres://`, please replace it with `postgresql://` otherwise you will get an error to set up the recorder.
 
 {% enddetails %}
 

--- a/source/_posts/2021-05-05-release-20215.markdown
+++ b/source/_posts/2021-05-05-release-20215.markdown
@@ -636,6 +636,9 @@ recover live. The `db_integrity_check` option has been deprecated.
 
 ([@bdraco] - [#49036] [#49098])
 
+If you are using a postgresql database please verify that your connection url starts with `postgresql://`.
+In case you use still the old url starting with `postgres://`, please replace it with `postgresql://` otherwise you will get an error to setup the recorder.
+
 {% enddetails %}
 
 {% details "RoonLabs music player" %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

SQLAlchemy 1.4 removed the deprecated `postgres` dialect name, the name `postgresql` must be used instead now.
As the dependency dump to 1.4 was done in 2021.5.0.
I think we should mention, that the old schema will create an error during recorder setup. So users don't wonder, why the boot is not completing successfully.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/50149

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
