### PR TITLE
Small clarification for queued automations

### DIFF
--- a/source/_docs/automation/modes.markdown
+++ b/source/_docs/automation/modes.markdown
@@ -11,7 +11,7 @@ Mode | Description
 -|-
 `single` | (Default) Do not start a new run. Issue a warning.
 `restart` | Start a new run after first stopping previous run.
-`queued` | Start a new run after all previous runs complete. Runs are guaranteed to execute in the order they were queued.
+`queued` | Start a new run after all previous runs complete. Runs are guaranteed to execute in the order they were queued. Note that subsequent queued automations will only join the queue if any conditions it may have are met at the time it is triggered.
 `parallel` | Start a new, independent run in parallel with previous runs.
 
 <p class='img'>


### PR DESCRIPTION
## Proposed change
Small clarification.
It is not clear that the conditions are evaluated *before* the automation joins the queue rather than at the point the queued automation reaches the front of the queue.

I think this is important information to explicitly state as the effect is that when an automation reaches the front of the queue its conditions may no longer be true but it will still carry out its actions.





## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
