### PR TITLE
Make documentation more complete

### DIFF
--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -25,7 +25,35 @@ To add a Nuki bridge to your installation, you need to enable developer mode on 
 
 {% include integrations/config_flow.md %}
 
+## Binary Sensors
+
+The integration provides a binary sensor if the Nuki door sensor is available. 
+
 ## Services
+
+### Service `lock.unlock`
+
+If the lock is a Nuki Smart Lock, the service will unlock the door. If the lock is a Nuki Opener, the service will enable the ring-to-open feature. See the [Nuki Website](https://support.nuki.io/hc/en-us/articles/360019424298-Ring-To-Open) for more details about this feature.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | Entity of the relevant lock.
+
+### Service `lock.lock`
+
+If the lock is a Nuki Smart Lock, the service will lock the door. If the lock is a Nuki Opener, the service will disable the ring-to-open feature. See the [Nuki Website](https://support.nuki.io/hc/en-us/articles/360019424298-Ring-To-Open) for more details about this feature.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | Entity of the relevant lock.
+
+### Service `lock.open`
+
+If the lock is a Nuki Smart Lock, the service will unlatch the door. If the lock is a Nuki Opener, the service will buzz the door open.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | Entity of the relevant lock.
 
 ### Service `nuki.lock_n_go`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The Nuki integration has some specifics that are not obvious just from the lock domain perspective. Especially using the lock and unlock services for the ring-to-open function was not documented. Also, the binary sensor has been added.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
