### PR TITLE
Add event containing the media output locations of the tts request

### DIFF
--- a/source/_integrations/tts.markdown
+++ b/source/_integrations/tts.markdown
@@ -181,3 +181,24 @@ $ curl -X POST -H "Authorization: Bearer <ACCESS TOKEN>" \
        -d '{"message": "I am speaking now", "platform": "amazon_polly"}' \
        http://localhost:8123/api/tts_get_url
 ```
+
+## Automations
+
+Automations can be triggered on TTS output event data using a template. The following automation will send a notification with the local path, URL PATH, URL and filename of the TTS output that was generated:
+
+{% raw %}
+
+```yaml
+#Send notification for new tts output
+automation:
+  alias: "New tts output alert"
+  trigger:
+    platform: event
+    event_type: tts
+  action:
+    service: notify.notify
+    data:
+      title: New tts output generated!
+      message: "Created {{ trigger.event.data.cache_filename }} in {{ trigger.event.data.cache_path }} which is accessible at <ha url> {{ trigger.event.data.url_path }} or by clicking {{ trigger.event.data.url }}"
+```
+{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I tried to get microsoft TTS to work on the alexa media_player addon.
Unfortunatly amazon has very specific restrictions on the format of the media being send to an echo device with the simon says skill. (https://developer.amazon.com/en-US/docs/alexa/custom-skills/speech-synthesis-markup-language-ssml-reference.html#audio)
Therefore, I need to convert the tts output to another format with an shell_command in order to play the file via the echo devices.

I first attempted to detect changes on the filesystem with the folder_watcher integration.
Unfortunatly this only triggers on new tts requests for which no cache file exists.
Since, the disk based storage of tts outputs is never cleared this would result in a one-time execution unless you cleanup the tts cache after every conversion.

Therefore, the better solution would be to create an hookable event in the tts component.
Which would allow listeners to retrieve the dynamically created tts output file and do whatever they want with this output.
This wouldn't interfere with existing setups since you specifically need to be listening to events of the new type "tts".


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/50252
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
