### PR TITLE
Added example of custom sensor for time trigger

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -589,6 +589,9 @@ automation:
 ```
 
 An example of a custom [template sensor](/integrations/template/) with the "timestamp" device class that adds 15 minutes to an input_datetime:
+
+{% raw %}
+
 ```yaml
 sensor:
 - unique_id: "phone_next_alarm"
@@ -604,6 +607,9 @@ sensor:
     
     {{ timeaware.isoformat() }}
 ```
+
+
+{% endraw %}
 
 ### Multiple Times
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -588,6 +588,23 @@ automation:
           entity_id: light.bedroom
 ```
 
+An example of a custom [template sensor](/integrations/template/) with the "timestamp" device class that adds 15 minutes to an input_datetime:
+```yaml
+sensor:
+- unique_id: "phone_next_alarm"
+  name: "Phone Next Alarm"
+  device_class: timestamp
+  state: >-
+    # This will create a datetime object that has no timezone:
+    {% set time = strptime(now().date() ~ states("input_datetime.phone_next_alarm"), "%Y-%m-%d%H:%M:%S") %}    
+    
+    # We need a timezone however, else Home Assistant can't compare this sensor with the current time.
+    # By using the astimezone() function we now create a timezone aware datetime object based on the local timezone:
+    {% set timeaware = time.astimezone(now().tzinfo) + timedelta(minutes = 15) %}
+    
+    {{ timeaware.isoformat() }}
+```
+
 ### Multiple Times
 
 Multiple times can be provided in a list. Both formats can be intermixed.


### PR DESCRIPTION
Time trigger refers to using a sensor with "device_class: timestamp" however I could find no examples of how to do this. I've added an example how such a sensor could be implemented

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
