### PR TITLE
Update screenlogic.set_color_mode service call description

### DIFF
--- a/source/_integrations/screenlogic.markdown
+++ b/source/_integrations/screenlogic.markdown
@@ -39,9 +39,9 @@ Sets the operation of any connected color-capable lights.
 
 | Service data attribute | Optional | Description                                                                                                                                                  |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `area_id`              | no       | An area containing the target ScreenLogic device. One of `area_id`, `device_id`, or `entity_id` is required. |
-| `device_id`            | no       | The id of the ScreenLogic device itself. One of `area_id`, `device_id`, or `entity_id` is required. |
-| `entity_id`            | no       | Any entity from the target ScreenLogic device. One of `area_id`, `device_id`, or `entity_id` is required. |
+| `area_id`              | no       | An area containing the target ScreenLogic device. One of `area_id`, `device_id` or `entity_id` is required. |
+| `device_id`            | no       | The id of the ScreenLogic device itself. One of `area_id`, `device_id` or `entity_id` is required. |
+| `entity_id`            | no       | Any entity from the target ScreenLogic device. One of `area_id`, `device_id` or `entity_id` is required. |
 | `color_mode`           | no       | The color mode to set. Valid values are listed below. |
 
 ## Reference

--- a/source/_integrations/screenlogic.markdown
+++ b/source/_integrations/screenlogic.markdown
@@ -39,8 +39,10 @@ Sets the operation of any connected color-capable lights.
 
 | Service data attribute | Optional | Description                                                                                                                                                  |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `target`               | no       | An `area` containing the ScreenLogic device, the ScreenLogic `device` itself, or any `entity` from the ScreenLogic device you wish to set the color mode on. |
-| `color_mode`           | no       | The color mode to set. Valid values are listed below.                                                                                                        |
+| `area_id`              | no       | An area containing the target ScreenLogic device. One of `area_id`, `device_id`, or `entity_id` is required. |
+| `device_id`            | no       | The id of the ScreenLogic device itself. One of `area_id`, `device_id`, or `entity_id` is required. |
+| `entity_id`            | no       | Any entity from the target ScreenLogic device. One of `area_id`, `device_id`, or `entity_id` is required. |
+| `color_mode`           | no       | The color mode to set. Valid values are listed below. |
 
 ## Reference
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update screenlogic.set_color_mode service call description to correctly describe the the YAML needed to successfully make the service call.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: #18191

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
