### PR TITLE
Duckdns now requires the suffix

### DIFF
--- a/source/_integrations/duckdns.markdown
+++ b/source/_integrations/duckdns.markdown
@@ -29,7 +29,7 @@ duckdns:
 
 {% configuration duckdns %}
   domain:
-    description: Your duckdns subdomain (without the `.duckdns.org` suffix).
+    description: Your duckdns subdomain (with the `.duckdns.org` suffix).
     required: true
     type: string
   access_token:


### PR DESCRIPTION
Update to indicate the duckdns plugins now need the domain suffix (.duckdns.org)
As me and [this redditor](https://www.reddit.com/r/homeassistant/comments/o45je5/duckdns_fails_after_update/) figured out.
Otherwise regex refuse the config change.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
