### PR TITLE
Service desc

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -266,9 +266,11 @@ action:
 
 This service will reset the meters on a device that supports the Meter Command Class.
 
+<div class='note info'>The service will reset all meters on the same endpoint of the entity(s) you target, so you should only choose one meter entity for a given node, endpoint, and meter type (if applicable). If you target multiple entities on the same node, endpoint, and meter type, you will trigger multiple reset calls which will generate unnecessary traffic on your network.</div>
+
 | Service Data Attribute | Required | Description                                                                                                        |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
-| `entity_id`            | yes      | Entity (or list of entities) for the meters you want to reset.               |
+| `entity_id`            | yes      | Entity (or list of entities) for the meters you want to reset. See note above for considerations.                  |
 | `meter_type`           | no       | If supported by the device, indicates the type of meter to reset. Not all devices support this option.             |
 | `value`                | no       | If supported by the device, indicates the value to reset the meter to. Not all devices support this option.   |
 


### PR DESCRIPTION
## Proposed change
One of the problems with making this service an entity service is that it actually acts on multiple entities. All meters on the same node and endpoint as the entity's primary value will be reset. This means that if a user selects multiple entities for each of their meters, they may end up calling the reset function multiple times.

For now, I have added a note in the service description and the docs about this nuance since we want to ship this for next week.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/53709
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
