### PR TITLE
Remove total_consumption attribute

### DIFF
--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -63,8 +63,6 @@ There are several attributes that can be useful for automations and templates.
 | `holiday_mode` | The state of the holiday mode (only available since Fritz!OS 7).
 | `summer_mode` | The state of the summer mode (only available since Fritz!OS 7).
 | `window_open` | The state of the window open detection (only available since Fritz!OS 7).
-| `temperature_unit` |  The unit of the temperature sensor (only available if the device support temperature sensor).
-| `temperature` | The current temperature sensor reading (only available if the device supports temperature sensor).
 
 ## Sensors
 
@@ -78,5 +76,3 @@ There are several attributes that can be useful for automations and templates.
 | --------- | ----------- |
 | `device_locked` | The state of the key lock at the device.
 | `locked` | The state of the lock for configuring the device via the app or the FRITZ!Box web interface.
-| `temperature_unit` |  The unit of the temperature sensor.
-| `temperature` | The current temperature sensor reading.

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -65,8 +65,6 @@ There are several attributes that can be useful for automations and templates.
 | `window_open` | The state of the window open detection (only available since Fritz!OS 7).
 | `temperature_unit` |  The unit of the temperature sensor (only available if the device support temperature sensor).
 | `temperature` | The current temperature sensor reading (only available if the device supports temperature sensor).
-| `total_consumption` | The total power consumption since the beginning of operation (only available if the device supports power meter function).
-| `total_consumption_unit` | The unit of the total_consumption (only available if the device supports power meter function).
 
 ## Sensors
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The extra attribute `total_consumption` of switch entities are removed and moved into own sensors.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#52562
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
