### PR TITLE
WIP: ecovacs - update docs on new 'skip_devices' option in ecovacs config

### DIFF
--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -29,6 +29,9 @@ ecovacs:
   password: YOUR_ECOVACS_PASSWORD
   country: YOUR_TWO_LETTER_COUNTRY_CODE
   continent: YOUR_TWO_LETTER_CONTINENT_CODE
+  skip_devices:
+    - OZMO_U2
+    - Basement
 ```
 
 {% configuration %}
@@ -48,6 +51,10 @@ continent:
   description: Your two-letter continent code (na, eu, etc).
   required: true
   type: string
+skip_devices:
+  description: A list of devices (by name, not id) to skip from being made available in Home Assistant, most usefull for new Ecovacs devices that this integration doesn't work with.
+  required: false
+  type: list
 {% endconfiguration %}
 
 Note: For some countries, you will need to set `continent` to `ww` (meaning worldwide.) There is unfortunately no way to know the correct settings other than guessing and checking. See the [sucks library protocol documentation](https://github.com/wpietri/sucks/blob/master/protocol.md) for more information about what has been figured out about the Ecovacs servers.


### PR DESCRIPTION
Matching docs PR for core code change

## Proposed change
This PR is to match the core code change to the ecovacs config to skip ecovacs devices


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
https://github.com/home-assistant/core/pull/52389

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
