### PR TITLE
SMTP: Add documentation for notification service call

### DIFF
--- a/source/_integrations/smtp.markdown
+++ b/source/_integrations/smtp.markdown
@@ -36,7 +36,7 @@ sender:
   required: true
   type: string
 recipient:
-  description: E-mail address of the recipient of the notification. This can be a recipient address or a list of addresses for multiple recipients.
+  description: Default E-mail address of the recipient of the notification. This can be a recipient address or a list of addresses for multiple recipients.<br>This is where you want to send your E-mail notifications by default (when not specifying `target` in the service call). Any E-mail address(es) specified in the service call's `target` field will override this recipient content.
   required: true
   type: [list, string]
 server:
@@ -113,11 +113,15 @@ burglar:
       data:
           title: "Intruder alert"
           message: "Intruder alert at apartment!!"
+          target:
+            - "my_intruder_alert@gmail.com"
           data:
               images:
                   - /home/pi/snapshot1.jpg
                   - /home/pi/snapshot2.jpg
 ```
+
+The optional `target` field is used to specify recipient(s) for this specific service call. When `target` field is not used, this message will be sent to default recipient(s), in this example, james@gmail.com and bob@gmail.com.
 
 The optional `images` field adds in-line image attachments to the email. This sends a text/HTML multi-part message instead of the plain text default.
 

--- a/source/_integrations/smtp.markdown
+++ b/source/_integrations/smtp.markdown
@@ -85,16 +85,16 @@ A sample configuration entry for Google Mail.
 notify:
   - name: "NOTIFIER_NAME"
     platform: smtp
-    server: "smtp.gmail.com"
+    server: "smtp.example.com"
     port: 587
     timeout: 15
-    sender: "john@gmail.com"
+    sender: "john@example.com"
     encryption: starttls
-    username: "john@gmail.com"
+    username: "john@example.com"
     password: "thePassword"
     recipient:
-      - "james@gmail.com"
-      - "bob@gmail.com"
+      - "james@example.com"
+      - "bob@example.com"
     sender_name: "My Home Assistant"
 ```
 
@@ -114,14 +114,14 @@ burglar:
           title: "Intruder alert"
           message: "Intruder alert at apartment!!"
           target:
-            - "my_intruder_alert@gmail.com"
+            - "my_intruder_alert@example.com"
           data:
               images:
                   - /home/pi/snapshot1.jpg
                   - /home/pi/snapshot2.jpg
 ```
 
-The optional `target` field is used to specify recipient(s) for this specific service call. When `target` field is not used, this message will be sent to default recipient(s), in this example, james@gmail.com and bob@gmail.com.
+The optional `target` field is used to specify recipient(s) for this specific service call. When `target` field is not used, this message will be sent to default recipient(s), in this example, james@example.com and bob@example.com.
 
 The optional `images` field adds in-line image attachments to the email. This sends a text/HTML multi-part message instead of the plain text default.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add support for parsing target field in a service call to override email recipient(s).
The recipient field in platform config is used as default recipient list when target field doesn't exist in a service call.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/47611
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
