### PR TITLE
Frontend docs for new dark mode themes

### DIFF
--- a/source/_integrations/frontend.markdown
+++ b/source/_integrations/frontend.markdown
@@ -50,6 +50,7 @@ frontend:
 ## Defining Themes
 
 ### Theme format
+
 The frontend integration allows you to create custom themes to influence the look and feel of the user interface.
 
 ```yaml
@@ -64,12 +65,13 @@ frontend:
       primary-color: steelblue
 ```
 
-The example above defines two themes named `happy` and `sad`. For each theme you can set values for CSS variables. If you want to provide hex color values, wrap those in apostrophes, since otherwise YAML would consider them to be comments (`primary-color: '#123456'`). For a partial list of variables used by the main frontend see [ha-style.ts](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/resources/ha-style.ts).
+The example above defines two themes named `happy` and `sad`. For each theme, you can set values for CSS variables. If you want to provide hex color values, wrap those in apostrophes, since otherwise, YAML would consider them a comment (`primary-color: '#123456'`). For a partial list of variables used by the main frontend see [ha-style.ts](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/resources/ha-style.ts).
 
 ### Dark mode support
-Starting with version 2021.6 it is also possible to create themes that are based on the default dark mode theme. New themes can also support both light and dark mode and allow the user to switch between those on the user profile page:
 
-[![Open your Home Assistant instance and show your Home Assistant user's profile.](https://my.home-assistant.io/badges/profile.svg)](https://my.home-assistant.io/redirect/profile/)
+It is also possible to create themes that are based on the default dark mode theme. New themes can also support both light and dark mode and allow the user to switch between those on the user profile page:
+
+{% my profile badge %}
 
 Extended example to show the mode definitions.
 
@@ -97,7 +99,7 @@ frontend:
 
 Theme `happy`: Same as in the previous example. This legacy format is still supported and will behave as before and automatically use the default light theme as the base.
 
-Theme `sad`: By using the new `mode` key plus the sub key `dark` this theme will now be based on the default dark theme. The final theme rules are determined in three steps: First the default dark theme CSS variables will be applied, then second the CSS variables from the top level of the theme that are mode-independent (`primary-color: steelblue` in this example) and lastly the mode specific CSS variables will be layered on top (`secondary-text-color: slategray`).
+Theme `sad`: By using the new `mode` key plus the subkey `dark` this theme will now be based on the default dark theme. The final theme rules are determined in three steps: First, the default dark theme CSS variables will be applied, then second the CSS variables from the top level of the theme that are mode-independent (`primary-color: steelblue` in this example) and lastly the mode-specific CSS variables will be layered on top (`secondary-text-color: slategray`).
 
 Note: Since this example theme only has a `dark` mode defined, this mode will automatically be used.
 

--- a/source/_integrations/frontend.markdown
+++ b/source/_integrations/frontend.markdown
@@ -49,7 +49,7 @@ frontend:
 
 ## Defining Themes
 
-### Legacy format
+### Theme format
 The frontend integration allows you to create custom themes to influence the look and feel of the user interface.
 
 ```yaml
@@ -66,7 +66,7 @@ frontend:
 
 The example above defines two themes named `happy` and `sad`. For each theme you can set values for CSS variables. If you want to provide hex color values, wrap those in apostrophes, since otherwise YAML would consider them to be comments (`primary-color: '#123456'`). For a partial list of variables used by the main frontend see [ha-style.ts](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/resources/ha-style.ts).
 
-### New mode aware format
+### Dark mode support
 Starting with version 2021.6 it is also possible to create themes that are based on the default dark mode theme. New themes can also support both light and dark mode and allow the user to switch between those on the user profile page:
 
 [![Open your Home Assistant instance and show your Home Assistant user's profile.](https://my.home-assistant.io/badges/profile.svg)](https://my.home-assistant.io/redirect/profile/)

--- a/source/_integrations/frontend.markdown
+++ b/source/_integrations/frontend.markdown
@@ -101,7 +101,7 @@ Theme `sad`: By using the new `mode` key plus the sub key `dark` this theme will
 
 Note: Since this example theme only has a `dark` mode defined, this mode will automatically be used.
 
-Theme `good_and_bad_days`: This theme has both a `light` and a `dark` mode section. That tells the frontend to allow the user to choose which mode to use from the user profile (default selection is based on the system settings). Independent of the selection, the primary color will be set to green, but based on the chosen mode either the default light or dark theme will be used as the basis for rendering, plus the secondary text color will be either olive or slategray.
+Theme `day_and_night`: This theme has both a `light` and a `dark` mode section. That tells the frontend to allow the user to choose which mode to use from the user profile (default selection is based on the system settings). Independent of the selection, the primary color will be set to green, but based on the chosen mode either the default light or dark theme will be used as the basis for rendering, plus the secondary text color will be either olive or slategray.
 
 ### Theme configuration splitting
 As with all configuration, you can either:

--- a/source/_integrations/frontend.markdown
+++ b/source/_integrations/frontend.markdown
@@ -49,7 +49,8 @@ frontend:
 
 ## Defining Themes
 
-Starting with version 0.49 you can define themes:
+### Legacy format
+The frontend integration allows you to create custom themes to influence the look and feel of the user interface.
 
 ```yaml
 # Example configuration.yaml entry
@@ -60,11 +61,49 @@ frontend:
       text-primary-color: purple
       mdc-theme-primary: plum
     sad:
-      primary-color: blue
+      primary-color: steelblue
 ```
 
-The example above defined two themes named `happy` and `sad`. For each theme you can set values for CSS variables. If you want to provide hex color values, wrap those in apostrophes, since otherwise YAML would consider them to be comments (`primary-color: '#123456'`). For a partial list of variables used by the main frontend see [ha-style.ts](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/resources/ha-style.ts).
+The example above defines two themes named `happy` and `sad`. For each theme you can set values for CSS variables. If you want to provide hex color values, wrap those in apostrophes, since otherwise YAML would consider them to be comments (`primary-color: '#123456'`). For a partial list of variables used by the main frontend see [ha-style.ts](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/resources/ha-style.ts).
 
+### New mode aware format
+Starting with version 2021.6 it is also possible to create themes that are based on the default dark mode theme. New themes can also support both light and dark mode and allow the user to switch between those on the user profile page:
+
+[![Open your Home Assistant instance and show your Home Assistant user's profile.](https://my.home-assistant.io/badges/profile.svg)](https://my.home-assistant.io/redirect/profile/)
+
+Extended example to show the mode definitions.
+
+```yaml
+# Example configuration.yaml entry
+frontend:
+  themes:
+    happy:
+      primary-color: pink
+      text-primary-color: purple
+      mdc-theme-primary: plum
+    sad:
+      primary-color: steelblue
+      modes:
+        dark:
+          secondary-text-color: slategray
+    day_and_night:
+      primary-color: coral
+      modes:
+        light:
+          secondary-text-color: olive
+        dark:  
+          secondary-text-color: slategray
+```
+
+Theme `happy`: Same as in the previous example. This legacy format is still supported and will behave as before and automatically use the default light theme as the base.
+
+Theme `sad`: By using the new `mode` key plus the sub key `dark` this theme will now be based on the default dark theme. The final theme rules are determined in three steps: First the default dark theme CSS variables will be applied, then second the CSS variables from the top level of the theme that are mode-independent (`primary-color: steelblue` in this example) and lastly the mode specific CSS variables will be layered on top (`secondary-text-color: slategray`).
+
+Note: Since this example theme only has a `dark` mode defined, this mode will automatically be used.
+
+Theme `good_and_bad_days`: This theme has both a `light` and a `dark` mode section. That tells the frontend to allow the user to choose which mode to use from the user profile (default selection is based on the system settings). Independent of the selection, the primary color will be set to green, but based on the chosen mode either the default light or dark theme will be used as the basis for rendering, plus the secondary text color will be either olive or slategray.
+
+### Theme configuration splitting
 As with all configuration, you can either:
 
 - Directly specify the themes inside your `configuration.yaml` file 
@@ -75,9 +114,9 @@ For more details about splitting up the configuration into multiple files, see [
 
 Check our [community forums](https://community.home-assistant.io/c/projects/themes) to find themes to use.
 
-## Setting themes
+## Setting Themes
 
-There are 2 themes-related services:
+There are two themes-related services:
 
  - `frontend.reload_themes`: Reloads theme configuration from your `configuration.yaml` file.
  - `frontend.set_theme`: Sets backend-preferred theme name.


### PR DESCRIPTION
## Proposed change
 Documentation for the new theme format that supports dark mode and mode switching.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/46532 and https://github.com/home-assistant/frontend/pull/8347
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
