### PR TITLE
Update zeroconf to show that the interface configuration has been centralized in the network integration

### DIFF
--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -36,6 +36,6 @@ zeroconf:
      default: true
 {% endconfiguration %}
 
-## Network interfacesa and auto detection
+## Network interfaces and auto detection
 
 Zeroconf chooses which interfaces to broadcast on based on the [Network](/integrations/network/) integration.

--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -29,11 +29,6 @@ zeroconf:
   description: 
   type: map
   keys:
-   default_interface:
-     description: By default, `zeroconf` will attempt to detect the best value based on available routing information. For systems that require broadcasting mDNS on all interfaces, change this option to `false` if `zeroconf` does not function.
-     required: false
-     type: boolean
-     default: true
    ipv6:
      description: By default, `zeroconf` will enable IPv6 support. If your network has trouble with IPv6 being enabled, you can set this option to `false`.
      required: false
@@ -41,10 +36,6 @@ zeroconf:
      default: true
 {% endconfiguration %}
 
-## `default_interface` auto detection
+## Network interfacesa and auto detection
 
-If the `default_interface` is unset, the value is auto-detected based on the system routing next hop for the mDNS broadcast address (`224.0.0.251`).
-
-If the next-hop cannot be detected or is a loopback address, `zeroconf` will broadcast on all interfaces. If the next hop is a non-loopback address, `zeroconf` will only broadcast on the default interface.
-
-Setting the `default_interface` to `true` or `false` will override the auto detection.
+Zeroconf chooses which interfaces to broadcast on based on the [Network](/integrations/network/) integration.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update zeroconf to show that the interface configuration has been centralized in the network integration

Depends on https://github.com/home-assistant/home-assistant.io/pull/17897


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/50874
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
