### PR TITLE
More numeric_state attribute/value_template docs

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -173,7 +173,7 @@ automation:
 
 ## Numeric state trigger
 
-Fires when the numeric value of an entity's state (or attribute's value if using the `attribute` property) **crosses** (and only when crossing) a given threshold. On state change of a specified entity, attempts to parse the state as a number and fires if the value is changing from above to below or from below to above the given threshold.
+Fires when the numeric value of an entity's state (or attribute's value if using the `attribute` property, or the calculated value if using the `value_template` property) **crosses** (and only when crossing) a given threshold. On state change of a specified entity, attempts to parse the state as a number and fires if the value is changing from above to below or from below to above the given threshold.
 
 {% raw %}
 
@@ -182,18 +182,48 @@ automation:
   trigger:
     - platform: numeric_state
       entity_id: sensor.temperature
-      # Optional
-      value_template: "{{ state.attributes.battery }}"
+      # If given, will trigger when the value of the given attribute for the given entity changes..
+      attribute: attribute_name
+      # ..or alternatively, will trigger when the value given by this evaluated template changes.
+      value_template: "{{ state.attributes.value - 5 }}"
       # At least one of the following required
       above: 17
       below: 25
-      # If given, will trigger when the value of the given attribute for the given entity changes
-      attribute: attribute_name
       # If given, will trigger when the condition has been true for X time; you can also use days and milliseconds.
       for:
         hours: 1
         minutes: 10
         seconds: 5
+```
+
+{% endraw %}
+
+When the `attribute` option is specified the trigger is compared to the given `attribute` instead of the state of the entity.
+
+{% raw %}
+
+```yaml
+automation:
+  trigger:
+    - platform: numeric_state
+      entity_id: climate.kitchen
+      attribute: current_temperature
+      above: 23
+```
+
+{% endraw %}
+
+More dynamic and complex calculations can be done with `value_template`.
+
+{% raw %}
+
+```yaml
+automation:
+  trigger:
+    - platform: numeric_state
+      entity_id: climate.kitchen
+      value_template: "{{ state.attributes.current_temperature - state.attributes.temperature_set_point }}"
+      above: 3
 ```
 
 {% endraw %}
@@ -225,8 +255,6 @@ automation:
   trigger:
     - platform: numeric_state
       entity_id: sensor.temperature
-      # Optional
-      value_template: "{{ state.attributes.battery }}"
       # At least one of the following required
       above: 17
       below: 25


### PR DESCRIPTION
## Proposed change

Adds a bit more documentation for the `attribute` and `value_template` properties for the `numeric_state` trigger. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
