### PR TITLE
Update acmeda.markdown

### DIFF
--- a/source/_integrations/acmeda.markdown
+++ b/source/_integrations/acmeda.markdown
@@ -17,15 +17,10 @@ ha_platforms:
 
 The Rollease Acmeda Automate integration allows you to control and monitor covers via your Rolelase Acmeda Automate hub. The integrations communicates directly with hubs on the local network, rather than connecting via the cloud or via RS-485. Devices are represented as a cover for monitoring and control as well as a sensor for monitoring battery condition.
 
-### Hub Versions
+### Supported devices
 
-Notice there are two versions of the hub referred to as v1 and v2. The v2 hub is the next generation from Rollease Acmeda. It uses the "Automate" branding, and a completely different network protocol. The v1 hub is no longer sold.
+- Automate Pulse Hub v1
 
-The integration for the v1 hub was written by atmurray and uses uses the [aiopulse API](https://pypi.org/project/aiopulse/), also written by atmurray.
-
-The v2 hub integration was written by sillyfrog and uses the [aiopulse2 API](github.com/sillyfrog/aiopulse2) which is the aiopulse API with modifications by sillfrog. Currently the v2 Integration is awaiting review for inclusion in HA, and is designed to be added as a custom HACS repository. Instructions for installing the v2 integration can be found [here](github.com/sillyfrog/Automate-Pulse-v2).
-
-The remainder of this description applies to both hub integrations.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/acmeda.markdown
+++ b/source/_integrations/acmeda.markdown
@@ -15,9 +15,17 @@ ha_platforms:
   - sensor
 ---
 
-The Rollease Acmeda Automate integration allows you to control and monitor covers via your Rolelase Acmeda Automate hub. The integration uses an [API](https://pypi.org/project/aiopulse/) to directly communicate with hubs on the local network, rather than connecting via the cloud or via RS-485.
+The Rollease Acmeda Automate integration allows you to control and monitor covers via your Rolelase Acmeda Automate hub. The integrations communicates directly with hubs on the local network, rather than connecting via the cloud or via RS-485. Devices are represented as a cover for monitoring and control as well as a sensor for monitoring battery condition.
 
-Devices are represented as a cover for monitoring and control as well as a sensor for monitoring battery condition.
+### Hub Versions
+
+Notice there are two versions of the hub referred to as v1 and v2. The v2 hub is the next generation from Rollease Acmeda. It uses the "Automate" branding, and a completely different network protocol. The v1 hub is no longer sold.
+
+The integration for the v1 hub was written by atmurray and uses uses the [aiopulse API](https://pypi.org/project/aiopulse/), also written by atmurray.
+
+The v2 hub integration was written by sillyfrog and uses the [aiopulse2 API](github.com/sillyfrog/aiopulse2) which is the aiopulse API with modifications by sillfrog. Currently the v2 Integration is awaiting review for inclusion in HA, and is designed to be added as a custom HACS repository. Instructions for installing the v2 integration can be found [here](github.com/sillyfrog/Automate-Pulse-v2).
+
+The remainder of this description applies to both hub integrations.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
Discuss different hub versions and reference v2 integration

## Proposed change
This document describes the Automate Pulse version 1 Hub Integration. My changes point out there are two versions of the hub, each with its own integration: v1 written by atmurray and v2 written by sillyfrog

## Type of change
- [ X] Spelling, grammar or other readability improvements (`current` branch).
- [ X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [ X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
