### PR TITLE
Minor typo updates to integrations/alert doco

### DIFF
--- a/source/_integrations/alert.markdown
+++ b/source/_integrations/alert.markdown
@@ -11,7 +11,7 @@ ha_domain: alert
 
 The `alert` integration is designed to notify you when problematic issues arise.
 For example, if the garage door is left open, the `alert` integration can be used
-remind you of this by sending you repeating notifications at customizable
+to remind you of this by sending you repeating notifications at customizable
 intervals. This is also used for low battery sensors,
 water leak sensors, or any condition that may need your attention.
 
@@ -27,7 +27,7 @@ State | Description
 
 ### Basic Example
 
-The `alert` integration makes use of any of the `notifications` integrations. To
+The `alert` integration makes use of any of the `notification` integrations. To
 setup the `alert` integration, first, you must setup a `notification` integration.
 Then, add the following to your configuration file:
 


### PR DESCRIPTION
## Proposed change
Very minor updates to documentation for the `alert` integration.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
