### PR TITLE
Update zwave-js docs with new parameter for multicast_set_value service

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -218,7 +218,7 @@ This service will set a value on a Z-Wave device. It is for advanced use cases w
 | `property_key`        	| no        	| ID of Property Key that you want to set the value for. 	                                                                                              |
 | `endpoint`   	          | no        	| ID of Endpoint that you want to set the value for. 	                                                                                                  |
 | `value`   	            | yes        	| The new value that you want to set. 	                                                                                                                |
-| `options`   	          | no        	| Set value options. Refer to the Z-Wave JS documentation for more information on what options can be set. 	                                                                                                                |
+| `options`   	          | no        	| Set value options map. Refer to the Z-Wave JS documentation for more information on what options can be set. 	                                                                                                                |
 | `wait_for_result`   	  | no        	| Boolean that indicates whether or not to wait for a response from the node. If not included in the payload, the integration will decide whether to wait or not. If set to `true`, note that the service call can take a while if setting a value on an asleep battery device. |
 
 ### Service `zwave_js.multicast_set_value`
@@ -235,6 +235,7 @@ This service will set a value on multiple Z-Wave devices using multicast. It is 
 | `property_key`        	| no        	| ID of Property Key that you want to set the value for. 	                                                                                              |
 | `endpoint`   	          | no        	| ID of Endpoint that you want to set the value for. 	                                                                                                  |
 | `value`   	            | yes        	| The new value that you want to set. 	                                                                                                                |
+| `options`   	          | no        	| Set value options map. Refer to the Z-Wave JS documentation for more information on what options can be set. 	                                                                                                                |
 
 ### Service `zwave_js.ping`
 


### PR DESCRIPTION
## Proposed change
Added a new parameter to the `zwave_js.multicast_set_value` service so we are documenting it here.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/53369
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
