### PR TITLE
Document default mode for openweathermap

### DIFF
--- a/source/_integrations/openweathermap.markdown
+++ b/source/_integrations/openweathermap.markdown
@@ -40,7 +40,7 @@ not be activated yet.
 | Name                 | Name of the integration                                                                                                                                                                                                                    |
 | Latitude             | Latitude for weather forecast and sensor                                                                                                                                                                                                   |
 | Longitude            | Longitude for weather forecast and sensor                                                                                                                                                                                                  |
-| Mode                 | Forecast mode, `hourly` for a three-hour forecast, `daily` for daily forecast using a paid API tier, `onecall_hourly` for an hourly forecast up to 2 days, or `onecall_daily` for a daily forecast up to 7 days (ideal for the free tier). |
+| Mode                 | Forecast mode, `hourly` for a three-hour forecast, `daily` for daily forecast using a paid API tier, `onecall_hourly` for an hourly forecast up to 2 days, or `onecall_daily` for a daily forecast up to 7 days (ideal for the free tier, default). |
 | Language             | Language for receiving data (only for `sensor`)                                                                                                                                                                                            |
 
 The integration creates a weather entity as well as sensors for supported weather conditions.


### PR DESCRIPTION
## Proposed change
Although onecall_daily is documented as ideal for the free tier, I had to read the source to confirm it was the default.  

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Adding this does not seem to break the formatting on the screen sizes I tried it with.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
