### PR TITLE
Update foscam.markdown

### DIFF
--- a/source/_integrations/foscam.markdown
+++ b/source/_integrations/foscam.markdown
@@ -56,7 +56,7 @@ Using the following card code you can achieve a card displaying the live video f
 
 ```yaml
 type: picture-elements
-entity: camera.bedroom
+image: camera.bedroom
 camera_image: camera.bedroom
 camera_view: live
 elements:


### PR DESCRIPTION
## Proposed change
Seems like the picture-entity has changed. Now the required tag is image instead entity
Source info:  https://www.home-assistant.io/lovelace/picture-elements/


