### PR TITLE
Add anchor to feedback section

### DIFF
--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -40,6 +40,16 @@ $primary-color: #049cdb;
     }
   }
 }
+.feedback {
+  h4 {
+    margin: 0 0 8px !important;
+
+    a {
+      text-decoration: none !important;
+      color: #000;
+    }
+  }
+}
 
 @media only screen and (max-width: $menu-collapse) {
   .search-container {

--- a/source/_includes/feedback.html
+++ b/source/_includes/feedback.html
@@ -1,6 +1,6 @@
 {% unless page.feedback == false %}
-<div class="material-card text feedback">
-  <b>Help us to improve our documentation</b><br />
+<div class="material-card text feedback" id="feedback_section">
+  <h4><a href="#feedback_section" class="title-link"><b> Help us to improve our documentation</b></a></h4>
   Suggest an edit to this page, or provide/view feedback for this page.
   <div class="links">
     <a


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds anchor to the feedback section, this makes it easier to point folks to where this is, by slapping a "#feedback_section" at the end of any  URL that have this, the browser jumps to this section on load.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
