### PR TITLE
Mqtt Fan example remove speed keyword from examples in preset_mode topics

### DIFF
--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -266,8 +266,8 @@ fan:
     oscillation_command_topic: "bedroom_fan/oscillation/set"
     percentage_state_topic: "bedroom_fan/speed/percentage_state"
     percentage_command_topic: "bedroom_fan/speed/percentage"
-    preset_mode_state_topic: "bedroom_fan/speed/preset_mode_state"
-    preset_mode_command_topic: "bedroom_fan/speed/preset_mode"
+    preset_mode_state_topic: "bedroom_fan/preset/preset_mode_state"
+    preset_mode_command_topic: "bedroom_fan/preset/preset_mode"
     preset_modes:
        -  "auto"
        -  "smart"
@@ -299,7 +299,7 @@ fan:
     oscillation_command_template: "{ oscillation: '{{ value }}'}"
     percentage_command_topic: "bedroom_fan/speed/percentage"
     percentage_command_template: "{ percentage: '{{ value }}'}"
-    preset_mode_command_topic: "bedroom_fan/speed/preset_mode"
+    preset_mode_command_topic: "bedroom_fan/preset/preset_mode"
     preset_mode_command_template: "{ preset_mode: '{{ value }}'}"
     preset_modes:
        -  "auto"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Improve the examples for mqtt fan. The examples used the `speed` keyword in the topics for `preset_mode` feature.
The word `speed` is replaced with `preset` to avoid confusion between preset modes and speeds.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
