### PR TITLE
Update modbus markdown typo

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -298,7 +298,7 @@ modbus:
         address: 100
         scan_interval: 20
         slave: 1
-      - name: "binary_ensor2"
+      - name: "binary_sensor2"
         address: 110
         device_class: door
         input_type: discrete_input


### PR DESCRIPTION
## Proposed change
Update "binary_ensor2" to "binary_sensor2" in example config


## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
