### PR TITLE
Remove service_executed from Events documentation

### DIFF
--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -45,14 +45,6 @@ Event `call_service` is fired to call a service.
 | `service_data`    | Dictionary with the service call parameters. Example: `{ 'brightness': 120 }`. |
 | `service_call_id` | String with a unique call id. Example: `23123-4`.                              |
 
-## Event `service_executed`
-
-Event `service_executed` is fired by the service handler to indicate the service is done.
-
-| Field             | Description                                                                               |
-| ----------------- | ----------------------------------------------------------------------------------------- |
-| `service_call_id` | String with the unique call id of the service call that was executed. Example: `23123-4`. |
-
 ## Event `automation_reloaded`
 
 Event `automation_reloaded` is fired when automations have been reloaded and thus might have changed.


### PR DESCRIPTION
No longer possible to listen to the service_executed after 0.84 per [this thread](https://community.home-assistant.io/t/service-executed-event-replacement/98538)

## Proposed change
<!-- 
    Remove service_executed from Events documentation
-->

Remove service_executed from Events documentation


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
