### PR TITLE
Adding AVR-S960H as a known supported device.

### DIFF
--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -54,6 +54,7 @@ Known supported devices:
 - Denon AVR-S710W
 - Denon AVR-S720W
 - Denon AVR-S750H
+- Denon AVR-S960H
 - Denon DN-500AV
 - Marantz M-CR510
 - Marantz M-CR511


### PR DESCRIPTION
## Proposed change
I have been utilizing the [Denon AVR](https://www.home-assistant.io/integrations/denonavr/) integration for 6+ months and I can confirm it is fully supported by the Denon AVR-S960H. 

I would like to document that `denon avr` supports this model.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
NA

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
