### PR TITLE
Update icloud.markdown with section on app specific passwords.

### DIFF
--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -45,7 +45,7 @@ Apple allows you to provide an [App Specific Password](https://support.apple.com
 2. In the Security section, click Generate Password below App-Specific Passwords.
 3. Follow the steps on your screen.
 
-After you generate your app-specific password, enter or paste it into the password field of the intergration.
+After you generate your app-specific password, enter or paste it into the password field of the integration.
 
 Any time you change or reset your primary Apple ID password, all your app-specific passwords are revoked automatically to protect the security of your account. You'll need to generate new app-specific passwords for any apps that you want to continue using.
 

--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -33,9 +33,21 @@ You may receive an email and a notification from Apple saying that someone has l
 For the notification, press "Allow", then "OK".
 </div>
 
+To prevent excessive battery drainage, a dynamic interval is used for each individual device instead of a fixed interval for all devices linked to one account. The dynamic interval is based on the current zone of a device, the distance towards home and the battery level of the device.
+
+## Two Factor Authentication
 If two-step authentication is enabled for your iCloud account, some time after Home Assistant startup the integration will ask to enter the verification code you receive on your device via a notification in the Home Assistant UI. The duration of this authentication is determined by Apple, so you will need to verify your account every now and then.
 
-To prevent excessive battery drainage, a dynamic interval is used for each individual device instead of a fixed interval for all devices linked to one account. The dynamic interval is based on the current zone of a device, the distance towards home and the battery level of the device.
+### App Specific Passwords
+Apple allows you to provide an [App Specific Password](https://support.apple.com/en-gb/HT204397), which **don't require two factor authentication**, and one could argue more secure than storing your iCloud password within Home Assistant.
+#### How to generate an app-specific password
+1. Sign in to your [Apple ID account page](https://appleid.apple.com/account/home).
+2. In the Security section, click Generate Password below App-Specific Passwords.
+3. Follow the steps on your screen.
+
+After you generate your app-specific password, enter or paste it into the password field of the intergration.
+
+Any time you change or reset your primary Apple ID password, all your app-specific passwords are revoked automatically to protect the security of your account. You'll need to generate new app-specific passwords for any apps that you want to continue using.
 
 ## In case of troubleshooting
 

--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -36,11 +36,13 @@ For the notification, press "Allow", then "OK".
 To prevent excessive battery drainage, a dynamic interval is used for each individual device instead of a fixed interval for all devices linked to one account. The dynamic interval is based on the current zone of a device, the distance towards home and the battery level of the device.
 
 ## Two Factor Authentication
+
 If two-step authentication is enabled for your iCloud account, some time after Home Assistant startup the integration will ask to enter the verification code you receive on your device via a notification in the Home Assistant UI. The duration of this authentication is determined by Apple, so you will need to verify your account every now and then.
 
 ### App Specific Passwords
 Apple allows you to provide an [App Specific Password](https://support.apple.com/en-gb/HT204397), which **don't require two factor authentication**, and one could argue more secure than storing your iCloud password within Home Assistant.
 #### How to generate an app-specific password
+
 1. Sign in to your [Apple ID account page](https://appleid.apple.com/account/home).
 2. In the Security section, click Generate Password below App-Specific Passwords.
 3. Follow the steps on your screen.


### PR DESCRIPTION
## Proposed change
Add section on app specific passwords which don't require a two factor authentication code.



## Type of change
Another way of integration with the icloud integration

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
