### PR TITLE
Add `to_yaml` and `from_yaml` to template documentation

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -271,13 +271,13 @@ To fix it, enforce the ISO conversion via `isoformat()`:
 
 {% endraw %}
 
-### To/From JSON
+### Serialization
 
 The `to_json` filter serializes an object to a JSON string. In some cases, it may be necessary to format a JSON string for use with a webhook, as a parameter for command-line utilities or any number of other applications. This can be complicated in a template, especially when dealing with escaping special characters. Using the `to_json` filter, this is handled automatically.
 
-The `from_json` filter operates similarly, but in the other direction, de-serializing a JSON string back into an object.
+Similarly, `to_yaml` serializes an object to a YAML string.
 
-### To/From JSON examples
+##### Serialization examples
 
 In this example, the special character '°' will be automatically escaped in order to produce valid JSON. The difference between the stringified object and the actual JSON is evident.
 
@@ -304,7 +304,15 @@ object|to_json: {"temperature": 25, "unit": "\u00b0C"}
 
 {% endraw %}
 
-Conversely, `from_json` can be used to de-serialize a JSON string back into an object to make it possible to easily extract usable data.
+### Deserialization
+
+The `from_json` filter operates in the other direction, de-serializing a JSON string back into an object.
+
+Similarly, the `from_yaml` filter de-serializes a YAML string back into an object.
+
+##### Deserialization examples
+
+`from_json` and `from_yaml` can be used to de-serialize a JSON string back into an object to make it possible to easily extract usable data.
 
 *Template*
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds documentation for the new `to_yaml` and `from_yaml` template helpers.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#52023
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
