### PR TITLE
Remove entity_id references in RainMachine service docs

### DIFF
--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -38,7 +38,6 @@ Disable a RainMachine program. This will mark the program switch as
 | Service Data Attribute    | Optional | Description                                                 |
 |---------------------------|----------|-------------------------------------------------------------|
 | `program_id  `              |      no  | The program to disable                                      |
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.disable_zone`
 
@@ -48,7 +47,6 @@ Disable a RainMachine zone. This will mark the zone switch as
 | Service Data Attribute    | Optional | Description                                                 |
 |---------------------------|----------|-------------------------------------------------------------|
 | `zone_id  `                 |      no  | The program to disable                                      |
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.enable_program`
 
@@ -57,7 +55,6 @@ Enable a RainMachine program.
 | Service Data Attribute    | Optional | Description                                                 |
 |---------------------------|----------|-------------------------------------------------------------|
 | `program_id  `              |      no  | The program to enable                                       |
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.enable_zone`
 
@@ -66,7 +63,6 @@ Enable a RainMachine zone.
 | Service Data Attribute    | Optional | Description                                                 |
 |---------------------------|----------|-------------------------------------------------------------|
 | `zone_id  `                 |      no  | The zone to enable                                          |
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.pause_watering`
 
@@ -75,7 +71,6 @@ Pause all watering activities for a number of seconds.
 | Service Data Attribute    | Optional | Description                                                 |
 |---------------------------|----------|-------------------------------------------------------------|
 | `seconds`                   |      no  | The number of seconds to pause                              |
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.start_program`
 
@@ -84,7 +79,6 @@ Start a RainMachine program.
 | Service Data Attribute    | Optional | Description                                                 |
 |---------------------------|----------|-------------------------------------------------------------|
 | `program_id  `              |      no  | The program to start                                        |
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.start_zone`
 
@@ -94,15 +88,10 @@ Start a RainMachine zone for a set number of seconds.
 |---------------------------|----------|-------------------------------------------------------------|
 | `zone_id`                   |      no  | The zone to start                                           |
 | `zone_run_time`             |      yes | The number of seconds to run; defaults to 60 seconds        |
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.stop_all`
 
 Stop all watering activities.
-
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.stop_program`
 
@@ -111,7 +100,6 @@ Stop a RainMachine program.
 | Service Data Attribute    | Optional | Description                                                 |
 |---------------------------|----------|-------------------------------------------------------------|
 | `program_id  `              |      no  | The program to stop                                         |
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.stop_zone`
 
@@ -120,15 +108,10 @@ Stop a RainMachine zone.
 | Service Data Attribute    | Optional | Description                                                 |
 |---------------------------|----------|-------------------------------------------------------------|
 | `zone_id  `                 |      no  | The zone to stop                                            |
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ### `rainmachine.unpause_watering`
 
 Unpause all watering activities.
-
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `entity_id`                 |      yes | An entity belonging to the RainMachine controller to adjust |
 
 ## Switch
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR removes some confusing (and ultimately, incorrect) RainMachine service docs. Previously, the `entity_id` field was classified as a data field; now that targets are more broadly implemented and understood, this PR removes those references.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/50732

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
