### PR TITLE
Document optional MQTT cover options

### DIFF
--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -435,7 +435,7 @@ cover:
   - platform: mqtt
     payload_open: "on"
     payload_close: 
-    payload_stop: "on
+    payload_stop: "on"
 ```
 
 {% endraw %}

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -422,6 +422,45 @@ cover:
 
 {% endraw %}
 
+### Configuration for disabling cover commands
+
+The example below shows a configuration for a cover that does not have a close command.
+Setting `payload_close` empty or to `null` disables the close command and will not show the close button.
+
+{% raw %}
+
+```yaml
+# Example configuration.yaml entry
+cover:
+  - platform: mqtt
+    payload_open: "on"
+    payload_close: 
+    payload_stop: "on
+```
+
+{% endraw %}
+The following commands can be disabled: `open`, `close`, `stop` by overriding their payloads: `payload_open`, `payload_close`, `payload_stop`
+
+For auto discovery message the payload needs to be set to `null`, example for cover without close command:
+{% raw %}
+
+```json
+{
+  "cover": [
+    {
+      "platform": "mqtt",
+      "payload_open": "on",
+      "payload_close": null,
+      "payload_stop": "on"
+    }
+  ]
+}
+```
+
+{% endraw %}
+
+### Testing your configuration
+
 To test, you can use the command line tool `mosquitto_pub` shipped with `mosquitto` or the `mosquitto-clients` package to send MQTT messages. This allows you to operate your cover manually:
 
 ```bash


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Make all payloads optional to allow cover that can be just open (e.g. gates that self close after some time)

Example entry for `configuration.yaml`:

```yaml
cover:
  - platform: mqtt
    payload_open: "on"
    payload_close: 
    payload_stop: "on"
```

or, via auto discovery:

```json
{
  "cover": [
    {
      "platform": "mqtt",
      "payload_open": "on",
      "payload_close": null,
      "payload_stop": "on"
    }
  ]
}
```


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/50579
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
