### PR TITLE
Document config flow for decora_wifi

### DIFF
--- a/source/_integrations/decora_wifi.markdown
+++ b/source/_integrations/decora_wifi.markdown
@@ -30,4 +30,4 @@ Once Home Assistant authenticates access, the Leviton Decora Wi-Fi integration w
 
 - A `light` for each device linked to your MyLeviton account.
 
-The integration reads the capabilities of each device (dimming, etc.) from the API, so devices with dimming or speed control capabilities will provide those controls in the Home Assitant UI.
+The integration reads the capabilities of each device (dimming, etc.) from the API, so devices with dimming or speed control capabilities will provide those controls in the Home Assistant UI.

--- a/source/_integrations/decora_wifi.markdown
+++ b/source/_integrations/decora_wifi.markdown
@@ -17,24 +17,16 @@ Supported devices (tested):
 - [DW6HD1-BZ](https://www.leviton.com/en/products/dw6hd-1bz) (Decora Smart Wi-Fi 600W Dimmer)
 - [DW15S-1BZ](https://www.leviton.com/en/products/dw15s-1bz) (Decora Smart Wi-Fi 15A Switch)
 - [DW15P-1BW](https://www.leviton.com/en/products/dw15p-1bw) (Decora Smart Wi-Fi Plug-in Outlet)
+- [DW4SF-1BW](https://www.leviton.com/en/products/dw4sf-1bw) (Decora Smart Wi-Fi Fan Speed Controller)
 
-To enable these lights, add the following lines to your `configuration.yaml` file:
+## Setup
 
-```yaml
-# Example configuration.yaml entry
-light:
-  - platform: decora_wifi
-    username: YOUR_USERNAME
-    password: YOUR_PASSWORD
-```
+You will need your MyLeviton login information (username, which is usually your email address, and password) to use this module.
 
-{% configuration %}
-username:
-  description: Your "My Leviton" app email address/user name.
-  required: true
-  type: string
-password:
-  description: Your "My Leviton" app password.
-  required: true
-  type: string
-{% endconfiguration %}
+## Configuration
+
+The preferred method for setting this integration up is by using the configuration flow. Go to the integrations page in your configuration and click on new integration -> Leviton Decora Wifi. Enter your credentials in the dialog and the integration will then set up. Once Home Assistant authenticates access, the `decora-wifi` integration will create the following platforms:
+
+- A `light` for each device linked to your MyLeviton account.
+
+The integration reads the capabilities of each device (dimming, etc.) from the API, so devices with dimming or speed control capabilities will provide those controls in the Home Assitant UI.

--- a/source/_integrations/decora_wifi.markdown
+++ b/source/_integrations/decora_wifi.markdown
@@ -19,13 +19,14 @@ Supported devices (tested):
 - [DW15P-1BW](https://www.leviton.com/en/products/dw15p-1bw) (Decora Smart Wi-Fi Plug-in Outlet)
 - [DW4SF-1BW](https://www.leviton.com/en/products/dw4sf-1bw) (Decora Smart Wi-Fi Fan Speed Controller)
 
-## Setup
+## Prerequisites
 
-You will need your MyLeviton login information (username, which is usually your email address, and password) to use this module.
+You will need your MyLeviton login information (username, which is usually your email address, and password) to use this integration.
 
-## Configuration
 
-The preferred method for setting this integration up is by using the configuration flow. Go to the integrations page in your configuration and click on new integration -> Leviton Decora Wifi. Enter your credentials in the dialog and the integration will then set up. Once Home Assistant authenticates access, the `decora-wifi` integration will create the following platforms:
+{% include integrations/config_flow.md %}
+
+Once Home Assistant authenticates access, the Leviton Decora Wi-Fi integration will create the following:
 
 - A `light` for each device linked to your MyLeviton account.
 


### PR DESCRIPTION
Documentation change to go with [PR#51092](https://github.com/home-assistant/core/pull/51092).

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51092
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
