### PR TITLE
Add `binary_sensor` documentation for Xiaomi Miio integration

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -22,6 +22,7 @@ ha_zeroconf: true
 ha_platforms:
   - air_quality
   - alarm_control_panel
+  - binary_sensor
   - device_tracker
   - fan
   - light
@@ -516,13 +517,14 @@ For supported Air Humidifiers additional entities for will be generated automati
 The sensor platform does not supply additional services.
 </div>
 
-| Platform     | Service(s)                 | Related auto generated device entities                       |
-|--------------|----------------------------|--------------------------------------------------------------|
-| `humidifier` | `set_humidity`, `set_mode` | Main device entity                                           |
-| `switch`     | `turn_on`, `turn_off`      | `buzzer`, `child_lock`, `cleaning_mode`, `dry_mode` and `led`|
-| `sensor`     | _None_                     | `actual_speed`, `humidity`, `temperature` and `water_level`  |
-| `number`     | `set_value`                | `motor_speed`                                                |
-| `select`     | `select_option`            | `led_brightness`                                             |
+| Platform        | Service(s)                 | Related auto generated device entities                       |
+|-----------------|----------------------------|--------------------------------------------------------------|
+| `humidifier`    | `set_humidity`, `set_mode` | Main device entity                                           |
+| `switch`        | `turn_on`, `turn_off`      | `buzzer`, `child_lock`, `cleaning_mode`, `dry_mode` and `led`|
+| `sensor`        | _None_                     | `actual_speed`, `humidity`, `temperature` and `water_level`  |
+| `number`        | `set_value`                | `motor_speed`                                                |
+| `select`        | `select_option`            | `led_brightness`                                             |
+| `binary_sensor` | _None_                     | `water_tank_empty` and `water_tank_detached`                 |
 
 ### Service `fan.set_percentage`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds information about `binary_sensor` platform.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/54096
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
