### PR TITLE
Update dht.markdown

### DIFF
--- a/source/_integrations/dht.markdown
+++ b/source/_integrations/dht.markdown
@@ -30,7 +30,7 @@ Add the following to your `configuration.yaml` file:
 sensor:
   platform: dht
   sensor: DHT22
-  pin: D23
+  pin: 23
   monitored_conditions:
     - temperature
     - humidity
@@ -71,7 +71,7 @@ humidity_offset:
   type: [integer, float]
 {% endconfiguration %}
 
-The name of the pin to which the sensor is connected has different names on different platforms. 'P8_11' for Beaglebone, 'D23' for Raspberry Pi.
+The name of the pin to which the sensor is connected has different names on different platforms. 'P8_11' for Beaglebone, '23' for Raspberry Pi.
 
 ### Example
 
@@ -81,7 +81,7 @@ An example for a Raspberry Pi 3 with a DHT22 sensor connected to GPIO4 (pin 7):
 sensor:
   - platform: dht
     sensor: DHT22
-    pin: D4
+    pin: 4
     temperature_offset: 2.1
     humidity_offset: -3.2
     monitored_conditions:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
pin D16 gives an error.
    if pin is None or int(pin) < 0 or int(pin) > 31:
ValueError: invalid literal for int() with base 10: 'D16'


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
