### PR TITLE
Mark Tasmota PR adding support for color_mode white and removing support for rgbw as breaking

### DIFF
--- a/source/_posts/2021-07-07-release-20217.markdown
+++ b/source/_posts/2021-07-07-release-20217.markdown
@@ -918,6 +918,29 @@ you might need to adjust them.
 
 {% enddetails %}
 
+{% details "Tasmota" %}
+
+Tasmota doesn't support independent control of all four channels of an RGBW light,
+so `rgbw_color` was a very poor fit for it and gave counter-intuitive results.
+Tasmota lights supporting color and white will now be added as a light supporting
+color modes `hs` and `white`, not as a light supporting color_mode `rgbw`.
+now supports setting `white` instead.
+
+Scenes setting a Tasmota light can updated by using the scene UI editor.
+
+Automations setting a Tasmota light need to be updated manually, to set a light to white mode do:
+```yaml
+  - service: light.turn_on
+    target:
+      entity_id: light.genbbc05
+    data:
+      white: 242
+```
+
+([@emontnemery] - [#51608]) ([tasmota docs])
+
+{% enddetails %}
+
 {% details "Switcher" %}
 
 In preparation for multi-device support, configuration via the UI and support

--- a/source/_posts/2021-07-07-release-20217.markdown
+++ b/source/_posts/2021-07-07-release-20217.markdown
@@ -926,7 +926,7 @@ Tasmota lights supporting color and white will now be added as a light supportin
 color modes `hs` and `white`, not as a light supporting color_mode `rgbw`.
 now supports setting `white` instead.
 
-Scenes setting a Tasmota light can updated by using the scene UI editor.
+Scenes setting a Tasmota light can be updated by using the scene UI editor.
 
 Automations setting a Tasmota light need to be updated manually, to set a light to white mode do:
 ```yaml


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Mark Tasmota PR adding support for color_mode white and removing support for rgbw as breaking


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
