### PR TITLE
Updated IoT class to Cloud Push.

### DIFF
--- a/source/_integrations/wirelesstag.markdown
+++ b/source/_integrations/wirelesstag.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Binary Sensor
   - Sensor
   - Switch
-ha_iot_class: Local Push
+ha_iot_class: Cloud Push
 ha_release: 0.68
 ha_domain: wirelesstag
 ha_platforms:
@@ -44,22 +44,6 @@ password:
   required: true
   type: string
 {% endconfiguration %}
-
-<div class='note'>
-
-To enable local push notifications from the Tags Manager, you need to add the IP address of the Tags Manager into `trusted_networks` under Authentication Providers. See the [Authentication Providers](https://www.home-assistant.io/docs/authentication/providers/#trusted-networks) for details.
- 
-If you are using a version prior to v0.89 you can do the whitelisting under the [HTTP](/integrations/http) integration.
-  
-Additionally, you need to add at least one [WirelessTag binary sensor](#binary-sensor) in the configuration to start receiving local push notifications.
-
-</div>
-
-<div class='note warning'>
-
-Tags Manager supports local push notifications for `http` schema only. So if your Home Assistant uses `https`, local push notifications are disabled and data is received via cloud polling.
-
-</div>
 
 ## Binary Sensor
 


### PR DESCRIPTION
Updated documentation according to switch to cloud push as a replacement to local push.

## Proposed change
Updated documentation according to switch to cloud push as a replacement to local push.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: * home-assistant/core#50984
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: #42292

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
