### PR TITLE
Fix sample yamls in TTS

### DIFF
--- a/source/_integrations/tts.markdown
+++ b/source/_integrations/tts.markdown
@@ -110,26 +110,26 @@ Say to all `media_player` device entities:
 ```yaml
 # Replace google_translate_say with <platform>_say when you use a different platform.
 service: tts.google_translate_say
-entity_id: "all"
 data:
-  message: "May the Force be with you."
+  entity_id: all
+  message: "May the force be with you."
 ```
 
 Say to the `media_player.floor` device entity:
 
 ```yaml
 service: tts.google_translate_say
-entity_id: media_player.floor
 data:
-  message: "May the Force be with you."
+  entity_id: media_player.floor
+  message: "May the force be with you."
 ```
 
 Say to the `media_player.floor` device entity in French:
 
 ```yaml
 service: tts.google_translate_say
-entity_id: media_player.floor
 data:
+  entity_id: media_player.floor
   message: "Que la force soit avec toi."
   language: "fr"
 ```


### PR DESCRIPTION

## Proposed change

I tried copying the example service call yaml files into the Developer Tools / Services page and they didn't work. The "Call Service" button was not enabled. I switched to the GUI mode and entered the values and the result was different yaml and it worked (the message was "said").

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

I followed the EDIT link from the page and then edited the file in the github editor.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
