### PR TITLE
Move power and energy attributes to sensors

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -5,6 +5,7 @@ ha_category:
   - Hub
   - Switch
   - Light
+  - Sensor
 ha_release: 0.89
 ha_iot_class: Local Polling
 ha_config_flow: true
@@ -24,6 +25,7 @@ There is currently support for the following device types within Home Assistant:
 
 - **Light**
 - **Switch**
+- **Sensor**
 
 In order to activate the support, you will have to enable the integration inside the configuration panel.
 The supported devices in your network are automatically discovered, but if you want to control devices residing in other networks you will need to configure them manually as shown below.
@@ -40,14 +42,14 @@ Plugs are type `switch` when autodiscovery has been disabled.
 - HS100
 - HS103
 - HS105
-- HS110 (This device is capable of reporting energy usage data to template sensors)
+- HS110 (confirmed to support consumption sensors)
 - KP105
-- KP115
+- KP115 (confirmed to support consumption sensors)
 
 ### Strip (Multi-Plug)
 
 - HS107 (indoor 2-outlet)
-- HS300 (powerstrip 6-outlet) (This device is capable of reporting energy usage data to template sensors)
+- HS300 (powerstrip 6-outlet) (confirmed to support consumption sensors)
 - KP303 (powerstrip 3-outlet)
 - KP400 (outdoor 2-outlet)
 - KP200 (indoor 2-outlet)
@@ -143,44 +145,3 @@ tplink:
     - host: 192.168.200.7
     - host: 192.168.200.8
 ```
-
-## Extracting Energy Sensor data
-
-Devices that are confirmed to support Consumption Reading;
-1. HS110
-2. HS300
-3. KP115
-4. Bulbs (device-specific, only current power consumption is commonly available)
-
-In order to get the power consumption readings from a TP-Link HS110 device, you'll have to create a [template sensor](/integrations/template/).
-In the example below, change all of the `my_tp_switch`'s to match your device's entity ID (without the domain). For example, if your entity is `switch.whale_heater` then replace `my_tp_switch` with `whale_heater`:
-
-{% raw %}
-
-```yaml
-sensor:
-  - platform: template
-    sensors:
-      my_tp_switch_amps:
-        friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Current"
-        value_template: "{{ state_attr('switch.my_tp_switch','current_a') }}"
-        unit_of_measurement: "A"
-      my_tp_switch_watts:
-        friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Power"
-        value_template: "{{ state_attr('switch.my_tp_switch','current_power_w') }}"
-        unit_of_measurement: "W"
-      my_tp_switch_total_kwh:
-        friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Total Consumption"
-        value_template: "{{ state_attr('switch.my_tp_switch','total_energy_kwh') }}"
-        unit_of_measurement: "kWh"
-      my_tp_switch_volts:
-        friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Voltage"
-        value_template: "{{ state_attr('switch.my_tp_switch','voltage') }}"
-        unit_of_measurement: "V"
-      my_tp_switch_today_kwh:
-        friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Today's Consumption"
-        value_template: "{{ state_attr('switch.my_tp_switch','today_energy_kwh') }}"
-        unit_of_measurement: "kWh"
-```
-
-{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
As discussed in home-assistant/architecture#579 all energy related properties and attributes of the switch entity were migrated into own sensors.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#53596
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
