### PR TITLE
Doc topic_template for mqtt.publish

### DIFF
--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -11,14 +11,15 @@ The MQTT integration will register the service `mqtt.publish` which allows publi
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `topic` | no | Topic to publish payload to.
+| `topic_template` | no | Template to render as topic to publish payload to.
 | `payload` | yes | Payload to publish.
-| `payload_template` | yes | Template to render as payload value. Ignored if payload given.
+| `payload_template` | yes | Template to render as payload value.
 | `qos` | yes | Quality of Service to use. (default: 0)
 | `retain` | yes | If message should have the retain flag set. (default: false)
 
-<div class='note'>
-You need to include either payload or payload_template, but not both.
-</div>
+<p class='note'>
+You must include either `topic` or `topic_template`, but not both. If providing a payload, you need to include either `payload` or `payload_template`, but not both.
+</p>
 
 ```yaml
 topic: home-assistant/light/1/command
@@ -28,6 +29,13 @@ payload: on
 {% raw %}
 ```yaml
 topic: home-assistant/light/1/state
+payload_template: "{{ states('device_tracker.paulus') }}"
+```
+{% endraw %}
+
+{% raw %}
+```yaml
+topic_template: "home-assistant/light/{{ states('sensor.light_active') }}/state"
 payload_template: "{{ states('device_tracker.paulus') }}"
 ```
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This documents the addition of the `topic_template` feature for `mqtt.publish` from https://github.com/home-assistant/core/pull/53743.

Additionally, this slightly rewords the overlapping, existing documentation on this service in order to explain how `payload` and `payload_template` work. The current documentation mentions that `payload_template` would be ignored if `payload` were specified, but this isn't the case; voluptuous will raise a schema error as these fields are marked as Exclusive.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/53743
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
