### PR TITLE
Add modbus climate hvac action and mode documentation

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -384,7 +384,7 @@ climates:
       type: [string]
       default: [`idle`]
     hvac_action_values:
-      description: "Register values that correspond to the hvac operations by your device, in order. If `off` is first in your `hvac_action_supported:` list, and is represented by a value of 0 in your device, use [0, ...]. See the example above."
+      description: "Register values that correspond to the HVAC operations by your device, in order. If `off` is first in your `hvac_action_supported:` list, and is represented by a value of 0 in your device, use [0, ...]. See the example above."
       required: false
       type: [integer]
     hvac_mode_register:

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -381,12 +381,12 @@ climates:
     hvac_action_supported:
       description: "List of current operations supported by your device. Options are `off`, `heating`, `cooling`, `drying`, `idle`, `fan`."
       required: false
-      type: list of strings
+      type: [string]
       default: [`idle`]
     hvac_action_values:
       description: "Register values that correspond to the hvac operations by your device, in order. If `off` is first in your `hvac_action_supported:` list, and is represented by a value of 0 in your device, use [0, ...]. See the example above."
       required: false
-      type: list of integers
+      type: [integer]
     hvac_mode_register:
       description: "Register address for the mode of the device."
       required: false
@@ -394,12 +394,12 @@ climates:
     hvac_mode_supported:
       description: "List of operations supported by your device. Options are `off`, `heat`, `cool`, `heat_cool`, `auto`, `dry`, `idle`, `fan_only`. If there is only one mode supported, be sure to include the brackets around it: [`heat`]"
       required: false
-      type: list of strings
+      type: [string]
       default: [`idle`]
     hvac_mode_values:
       description: "Register values that correspond to the operations supported by your device, in order. If `off` is first in your `hvac_mode_supported:` list, and is represented by a value of 0 in your device, use [0, ...]. See the example above."
       required: false
-      type: list of integers
+      type: [integer]
 {% endconfiguration %}
 
 #### Service `modbus.set-temperature`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This documentation pull request is in support of a pull request for home-assistant/core. The goal is to outline the use of a new feature: hvac_modes and hvac_actions being supported for modbus climate devices. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/52768
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
