### PR TITLE
Show number of installation is use base <1%

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -21,7 +21,7 @@
 
   <div class='section'>
     The {{ page.name | default: page.title }} integration was introduced in Home Assistant {{ page.ha_release | default: "unknown" }},
-    and it's used by <a title="Open analytics.home-assistant.io" href="https://analytics.home-assistant.io" target="_blank" rel="noopener">
+    and it's used by <a title="Open analytics.home-assistant.io" href="https://analytics.home-assistant.io/#integrations" target="_blank" rel="noopener">
     
     {% if percentage < 1 %}
       {{ site.data.analytics_data.integrations[page.ha_domain] }}</a> active installations.

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -1,3 +1,4 @@
+{% assign percentage = 100.0 | times: site.data.analytics_data.integrations[page.ha_domain] | divided_by: site.data.analytics_data.reports_integrations | round: 1 %}
 <section class="aside-module grid__item one-whole lap-one-half">
 
   <div class='brand-logo-container section'>
@@ -21,7 +22,12 @@
   <div class='section'>
     The {{ page.name | default: page.title }} integration was introduced in Home Assistant {{ page.ha_release | default: "unknown" }},
     and it's used by <a title="Open analytics.home-assistant.io" href="https://analytics.home-assistant.io" target="_blank" rel="noopener">
-    {{ 100.0 | times: site.data.analytics_data.integrations[page.ha_domain] | divided_by: site.data.analytics_data.reports_integrations | round: 1 | remove: ".0" }}%</a> of the active installations.
+    
+    {% if percentage < 1 %}
+      {{ site.data.analytics_data.integrations[page.ha_domain] }}</a> active installation.
+    {% else %}
+      {{ percentage | remove: ".0" }}%</a> of the active installations.
+    {% endif %}
 
     {%- if page.ha_iot_class %}
       Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}</a>

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -24,7 +24,7 @@
     and it's used by <a title="Open analytics.home-assistant.io" href="https://analytics.home-assistant.io" target="_blank" rel="noopener">
     
     {% if percentage < 1 %}
-      {{ site.data.analytics_data.integrations[page.ha_domain] }}</a> active installation.
+      {{ site.data.analytics_data.integrations[page.ha_domain] }}</a> active installations.
     {% else %}
       {{ percentage | remove: ".0" }}%</a> of the active installations.
     {% endif %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adjusts the sidebar to show the number of active installations when the usage percentage is below 1%.


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
