### PR TITLE
Add precision and time_unit to config variables

### DIFF
--- a/source/_integrations/history_stats.markdown
+++ b/source/_integrations/history_stats.markdown
@@ -61,6 +61,16 @@ type:
   required: false
   default: time
   type: string
+precision:
+  description: Indicates the number of decimals in the state value for sensors of type `time` or `ratio`.  Precision is defined by the [`round()`](/docs/configuration/templating/#numeric-functions-and-filters) operation. Set it to `2` to round the state value to two decimals (default), for example, or to `4` to round it to four decimals.
+  required: false
+  default: 2
+  type: integer
+time_unit:
+  description: Defines the *unit of time* (days, hours, minutes, or seconds) to be used in the state value for sensors of type `time`.  Valid units are `d` (days), `h` (hours) (default), `min` (minutes), or `s` (seconds).  For example, set it to `"s"` to display the state value in *seconds*, instead of hours.
+  required: false
+  default: "h"
+  type: string
 start:
   description: When to start the measure (timestamp or datetime).
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

- Add `precision` and `time_unit` configuration variables to the documentation of the History Stats integration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/52474
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
