### PR TITLE
extend fritz doc

### DIFF
--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -79,7 +79,7 @@ These can be changed at **AVM FRITZ!Box Tools** -> **Configure** on the Integrat
 
 ### Parental control
 
-Parental control switches can be used to enable and disable internet access of individual devices. If a device has internet access (no internet access) it will be enabled (disabled). You can also find the current blocking state of the individual devices in the UI of the fritzbox under `Internet` -> `Filters` -> `Parental Controls` -> `Device Block`
+Parental control switches can be used to enable and disable internet access of individual devices. If a device has internet access (no internet access) it will be enabled (disabled). You can also find the current blocking state of the individual devices in the UI of the FRITZ!Box under `Internet` -> `Filters` -> `Parental Controls` -> `Device Block`
 
 Parental control switches are designed for advanced users, thus they are disabled by default. You need to enable the wanted entities manually.
 
@@ -103,7 +103,7 @@ As a result, this integration will create entities only for rules that have your
 
 **Script: Reconnect / get new IP**
 
-The following script can be used to easily add a reconnect button to your UI. If you want to reboot your fritzbox, you can use fritzbox_tools.reboot instead.
+The following script can be used to easily add a reconnect button to your UI. If you want to reboot your FRITZ!Box, you can use `fritzbox_tools.reboot` instead.
 
 ```yaml
 fritz_box_reconnect:

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -79,6 +79,8 @@ These can be changed at **AVM FRITZ!Box Tools** -> **Configure** on the Integrat
 
 ### Parental control
 
+Parental control switches can be used to enable and disable internet access of individual devices. If a device has internet access (no internet access) it will be enabled (disabled). You can also find the current blocking state of the individual devices in the UI of the fritzbox under `Internet` -> `Filters` -> `Parental Controls` -> `Device Block`
+
 Parental control switches are designed for advanced users, thus they are disabled by default. You need to enable the wanted entities manually.
 
 ### Device Tracker
@@ -91,3 +93,55 @@ Parental control switches are designed for advanced users, thus they are disable
 
 Due to security reasons, AVM implemented the ability to enable/disable a port forward rule only from the host involved in the rule.
 As a result, this integration will create entities only for rules that have your Home Assistant host as a destination.
+
+**Note 1**: On your FRITZ!Box, enable the setting `Permit independent port sharing for this device` for the device which runs HA (`Internet` -> `Permit Access` -> `<Name of HA device>`)
+
+**Note 2**: Only works if you have a dedicated IPv4 address (it won't work with DS-Lite)
+
+## Example Automations and Scripts
+
+
+**Script: Reconnect / get new IP**
+
+The following script can be used to easily add a reconnect button to your UI. If you want to reboot your fritzbox, you can use fritzbox_tools.reboot instead.
+
+```yaml
+fritz_box_reconnect:
+  alias: "Reconnect FRITZ!Box"
+  sequence:
+    - service: fritz.reconnect
+      target:
+        entity_id: binary_sensor.fritz_box_7530_connectivity
+
+```
+**Automation: Reconnect / get new IP every night**
+
+```yaml
+automation:
+- alias: "System: Reconnect FRITZ!Box"
+  trigger:
+    platform: time
+    at: '05:00:00'
+  action:
+    - service: fritz.reconnect
+      target:
+        entity_id: binary_sensor.[fritzbox]_connectivity
+
+```
+
+**Automation: Phone notification with wifi credentials when guest wifi is created**
+
+```yaml
+automation:
+  - alias: "Guests Wifi Turned On -> Send Password To Phone"
+    trigger:
+      platform: state
+      entity_id: switch.[fritzbox]_[wifi name]
+      to: 'on'
+    action:
+      - service: notify.n
+        data:
+          title: "Guest wifi is enabled"
+          message: "Password: ..."
+
+```

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -79,7 +79,7 @@ These can be changed at **AVM FRITZ!Box Tools** -> **Configure** on the Integrat
 
 ### Parental control
 
-Parental control switches can be used to enable and disable internet access of individual devices. If a device has internet access (no internet access) it will be enabled (disabled). You can also find the current blocking state of the individual devices in the UI of the FRITZ!Box under `Internet` -> `Filters` -> `Parental Controls` -> `Device Block`
+Parental control switches can be used to enable and disable internet access of individual devices. If a device has internet access it will be enabled, otherwise it will be disabled. You can also find the current blocking state of the individual devices in the UI of the FRITZ!Box under `Internet` -> `Filters` -> `Parental Controls` -> `Device Block`
 
 Parental control switches are designed for advanced users, thus they are disabled by default. You need to enable the wanted entities manually.
 

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -120,12 +120,12 @@ fritz_box_reconnect:
 automation:
 - alias: "System: Reconnect FRITZ!Box"
   trigger:
-    platform: time
-    at: '05:00:00'
+    - platform: time
+      at: '05:00:00'
   action:
     - service: fritz.reconnect
       target:
-        entity_id: binary_sensor.[fritzbox]_connectivity
+        entity_id: binary_sensor.fritzbox_x_connectivity
 
 ```
 
@@ -135,11 +135,11 @@ automation:
 automation:
   - alias: "Guests Wifi Turned On -> Send Password To Phone"
     trigger:
-      platform: state
-      entity_id: switch.[fritzbox]_[wifi name]
-      to: 'on'
+      - platform: state
+        entity_id: switch.fritzbox_x_wifi_x
+        to: 'on'
     action:
-      - service: notify.n
+      - service: notify.notify
         data:
           title: "Guest wifi is enabled"
           message: "Password: ..."

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -137,7 +137,7 @@ automation:
     trigger:
       platform: state
       entity_id: switch.[fritzbox]_[wifi name]
-      to: 'on'
+      to: "on"
     action:
       - service: notify.n
         data:

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -121,7 +121,7 @@ automation:
 - alias: "System: Reconnect FRITZ!Box"
   trigger:
     platform: time
-    at: '05:00:00'
+    at: "05:00:00"
   action:
     - service: fritz.reconnect
       target:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds a few examples and hints for the usage of the fritz component.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
Bases on #18444
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/52721
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
