### PR TITLE
Update prometheus configuration example for version 2.26+

### DIFF
--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -172,7 +172,9 @@ You can then configure Prometheus to fetch metrics from Home Assistant by adding
     static_configs:
       - targets: ['HOSTNAME:8123']
 ```
-The format to configure the bearer token have changed in Prometheus 2.26, so if you have a newer version, you can use this configuration sample: 
+
+The format to configure the bearer token has changed in Prometheus 2.26, so if you have a newer version, you can use this configuration sample:
+
 ```yaml
 # Example Prometheus scrape_configs entry (For version 2.26+
   - job_name: "hass"

--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -172,6 +172,21 @@ You can then configure Prometheus to fetch metrics from Home Assistant by adding
     static_configs:
       - targets: ['HOSTNAME:8123']
 ```
+The format to configure the bearer token have changed in Prometheus 2.26, so if you have a newer version, you can use this configuration sample: 
+```yaml
+# Example Prometheus scrape_configs entry (For version 2.26+
+  - job_name: "hass"
+    scrape_interval: 60s
+    metrics_path: /api/prometheus
+
+    # Long-Lived Access Token
+    authorization:
+      credentials: "your.longlived.token"
+
+    scheme: https
+    static_configs:
+      - targets: ['HOSTNAME:8123']
+```
 
 When looking into the metrics on the Prometheus side, there will be:
 


### PR DESCRIPTION
The bearer token configuration entry have changed format in the latest Prometheus (starting at version 2.26). 
Instead of bearer_token:, it needs a authorization: credentials: entry.

## Proposed change
Add a configuration sample for prometheus 2.26+


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
