### PR TITLE
Fix typo. "no need for" rather than "not need for"

### DIFF
--- a/source/_includes/custom/features.html
+++ b/source/_includes/custom/features.html
@@ -60,7 +60,7 @@
       All your smart home data stays local
     </div>
     <div class="card-content">
-      <p>Home Assistant keeps your data local, not need for a cloud.</p>
+      <p>Home Assistant keeps your data local, no need for a cloud.</p>
 
       <p>
         Home Assistant communicates with your devices locally, and will fallback


### PR DESCRIPTION
## Proposed change
Just a small typo/grammatical fix. "not need for a cloud" should be "no need for a cloud".

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
