### PR TITLE
Update bluetooth_tracker.markdown

### DIFF
--- a/source/_integrations/bluetooth_tracker.markdown
+++ b/source/_integrations/bluetooth_tracker.markdown
@@ -43,7 +43,9 @@ device_id:
   default: "`-1` (The first available Bluetooth adapter)"
 {% endconfiguration %}
 
-In some cases it can be that your device is not discovered. In that case let your phone scan for Bluetooth devices while you restart Home Assistant. Just hit `Scan` on your phone all the time until Home Assistant is fully restarted and the device should appear in `known_devices.yaml`.
+In some cases it can be that your device is not discovered. In that case let your phone scan for Bluetooth devices while you restart Home Assistant. Just hit `Scan` on your phone all the time (or keep the Bluetooth device view open on an iOS device) until Home Assistant is fully restarted and the device should appear in `known_devices.yaml`.
+
+The integration will try to create an entity using the device name that is detected. If such an entity already exists (for example because you are already using the [Companion App](https://companion.home-assistant.io/) for this device) no entity will be created and the log file will show an error that the `The see service is not supported for this entity device_tracker.device` (as it is not a `device_tracker` entity). You can rename the other conflicting entity, next time the device is detected a new entity with the same name will be created.
 
 For additional configuration variables check the [Device tracker page](/integrations/device_tracker/).
 


### PR DESCRIPTION
Added info about conflicting entities, see this thread for more info:
https://community.home-assistant.io/t/new-97-2-setup-bluetooth-device-tracker-does-nothing/133921/7

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
