### PR TITLE
Document automation trigger ID template variables

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -9,6 +9,15 @@ Automations support [templating](/docs/configuration/templating/) in the same wa
 
 The following tables show the available trigger data per platform.
 
+### All
+
+The following describes trigger data associated with all platforms.
+
+| Template variable | Data |
+| ---- | ---- |
+| `trigger.id` | Optional trigger `id`, or index of the trigger.
+| `trigger.idx` | Index of the trigger.
+
 ### Event
 
 | Template variable | Data |
@@ -113,12 +122,15 @@ automation:
   trigger:
     - platform: state
       entity_id: device_tracker.paulus
+      id: paulus_device
   action:
     - service: notify.notify
       data:
         message: >
           Paulus just changed from {{ trigger.from_state.state }}
           to {{ trigger.to_state.state }}
+          
+          This was triggered by {{ trigger.id }}
 
 automation 2:
   trigger:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This documents the trigger IDs and index variables [available in trigger_data]((https://github.com/home-assistant/core/blob/master/homeassistant/helpers/trigger.py#L79)) for all trigger platforms in templating.  This was was mentioned in the [2021.7 release notes](https://www.home-assistant.io/blog/2021/07/07/release-20217/#trigger-conditions-and-trigger-ids).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue:  Feature request https://community.home-assistant.io/t/trigger-variable-to-have-access-to-trigger-id/321404

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
