### PR TITLE
Add service homeassistant.save_persistent_states

### DIFF
--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -134,3 +134,10 @@ action:
     - light.living_room
     - switch.coffe_pot
 ```
+
+### Service `homeassistant.save_persistent_states`
+
+Save the persistent states (for entities derived from RestoreEntity) immediately.
+Maintain the normal periodic saving interval.
+
+Normally these states are saved at startup, every 15 minutes and at shutdown.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add the service homeassistant.save_persistent_states

Currently persistent states (for entities derived from RestoreEntity) are saved at hass startup, every 15 minutes there after, and prior to shutdown.

If the power goes down and the entity (i.e. maybe a device) has no way to save some state information internally, then any state changes sinse the last save are lost.

This service forces the state to be saved immediately and then resume the 15 minute interval.
This will allow critical automations to reduce the vulnerable interval of lost state to ms instead of up to 15 minutes.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  [53881](https://github.com/home-assistant/core/pull/53881)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
