### PR TITLE
Add description of ""close_comm_on_error".

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -48,6 +48,11 @@ modbus:
 ```
 
 {% configuration %}
+close_comm_on_error:
+  description: Determines if the modbus communication is closed when an error occurs, default is true. Some serial-rs485 adapters sends garble to HA when opened, this lead to a disconnect and a new connect, which can continue. If in a running communication the debug log contains a message from pymodbus, with the text "cleaning....", then try this parameter.
+  required: false
+  default: true
+  type: boolean
 delay:
   description: Time to delay messages in seconds after connecting. Some modbus devices need a delay typically 1-2 seconds after connection is established in order to prepare the communication. If a device accepts connecting with no response to the requests sent or the device disconnects, this parameter might help.
   required: false

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -49,7 +49,7 @@ modbus:
 
 {% configuration %}
 close_comm_on_error:
-  description: Determines if the modbus communication is closed when an error occurs, default is true. Some serial-rs485 adapters sends garble to HA when opened, this leads to a disconnect and a new connect, which can continue. If in a running communication the debug log contains a message from pymodbus, with the text "cleaning....", then try this parameter.
+  description: Determines if the modbus communication is closed when an error occurs, default is true. Some serial-rs485 adapters send garble to HA when opened, this leads to a disconnect and a new connect, which can continue. If in a running communication the debug log contains a message from pymodbus, with the text "cleaning....", then try this parameter.
   required: false
   default: true
   type: boolean

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -49,7 +49,7 @@ modbus:
 
 {% configuration %}
 close_comm_on_error:
-  description: Determines if the modbus communication is closed when an error occurs, default is true. Some serial-rs485 adapters sends garble to HA when opened, this lead to a disconnect and a new connect, which can continue. If in a running communication the debug log contains a message from pymodbus, with the text "cleaning....", then try this parameter.
+  description: Determines if the modbus communication is closed when an error occurs, default is true. Some serial-rs485 adapters sends garble to HA when opened, this leads to a disconnect and a new connect, which can continue. If in a running communication the debug log contains a message from pymodbus, with the text "cleaning....", then try this parameter.
   required: false
   default: true
   type: boolean


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add description of new configuration attribute in modbus.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
https://github.com/home-assistant/core/pull/50583 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
