### PR TITLE
Add IoTaWatt integration doc

### DIFF
--- a/source/_integrations/iotawatt.markdown
+++ b/source/_integrations/iotawatt.markdown
@@ -1,0 +1,19 @@
+---
+title: IoTaWatt
+description: Instructions on how to integrate IoTaWatt into Home Assistant.
+ha_release: 2021.9
+ha_category:
+  - Energy
+ha_iot_class: Local Polling
+ha_config_flow: true
+ha_domain: iotawatt
+ha_codeowners:
+  - '@gtdiehl'
+ha_platforms:
+  - sensor
+---
+A sensor platform for the [IoTaWatt](https://www.iotawatt.com/) Open WiFi Electricity Monitor. It 
+will collect data from the Current Transformer Clamps (Input CTs) and any Outputs that are defined on the IoTaWatt
+and create them as sensors in Home Assistant.
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documentation for new IoTaWatt component

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/55364
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2732
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
