### PR TITLE
Add documentation on new template functions for devices

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -18,6 +18,15 @@ The following describes trigger data associated with all platforms.
 | `trigger.id` | Optional trigger `id`, or index of the trigger.
 | `trigger.idx` | Index of the trigger.
 
+### Device
+
+| Template variable | Data |
+| ---- | ---- |
+| `trigger.platform` | Hardcoded: `device`.
+| `trigger.event` | Event object that matched.
+| `trigger.event.event_type` | Event type.
+| `trigger.event.data` | Optional event data.
+
 ### Event
 
 | Template variable | Data |

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -207,6 +207,26 @@ The same thing can also be expressed as a filter:
 
 {% endraw %}
 
+### Devices
+
+- `device_entities(device_id)` returns a list of entities that are associated with a given device ID. Can also be used as a filter.
+- `device_attr(device_id, attr_name)` returns the value of `attr_name` for the given device ID in the device registry. Not supported in [limited templates](#limited-templates).
+- `is_device_attr(device_id, attr_name, attr_value)` returns whether the value of `attr_name` for the given device ID matches `attr_value`. Not supported in [limited templates](#limited-templates).
+
+#### Devices examples
+
+{% raw %}
+
+```text
+{{ state_attr('deadbeefdeadbeefdeadbeefdeadbeef', 'manufacturer') }}  # Sony
+```
+
+```text
+{{ is_state_attr('deadbeefdeadbeefdeadbeefdeadbeef', 'manufacturer', 'Sony') }}  # true
+```
+
+{% endraw %}
+
 ### Time
 
 `now()` and `utcnow()` are not supported in [limited templates](#limited-templates).

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -210,8 +210,9 @@ The same thing can also be expressed as a filter:
 ### Devices
 
 - `device_entities(device_id)` returns a list of entities that are associated with a given device ID. Can also be used as a filter.
-- `device_attr(device_id, attr_name)` returns the value of `attr_name` for the given device ID in the device registry. Not supported in [limited templates](#limited-templates).
-- `is_device_attr(device_id, attr_name, attr_value)` returns whether the value of `attr_name` for the given device ID matches `attr_value`. Not supported in [limited templates](#limited-templates).
+- `device_attr(device_or_entity_id, attr_name)` returns the value of `attr_name` for the given device or entity ID. Not supported in [limited templates](#limited-templates).
+- `is_device_attr(device_or_entity_id, attr_name, attr_value)` returns whether the value of `attr_name` for the given device or entity ID matches `attr_value`. Not supported in [limited templates](#limited-templates).
+- `to_device_id(entity_id)` returns the device ID for a given entity ID. Can also be used as a filter
 
 #### Devices examples
 
@@ -223,6 +224,10 @@ The same thing can also be expressed as a filter:
 
 ```text
 {{ is_device_attr('deadbeefdeadbeefdeadbeefdeadbeef', 'manufacturer', 'Sony') }}  # true
+```
+
+```text
+{{ to_device_id('sensor.sony') }}  # deadbeefdeadbeefdeadbeefdeadbeef
 ```
 
 {% endraw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -212,7 +212,7 @@ The same thing can also be expressed as a filter:
 - `device_entities(device_id)` returns a list of entities that are associated with a given device ID. Can also be used as a filter.
 - `device_attr(device_or_entity_id, attr_name)` returns the value of `attr_name` for the given device or entity ID. Not supported in [limited templates](#limited-templates).
 - `is_device_attr(device_or_entity_id, attr_name, attr_value)` returns whether the value of `attr_name` for the given device or entity ID matches `attr_value`. Not supported in [limited templates](#limited-templates).
-- `to_device_id(entity_id)` returns the device ID for a given entity ID. Can also be used as a filter
+- `device_id(entity_id)` returns the device ID for a given entity ID. Can also be used as a filter
 
 #### Devices examples
 
@@ -227,7 +227,7 @@ The same thing can also be expressed as a filter:
 ```
 
 ```text
-{{ to_device_id('sensor.sony') }}  # deadbeefdeadbeefdeadbeefdeadbeef
+{{ device_id('sensor.sony') }}  # deadbeefdeadbeefdeadbeefdeadbeef
 ```
 
 {% endraw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -212,7 +212,7 @@ The same thing can also be expressed as a filter:
 - `device_entities(device_id)` returns a list of entities that are associated with a given device ID. Can also be used as a filter.
 - `device_attr(device_or_entity_id, attr_name)` returns the value of `attr_name` for the given device or entity ID. Not supported in [limited templates](#limited-templates).
 - `is_device_attr(device_or_entity_id, attr_name, attr_value)` returns whether the value of `attr_name` for the given device or entity ID matches `attr_value`. Not supported in [limited templates](#limited-templates).
-- `device_id(entity_id)` returns the device ID for a given entity ID. Can also be used as a filter
+- `to_device_id(entity_id)` returns the device ID for a given entity ID. Can also be used as a filter
 
 #### Devices examples
 
@@ -227,7 +227,7 @@ The same thing can also be expressed as a filter:
 ```
 
 ```text
-{{ device_id('sensor.sony') }}  # deadbeefdeadbeefdeadbeefdeadbeef
+{{ to_device_id('sensor.sony') }}  # deadbeefdeadbeefdeadbeefdeadbeef
 ```
 
 {% endraw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -218,11 +218,11 @@ The same thing can also be expressed as a filter:
 {% raw %}
 
 ```text
-{{ state_attr('deadbeefdeadbeefdeadbeefdeadbeef', 'manufacturer') }}  # Sony
+{{ device_attr('deadbeefdeadbeefdeadbeefdeadbeef', 'manufacturer') }}  # Sony
 ```
 
 ```text
-{{ is_state_attr('deadbeefdeadbeefdeadbeefdeadbeef', 'manufacturer', 'Sony') }}  # true
+{{ is_device_attr('deadbeefdeadbeefdeadbeefdeadbeef', 'manufacturer', 'Sony') }}  # true
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
In the linked PR we add some new template functions that allow templates access to the DeviceRegistry. While implementing this, I found the `device_entities` function/filter that was also undocumented so I added some notes on that as well.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/53131
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
