### PR TITLE
Fix MQTT cover rebase

### DIFF
--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -568,25 +568,6 @@ cover:
 ```
 
 {% endraw %}
-The following commands can be disabled: `open`, `close`, `stop` by overriding their payloads: `payload_open`, `payload_close`, `payload_stop`
-
-For auto discovery message the payload needs to be set to `null`, example for cover without close command:
-{% raw %}
-
-```json
-{
-  "cover": [
-    {
-      "platform": "mqtt",
-      "payload_open": "on",
-      "payload_close": null,
-      "payload_stop": "on"
-    }
-  ]
-}
-```
-
-{% endraw %}
 
 ### Testing your configuration
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fix rebase error from https://github.com/home-assistant/home-assistant.io/pull/17738
The following section in the end appears twice, 2nd part should be removed:
```txt
The following commands can be disabled: open, close, stop by overriding their payloads: payload_open, payload_close, payload_stop

For auto discovery message the payload needs to be set to null, example for cover without close command:

{
  "cover": [
    {
      "platform": "mqtt",
      "payload_open": "on",
      "payload_close": null,
      "payload_stop": "on"
    }
  ]
}
```

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
