### PR TITLE
Update samsungtv for built-in wake on lan support

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -51,9 +51,11 @@ turn_on_action:
 
 After saving the YAML configuration, the TV must be turned on _before_ launching Home Assistant in order for the TV to be registered the first time.
 
-#### Wake up TV
+#### Wake up TV / TV does not turn on
 
-To wake up the TV when switched off you can use the [wake-on-lan](/integrations/wake_on_lan/) integration and call a service. This is not possible with every device.
+If the integration knows the MAC address of the TV from discovery, it will attempt to wake it using wake on lan when calling turn on. Wake on lan must be enabled on the TV for this to work. If the TV is connected to a smart strip or requires a more complex turn on process, a `turn_on_action` can be provided that will take precedence over the built-in wake on lan functionality.
+
+To wake up the TV when switched off you can use the [wake-on-lan](/integrations/wake_on_lan/) integration and call a service.
 
 ```yaml
 wake_on_lan:

--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -53,7 +53,7 @@ After saving the YAML configuration, the TV must be turned on _before_ launching
 
 #### Wake up TV / TV does not turn on
 
-If the integration knows the MAC address of the TV from discovery, it will attempt to wake it using wake on lan when calling turn on. Wake on lan must be enabled on the TV for this to work. If the TV is connected to a smart strip or requires a more complex turn on process, a `turn_on_action` can be provided that will take precedence over the built-in wake on lan functionality.
+If the integration knows the MAC address of the TV from discovery, it will attempt to wake it using wake on LAN when calling turn on. Wake on LAN must be enabled on the TV for this to work. If the TV is connected to a smart strip or requires a more complex turn-on process, a `turn_on_action` can be provided that will take precedence over the built-in wake on LAN functionality.
 
 To wake up the TV when switched off you can use the [wake-on-lan](/integrations/wake_on_lan/) integration and call a service.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update samsungtv for built-in wake on lan support

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/50964
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
