### PR TITLE
Fix typo in the light integration from 17513.

### DIFF
--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -26,7 +26,7 @@ The `.default` suffix should be added to the entity identifier of each light to 
 
 <div class='note'>
 
-If a light entity is in the `on` state, the default profile brightness and will only be applied if it is called in the service call data attribute `profile`, like any other named profile. The transition attribute will be applied for all `light.turn_on`, `light.toggle` and `light.turn_off` service calls, unless specified otherwise in the service call data.
+If a light entity is in the `on` state, the default profile brightness will only be applied if it is called in the service call data attribute `profile`, like any other named profile. The transition attribute will be applied for all `light.turn_on`, `light.toggle` and `light.turn_off` service calls, unless specified otherwise in the service call data.
 
 </div>
 


### PR DESCRIPTION
## Proposed change
Missed typo in https://github.com/home-assistant/home-assistant.io/pull/17513


## Type of change

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
