### PR TITLE
Update superpetcare documentation with setup hints

### DIFF
--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -58,4 +58,4 @@ This service lets you change the locking state of a flap.
 
 
 ## Initial Setup / Hints
-On initial setup, your cats won't have an in / out status. This is an edge case which causes the intergration to fail to load with KeyError: 'status', simply make sure all cats have a location, this can be done manually via the Sure website.
+On initial setup, your cats won't have an in / out status. This is an edge case which causes the integration to fail to load with KeyError: 'status', simply make sure all cats have a location, this can be done manually via the Sure website.

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -55,3 +55,7 @@ This service lets you change the locking state of a flap.
 - `locked_in` - flap is 'in only' - pets can come in but not go back out.
 - `locked_out` - flap is 'out only' - pets can go out, but not back in.
 - `locked_all` - flap is locked both ways.
+
+
+## Initial Setup / Hints
+On initial setup, your cats won't have an in / out status. This is an edge case which causes the intergration to fail to load with KeyError: 'status', simply make sure all cats have a location, this can be done manually via the Sure website.


### PR DESCRIPTION
Identified edge case, I lack the talent to correct this, but I can at least document the (easy) workaround

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
