### PR TITLE
Remove information about YAML configuration for Sony Bravia TV

### DIFF
--- a/source/_integrations/braviatv.markdown
+++ b/source/_integrations/braviatv.markdown
@@ -27,7 +27,6 @@ Almost all [Sony Bravia TV 2013 and newer](https://info.tvsideview.sony.net/en_w
 
 To ensure a clean re-configuration, please perform the following steps:
 
-- Ensure that all braviatv entries in `configuration.yaml` have been removed and `bravia.conf` does not exist in your `.homeassistant` folder.
 - Remove the entities you are reconfiguring from Home Assistant.
 - Restart Home Assistant.
 - Perform the [TV does not generate new pin](#tv-does-not-generate-new-pin) steps.
@@ -39,35 +38,6 @@ If you have previously set up your TV with any Home Assistant instances, you mus
 
 - On your TV, go to: **Settings** -> **Network** -> **Remote device settings** -> **Deregister remote device**. Disable and re-enable the **Control remotely** after. Menu titles may differ slightly between models. If needed, refer to your specific model's [manual](https://www.sony.com/electronics/support/manuals) for additional guidiance.
 - Reset your TV to factory condition.
-
-## Configuration using YAML
-
-<div class='note warning'>
-
-New setups via `configuration.yaml` file are currently not supported.
-
-</div>
-
-If you are updating from a previous version of Home Assistant and have the following configuration in your `configuration.yaml` file in addition to a `bravia.conf` file it will be imported to the Integrations:
-
-```yaml
-# Example configuration.yaml entry
-media_player:
-  - platform: braviatv
-    host: IP_ADDRESS
-```
-
-{% configuration %}
-host:
-  description: The IP of the Sony Bravia TV, e.g., 192.168.0.10
-  required: true
-  type: string
-name:
-  description: The name to use on the frontend.
-  required: false
-  default: Sony Bravia TV
-  type: string
-{% endconfiguration %}
 
 ## Remote
 
@@ -200,7 +170,7 @@ The integration allows you to change ignored TV sources from the front end. Ente
 ### For TVs older than 2013
 
 <div class='note warning'>
-  
+
 This is not part of the Bravia TV integration. Extra Configuration does not apply to the steps below.
 
 </div>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR removes information about YAML configuration import for Sony Bravia TV integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/52141
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
