### PR TITLE
Add Silicon Labs SLUSB7000A to the supported list

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -11,18 +11,13 @@ This Z-Wave integration is deprecated and replaced with a [new implementation ba
 
 ## Supported Z-Wave USB Sticks & Hardware Modules
 
-You need to have a compatible Z-Wave stick or module installed. This needs to be a *static controller*, which most Z-Wave sticks and modules will be. If yours is a *bridge* device then it won't work with [OpenZWave](http://openzwave.com/), which is what provides Home Assistant's Z-Wave capabilities. USB sticks using the new 700 series Z-Wave platform are not compatible. The following devices have been confirmed to work:
+You need to have a compatible Z-Wave stick or module installed. This needs to be a *static controller*, which most Z-Wave sticks and modules will be. If yours is a *bridge* device then it won't work with [OpenZWave](http://openzwave.com/), which is what provides Home Assistant's Z-Wave capabilities. The following devices have been confirmed to work:
 
-<div class='note'>
-  
-There are [known compatibility issues](https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=245031#p1502030) with older hardware versions of the Aeotec stick not working on the Raspberry Pi 4. Aeotec has released a 2020 hardware revision ZW090-A/B/C Gen5+ with Pi 4 compatibility. Both hardware revisions are still being sold, make informed purchasing decisions if using paired with a Pi 4.
-
-</div>
-
-- Aeotec Z-Stick Series 5
+- Aeotec Z-Stick Series 5 (see note below)
 - Everspring USB stick - Gen 5
 - GoControl HUSBZB-1 stick
 - Sigma Designs UZB stick
+- Silicon Labs SLUSB7000A 
 - Vision USB stick - Gen5
 - Zooz Z-Wave Plus S2 stick ZST10
 - ZWave.me Razberry Board
@@ -46,6 +41,12 @@ The alternative to a stick is a hub that supports Z-Wave. Home Assistant support
 ## Controller Notes
 
 ### Aeotec Stick
+
+<div class='note'>
+  
+There are [known compatibility issues](https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=245031#p1502030) with older hardware versions of the Aeotec stick not working on the Raspberry Pi 4. Aeotec has released a 2020 hardware revision ZW090-A/B/C Gen5+ with Pi 4 compatibility. Both hardware revisions are still being sold, make informed purchasing decisions if using paired with a Pi 4.
+
+</div>
 
 By default this will turn on "disco lights", which you can turn off by following the instructions in the [device specific page](/docs/z-wave/device-specific/#aeotec-z-stick)
 


### PR DESCRIPTION
## Proposed change

I have personally been running this fine for several months now without any problems. There are also reports of others using it with Z-wave JS, e.g. https://github.com/zwave-js/node-zwave-js/issues/1357#issuecomment-821464731

This also means that the sentence about no 700 series controller being supported are no longer true.

I also propose moving down the Aeotec note to the bottom since I think it looked a bit ugly to have such a big note at the top of the list that only affects one stick.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
