### PR TITLE
Fix docker command

### DIFF
--- a/source/_includes/installation/container/cli.md
+++ b/source/_includes/installation/container/cli.md
@@ -4,11 +4,11 @@
   content: |
 
     ```bash
-    docker run --init -d \
+    docker run -d \
       --name homeassistant \
       --privileged \
       --restart=unless-stopped \
-      -v /etc/localtime:/etc/localtime:ro \
+      -e TZ=MY_TIME_ZONE \
       -v /PATH_TO_YOUR_CONFIG:/config \
       --network=host \
       {{ include.image | default: site.installation.container.base }}:{{ include.tag | default: 'stable' }}
@@ -34,12 +34,12 @@
 
     ```bash
     # finally, start a new one
-    docker run --init -d \
+    docker run -d \
       --name homeassistant \
       --restart=unless-stopped \
       --privileged \
+      -e TZ=MY_TIME_ZONE \
       -v /PATH_TO_YOUR_CONFIG:/config \
-      -v /etc/localtime:/etc/localtime:ro \
       --network=host \
       {{ include.image | default: site.installation.container.base }}:{{ include.tag | default: 'stable' }}
     ```


### PR DESCRIPTION
## Proposed change

We use our own init system, with the `--init` command, we run now an init system in a init system. It's better to use the TZ env variable for timezone as copy the hole folder from OS into container which is maybe not the same OS and could run into issues with the format.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
