### PR TITLE
Add siren platform to devolo Home Control

### DIFF
--- a/source/_integrations/devolo_home_control.markdown
+++ b/source/_integrations/devolo_home_control.markdown
@@ -7,6 +7,7 @@ ha_category:
   - Cover
   - Light
   - Sensor
+  - Siren
   - Switch
 ha_release: '0.110'
 ha_iot_class: Local Push
@@ -22,6 +23,7 @@ ha_platforms:
   - cover
   - light
   - sensor
+  - siren
   - switch
 ha_zeroconf: true
 ---
@@ -91,3 +93,9 @@ The integration provides support for the following features:
 - Temperature and brightness of devolo Sensors, that support it
 - Consumptions of devolo and Qubino devices, that support it
 - Voltage of devolo Metering Plug v2
+
+## Siren
+
+The integration provides support for the following Z-Wave devices:
+
+- devolo Siren

--- a/source/_integrations/devolo_home_control.markdown
+++ b/source/_integrations/devolo_home_control.markdown
@@ -9,7 +9,7 @@ ha_category:
   - Sensor
   - Siren
   - Switch
-ha_release: '0.110'
+ha_release: '2022.2'
 ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:

--- a/source/_integrations/devolo_home_control.markdown
+++ b/source/_integrations/devolo_home_control.markdown
@@ -9,7 +9,7 @@ ha_category:
   - Sensor
   - Siren
   - Switch
-ha_release: '2022.2'
+ha_release: '0.110'
 ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds the siren platform to the devolo Home Control integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/53400
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
