### PR TITLE
Describe Sonos media_player.play_media support

### DIFF
--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -42,15 +42,17 @@ The Sonos integration adds one `switch` for each alarm set in the Sonos app. The
 
 ## Playing media
 
-Sonos accepts a variety of `media_content_id` formats in the `media_player.play_media` service, but most commonly as URIs. For example, both Spotify and Tidal share links can be provided as-is. Playback of [music hosted on a Plex server](https://www.home-assistant.io/integrations/plex#sonos-playback) is possible. Direct HTTP/HTTPS links to local or remote media files can also be used if the Sonos device can reach the URI directly, but specific media encoding support may vary.
+Sonos accepts a variety of `media_content_id` formats in the `media_player.play_media` service, but most commonly as URIs. For example, both Spotify and Tidal share links can be provided as-is. Playback of [music hosted on a Plex server](/integrations/plex#sonos-playback) is possible. Direct HTTP/HTTPS links to local or remote media files can also be used if the Sonos device can reach the URI directly, but specific media encoding support may vary.
 
 Spotify share links can also be provided in the `spotify:playlist:abcdefghij0123456789XY` format.
 
-An optional `enqueue` argument can be added to the service call. If `True`, the media will be appended to the end of the playback queue. If not provided or `False` then the queue will be replaced
+An optional `enqueue` argument can be added to the service call. If `true`, the media will be appended to the end of the playback queue. If not provided or `false` then the queue will be replaced.
 
 ### Examples:
+
+This is an example service call that plays an audio file from a web server on the local network (like the Home Assistant built-in webserver):
+
 ```yaml
-# Play an audio file from the local network:
 service: media_player.play_media
 target:
   entity_id: media_player.sonos
@@ -59,8 +61,9 @@ data:
   media_content_id: "http://192.168.1.50:8123/local/sound_files/doorbell-front.mp3"
 ```
 
+Sonos can also play music or playlists from Spotify if linked in Sonos. Full Spotify URIs and Spotify ID codes can both be used directly. An example service call:
+
 ```yaml
-# Play a Spotify playlist
 service: media_player.play_media
 target:
   entity_id: media_player.sonos
@@ -70,8 +73,9 @@ data:
   enqueue: true
 ```
 
+Run a [Plex Media Server](/integrations/plex#sonos-playback) in your home? The Sonos integration can work with that as well. This example plays music directly from your Plex server:
+
 ```yaml
-# Play a Plex album (see link above for requirements)
 service: media_player.play_media
 target:
   entity_id: media_player.sonos

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -44,7 +44,7 @@ The Sonos integration adds one `switch` for each alarm set in the Sonos app. The
 
 Sonos accepts a variety of `media_content_id` formats in the `media_player.play_media` service, but most commonly as URIs. For example, both Spotify and Tidal share links can be provided as-is. Playback of [music hosted on a Plex server](/integrations/plex#sonos-playback) is possible. Direct HTTP/HTTPS links to local or remote media files can also be used if the Sonos device can reach the URI directly, but specific media encoding support may vary.
 
-Spotify share links can also be provided in the `spotify:playlist:abcdefghij0123456789XY` format.
+Music services which require an account (e.g., Spotify) must first be configured using the Sonos app.
 
 An optional `enqueue` argument can be added to the service call. If `true`, the media will be appended to the end of the playback queue. If not provided or `false` then the queue will be replaced.
 
@@ -61,7 +61,7 @@ data:
   media_content_id: "http://192.168.1.50:8123/local/sound_files/doorbell-front.mp3"
 ```
 
-Sonos can also play music or playlists from Spotify if linked in Sonos. Full Spotify URIs and Spotify ID codes can both be used directly. An example service call:
+Sonos can also play music or playlists from Spotify. Full Spotify URIs and ID codes can both be used directly. An example service call:
 
 ```yaml
 service: media_player.play_media

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -61,7 +61,7 @@ data:
   media_content_id: "http://192.168.1.50:8123/local/sound_files/doorbell-front.mp3"
 ```
 
-Sonos can also play music or playlists from Spotify. Full Spotify URIs and ID codes can both be used directly. An example service call:
+Sonos can also play music or playlists from Spotify. Both Spotify URIs and URLs can be used directly. An example service call using a playlist URI:
 
 ```yaml
 service: media_player.play_media
@@ -71,6 +71,17 @@ data:
   media_content_type: "playlist"
   media_content_id: "spotify:playlist:abcdefghij0123456789XY"
   enqueue: true
+```
+
+An example service call using a Spotify URL:
+
+```yaml
+service: media_player.play_media
+target:
+  entity_id: media_player.sonos
+data:
+  media_content_type: "music"
+  media_content_id: "https://open.spotify.com/album/abcdefghij0123456789YZ"
 ```
 
 Run a [Plex Media Server](/integrations/plex#sonos-playback) in your home? The Sonos integration can work with that as well. This example plays music directly from your Plex server:

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -40,20 +40,49 @@ The battery sensors rely on working change events or updates will be delayed. S1
 
 The Sonos integration adds one `switch` for each alarm set in the Sonos app. The alarm switches are detected, deleted and assigned automatically and come with several attributes that help to monitor Sonos alarms.
 
-## Services
+## Playing media
 
-### Service `media_player.play_media`
-
-Sonos accepts a variety of `media_content_id` formats for playback, but most commonly as URIs. For example, both Spotify and Tidal share links can be provided as-is. Playback of [music hosted on a Plex server](https://www.home-assistant.io/integrations/plex#sonos-playback) is possible. Direct HTTP/HTTPS links to media files can also be used if the Sonos device can reach the URI directly, but specific media encoding support may vary.
+Sonos accepts a variety of `media_content_id` formats in the `media_player.play_media` service, but most commonly as URIs. For example, both Spotify and Tidal share links can be provided as-is. Playback of [music hosted on a Plex server](https://www.home-assistant.io/integrations/plex#sonos-playback) is possible. Direct HTTP/HTTPS links to local or remote media files can also be used if the Sonos device can reach the URI directly, but specific media encoding support may vary.
 
 Spotify share links can also be provided in the `spotify:playlist:abcdefghij0123456789XY` format.
 
-| Service data attribute | Optional | Description                                                                                                                                                            |
-| -----------------------| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id`            |       no | The `entity_id` of the target Sonos device. |
-| `media_content_id`     |       no | A media identifier, normally in a URI format. Must be reachable directly from the Sonos device. |
-| `media_content_type`   |       no | Should be one of `music`, `track`, or `playlist`. |
-| `enqueue`              |      yes | Set to `True` to add the media to the end of the playback queue. If empty or `False` the queue will be replaced. |
+An optional `enqueue` argument can be added to the service call. If `True`, the media will be appended to the end of the playback queue. If not provided or `False` then the queue will be replaced
+
+### Examples:
+```yaml
+# Play an audio file from the local network:
+service: media_player.play_media
+target:
+  entity_id: media_player.sonos
+data:
+  media_content_type: "music"
+  media_content_id: "http://192.168.1.50:8123/local/sound_files/doorbell-front.mp3"
+```
+
+```yaml
+# Play a Spotify playlist
+service: media_player.play_media
+target:
+  entity_id: media_player.sonos
+data:
+  media_content_type: "playlist"
+  media_content_id: "spotify:playlist:abcdefghij0123456789XY"
+  enqueue: true
+```
+
+```yaml
+# Play a Plex album (see link above for requirements)
+service: media_player.play_media
+target:
+  entity_id: media_player.sonos
+data:
+  media_content_type: "music"
+  media_content_id: 'plex://{ "library_name": "Music", "artist_name": "M83", "album_name": "Hurry Up, We're Dreaming" }'
+```
+
+## Services
+
+The Sonos integration makes various custom services available.
 
 ### Service `sonos.snapshot`
 

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -42,7 +42,18 @@ The Sonos integration adds one `switch` for each alarm set in the Sonos app. The
 
 ## Services
 
-The Sonos integration makes various custom services available.
+### Service `media_player.play_media`
+
+Sonos accepts a variety of `media_content_id` formats for playback, but most commonly as URIs. For example, both Spotify and Tidal share links can be provided as-is. Playback of [music hosted on a Plex server](https://www.home-assistant.io/integrations/plex#sonos-playback) is possible. Direct HTTP/HTTPS links to media files can also be used if the Sonos device can reach the URI directly, but specific media encoding support may vary.
+
+Spotify share links can also be provided in the `spotify:playlist:abcdefghij0123456789XY` format.
+
+| Service data attribute | Optional | Description                                                                                                                                                            |
+| -----------------------| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `entity_id`            |       no | The `entity_id` of the target Sonos device. |
+| `media_content_id`     |       no | A media identifier, normally in a URI format. Must be reachable directly from the Sonos device. |
+| `media_content_type`   |       no | Should be one of `music`, `track`, or `playlist`. |
+| `enqueue`              |      yes | Set to `True` to add the media to the end of the playback queue. If empty or `False` the queue will be replaced. |
 
 ### Service `sonos.snapshot`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
There seems to be some confusion on what `media_content_id` values that Sonos can support. This adds an explicit service description to the Sonos integration page with some examples.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
