### PR TITLE
add smarttub.reset_reminder

### DIFF
--- a/source/_integrations/smarttub.markdown
+++ b/source/_integrations/smarttub.markdown
@@ -63,3 +63,12 @@ This service allows you to temporarily suppress a maintenance reminder on a hot 
 | ---------------------- | -------- | ----------- | ------- |
 | `entity_id` | no | The entity to update. | binary_sensor.jacuzzi_j_335_refresh_water_reminder
 | `days` | no | The number of days to snooze the reminder (minimum 10). | 10
+
+### Service `smarttub.reset_reminder`
+
+This service allows you to reset a maintenance reminder on a hot tub.
+
+| Service data attribute | Optional | Description | Example |
+| ---------------------- | -------- | ----------- | ------- |
+| `entity_id` | no | The entity to update. | binary_sensor.jacuzzi_j_335_refresh_water_reminder
+| `days` | no | The number of days when reminder should trigger next (minimum 30). | 180


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for new service `smarttub.reset_reminder`

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51824
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
