### PR TITLE
Add documentation for new integration dyson_local

### DIFF
--- a/source/_integrations/dyson_local.markdown
+++ b/source/_integrations/dyson_local.markdown
@@ -1,0 +1,30 @@
+---
+title: Dyson Local
+description: Instructions on how to integrate Dyson Local into Home Assistant.
+ha_category:
+  - Binary Sensor
+  - Sensor
+  - Vacuum
+ha_iot_class: Local Push
+ha_release: '2021.9'
+ha_config_flow: true
+ha_domain: dyson_local
+ha_platforms:
+  - binary_sensor
+  - sensor
+  - vacuum
+ha_codeowners:
+  - '@xiaonanshen'
+---
+
+Dyson Local uses MQTT-based protocol to communicate with local [Dyson](https://www.dyson.com) devices using credentials. Currently it supports
+
+- Dyson 360 Eye robot vacuum
+
+{% include integrations/config_flow.md %}
+
+### Finding device WiFi information
+
+To find the WiFi information of a device, you need to look for a sticker on the front or back of the user's manual. You can also find it on the body of the device:
+
+- Dyson 360 Eye robot vacuum: behind the clear bin


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for new core integration `dyson_local`


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#53801
- Link to parent pull request in the Brands repository: home-assistant/brands#2725
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
