### PR TITLE
Currenty Symbol to Code

### DIFF
--- a/source/_docs/configuration/basic.markdown
+++ b/source/_docs/configuration/basic.markdown
@@ -14,7 +14,7 @@ homeassistant:
   longitude: 117.22743
   elevation: 430
   unit_system: metric
-  currency: "$",
+  currency: "AUD",
   time_zone: "America/Los_Angeles"
   external_url: "https://www.example.com"
   internal_url: "http://homeassistant.local:8123"
@@ -61,7 +61,7 @@ time_zone:
   required: false
   type: string
 currency:
-  description: The default currency symbol for your location.
+  description: "The default currency code for your location. [Wikipedia's list of currency codes](https://en.wikipedia.org/wiki/ISO_4217#Active_codes)"
   required: false
   type: string
 external_url:

--- a/source/_docs/configuration/basic.markdown
+++ b/source/_docs/configuration/basic.markdown
@@ -14,7 +14,7 @@ homeassistant:
   longitude: 117.22743
   elevation: 430
   unit_system: metric
-  currency: "AUD",
+  currency: "USD",
   time_zone: "America/Los_Angeles"
   external_url: "https://www.example.com"
   internal_url: "http://homeassistant.local:8123"


### PR DESCRIPTION
Updated docs for the "Currency" switch from symbol to code in configuration.yaml

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
