### PR TITLE
KNX: Remove deprecated create_sensors option

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -705,11 +705,6 @@ max_temp:
   description: Override the maximum temperature.
   required: false
   type: float
-create_temperature_sensors:
-  description: If true, dedicated sensor entities are created for current and target temperature.
-  required: false
-  type: boolean
-  default: false
 {% endconfiguration %}
 
 ## Cover
@@ -1337,7 +1332,6 @@ knx:
       address_day_night: "7/0/8"
       address_air_pressure: "7/0/9"
       address_humidity: "7/0/10"
-      create_sensors: false
       sync_state: true
 ```
 
@@ -1399,11 +1393,6 @@ address_humidity:
   description: KNX address for reading current humidity. *DPT 9.007*
   required: false
   type: [string, list]
-create_sensors:
-  description: If true, dedicated sensor entities are created for all configured properties.
-  required: false
-  type: boolean
-  default: false
 sync_state:
   description: Actively read the value from the bus. If `false` no GroupValueRead telegrams will be sent to the bus.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove deprecated create_sensors option for climate and weather platforms


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
https://github.com/home-assistant/core/pull/49638
https://github.com/home-assistant/core/pull/49640
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
