### PR TITLE
Add Switcher config flow discovery support

### DIFF
--- a/source/_integrations/switcher_kis.markdown
+++ b/source/_integrations/switcher_kis.markdown
@@ -24,39 +24,7 @@ Supported devices:
 - Switcher V2 (Qualcomm chipset - from firmware 72.32)
 - Switcher V4
 
-To enable it, add an entry to your `configuration.yaml` according to the following configuration instructions.
-
-To retrieve your device's details, please follow the instructions [here](https://github.com/NightRang3r/Switcher-V2-Python).
-
-<div class='note warning'>
-  Please note, the Switcher-V2-Python script is written in python 2.7 syntax, it won't run with python 3.x.
-</div>
-
-<div class='note warning'>
-  Please note, for the Switcher-V2-Python script to run successfully, you need to configure your device to work locally.
-</div>
-
-```yaml
-switcher_kis:
-  phone_id: "REPLACE_WITH_PHONE_ID"
-  device_id: "REPLACE_WITH_DEVICE_ID"
-  device_password: "REPLACE_WITH_DEVICE_PASSWORD"
-```
-
-{% configuration %}
-phone_id:
-  description: The device's phone id.
-  required: true
-  type: string
-device_id:
-  description: The device's id.
-  required: true
-  type: string
-device_password:
-  description: The device's password.
-  required: true
-  type: string
-{% endconfiguration %}
+{% include integrations/config_flow.md %}
 
 ## Sensors
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update Switcher integration (`switcher_kis`) docs to config flow


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/52316
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
