### PR TITLE
Add MQTT humidifier documentation

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -149,8 +149,6 @@ Supported abbreviations:
     'hum_cmd_tpl':         'target_humidity_command_template',
     'hum_stat_t':          'target_humidity_state_topic',
     'hum_stat_tpl':        'target_humidity_state_template',
-    'hum_rng_max':         'humidity_range_max',
-    'hum_rng_min':         'humidity_range_min',
     'json_attr':           'json_attributes',
     'json_attr_t':         'json_attributes_topic',
     'json_attr_tpl':       'json_attributes_template',

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -164,7 +164,7 @@ Supported abbreviations:
     'mode_cmd_t':          'mode_command_topic',
     'mode_stat_tpl':       'mode_state_template',
     'mode_stat_t':         'mode_state_topic',
-    'avail_modes':               'available_modes',
+    'modes':               'modes',
     'name':                'name',
     'off_dly':             'off_delay',
     'on_cmd_type':         'on_command_type',

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -164,7 +164,7 @@ Supported abbreviations:
     'mode_cmd_t':          'mode_command_topic',
     'mode_stat_tpl':       'mode_state_template',
     'mode_stat_t':         'mode_state_topic',
-    'modes':               'modes',
+    'modes':               'available_modes',
     'name':                'name',
     'off_dly':             'off_delay',
     'on_cmd_type':         'on_command_type',

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -164,7 +164,7 @@ Supported abbreviations:
     'mode_cmd_t':          'mode_command_topic',
     'mode_stat_tpl':       'mode_state_template',
     'mode_stat_t':         'mode_state_topic',
-    'modes':               'available_modes',
+    'avail_modes':               'available_modes',
     'name':                'name',
     'off_dly':             'off_delay',
     'on_cmd_type':         'on_command_type',

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -15,6 +15,7 @@ Supported by MQTT discovery:
 - [Device Trackers](/integrations/device_tracker.mqtt/)
 - [Device Triggers](/integrations/device_trigger.mqtt/)
 - [Fans](/integrations/fan.mqtt/)
+- [Humidifiers](/integrations/humidifier.mqtt/)
 - [HVACs](/integrations/climate.mqtt/)
 - [Lights](/integrations/light.mqtt/)
 - [Locks](/integrations/lock.mqtt/)
@@ -144,6 +145,12 @@ Supported abbreviations:
     'hs_val_tpl':          'hs_value_template',
     'ic':                  'icon',
     'init':                'initial',
+    'hum_cmd_t':           'target_humidity_command_topic',
+    'hum_cmd_tpl':         'target_humidity_command_template',
+    'hum_stat_t':          'target_humidity_state_topic',
+    'hum_stat_tpl':        'target_humidity_state_template',
+    'hum_rng_max':         'humidity_range_max',
+    'hum_rng_min':         'humidity_range_min',
     'json_attr':           'json_attributes',
     'json_attr_t':         'json_attributes_topic',
     'json_attr_tpl':       'json_attributes_template',
@@ -151,10 +158,13 @@ Supported abbreviations:
     'min_mirs':            'min_mireds',
     'max_temp':            'max_temp',
     'min_temp':            'min_temp',
+    'max_hum':             'max_humidity',
+    'min_hum':             'min_humidity',
     'mode_cmd_tpl':        'mode_command_template',
     'mode_cmd_t':          'mode_command_topic',
     'mode_stat_tpl':       'mode_state_template',
     'mode_stat_t':         'mode_state_topic',
+    'modes':               'modes',
     'name':                'name',
     'off_dly':             'off_delay',
     'on_cmd_type':         'on_command_type',
@@ -191,6 +201,8 @@ Supported abbreviations:
     'pl_strt':             'payload_start',
     'pl_stpa':             'payload_start_pause',
     'pl_ret':              'payload_return_to_base',
+    'pl_rst_hum':          'payload_reset_humidity',
+    'pl_rst_mode':         'payload_reset_mode',    
     'pl_rst_pct':          'payload_reset_percentage',
     'pl_rst_pr_mode':      'payload_reset_preset_mode',
     'pl_toff':             'payload_turn_off',

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -102,21 +102,16 @@ device:
       description: 'Identifier of a device that routes messages between this device and Home Assistant. Examples of such devices are hubs, or parent devices of a sub-device. This is used to show device topology in Home Assistant.'
       required: false
       type: string
+device_class:
+  description: The device class of the MQTT device. Must be either `humidifier` or `dehumidifier`.
+  required: false
+  type: string
+  default: humidifier
 enabled_by_default:
   description: Flag which defines if the entity should be enabled when first added.
   required: false
   type: boolean
   default: true
-humidity_range_max:
-  description: The maximum of numeric output range for `target_humidity_command_topic` where `humidity_range_max` represents a target humidity of 100 %.
-  required: false
-  type: integer
-  default: 100
-humidity_range_min:
-  description: The minimum of numeric output range for `target_humidity_command_topic` where `humidity_range_min` represents a target humidity of 0 %.
-  required: false
-  type: integer
-  default: 0
 icon:
   description: "[Icon](/docs/configuration/customizing-devices/#icon) for the entity."
   required: false
@@ -266,6 +261,7 @@ The example below shows a full configuration for a MQTT humidifier including mod
 humidifier:
   - platform: mqtt
     name: "Bedroom humidifier"
+    device_class: "humidifier"
     state_topic: "bedroom_humidifier/on/state"
     command_topic: "bedroom_humidifier/on/set"
     target_humidity_command_topic: "bedroom_humidifier/humidity/set"
@@ -287,39 +283,6 @@ humidifier:
     payload_off: "false"
     min_humidity: 30
     max_humidity: 80
-```
-
-{% endraw %}
-
-### Using templates and humidity range
-
-This example demonstrates how to use a humidity range templates for devices with a limited target humidity range.
-
-The configuration below supports the following target humidity settings: [ `30`, `40`, `50`, `60`, `70`, `80`].
-
-The humidity range will transform the valid humidity settings in range from 30%..80% to a numeric range from 3..8.
-The target humidity command template ensures the numeric output payload on `target_humidity_command_topic` is multiplied with 10.
-
-When reading the target humidity state payload from `target_humidity_state_topic`, the target humidity value template ensures the received numeric payload is divided back to the numeric range.
-The humidity range setting converts this numeric value back to a valid target humidity.
-
-{% raw %}
-
-```yaml
-# Example configuration.yaml with templates and humidity range
-humidifier:
-  - platform: mqtt
-    name: "Bedroom humidifier"
-    command_topic: "bedroom_humidifier/on/set"
-    state_topic: "bedroom_humidifier/on/state"
-    target_humidity_command_topic: "bedroom_humidifier/humidity/set"
-    target_humidity_state_topic: "bedroom_humidifier/humidity/state"
-    target_humidity_command_template: "{{ value * 10 }}"
-    target_humidity_state_template: "{{ float(value) / 10 | int }}"
-    min_humidity: 30
-    max_humidity: 80
-    humidity_range_min: 0
-    humidity_range_max: 10       
 ```
 
 {% endraw %}

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -3,7 +3,7 @@ title: "MQTT Humidifier"
 description: "Instructions on how to integrate MQTT humidifiers into Home Assistant."
 ha_category:
   - Humidifier
-ha_release: 2021.8.0
+ha_release: 2021.8
 ha_iot_class: Configurable
 ha_domain: mqtt
 ---

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -49,7 +49,7 @@ availability:
       required: true
       type: string
 available_modes:
-  description: List of modes this humidifier is capable of running at. Common examples include `normal`, `eco`, `away`, `boost`, `comfort`, `home`, `sleep`, `auto` and `baby`. These examples offer built-in translations but other custom modes are allowed as well.
+  description: List of available modes this humidifier is capable of running at. Common examples include `normal`, `eco`, `away`, `boost`, `comfort`, `home`, `sleep`, `auto` and `baby`. These examples offer built-in translations but other custom modes are allowed as well.
   required: false
   type: [list]
   default: []

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -1,0 +1,320 @@
+---
+title: "MQTT Humidifier"
+description: "Instructions on how to integrate MQTT humidifiers into Home Assistant."
+ha_category:
+  - Humidifier
+ha_release: 2021.8.0
+ha_iot_class: Configurable
+ha_domain: mqtt
+---
+
+The `mqtt` humidifier platform lets you control your MQTT enabled humidifiers.
+
+## Configuration
+
+In an ideal scenario, the MQTT device will have a `state_topic` to publish state changes. If these messages are published with a `RETAIN` flag, the MQTT humidifier will receive an instant state update after subscription and will start with the correct state. Otherwise, the initial state of the humidifier will be `false` / `off`.
+
+When a `state_topic` is not available, the humidifier will work in optimistic mode. In this mode, the humidifier will immediately change state after every command. Otherwise, the humidifier will wait for state confirmation from the device (message from `state_topic`).
+
+Optimistic mode can be forced even if a `state_topic` is available. Try to enable it if you are experiencing incorrect humidifier operation.
+
+To enable MQTT humidifiers in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+humidifier:
+  - platform: mqtt
+    command_topic: "bedroom_humidifier/on/set"
+    target_humidity_command_topic: "bedroom_humidifier/humidity/set"
+```
+
+{% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
+availability_mode:
+  description: When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all`, `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any`, `payload_available` must be received on at least one configured availability topic before the entity is marked as online. If set to `latest`, the last `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
+  required: false
+  type: string
+  default: latest
+availability_topic:
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
+  required: false
+  type: string
+command_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to generate the payload to send to `command_topic`.
+  required: false
+  type: template
+command_topic:
+  description: The MQTT topic to publish commands to change the humidifier state.
+  required: true
+  type: string
+device:
+  description: "Information about the device this humidifier is a part of to tie it into the [device registry](https://developers.home-assistant.io/docs/en/device_registry_index.html). Only works through [MQTT discovery](/docs/mqtt/discovery/) and when [`unique_id`](#unique_id) is set. At least one of identifiers or connections must be present to identify the device."
+  required: false
+  type: map
+  keys:
+    connections:
+      description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
+      required: false
+      type: [list, map]
+    identifiers:
+      description: A list of IDs that uniquely identify the device. For example a serial number.
+      required: false
+      type: [string, list]
+    manufacturer:
+      description: The manufacturer of the device.
+      required: false
+      type: string
+    model:
+      description: The model of the device.
+      required: false
+      type: string
+    name:
+      description: The name of the device.
+      required: false
+      type: string
+    suggested_area:
+      description: 'Suggest an area if the device isn’t in one yet.'
+      required: false
+      type: string
+    sw_version:
+      description: The firmware version of the device.
+      required: false
+      type: string
+    via_device:
+      description: 'Identifier of a device that routes messages between this device and Home Assistant. Examples of such devices are hubs, or parent devices of a sub-device. This is used to show device topology in Home Assistant.'
+      required: false
+      type: string
+enabled_by_default:
+  description: Flag which defines if the entity should be enabled when first added.
+  required: false
+  type: boolean
+  default: true
+humidity_range_max:
+  description: The maximum of numeric output range for `target_humidity_command_topic` where `humidity_range_max` represents a target humidity of 100 %.
+  required: false
+  type: integer
+  default: 100
+humidity_range_min:
+  description: The minimum of numeric output range for `target_humidity_command_topic` where `humidity_range_min` represents a target humidity of 0 %.
+  required: false
+  type: integer
+  default: 0
+icon:
+  description: "[Icon](/docs/configuration/customizing-devices/#icon) for the entity."
+  required: false
+  type: icon
+json_attributes_template:
+  description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the JSON dictionary from messages received on the `json_attributes_topic`. Usage example can be found in [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-template-configuration) documentation."
+  required: false
+  type: template
+json_attributes_topic:
+  description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor attributes. Usage example can be found in [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-topic-configuration) documentation.
+  required: false
+  type: string
+max_humidity:
+  description: The minimum target humidity percentage that can be set.
+  required: false
+  type: integer
+  default: 100
+min_humidity:
+  description: The maximum target humidity percentage that can be set.
+  required: false
+  type: integer
+  default: 0
+name:
+  description: The name of the humidifier.
+  required: false
+  type: string
+  default: MQTT humidifier
+optimistic:
+  description: Flag that defines if humidifier works in optimistic mode
+  required: false
+  type: boolean
+  default: "`true` if no state topic defined, else `false`."
+payload_available:
+  description: The payload that represents the available state.
+  required: false
+  type: string
+  default: online
+payload_not_available:
+  description: The payload that represents the unavailable state.
+  required: false
+  type: string
+  default: offline
+payload_off:
+  description: The payload that represents the stop state.
+  required: false
+  type: string
+  default: "OFF"
+payload_on:
+  description: The payload that represents the running state.
+  required: false
+  type: string
+  default: "ON"
+payload_reset_humidity:
+  description: A special payload that resets the `target_humidity` state attribute to `None` when received at the `target_humidity_state_topic`.
+  required: false
+  type: string
+  default: 'None'
+payload_reset_mode:
+  description: A special payload that resets the `mode` state attribute to `None` when received at the `mode_state_topic`.
+  required: false
+  type: string
+  default: 'None'
+target_humidity_command_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to generate the payload to send to `target_humidity_command_topic`.
+  required: false
+  type: template
+target_humidity_command_topic:
+  description: The MQTT topic to publish commands to change the humidifier target humidity state based on a percentage.
+  required: true
+  type: string
+target_humidity_state_topic:
+  description: The MQTT topic subscribed to receive humidifier target humidity.
+  required: false
+  type: string
+target_humidity_value_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value for the humidifier `target_humidity` state.
+  required: false
+  type: string
+mode_command_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to generate the payload to send to `mode_command_topic`.
+  required: false
+  type: template
+mode_command_topic:
+  description: The MQTT topic to publish commands to change the `mode` on the humidifier.
+  required: false
+  type: string
+mode_state_topic:
+  description: The MQTT topic subscribed to receive the humidifier `mode`.
+  required: false
+  type: string
+mode_value_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value for the humidifier `mode` state.
+  required: false
+  type: string
+modes:
+  description: List of modes this humidifier is capable of running at. Common examples include `normal`, `eco`, `away`, `boost`, `comfort`, `home`, `sleep`, `auto` and `baby`. These examples offer built-in translations but other custom modes are allowed as well.
+  required: false
+  type: [list]
+  default: []
+qos:
+  description: The maximum QoS level of the state topic.
+  required: false
+  type: integer
+  default: 0
+retain:
+  description: If the published message should have the retain flag on or not.
+  required: false
+  type: boolean
+  default: true
+state_topic:
+  description: The MQTT topic subscribed to receive state updates.
+  required: false
+  type: string
+state_value_template:
+  description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the state."
+  required: false
+  type: string
+unique_id:
+  description: An ID that uniquely identifies this humidifier. If two humidifiers have the same unique ID, Home Assistant will raise an exception.
+  required: false
+  type: string
+{% endconfiguration %}
+
+<div class='note warning'>
+
+Make sure that your topics match exactly. `some-topic/` and `some-topic` are different topics.
+
+</div>
+
+## Examples
+
+In this section you find some real-life examples of how to use this humidifier.
+
+### Full configuration
+
+The example below shows a full configuration for a MQTT humidifier including modes.
+
+{% raw %}
+
+```yaml
+# Example configuration.yaml
+humidifier:
+  - platform: mqtt
+    name: "Bedroom humidifier"
+    state_topic: "bedroom_humidifier/on/state"
+    command_topic: "bedroom_humidifier/on/set"
+    target_humidity_command_topic: "bedroom_humidifier/humidity/set"
+    target_humidity_state_topic: "bedroom_humidifier/humidity/state"
+    mode_state_topic: "bedroom_humidifier/mode/state"
+    mode_command_topic: "bedroom_humidifier/preset/preset_mode"
+    modes:
+      - "normal"
+      - "eco"
+      - "away"
+      - "boost"
+      - "comfort"
+      - "home"
+      - "sleep"
+      - "auto"
+      - "baby"
+    qos: 0
+    payload_on: "true"
+    payload_off: "false"
+    min_humidity: 30
+    max_humidity: 80
+```
+
+{% endraw %}
+
+### Using templates and humidity range
+
+This example demonstrates how to use a humidity range templates for devices with a limited target humidity range.
+
+The configuration below supports the following target humidity settings: [ `30`, `40`, `50`, `60`, `70`, `80`].
+
+The humidity range will transform the valid humidity settings in range from 30%..80% to a numeric range from 3..8.
+The target humidity command template ensures the numeric output payload on `target_humidity_command_topic` is multiplied with 10.
+
+When reading the target humidity state payload from `target_humidity_state_topic`, the target humidity value template ensures the received numeric payload is divided back to the numeric range.
+The humidity range setting converts this numeric value back to a valid target humidity.
+
+{% raw %}
+
+```yaml
+# Example configuration.yaml with templates and humidity range
+humidifier:
+  - platform: mqtt
+    name: "Bedroom humidifier"
+    command_topic: "bedroom_humidifier/on/set"
+    state_topic: "bedroom_humidifier/on/state"
+    target_humidity_command_topic: "bedroom_humidifier/humidity/set"
+    target_humidity_state_topic: "bedroom_humidifier/humidity/state"
+    target_humidity_command_template: "{{ value * 10 }}"
+    target_humidity_value_template: "{{ float(value) / 10 | int }}"
+    min_humidity: 30
+    max_humidity: 80
+    humidity_range_min: 0
+    humidity_range_max: 10       
+```
+
+{% endraw %}

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -48,11 +48,6 @@ availability:
       description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
-available_modes:
-  description: List of available modes this humidifier is capable of running at. Common examples include `normal`, `eco`, `away`, `boost`, `comfort`, `home`, `sleep`, `auto` and `baby`. These examples offer built-in translations but other custom modes are allowed as well.
-  required: false
-  type: [list]
-  default: []
 availability_mode:
   description: When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all`, `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any`, `payload_available` must be received on at least one configured availability topic before the entity is marked as online. If set to `latest`, the last `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
   required: false
@@ -144,6 +139,11 @@ min_humidity:
   required: false
   type: integer
   default: 0
+modes:
+  description: List of available modes this humidifier is capable of running at. Common examples include `normal`, `eco`, `away`, `boost`, `comfort`, `home`, `sleep`, `auto` and `baby`. These examples offer built-in translations but other custom modes are allowed as well.
+  required: false
+  type: [list]
+  default: []
 name:
   description: The name of the humidifier.
   required: false
@@ -205,7 +205,7 @@ mode_command_template:
   required: false
   type: template
 mode_command_topic:
-  description: The MQTT topic to publish commands to change the `mode` on the humidifier.
+  description: The MQTT topic to publish commands to change the `mode` on the humidifier. This attribute ust be configured together with the `modes` attribute.
   required: false
   type: string
 mode_state_topic:
@@ -216,6 +216,11 @@ mode_value_template:
   description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value for the humidifier `mode` state.
   required: false
   type: string
+modes:
+  description: List of available modes this humidifier is capable of running at. Common examples include `normal`, `eco`, `away`, `boost`, `comfort`, `home`, `sleep`, `auto` and `baby`. These examples offer built-in translations but other custom modes are allowed as well.  This attribute ust be configured together with the `mode_command_topic` attribute.
+  required: false
+  type: [list]
+  default: []
 qos:
   description: The maximum QoS level of the state topic.
   required: false
@@ -267,7 +272,7 @@ humidifier:
     target_humidity_state_topic: "bedroom_humidifier/humidity/state"
     mode_state_topic: "bedroom_humidifier/mode/state"
     mode_command_topic: "bedroom_humidifier/preset/preset_mode"
-    available_modes:
+    modes:
       - "normal"
       - "eco"
       - "away"
@@ -310,7 +315,7 @@ humidifier:
     target_humidity_command_topic: "bedroom_humidifier/humidity/set"
     target_humidity_state_topic: "bedroom_humidifier/humidity/state"
     target_humidity_command_template: "{{ value * 10 }}"
-    target_humidity_value_template: "{{ float(value) / 10 | int }}"
+    target_humidity_state_template: "{{ float(value) / 10 | int }}"
     min_humidity: 30
     max_humidity: 80
     humidity_range_min: 0

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -48,6 +48,11 @@ availability:
       description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
+available_modes:
+  description: List of modes this humidifier is capable of running at. Common examples include `normal`, `eco`, `away`, `boost`, `comfort`, `home`, `sleep`, `auto` and `baby`. These examples offer built-in translations but other custom modes are allowed as well.
+  required: false
+  type: [list]
+  default: []
 availability_mode:
   description: When `availability` is configured, this controls the conditions needed to set the entity to `available`. Valid entries are `all`, `any`, and `latest`. If set to `all`, `payload_available` must be received on all configured availability topics before the entity is marked as online. If set to `any`, `payload_available` must be received on at least one configured availability topic before the entity is marked as online. If set to `latest`, the last `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
   required: false
@@ -211,11 +216,6 @@ mode_value_template:
   description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value for the humidifier `mode` state.
   required: false
   type: string
-modes:
-  description: List of modes this humidifier is capable of running at. Common examples include `normal`, `eco`, `away`, `boost`, `comfort`, `home`, `sleep`, `auto` and `baby`. These examples offer built-in translations but other custom modes are allowed as well.
-  required: false
-  type: [list]
-  default: []
 qos:
   description: The maximum QoS level of the state topic.
   required: false
@@ -267,7 +267,7 @@ humidifier:
     target_humidity_state_topic: "bedroom_humidifier/humidity/state"
     mode_state_topic: "bedroom_humidifier/mode/state"
     mode_command_topic: "bedroom_humidifier/preset/preset_mode"
-    modes:
+    available_modes:
       - "normal"
       - "eco"
       - "away"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the new MQTT humidifier platform integration,

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/52828
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
