### PR TITLE
Clean up device vs entity mixup in older documentation

### DIFF
--- a/source/_docs/configuration/devices.markdown
+++ b/source/_docs/configuration/devices.markdown
@@ -3,16 +3,16 @@ title: "Adding devices to Home Assistant"
 description: "Steps to help you get your devices in Home Assistant."
 ---
 
-Home Assistant will be able to automatically discover many devices and services available on your network if you have [the discovery component](/integrations/discovery/) enabled (the default setting).
+Home Assistant will be able to automatically discover many devices and services
+available on your network.
 
-See the [integrations overview page](/integrations/) to find installation instructions for your devices and services. If you can't find support for your favorite device or service, [consider adding support](/developers/add_new_platform/).
+See the [integrations overview page](/integrations/) to find installation
+instructions for your devices and services. Most integration can be
+fully configured via the user interface these days; however, some older or
+more complex integrations may need to be configured manually using YAML.
 
-Classification for the available integrations:
-
-- [IoT class](/blog/2016/02/12/classifying-the-internet-of-things): Classifier for the device's behavior.
-- [Quality scale](/docs/quality_scale/): Representation of the integration's quality.
-
-Usually every entity needs its own entry in the `configuration.yaml` file. There are two styles for multiple entries:
+For some of these integrations, every entity needs its own entry in the
+`configuration.yaml` file. There are two styles for multiple entity entries:
 
 ## Style 1: Collect every entity under the "parent"
 
@@ -32,9 +32,10 @@ switch:
   - platform: vera
 ```
 
-## Style 2: List each device separately
+## Style 2: List each entity separately
 
-You need to append numbers or strings to differentiate the entries, as in the example below. The appended number or string must be unique.
+You need to append numbers or strings to differentiate the entries, as in the
+example below. The appended number or string must be unique.
 
 ```yaml
 sensor bedroom:
@@ -59,10 +60,12 @@ switch 2:
   platform: vera
 ```
 
-## Grouping devices
+## Grouping entities
 
-Once you have several devices set up, it is time to organize them into groups.
-Each group consists of a name and a list of entity IDs. Entity IDs can be retrieved from the web interface by using the {% my developer_states title="States page in the Developer Tools" %}.
+Once you have several entities set up, it is time to organize them into groups.
+Each group consists of a name and a list of entity IDs. Entity IDs can be
+retrieved from the web interface by using the
+{% my developer_states title="States page in the Developer Tools" %}.
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Eventually, this documentation needs to go... 👋 

However, for now, I agree with the report in #17865, the way devices & entities are mixed up in terminology, is really confusing.

This is probably caused that we didn't have "devices" in Home Assistant back in the day.

This PR aims to at least remove the confusion and add some consistency.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #17865

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
