### PR TITLE
Fix invalid time pattern for "every hour" example

### DIFF
--- a/source/_integrations/openuv.markdown
+++ b/source/_integrations/openuv.markdown
@@ -148,7 +148,7 @@ automation:
   - alias: "Update OpenUV every hour (24 of 50 calls per day)"
     trigger:
       platform: time_pattern
-      minutes: "/60"
+      hours: "*"
     action:
       service: openuv.update_data
 ```


### PR DESCRIPTION
## Proposed change
The example for the "every hour" trigger uses an invalid time pattern format `minutes: "/60"` which throws the following error.
 
``` Invalid config for [automation]: must be a value between 0 and 59 for dictionary value @ data['minutes']```
 
Propose replacing it with `hours: "*"`

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
