### PR TITLE
Add sensor platform to Meteoclimatic integration

### DIFF
--- a/source/_integrations/meteoclimatic.markdown
+++ b/source/_integrations/meteoclimatic.markdown
@@ -20,30 +20,30 @@ The Meteoclimatic integration uses the [Meteoclimatic](https://www.meteoclimatic
 There is currently support for the following platforms within Home Assistant:
 
 - Weather
-- [Sensor](#sensor-platforms)
+- [Sensor](#sensor)
 
 It displays the current weather along with individual sensors that include daily maximum and minimum values.
 
 {% include integrations/config_flow.md %}
 
-## Sensor platforms
+## Sensor
 
-All the following sensors will be created:
+This integration provides the following sensors:
 
-|Entity|Description|
+|Name|Description|
 |------|-----------|
-|`daily_max_humidity`|Maximum humidity for the past 24 hours in %|
-|`daily_max_pressure`|Maximum pressure for the past 24 hours in hPa|
-|`daily_max_temperature`|Maximum temperature for the past 24 hours in °C|
-|`daily_max_wind_speed`|Maximum wind speed for the past 24 hours in km/h|
-|`daily_min_humidity`|Minimum humidity for the past 24 hours in %|
-|`daily_min_pressure`|Minimum pressure for the past 24 hours in hPa|
-|`daily_min_temperature`|Minimum temperature for the past 24 hours in °C|
-|`daily_precipitation`|Precipitation cumulation for past 24 hours in mm|
-|`humidity`|The current humidity in %|
-|`pressure`|The current pressure in hPa|
-|`temperature`|The current temperature in °C|
-|`wind_bearing`|The current wind bearing in °|
-|`wind_speed`|The current wind speed in km/h|
+|Daily Max Humidity|Maximum humidity for the past 24 hours in %|
+|Daily Max Pressure|Maximum pressure for the past 24 hours in hPa|
+|Daily Max Temperature|Maximum temperature for the past 24 hours in °C|
+|Daily Max Wind Speed|Maximum wind speed for the past 24 hours in km/h|
+|Daily Min Humidity|Minimum humidity for the past 24 hours in %|
+|Daily Min Pressure|Minimum pressure for the past 24 hours in hPa|
+|Daily Min Temperature|Minimum temperature for the past 24 hours in °C|
+|Daily Precipitation|Precipitation cumulation for past 24 hours in mm|
+|Humidity|The current humidity in %|
+|Pressure|The current pressure in hPa|
+|Temperature|The current temperature in °C|
+|Wind Bearing|The current wind bearing in °|
+|Wind Speed|The current wind speed in km/h|
 
-Warning: As not all weather stations have the same capabilities, some entities might not be available for certain weather stations. Entities are only added if data is available and provided by Meteoclimatic.
+Warning: As not all weather stations have the same capabilities, some sensors might not be available for certain weather stations. Sensors are only added if data is available and provided by Meteoclimatic.

--- a/source/_integrations/meteoclimatic.markdown
+++ b/source/_integrations/meteoclimatic.markdown
@@ -31,7 +31,7 @@ It displays the current weather along with individual sensors that include daily
 This integration provides the following sensors:
 
 |Name|Description|
-|------|-----------|
+|----|-----------|
 |Daily Max Humidity|Maximum humidity for the past 24 hours in %|
 |Daily Max Pressure|Maximum pressure for the past 24 hours in hPa|
 |Daily Max Temperature|Maximum temperature for the past 24 hours in °C|

--- a/source/_integrations/meteoclimatic.markdown
+++ b/source/_integrations/meteoclimatic.markdown
@@ -4,12 +4,14 @@ description: Instructions on how to integrate Meteoclimatic within Home Assistan
 ha_release: 2021.6
 ha_iot_class: Cloud Polling
 ha_category:
+  - Sensor
   - Weather
 ha_codeowners:
   - '@adrianmo'
 ha_config_flow: true
 ha_domain: meteoclimatic
 ha_platforms:
+  - sensor
   - weather
 ---
 
@@ -18,7 +20,30 @@ The Meteoclimatic integration uses the [Meteoclimatic](https://www.meteoclimatic
 There is currently support for the following platforms within Home Assistant:
 
 - Weather
+- [Sensor](#sensor-platforms)
 
-It displays the current weather reported by specific Meteoclimatic stations.
+It displays the current weather along with individual sensors that include daily maximum and minimum values.
 
 {% include integrations/config_flow.md %}
+
+## Sensor platforms
+
+All the following sensors will be created:
+
+|Entity|Description|
+|------|-----------|
+|`daily_max_humidity`|Maximum humidity for the past 24 hours in %|
+|`daily_max_pressure`|Maximum pressure for the past 24 hours in hPa|
+|`daily_max_temperature`|Maximum temperature for the past 24 hours in °C|
+|`daily_max_wind_speed`|Maximum wind speed for the past 24 hours in km/h|
+|`daily_min_humidity`|Minimum humidity for the past 24 hours in %|
+|`daily_min_pressure`|Minimum pressure for the past 24 hours in hPa|
+|`daily_min_temperature`|Minimum temperature for the past 24 hours in °C|
+|`daily_precipitation`|Precipitation cumulation for past 24 hours in mm|
+|`humidity`|The current humidity in %|
+|`pressure`|The current pressure in hPa|
+|`temperature`|The current temperature in °C|
+|`wind_bearing`|The current wind bearing in °|
+|`wind_speed`|The current wind speed in km/h|
+
+Warning: As not all weather stations have the same capabilities, some entities might not be available for certain weather stations. Entities are only added if data is available and provided by Meteoclimatic.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for the new sensor platform of the Meteoclimatic integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51467
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
