### PR TITLE
Alert ignorable states

### DIFF
--- a/source/_integrations/alert.markdown
+++ b/source/_integrations/alert.markdown
@@ -105,7 +105,11 @@ notifiers:
 data:
   description: "Dictionary of extra parameters to send to the notifier."
   required: false
-  type: list  
+  type: list
+ignore_states:
+  description: "List of states of the monitored entity to ignore."
+  required: false
+  type: list
 {% endconfiguration %}
 
 In this example, the garage door status (`input_boolean.garage_door`) is watched
@@ -286,6 +290,33 @@ but you will still receive the done message.
     - service: alert.turn_off
       target:
         entity_id: alert.garage_door
+```
+
+### Ignoring states
+
+Under some circumstances it may be desired to ignore states of an entity
+to clear an alert.
+
+For example if a device enters an error state but disconnects from Home
+Assistant and reconnects later. The alert gets cleared when the device gets
+```unavailable``` and fires again when the device reconnects and is still in
+error state. This can lead to an annoying behavior.
+
+To prevent the alert from being cleared on certain states use the
+`ignore_states` list configuration parameter:
+
+```yaml
+alert:
+  my_esphome_device:
+    name: My ESPHome device has en error!
+    entity_id: sensor.my_eshome_device_status
+    state: 'Error'
+    ignore_states:
+      - 'unavailable'
+    message: My ESPHome device has en error!
+    repeat: 5
+    notifiers:
+      - my_iphone
 ```
 
 [template]: /docs/configuration/templating/


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51109
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
