### PR TITLE
Example of multiple state_filter was incorrect

### DIFF
--- a/source/_lovelace/entity-filter.markdown
+++ b/source/_lovelace/entity-filter.markdown
@@ -127,7 +127,7 @@ card:
   Entity filter combined with glance card.
 </p>
 
-You can also specify multiple `state_filter` conditions, in which case the entity will be displayed if it matches any condition. This example will display everyone who isn't at home or at work.
+You can also specify multiple `state_filter` conditions, in which case the entity will be displayed if it matches any condition. This example will display everyone who is at home or at work.
 
 ```yaml
 type: entity-filter
@@ -136,13 +136,13 @@ entities:
   - device_tracker.demo_anne_therese
   - device_tracker.demo_home_boy
 state_filter:
-  - operator: "!="
+  - operator: "=="
     value: home
-  - operator: "!="
+  - operator: "=="
     value: work    
 card:
   type: glance
-  title: Who's Running Errands
+  title: Who's at work or home
 ```
 
 Specify filter for a single entity.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fixing example for  `entity-filter`  as the given example doesn't actually work as described

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
The example using '!=' meant that the filter shows everything as a person at home is not at work and a person at work is not at home. (As multiple state_filter operate with 'OR' logic)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
