### PR TITLE
Add documentation about services for Mazda integration 

### DIFF
--- a/source/_integrations/mazda.markdown
+++ b/source/_integrations/mazda.markdown
@@ -57,6 +57,12 @@ Displays the current door lock status of the vehicle, and locks/unlocks the door
 
 ## Services
 
+This integration offers several services for interacting with Mazda vehicles. All of the services require the following input parameter:
+
+| Parameter | YAML ID | Description |
+| --------- | ------- | ----------- |
+| Vehicle | `device_id` | The vehicle to execute the service for. In YAML mode, this is the device ID of the vehicle. |
+
 ### Start engine
 
 Starts the vehicle engine. The vehicle engine can only be remotely started 2 consecutive times. To reset this counter, the vehicle must be driven.
@@ -76,6 +82,14 @@ Stops charging the vehicle battery. This only works with electric vehicles.
 ### Send POI
 
 Send a GPS location to the vehicle's navigation system as a POI (Point of Interest). Requires a navigation SD card installed in the vehicle.
+
+This service requires the following input parameters in addition to the vehicle:
+
+| Parameter | YAML ID | Description |
+| --------- | ------- | ----------- |
+| Latitude | `latitude` | The latitude of the location to send. |
+| Longitude | `longitude` | The longitude of the location to send. |
+| POI name | `poi_name` | A friendly name for the location. |
 
 ### Turn on hazard lights
 

--- a/source/_integrations/mazda.markdown
+++ b/source/_integrations/mazda.markdown
@@ -59,7 +59,7 @@ Displays the current door lock status of the vehicle, and locks/unlocks the door
 
 This integration offers several services for interacting with Mazda vehicles.
 
-### Service `start_engine`
+### Service `mazda.start_engine`
 
 Starts the vehicle engine. The vehicle engine can only be remotely started 2 consecutive times. To reset this counter, the vehicle must be driven.
 
@@ -67,7 +67,7 @@ Starts the vehicle engine. The vehicle engine can only be remotely started 2 con
 | ---------------------- | -------- | ----------- |
 | `device_id` | yes | The device ID of the vehicle to start |
 
-### Service `stop_engine`
+### Service `mazda.stop_engine`
 
 Stops the vehicle engine. This only works if the vehicle was remotely started.
 
@@ -75,7 +75,7 @@ Stops the vehicle engine. This only works if the vehicle was remotely started.
 | ---------------------- | -------- | ----------- |
 | `device_id` | yes | The device ID of the vehicle to stop |
 
-### Service `start_charging`
+### Service `mazda.start_charging`
 
 Starts charging the vehicle battery. This only works with electric vehicles.
 
@@ -83,7 +83,7 @@ Starts charging the vehicle battery. This only works with electric vehicles.
 | ---------------------- | -------- | ----------- |
 | `device_id` | yes | The device ID of the vehicle to start charging |
 
-### Service `stop_charging`
+### Service `mazda.stop_charging`
 
 Stops charging the vehicle battery. This only works with electric vehicles.
 
@@ -91,7 +91,7 @@ Stops charging the vehicle battery. This only works with electric vehicles.
 | ---------------------- | -------- | ----------- |
 | `device_id` | yes | The device ID of the vehicle to stop charging |
 
-### Service `send_poi`
+### Service `mazda.send_poi`
 
 Send a GPS location to the vehicle's navigation system as a POI (Point of Interest). Requires a navigation SD card installed in the vehicle.
 
@@ -102,7 +102,7 @@ Send a GPS location to the vehicle's navigation system as a POI (Point of Intere
 | `longitude` | yes | The longitude of the location to send. |
 | `poi_name` | yes | A friendly name for the location. |
 
-### Service `turn_on_hazard_lights`
+### Service `mazda.turn_on_hazard_lights`
 
 Turn on the vehicle hazard lights. The lights will flash briefly and then turn off.
 
@@ -110,7 +110,7 @@ Turn on the vehicle hazard lights. The lights will flash briefly and then turn o
 | ---------------------- | -------- | ----------- |
 | `device_id` | yes | The device ID of the vehicle to turn hazard lights on |
 
-### Service `turn_off_hazard_lights`
+### Service `mazda.turn_off_hazard_lights`
 
 Temporarily turn off the vehicle hazard lights if they have been manually turned on from inside the vehicle. If a door is opened, the hazard lights will turn back on.
 

--- a/source/_integrations/mazda.markdown
+++ b/source/_integrations/mazda.markdown
@@ -57,47 +57,66 @@ Displays the current door lock status of the vehicle, and locks/unlocks the door
 
 ## Services
 
-This integration offers several services for interacting with Mazda vehicles. All of the services require the following input parameter:
+This integration offers several services for interacting with Mazda vehicles.
 
-| Parameter | YAML ID | Description |
-| --------- | ------- | ----------- |
-| Vehicle | `device_id` | The vehicle to execute the service for. In YAML mode, this is the device ID of the vehicle. |
-
-### Start engine
+### Service `start_engine`
 
 Starts the vehicle engine. The vehicle engine can only be remotely started 2 consecutive times. To reset this counter, the vehicle must be driven.
 
-### Stop engine
+| Service Data Attribute | Required | Description |
+| ---------------------- | -------- | ----------- |
+| `device_id` | yes | The device ID of the vehicle to start |
+
+### Service `stop_engine`
 
 Stops the vehicle engine. This only works if the vehicle was remotely started.
 
-### Start charging
+| Service Data Attribute | Required | Description |
+| ---------------------- | -------- | ----------- |
+| `device_id` | yes | The device ID of the vehicle to stop |
+
+### Service `start_charging`
 
 Starts charging the vehicle battery. This only works with electric vehicles.
 
-### Stop charging
+| Service Data Attribute | Required | Description |
+| ---------------------- | -------- | ----------- |
+| `device_id` | yes | The device ID of the vehicle to start charging |
+
+### Service `stop_charging`
 
 Stops charging the vehicle battery. This only works with electric vehicles.
 
-### Send POI
+| Service Data Attribute | Required | Description |
+| ---------------------- | -------- | ----------- |
+| `device_id` | yes | The device ID of the vehicle to stop charging |
+
+### Service `send_poi`
 
 Send a GPS location to the vehicle's navigation system as a POI (Point of Interest). Requires a navigation SD card installed in the vehicle.
 
-This service requires the following input parameters in addition to the vehicle:
+| Service Data Attribute | Required | Description |
+| ---------------------- | -------- | ----------- |
+| `device_id` | yes | The device ID of the vehicle to send the GPS location to |
+| `latitude` | yes | The latitude of the location to send. |
+| `longitude` | yes | The longitude of the location to send. |
+| `poi_name` | yes | A friendly name for the location. |
 
-| Parameter | YAML ID | Description |
-| --------- | ------- | ----------- |
-| Latitude | `latitude` | The latitude of the location to send. |
-| Longitude | `longitude` | The longitude of the location to send. |
-| POI name | `poi_name` | A friendly name for the location. |
-
-### Turn on hazard lights
+### Service `turn_on_hazard_lights`
 
 Turn on the vehicle hazard lights. The lights will flash briefly and then turn off.
 
-### Turn off hazard lights
+| Service Data Attribute | Required | Description |
+| ---------------------- | -------- | ----------- |
+| `device_id` | yes | The device ID of the vehicle to turn hazard lights on |
+
+### Service `turn_off_hazard_lights`
 
 Temporarily turn off the vehicle hazard lights if they have been manually turned on from inside the vehicle. If a door is opened, the hazard lights will turn back on.
+
+| Service Data Attribute | Required | Description |
+| ---------------------- | -------- | ----------- |
+| `device_id` | yes | The device ID of the vehicle to turn hazard lights off |
 
 ## Disclaimer
 

--- a/source/_integrations/mazda.markdown
+++ b/source/_integrations/mazda.markdown
@@ -55,6 +55,36 @@ Displays the current door lock status of the vehicle, and locks/unlocks the door
     The "Automatic Re-Lock" feature will automatically re-lock the doors if they are not opened shortly after being unlocked. This applies regardless of whether you are using the key, or unlocking the doors remotely using Home Assistant or the MyMazda app.
 </div>
 
+## Services
+
+### Start engine
+
+Starts the vehicle engine. The vehicle engine can only be remotely started 2 consecutive times. To reset this counter, the vehicle must be driven.
+
+### Stop engine
+
+Stops the vehicle engine. This only works if the vehicle was remotely started.
+
+### Start charging
+
+Starts charging the vehicle battery. This only works with electric vehicles.
+
+### Stop charging
+
+Stops charging the vehicle battery. This only works with electric vehicles.
+
+### Send POI
+
+Send a GPS location to the vehicle's navigation system as a POI (Point of Interest). Requires a navigation SD card installed in the vehicle.
+
+### Turn on hazard lights
+
+Turn on the vehicle hazard lights. The lights will flash briefly and then turn off.
+
+### Turn off hazard lights
+
+Temporarily turn off the vehicle hazard lights if they have been manually turned on from inside the vehicle. If a door is opened, the hazard lights will turn back on.
+
 ## Disclaimer
 
 This integration is not affiliated with or endorsed by Mazda.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation about newly added services for the Mazda integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51016
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
