### PR TITLE
Add unique ID support to light, cover and media player groups

### DIFF
--- a/source/_integrations/cover.group.markdown
+++ b/source/_integrations/cover.group.markdown
@@ -23,15 +23,19 @@ cover:
 ```
 
 {% configuration %}
-  name:
-    description: Name to use in the frontend.
-    required: false
-    type: string
-    default: "Cover Group"
-  entities:
-    description: List of all cover entities you want to control.
-    required: true
-    type: [string, list]
+entities:
+  description: List of all cover entities you want to control.
+  required: true
+  type: [string, list]
+name:
+  description: Name to use in the frontend.
+  required: false
+  type: string
+  default: "Cover Group"
+unique_id:
+  description: An ID that uniquely identifies this cover group. If two covers have the same unique ID, Home Assistant will raise an error.
+  required: false
+  type: string
 {% endconfiguration %}
 
 ## Functionality

--- a/source/_integrations/light.group.markdown
+++ b/source/_integrations/light.group.markdown
@@ -26,14 +26,18 @@ light:
 ```
 
 {% configuration %}
-  name:
-    description: The name of the light group. Defaults to "Light Group".
-    required: false
-    type: string
-  entities:
-    description: A list of entities to be included in the light group.
-    required: true
-    type: [string, list]
+entities:
+  description: A list of entities to be included in the light group.
+  required: true
+  type: [string, list]
+name:
+  description: The name of the light group. Defaults to "Light Group".
+  required: false
+  type: string
+unique_id:
+  description: An ID that uniquely identifies this light group. If two lights have the same unique ID, Home Assistant will raise an error.
+  required: false
+  type: string
 {% endconfiguration %}
 
 <p class='img'>

--- a/source/_integrations/media_player.group.markdown
+++ b/source/_integrations/media_player.group.markdown
@@ -23,14 +23,18 @@ media_player:
 ```
 
 {% configuration %}
-  name:
-    description: The name of the media player group. Defaults to "Media Group".
-    required: false
-    type: string
-  entities:
-    description: A list of entities to be included in the media player group.
-    required: true
-    type: [string, list]
+entities:
+  description: A list of entities to be included in the media player group.
+  required: true
+  type: [string, list]
+name:
+  description: The name of the media player group. Defaults to "Media Group".
+  required: false
+  type: string
+unique_id:
+  description: An ID that uniquely identifies this media player group. If two media players have the same unique ID, Home Assistant will raise an error.
+  required: false
+  type: string
 {% endconfiguration %}
 
 ## Script Example


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the added `unique_id` configuration option for our domain-specific groups.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/53225
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
