### PR TITLE
Allow number & sensors references in numeric_state triggers/conditions

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -182,17 +182,17 @@ Listing above and below together means the numeric_state has to be between the t
 In the example above, the trigger would fire a single time if a numeric_state goes into the 17.1-24.9 range (from 17 and below or 25 and above). It will only fire again, once it has left the defined range and enters it again.
 </div>
 
-Number helpers (`input_number` entities) can be used in the `above` and `below` thresholds, making
-the trigger more dynamic, like:
+Number helpers (`input_number` entities), `number` and `sensor` entities that
+contain a numeric value, an be used in the `above` and `below` thresholds,
+making the trigger more dynamic, like:
 
 ```yaml
 automation:
   trigger:
     - platform: numeric_state
-      entity_id: sensor.temperature
-      # input_number entity id can be specified for above and/or below thresholds
-      above: input_number.temperature_threshold_high
-      below: input_number.temperature_threshold_low
+      entity_id: sensor.outside_temperature
+      # Other entity ids can be specified for above and/or below thresholds
+      above: sensor.inside_temperature
 ```
 
 The `for:` can also be specified as `HH:MM:SS` like this:

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -154,7 +154,8 @@ condition:
   below: 25
 ```
 
-Number helpers (`input_number` entities) can be used in the `above` and `below`
+Number helpers (`input_number` entities), `number` and `sensor` entities that
+contain a numeric value, can be used in the `above` and `below`
 options to make the condition more dynamic.
 
 ```yaml


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Back in 2020, we added support for referencing `input_number.*` entities in the numeric state triggers and conditions, making those more dynamic.

The parent PR extended this to the `number` and `sensor` domains.

```yaml
condition:
  - condition: numeric_state
    entity_id: sensor.outside_temperature
    above: sensor.inside_temperature
```

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51439
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
