### PR TITLE
Migrate Switcher entity attributes to sensors

### DIFF
--- a/source/_integrations/switcher_kis.markdown
+++ b/source/_integrations/switcher_kis.markdown
@@ -48,21 +48,14 @@ device_password:
   type: string
 {% endconfiguration %}
 
-## Switch State Attributes
+## Sensors
 
-| Attribute          | Type    | Description                                            | Example           |
-| ------------------ | ------- | ------------------------------------------------------ | ----------------- |
-| `friendly_name`    | string  | Defaults to the device's configured name.              | "Switcher Boiler" |
-| `auto_off_set`     | string  | The auto shutdown time limit configured on the device. | "01:30:00"        |
-| `remaining_time`   | string  | Time remaining to shutdown (auto or timer).            | "01:29:41"        |
-| `electric_current` | float   | The electric current in amps.                          | 12.5              |
-| `current_power_w`  | integer | The current power used in watts.                       | 2756              |
-
-<div class='note warning'>
-
-  Please note, the following attributes are not eligible when the device is off and therefore will not appear as state attributes: `remaining_time`, `electric_current`, `current_power_w`.
-
-</div>
+| Sensor Name         | Description                                            | Example           |
+| ------------------- | ------------------------------------------------------ | ----------------- |
+| `Auto Shutdown`     | The auto shutdown time limit configured on the device  | 01:30:00          |
+| `Remaining Time`    | Time remaining to shutdown (auto or timer)             | 01:29:41          |
+| `Electric Current`  | The electric current in amps                           | 12.5 A            |
+| `Power Consumption` | The power consumption in watts                         | 2756 W            |
 
 ## Services
 
@@ -74,8 +67,8 @@ Meaning the device will turn itself off when reaching the auto-off configuration
 
 | Service Field | Mandatory | Description                                                                            | Example                    |
 | ------------- | --------- | -------------------------------------------------------------------------------------- | -------------------------- |
-| `entity_id`   | Yes       | Name of the entity id associated with the integration, used for permission validation. | switch.switcher_kis_boiler |
-| `auto_off`    | Yes       | Time period string containing hours and minutes.                                       | "02:30"                    |
+| `entity_id`   | Yes       | Name of the entity id associated with the integration, used for permission validation  | switch.switcher_kis_boiler |
+| `auto_off`    | Yes       | Time period string containing hours and minutes                                        | "02:30"                    |
 
 ### Service: `switcher_kis.turn_on_with_timer`
 
@@ -85,5 +78,5 @@ Meaning the device will turn itself off when timer ends.
 Note: This does not affect the auto off timer.
 | Service Field | Mandatory | Description                                                                            | Example                    |
 | ------------- | --------- | -------------------------------------------------------------------------------------- | -------------------------- |
-| `entity_id`   | Yes       | Name of the entity id associated with the integration, used for permission validation. | switch.switcher_kis_boiler |
+| `entity_id`   | Yes       | Name of the entity id associated with the integration, used for permission validation  | switch.switcher_kis_boiler |
 | `timer_minutes`    | Yes       | Integer containing timer minutes (valid range 1 to 150)                                      | 90                    |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
In preparation for multi device support and config flow discovery I am migrating entity attributes into sensors to be later added as device entities. The following switch entity attributes migrated to sensors:

| Attribute | Sensor Name |
| ------------- | ------------- |
| `power_consumption` | Power Consumption |
| `electric_current` | Electric Current |
| `remaining_time` | Remaining Time |
| `auto_off_set` | Auto Shutdown |


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51964
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
