### PR TITLE
Change Modbus climate to use standard attribute names 

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -277,8 +277,8 @@ modbus:
     port: 502
     climates:
       - name: "Watlow F4T"
-        current_temp_register: 27586
-        current_temp_register_type: holding
+        address: 27586
+        input_type: holding
         data_count: 1
         data_type: custom
         max_temp: 35
@@ -299,15 +299,10 @@ climates:
   required: false
   type: [map]
   keys:
-    current_temp_register:
+    address:
       description: Register address for current temperature (process value).
       required: true
       type: integer
-    current_temp_register_type:
-      description: Modbus register type (`holding`, `input`) for current temperature.
-      required: false
-      type: string
-      default: holding
     data_count:
       description: Number of registers to read.
       required: false
@@ -318,6 +313,11 @@ climates:
       required: false
       type: string
       default: float  
+    input_type:
+      description: Modbus register type (`holding`, `input`) for current temperature.
+      required: false
+      type: string
+      default: holding
     max_temp:
       description: Maximum setpoint temperature.
       required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Change:
    current_temp_register --> address
    current_temp_register_type --> input_type

With this change all platforms use address/input_type for the primary modbus address.




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
https://github.com/home-assistant/core/pull/51202
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
