### PR TITLE
Clarify unit_prefix and unit_time for Riemann sum integral

### DIFF
--- a/source/_integrations/integration.markdown
+++ b/source/_integrations/integration.markdown
@@ -64,7 +64,9 @@ method:
   default: trapezoidal
 {% endconfiguration %}
 
-In case you have an appliance which produces spikey consumption (like an on/off electrical boiler) you should opt for the `left` method to get accurate readings. If `unit` is set then `unit_prefix` and `unit_time` are ignored.
+In case you have an appliance which produces spikey consumption (like an on/off electrical boiler) you should opt for the `left` method to get accurate readings.
+
+The unit of `source` together with `unit_prefix` and `unit_time` is used to generate a unit for the integral product (e.g. a source in `W` with prefix `k` and time `h` would result in `kWh`). You can override this behaviour by providing a custom value for `unit`. Note that `unit_prefix` and `unit_time` are _also_ relevant to the Riemann sum calculation. Even if you provide a custom value for `unit`, ensure prefix and time accurately reflect the properties of your source data.
 
 ## Energy
 

--- a/source/_integrations/integration.markdown
+++ b/source/_integrations/integration.markdown
@@ -66,7 +66,7 @@ method:
 
 In case you have an appliance which produces spikey consumption (like an on/off electrical boiler) you should opt for the `left` method to get accurate readings.
 
-The unit of `source` together with `unit_prefix` and `unit_time` is used to generate a unit for the integral product (e.g. a source in `W` with prefix `k` and time `h` would result in `kWh`). You can override this behaviour by providing a custom value for `unit`. Note that `unit_prefix` and `unit_time` are _also_ relevant to the Riemann sum calculation. Even if you provide a custom value for `unit`, ensure prefix and time accurately reflect the properties of your source data.
+The unit of `source` together with `unit_prefix` and `unit_time` is used to generate a unit for the integral product (e.g. a source in `W` with prefix `k` and time `h` would result in `kWh`). You can override this behavior by providing a custom value for `unit`. Note that `unit_prefix` and `unit_time` are _also_ relevant to the Riemann sum calculation. Even if you provide a custom value for `unit`, ensure prefix and time accurately reflect the properties of your source data.
 
 ## Energy
 


### PR DESCRIPTION
## Proposed change
Clarify usage/function of `unit_prefix` and `unit_time` in the integration (Riemann sum integral) documentation.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/home-assistant.io/issues/13849

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
