### PR TITLE
Warn about new-style template sensors

### DIFF
--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -17,6 +17,8 @@ homeassistant:
 
 The package configuration can include: `switch`, `light`, `automation`, `groups`, or most other Home Assistant integrations including hardware platforms.
 
+**[New-style template sensors](/integrations/template/) cannot be used with packages.**
+
 It can be specified inline or in a separate YAML file using `!include`.
 
 Inline example, main `configuration.yaml`:

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -40,6 +40,8 @@ Sensor and binary sensor template entities are defined in your YAML configuratio
 
 _For old sensor/binary sensor configuration format, [see below](#legacy-binary-sensor-configuration-format)._
 
+**New-style template sensors cannot be used with [packages](/docs/configuration/packages/).** 
+
 ## State-based template sensors
 
 Template entities will by default update as soon as any of the referenced data in the template updates.


### PR DESCRIPTION
Many users have been surprised that they cannot use new-style template sensors in packages:  https://community.home-assistant.io/t/allow-integration-template-in-packages/305865; home-assistant/core#49212.  Documentation should be updated to reflect this.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
