### PR TITLE
Add google_translate configuration variables

### DIFF
--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -18,8 +18,7 @@ To enable text-to-speech with Google, add the following lines to your `configura
 
 ```yaml
 # Example configuration.yaml entry
-tts:
-  - platform: google_translate
+google_translate:
 ```
 
 {% configuration %}
@@ -28,6 +27,16 @@ language:
   required: false
   type: string
   default: "`en`"
+tld:
+  description: "Top-level domain for the Google Translate host, i.e `https://translate.google.<tld>`."
+  required: false
+  type: string
+  default: "`com`"
+slow:
+  description: "Reads text more slowly."
+  required: false
+  type: boolean
+  default: "`false`"
 {% endconfiguration %}
 
 Check the [complete list of supported languages](https://translate.google.com/intl/en_ALL/about/languages/) (languages where "Talk" feature is enabled in Google Translate) for allowed values.
@@ -38,6 +47,20 @@ For more information about using text-to-speech with Home Assistant and more det
 ## Full configuration example
 
 A full configuration sample including optional variables:
+
+```yaml
+# Example configuration.yaml entry
+google_translate:
+    language: "de"
+    tld: "cn"
+    slow: false
+```
+
+## Legacy tts configuration format
+
+_This format still works but is no longer recommended. [Use modern configuration](#configuration-variables)._
+
+This format is configured as a platform for the `tts` integration and not directly under the `google_translate` integration.
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
`google_translate` is a very convenient built-in text-to-speech platform, but users in some areas cannot directly access its server. Add `tld` configuration variables can help them use it normally.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/52004
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
