### PR TITLE
Update Omnilogic documentation for light platform.

### DIFF
--- a/source/_integrations/omnilogic.markdown
+++ b/source/_integrations/omnilogic.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to configure Hayward OmniLogic integration.
 ha_category:
   - Sensor
   - Switch
+  - Light
 ha_release: 0.116
 ha_iot_class: Cloud Polling
 ha_config_flow: true
@@ -14,6 +15,8 @@ ha_codeowners:
 ha_domain: omnilogic
 ha_platforms:
   - sensor
+  - switch
+  - light
 ---
 
 [Hayward OmniLogic](https://www.hayward-pool.com/shop/en/pools/omnilogic-i-auomni--1) smart pool and spa technology control.
@@ -22,12 +25,44 @@ There is currently support for the following device types within Home Assistant:
 
 - ***Sensor*** - Air Temperature, Water Temperature, Variable Pump Speed, Chlorinator Setting, Salt Level, pH, and ORP
 - ***Switch*** - All relays, pumps (single, dual, variable speed), and relay-based lights.
+- ***Light*** - Colorlogic Lights (V1 and V2).
 
 {% include integrations/config_flow.md %}
 
+## Sensor Platform Options
+
+If you have pH sensors in your Omnilogic setup, you can add an offset to correct reporting from the sensor in the integration configuration.
+
+## Switch Platform
+
+The switch platform contains a custom service to allow you to set the speed on variable speed pumps.
+
+To set pump speed, call the `omnilogic.set_pump_speed` service as following:
+
+```yaml
+service: omnilogic.set_pump_speed
+data:
+  entity_id: Entity ID of the Pump
+  speed: Speed (0-100%)
+```
+
+## Light Platform
+
+The light platform allows you to set the color or effect of your lights from the effect list supported by your light version.
+
+If you have V2 Colorlogic lights you can also set the brightness and speed of the lights using the custom service `omnilogic.set_v2_lights` as following:
+
+```yaml
+service: omnilogic.set_v2_lights
+data:
+  entity_id: Entity ID of the Lights
+  speed: Speed (0-8) for the light effect (optional)
+  brightness: Brightness (0-4) for the lights (optional)
+```
+
 ## Known limitations
 
-- The platform only supports sensors and switches at the current release. Future releases will include light/water heater for control of Colorlogic lights and pool heaters.
+- The platform only supports sensors, lights and switches at the current release. A future release will include water heater for control of pool heaters.
 
 ## Debugging integration
 
@@ -39,3 +74,4 @@ logger:
   logs:
     omnilogic: debug
     homeassistant.components.omnilogic: debug
+```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update Omnilogic integration documentation for the light platform PR.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/50408
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
