### PR TITLE
Correct SMA energy meter entity descriptions

### DIFF
--- a/source/_integrations/sma.markdown
+++ b/source/_integrations/sma.markdown
@@ -66,8 +66,8 @@ The SMA WebConnect module supports a wide variety of sensors, but not all of the
 | metering_power_supplied | W | Power supplied |
 | metering_power_absorbed | W | Power absorbed |
 | metering_frequency | Hz | Grid frequency |
-| metering_total_yield | kWh | Total power from the grid |
-| metering_total_absorbed | kWh | Total power supplied to the grid |
+| metering_total_yield | kWh | Total power supplied to the grid |
+| metering_total_absorbed | kWh | Total power from the grid |
 | metering_current_l1 | A | Current for phase 1 |
 | metering_current_l2 | A | Current for phase 2 |
 | metering_current_l3 | A | Current for phase 3 |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
`metering_total_yield` and `metering_total_absorbed` descriptions were swapped.

total_yield goes up during the day. total_absorbed goes up during the night.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
