### PR TITLE
Remove `air_quality` from Nettigo Air Monitor documentation

### DIFF
--- a/source/_integrations/nam.markdown
+++ b/source/_integrations/nam.markdown
@@ -10,7 +10,6 @@ ha_codeowners:
   - '@bieniu'
 ha_domain: nam
 ha_platforms:
-  - air_quality
   - sensor
 ha_quality_scale: platinum
 ha_zeroconf: true
@@ -24,6 +23,7 @@ The integration currently has support for the following sensors:
 - BMP280
 - DHT22
 - HECA
+- MH-Z14A
 - SDS011
 - SHT3X
 - SPS30


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The AirQuality platform has been marked as deprecated. Nettiga Air Monitor integration migrates the `air_quality` entities to the `sensor` entities.
This PR:
- removes information about `air_quality` platform
- adds missing information about supported sensor MH-Z14A


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/52152
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
