### PR TITLE
Add wake_on_lan to netcast example

### DIFF
--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -51,15 +51,18 @@ Just add the token to your configuration and restart Home Assistant and the medi
 
 ## Advanced configuration
 
-The example below shows how you can use the `turn_on_action`
+The example below shows how you can use the `turn_on_action` the [`wake_on_lan` integration](/integrations/wake_on_lan/).
 
 ```yaml
-# Example configuration.yaml entry
+wake_on_lan: # enables `wake_on_lan` integration
+
+# Enables the `lg_netcast` media player
 media_player:
   - platform: lg_netcast
     host: 192.168.0.20
     turn_on_action:
-      service: switch.turn_on
-      target:
-        entity_id: switch.tv_switch
+      service: wake_on_lan.send_magic_packet
+      data:
+        mac: AA-BB-CC-DD-EE-FF
+        broadcast_address: 11.22.33.44
 ```

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -117,7 +117,7 @@ This usually only works if the TV is connected to the same network. Routing the 
 
 ```yaml
 # Example configuration.yaml entry
-wake_on_lan: # enables `wake_on_lan` domain
+wake_on_lan: # enables `wake_on_lan` integration
 
 webostv:
   host: 192.168.0.10


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: closes #17059

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
