### PR TITLE
Add Crownstone documentation

### DIFF
--- a/source/_integrations/crownstone.markdown
+++ b/source/_integrations/crownstone.markdown
@@ -1,0 +1,53 @@
+---
+title: Crownstone
+description: Instructions on how to setup the Crownstone integration within Home Assistant.
+ha_category:
+  - Light
+  - Switch
+ha_iot_class: Cloud Push  
+ha_release: '2021.7'
+ha_config_flow: true
+ha_quality_scale: silver
+ha_codeowners:
+  - '@Crownstone'
+  - '@RicArch97'
+ha_domain: crownstone
+---
+
+The **Crownstone** integration allows you to control your Crownstones either via the cloud or using a [Crownstone USB](#crownstone-usb) dongle.
+
+The Crownstone integration supports the following Crownstone devices:
+
+- Crownstone Plug (This can be plugged directly into an existing power outlet)
+- Crownstone Built-In One (This can be put behind power outlets, lamp fixtures, or switches)
+
+{% include integrations/config_flow.md %}
+
+## Options
+
+Options for the Crownstone integration can be set going to **Configuration** -> **Integrations** -> **Crownstone** -> **Configure**.
+
+{% configuration_basic %}
+Use a Crownstone USB dongle to enable local data transmission:
+  description: "Enabling this option will launch a flow, which will allow you to configure a Crownstone USB dongle. You may have to refresh the page to see the pop-up. Disabling this option will remove current configuration."
+{% endconfiguration_basic %}
+
+## Crownstones
+
+Crownstones have the ability to dim, however dimming is disabled by default. To enable dimming for a Crownstone:
+
+1. Go to your Crownstone app
+2. Tap on a Crownstone that you want to enable the dimming functionality
+3. Tap on **Abilities**
+4. Toggle **Dimming** on
+
+When you have changed an ability through the Crownstone app, the change will be automatically updated in Home Assistant. Note that Home Assistant will reload the entry when dimming is changed.
+
+Enabling dimming is at own risk. It is recommended to only use dimming on lights.
+
+## Crownstone USB
+
+The default connection method of the Crownstone integration is Cloud Polling. However a [Crownstone USB](https://shop.crownstone.rocks/products/crownstone-usb-dongle) is available. Instead of switching and dimming Crownstones using the Cloud, this dongle hooks directly into the Crownstone mesh to switch Crownstones, which means the latencies are really low.
+
+Furthermore, the Crownstone USB dongle allows for independent switching of Crownstones. When using the Cloud, a smartphone must be in
+the Sphere to switch the Crownstone.

--- a/source/_integrations/crownstone.markdown
+++ b/source/_integrations/crownstone.markdown
@@ -14,7 +14,7 @@ ha_codeowners:
 ha_domain: crownstone
 ---
 
-The **Crownstone** integration allows you to control your Crownstones either via the cloud or using a [Crownstone USB](#crownstone-usb) dongle.
+The Crownstone integration allows you to control your Crownstones either via the cloud or using a [Crownstone USB](#crownstone-usb) dongle.
 
 The Crownstone integration supports the following Crownstone devices:
 
@@ -23,9 +23,7 @@ The Crownstone integration supports the following Crownstone devices:
 
 {% include integrations/config_flow.md %}
 
-## Options
-
-Options for the Crownstone integration can be set going to **Configuration** -> **Integrations** -> **Crownstone** -> **Configure**.
+{% include integrations/options_flow.md %}
 
 {% configuration_basic %}
 Use a Crownstone USB dongle to enable local data transmission:
@@ -47,7 +45,7 @@ Enabling dimming is at own risk. It is recommended to only use dimming on lights
 
 ## Crownstone USB
 
-The default connection method of the Crownstone integration is Cloud Polling. However a [Crownstone USB](https://shop.crownstone.rocks/products/crownstone-usb-dongle) is available. Instead of switching and dimming Crownstones using the Cloud, this dongle hooks directly into the Crownstone mesh to switch Crownstones, which means the latencies are really low.
+The default connection method of the Crownstone integration is Cloud Polling. However, a [Crownstone USB](https://shop.crownstone.rocks/products/crownstone-usb-dongle) is available. Instead of switching and dimming Crownstones using the Cloud, this dongle hooks directly into the Crownstone mesh to switch Crownstones, which means the latencies are really low.
 
 Furthermore, the Crownstone USB dongle allows for independent switching of Crownstones. When using the Cloud, a smartphone must be in
 the Sphere to switch the Crownstone.

--- a/source/_integrations/crownstone.markdown
+++ b/source/_integrations/crownstone.markdown
@@ -22,7 +22,7 @@ The Crownstone integration supports the following Crownstone devices:
 
 {% include integrations/config_flow.md %}
 
-{% include integrations/options_flow.md %}
+{% include integrations/option_flow.md %}
 
 {% configuration_basic %}
 Use a Crownstone USB dongle to enable local data transmission:

--- a/source/_integrations/crownstone.markdown
+++ b/source/_integrations/crownstone.markdown
@@ -3,9 +3,8 @@ title: Crownstone
 description: Instructions on how to setup the Crownstone integration within Home Assistant.
 ha_category:
   - Light
-  - Switch
 ha_iot_class: Cloud Push  
-ha_release: '2021.7'
+ha_release: '2021.10'
 ha_config_flow: true
 ha_quality_scale: silver
 ha_codeowners:
@@ -27,7 +26,9 @@ The Crownstone integration supports the following Crownstone devices:
 
 {% configuration_basic %}
 Use a Crownstone USB dongle to enable local data transmission:
-  description: "Enabling this option will launch a flow, which will allow you to configure a Crownstone USB dongle. You may have to refresh the page to see the pop-up. Disabling this option will remove current configuration."
+  description: "Enabling this option will launch a flow, which will allow you to configure a Crownstone USB dongle. Disabling this option will remove current configuration."
+Crownstone Sphere where the USB is located:
+  description: "This option is available when a Crownstone USB dongle is configured, and there are multiple Crownstone Spheres available. You can select in which Sphere the USB dongle is currently located."
 {% endconfiguration_basic %}
 
 ## Crownstones


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds documentation for the upcoming Crownstone integration in Home Assistant core.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/50677
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2583

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
