### PR TITLE
Add referencing sensor entities for before/after in time conditions

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -474,14 +474,28 @@ A better weekday condition could be by using the [Workday Binary Sensor](/integr
 
 </div>
 
-For the `after` and `before` options a time helper (`input_datetime` entity) can be used instead.
+For the `after` and `before` options a time helper (`input_datetime` entity)
+or another `sensor` entity containing a timestamp with the "timestamp" device
+class, can be used instead.
 
 ```yaml
 condition:
-  condition: time
-  after: input_datetime.house_silent_hours_start
-  before: input_datetime.house_silent_hours_end
+  - alias: "Example referencing a time helper"
+    condition: time
+    after: input_datetime.house_silent_hours_start
+    before: input_datetime.house_silent_hours_end
+
+  - alias: "Example referencing another sensor"
+    after: sensor.groceries_delivery_time
 ```
+
+<div class='note warning'>
+
+Please note that the time condition only takes the time into account. If
+an referenced sensor or helper entity contains a timestamp with a date, the
+date part is fully ignored.
+
+</div>
 
 ## Zone condition
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents that we can now reference other sensor entities in time conditions.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51444
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
