### PR TITLE
Typo in automation.turn_off part

### DIFF
--- a/source/_docs/automation/services.markdown
+++ b/source/_docs/automation/services.markdown
@@ -19,7 +19,7 @@ This service disables the automation's triggers, and optionally stops any curren
 
 Service data attribute | Optional | Description
 -|-|-
-`entity_id` | no | Entity ID of automation to turn on. Can be a list. `none` or `all` are also accepted.
+`entity_id` | no | Entity ID of automation to turn off. Can be a list. `none` or `all` are also accepted.
 `stop_actions` | yes | Stop any currently active actions (defaults to true).
 
 ## Service {% my developer_call_service service="automation.toggle" %}


### PR DESCRIPTION
Changed "on" to "off", because the service automation.turn_off turns automations off, not on.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
