### PR TITLE
Unified entity_id for easier readability and setup

### DIFF
--- a/source/_integrations/manual.markdown
+++ b/source/_integrations/manual.markdown
@@ -171,12 +171,12 @@ automation:
       to: "open"
   condition:
     - condition: state
-      entity_id: alarm_control_panel.ha_alarm
+      entity_id: alarm_control_panel.home_alarm
       state: armed_away
   action:
     service: alarm_control_panel.alarm_trigger
     target:
-      entity_id: alarm_control_panel.ha_alarm
+      entity_id: alarm_control_panel.home_alarm
 ```
 
 Sending a notification when the alarm is triggered.
@@ -186,7 +186,7 @@ automation:
   - alias: 'Send notification when alarm triggered'
     trigger:
       - platform: state
-        entity_id: alarm_control_panel.ha_alarm
+        entity_id: alarm_control_panel.home_alarm
         to: "triggered"
     action:
       - service: notify.notify
@@ -207,7 +207,7 @@ automation:
     action:
       - service: alarm_control_panel.alarm_disarm
         target:
-          entity_id: alarm_control_panel.house_alarm
+          entity_id: alarm_control_panel.home_alarm
 ```
 
 Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pending Status


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation tweak, when I first read the examples I was confused why each example had a different entity_id. This change adds conformity to the examples. I chose “home_alarm” over “house_alarm” because it felt more personal, and I choose “home_alarm” over “ha_alarm” because at first I wondered if “ha_alarm” was some magic internal variable where “home_alarm” I knew wasn’t. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
