### PR TITLE
Add select platform back to Rituals Perfume Genie

### DIFF
--- a/source/_integrations/rituals_perfume_genie.markdown
+++ b/source/_integrations/rituals_perfume_genie.markdown
@@ -16,6 +16,7 @@ ha_domain: rituals_perfume_genie
 ha_platforms:
   - binary_sensor
   - number
+  - select
   - sensor
   - switch
 ---


### PR DESCRIPTION
## Proposed change

The select platform was removed in "Sync codebase with docs for 2021.7"  https://github.com/home-assistant/home-assistant.io/commit/100cfa585c59df9d71063c274b8a179336fd7dca by @frenck.

Select is in core 2021.7:
https://github.com/home-assistant/core/blob/2021.7.4/homeassistant/components/rituals_perfume_genie/select.py

The Select category was not removed.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
