### PR TITLE
Remove manual interaction section

### DIFF
--- a/source/_integrations/mystrom.markdown
+++ b/source/_integrations/mystrom.markdown
@@ -188,21 +188,6 @@ name:
   default: myStrom Switch
 {% endconfiguration %}
 
-Check if you are able to access the device located at `http://IP_ADRRESS`. The details about your switch is provided as a JSON response.
-
-```bash
-$ curl -X GET -H "Content-Type: application/json" http://IP_ADDRESS/report
-{
-  "power": 0,
-  "relay": false
-}
-```
-
-or change its state:
-
-```bash
-curl -G -X GET http://IP_ADDRESS/relay -d 'state=1'
-```
 
 ### Get the current power consumption
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove the section about the manual interaction with the device's API. myStrom has published a full overview of the [API](https://api.mystrom.ch/) of all their devices. Thus, if one is interested then the search engines will probably point to the documentation of the manufacturer anyways.   

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #17951

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
