### PR TITLE
Add Fritz missing info for device profiles and port forwards

### DIFF
--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -77,6 +77,17 @@ These can be changed at **AVM FRITZ!Box Tools** -> **Configure** on the Integrat
 
 ## Additional info
 
+### Device Profile
+
+Device profiles are designed for advanced users, thus they are disabled by default. You need to enable the wanted entities manually.
+
+### Device Tracker
+
 **Note 1**: All devices to be tracked, even the new detected, are disabled by default. You need to enable the wanted entities manually.
 
 **Note 2**: If you don't want to automatically track newly detected devices, disable the integration system option `Enable new added entities`.
+
+### Port Forward
+
+Due to security reasons, AVM implemented the ability to enable/disable a port forward rule only from the host involved in the rule.
+As a result this integration will create entities only for rules that have your HA host as destination.

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -90,4 +90,4 @@ Device profiles are designed for advanced users, thus they are disabled by defau
 ### Port Forward
 
 Due to security reasons, AVM implemented the ability to enable/disable a port forward rule only from the host involved in the rule.
-As a result this integration will create entities only for rules that have your HA host as destination.
+As a result, this integration will create entities only for rules that have your Home Assistant host as a destination.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add important info about device profiles and port forwards to help users understand the way the integration works.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
