### PR TITLE
Add active_state_address and command_value_state_address to KNX climate

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -628,6 +628,14 @@ setpoint_shift_max:
   required: false
   default: 6
   type: float
+active_state_address:
+  description: KNX address for reading current activity. `0` is idle, `1` is active. *DPT 1
+  required: false
+  type: [string, list]
+command_value_state_address:
+  description: KNX address for reading current command_value in percent. `0` sets the climate entity to idle if `active_state_address` is not set. *DPT 5.001*
+  required: false
+  type: [string, list]
 operation_mode_address:
   description: KNX address for setting operation mode (Frost protection/night/comfort). *DPT 20.102*
   required: false

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -629,7 +629,7 @@ setpoint_shift_max:
   default: 6
   type: float
 active_state_address:
-  description: KNX address for reading current activity. `0` is idle, `1` is active. *DPT 1
+  description: KNX address for reading current activity. `0` is idle, `1` is active. *DPT 1*
   required: false
   type: [string, list]
 command_value_state_address:

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -633,7 +633,7 @@ active_state_address:
   required: false
   type: [string, list]
 command_value_state_address:
-  description: KNX address for reading current command_value in percent. `0` sets the climate entity to idle if `active_state_address` is not set. *DPT 5.001*
+  description: KNX address for reading current command value in percent. `0` sets the climate entity to idle if `active_state_address` is not set. *DPT 5.001*
   required: false
   type: [string, list]
 operation_mode_address:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add active_state_address and command_value_state_address to KNX climate
used for idle hvac_action.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/52006
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
