### PR TITLE
Mqtt fan docs update for new state reset attributes

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -189,6 +189,8 @@ Supported abbreviations:
     'pl_strt':             'payload_start',
     'pl_stpa':             'payload_start_pause',
     'pl_ret':              'payload_return_to_base',
+    'pl_rst_pct':          'payload_reset_percentage',
+    'pl_rst_pr_mode':      'payload_reset_preset_mode',
     'pl_toff':             'payload_turn_off',
     'pl_ton':              'payload_turn_on',
     'pl_unlk':             'payload_unlock',

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -170,12 +170,12 @@ payload_oscillation_on:
   type: string
   default: oscillate_on
 payload_reset_percentage:
-  description: A special payload that resets the `percentage` speed attribute state when received at the `percentage_state_topic`.
+  description: A special payload that resets the `percentage` state attribute to `None` when received at the `percentage_state_topic`.
   required: false
   type: string
   default: 'None'
 payload_reset_preset_mode:
-  description: A special payload that resets the `preset_mode` attribute state state when received at the `preset_mode_state_topic`.
+  description: A special payload that resets the `preset_mode` state attribute to `None` when received at the `preset_mode_state_topic`.
   required: false
   type: string
   default: 'None'

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -169,6 +169,16 @@ payload_oscillation_on:
   required: false
   type: string
   default: oscillate_on
+payload_reset_percentage:
+  description: A special payload that resets the `percentage` speed attribute state when received at the `percentage_state_topic`.
+  required: false
+  type: string
+  default: 'None'
+payload_reset_preset_mode:
+  description: A special payload that resets the `preset_mode` attribute state state when received at the `preset_mode_state_topic`.
+  required: false
+  type: string
+  default: 'None'
 percentage_command_template:
   description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to generate the payload to send to `percentage_command_topic`.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update documentation for two new introduced attributes that allow to reset `preset_mode` or `percentage` state.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/50565
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
