### PR TITLE
fix out of date rainbird docs

### DIFF
--- a/source/_integrations/rainbird.markdown
+++ b/source/_integrations/rainbird.markdown
@@ -75,7 +75,8 @@ More complex configuration using all possible features could look like this exam
 rainbird:
   - host: IP_ADDRESS_OF_MODULE
     password: YOUR_PASSWORD
-    trigger_time: 6
+    trigger_time:
+      minutes: 6
     zones:
       1:
         friendly_name: My zone 1
@@ -83,7 +84,8 @@ rainbird:
           minutes: 6
       2:
         friendly_name: My zone 2
-        trigger_time: 2
+        trigger_time:
+          minutes: 2
   - host: IP_ADDRESS_OF_ANOTHER_MODULE
     password: YOUR_ANOTHER_PASSWORD
     trigger_time: 0:06
@@ -126,12 +128,11 @@ The service can be used as part of an automation script. For example:
 automation:
   - alias: "Turn irrigation on"
     trigger:
-      platform: time
-      at: "5:30:00"
+      - platform: time
+        at: "5:30:00"
     action:
-      service: rainbird.start_irrigation
-      target:
-        entity_id: switch.sprinkler_1
-      data:
-        duration: 5
+      - service: rainbird.start_irrigation
+        data:
+          entity_id: switch.sprinkler_1
+          duration: 5
 ```


### PR DESCRIPTION

## Proposed change

- Fix a couple missing times that reference `seconds` instead of `minutes` (users following these instructions as they were will get errors; see home-assistant/core#36214)
- Bring example automation yml format up to date.

## Type of change
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
