### PR TITLE
MQTT Fan docs - sorted config and small text corrections

### DIFF
--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -270,8 +270,6 @@ In this section you find some real-life examples of how to use this fan.
 The example below shows a full configuration for a MQTT fan using percentage and preset modes.
 There are 10 speeds within the speed range, so  `percentage_step` = 100 / 10 steps = 10.0 %.
 
-{% raw %}
-
 ```yaml
 # Example using percentage based speeds with preset modes configuration.yaml
 fan:
@@ -299,8 +297,6 @@ fan:
     speed_range_min: 1
     speed_range_max: 10
 ```
-
-{% endraw %}
 
 ### Configuration using command templates
 

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -197,7 +197,7 @@ percentage_state_topic:
   required: false
   type: string
 percentage_value_template:
-  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from fan percentage speed.
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the `percentage` value from the payload received on `percentage_state_topic`.
   required: false
   type: string
 preset_mode_command_template:
@@ -213,7 +213,7 @@ preset_mode_state_topic:
   required: false
   type: string
 preset_mode_value_template:
-  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the preset_mode payload.
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the `preset_mode` value from the payload received on `preset_mode_state_topic`.
   required: false
   type: string
 preset_modes:
@@ -231,16 +231,16 @@ retain:
   required: false
   type: boolean
   default: true
-speed_range_min:
-  description: The minimum of numeric output range (`off` not included, so `speed_range_min` - 1 represents 0%). The number of speeds within the speed_range / 100 will determine the `percentage_step`.
-  required: false
-  type: integer
-  default: 1
 speed_range_max:
-  description: The maximum of numeric output range (representing 100%). The number of speeds within the speed_range / 100 will determine the `percentage_step`.
+  description: The maximum of numeric output range (representing 100 %). The number of speeds within the `speed_range` / `100` will determine the `percentage_step`.
   required: false
   type: integer
   default: 100
+speed_range_min:
+  description: The minimum of numeric output range (`off` not included, so `speed_range_min` - `1` represents 0 %). The number of speeds within the speed_range / 100 will determine the `percentage_step`.
+  required: false
+  type: integer
+  default: 1
 state_topic:
   description: The MQTT topic subscribed to receive state updates.
   required: false
@@ -270,6 +270,8 @@ In this section you find some real-life examples of how to use this fan.
 The example below shows a full configuration for a MQTT fan using percentage and preset modes.
 There are 10 speeds within the speed range, so  `percentage_step` = 100 / 10 steps = 10.0 %.
 
+{% raw %}
+
 ```yaml
 # Example using percentage based speeds with preset modes configuration.yaml
 fan:
@@ -298,13 +300,16 @@ fan:
     speed_range_max: 10
 ```
 
-{% raw %}
+{% endraw %}
+
+### Configuration using command templates
 
 This example demonstrates how to use command templates with JSON output.
 
+{% raw %}
+
 ```yaml
-# Example configuration.yaml
-# Example using command templates
+# Example configuration.yaml with command templates
 fan:
   - platform: mqtt
     name: "Bedroom Fan"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
MQTT Fan docs update:

- Small text corrections/improvements
- Sorted configuration attributes

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
