### PR TITLE
Add cover platform to Bosch SHC integration

### DIFF
--- a/source/_integrations/bosch_shc.markdown
+++ b/source/_integrations/bosch_shc.markdown
@@ -3,6 +3,9 @@ title: Bosch SHC
 description: Integrate Bosch SHC.
 ha_category:
   - Binary Sensor
+  - Cover
+  - Hub
+  - Sensor
 ha_release: 2021.6
 ha_iot_class: Local Push
 ha_config_flow: true
@@ -11,6 +14,7 @@ ha_codeowners:
 ha_domain: bosch_shc
 ha_platforms:
   - binary_sensor
+  - cover
   - sensor
 ha_zeroconf: true
 ---

--- a/source/_integrations/bosch_shc.markdown
+++ b/source/_integrations/bosch_shc.markdown
@@ -15,33 +15,36 @@ ha_platforms:
 ha_zeroconf: true
 ---
 
-The Bosch SHC integration allows you to integrate your [Bosch Smart Home Controller](https://www.bosch-smarthome.com) into Home Assistant.
+The Bosch SHC integration allows you to connect your [Bosch Smart Home Controller](https://www.bosch-smarthome.com) to Home Assistant in order to control and monitor your Bosch Smart Home devices.
 
 There is currently support for the following device types within Home Assistant:
 
 - [Binary Sensor](#binary-sensor)
+- [Cover](#cover)
 - [Sensor](#sensor)
 
 {% include integrations/config_flow.md %}
 
 ### Binary Sensor
 
-The binary sensor platform allows you to monitor the states of your shutter contact sensors. Binary sensor devices are added for each of the following devices:
+The binary sensor platform allows you to monitor the states of your shutter contact and battery sensors. Binary sensor devices are added for each of the following devices:
 
 - Shutter Contact
+- Battery powered devices
+
+### Cover
+
+The cover platform allows you to control your covers. Cover devices are added for each Shutter Control device.
 
 ### Sensor
 
-The sensor platform allows you to monitor the states of your temperature, humidity, purity, air quality, power, energy, valve tappet and battery sensors. Sensor devices are added for each of the following devices:
+The sensor platform allows you to monitor the states of your temperature, humidity, purity, air quality, power, energy, and valve tappet sensors. Sensor devices are added for each of the following devices:
 
 - Thermostat
 - Wall Thermostat
 - Twinguard
 - Smart Plug
 - Smart Plug Compact
-- Smoke Detector
-- Shutter Contact
-- Universal Switch
 
 ## Client registration
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

* Add documentation of cover platform for bosch_shc integration. 
* Fixed description for battery powered devices from PR https://github.com/home-assistant/core/pull/50720. This is not yet in the `current` branch, so I guess chosing the `next` branch for this is correct.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51443
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
