### PR TITLE
Seventeentrack integration with config flow

### DIFF
--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -1,18 +1,21 @@
 ---
 title: 17TRACK
-description: Instructions on how to use 17track.net data within Home Assistant
+description: How to integrate 17track.net data within Home Assistant
 ha_category:
   - Postal Service
 ha_release: 0.83
 ha_iot_class: Cloud Polling
 ha_codeowners:
   - '@bachya'
+  - '@engrbm87'
 ha_domain: seventeentrack
 ha_platforms:
   - sensor
 ---
 
-The `seventeentrack` sensor platform allows users to get package data tied to their [17track.net](https://www.17track.net/en) account. The platform creates both summary sensors, which show the number of packages in a current state (e.g., "In Transit"), as well as individual sensors for each package within the account.
+The Seventeentrack integration allows users to get package data tied to their [17track.net](https://www.17track.net/en) account. A sesnor is created for each status type received from the Summary data retruned by the api. Each sensor will include the list of packages with their details in the attribute `Packages`. 
+
+An `all_packages` sensor is created that holds all packages in its `Packages` attribute. Below you will find an example showing how to create template sensor for individual package to monitor its status and other attributes.
 
 <div class='note warning'>
 
@@ -22,38 +25,51 @@ Although the 17track.net website states that account passwords cannot be longer 
 
 ## Configuration
 
-To enable the platform, add the following lines to your `configuration.yaml`
-file:
+{% include integrations/config_flow.md %}
 
-```yaml
-sensor:
-  - platform: seventeentrack
-    username: EMAIL_ADDRESS
-    password: YOUR_PASSWORD
-```
+## Integration Sensors
 
-{% configuration %}
-username:
-  description: The email address associated with your 17track.net account.
-  required: true
-  type: string
-password:
-  description: The password associated with your 17track.net account.
-  required: true
-  type: string
-show_archived:
-  description: Whether sensors should be created for archived packages.
-  required: false
-  type: boolean
-  default: false
-show_delivered:
-  description: Whether sensors should be created for delivered packages.
-  required: false
-  type: boolean
-  default: false
-{% endconfiguration %}
+ Currently the summary data returns the following package types:
+
+- Delivered: Number of packages delievered
+- Expired: Number of packages expired
+- In Transit: Number of packages in transit
+- Not Found: Number of packages not found
+- Ready to be picked up: Number of packages ready to be picked up
+- Returned: Number of packages returned
+- Undelivered: Number of packages undelievered
+
+## Services
+
+### Service `add_package`
+
+Adds a new package to your 17Track account. 
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `tracking_number`    | no | The trakcing number of the package
+| `friendly_name` | yes | set friendly name for the added package
 
 ## Examples
+
+### Individual package template sensor
+
+Use the following configuration to create a template sensor for an individual package. The below assumes you are using the default name for the integration.
+
+{% raw %}
+
+```yaml
+template:
+  - sensor:
+      - name: "My package"
+        state: "{{ state_attr('sensor.seventeentrack_all_packages', 'packages')['<tracking_number>'].status }}"
+        attributes:
+          info_text: "{{ state_attr('sensor.seventeentrack_all_packages', 'packages')['<tracking_number>'].info_text }}"
+          origin_country: "{{ state_attr('sensor.seventeentrack_all_packages', 'packages')['<tracking_number>'].origin_country }}"
+
+```
+
+{% endraw %}
 
 ### Lovelace summary card
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
17Track integration updated with config flow option.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51057
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
