### PR TITLE
Switcher KIS Documentation: Add clarification about old firmware versions.

### DIFF
--- a/source/_integrations/switcher_kis.markdown
+++ b/source/_integrations/switcher_kis.markdown
@@ -25,6 +25,8 @@ Supported devices:
 - Switcher V2 (Qualcomm chipset - from firmware 72.32)
 - Switcher V4
 
+If you completed the config flow but still unable to control the device, please make sure your device's firmware is up-to-date.
+
 {% include integrations/config_flow.md %}
 
 ## Sensors

--- a/source/_integrations/switcher_kis.markdown
+++ b/source/_integrations/switcher_kis.markdown
@@ -25,7 +25,7 @@ Supported devices:
 - Switcher V2 (Qualcomm chipset - from firmware 72.32)
 - Switcher V4
 
-If you completed the config flow but still unable to control the device, please make sure your device's firmware is up-to-date.
+If you completed the integration setup but are still unable to control the device, please make sure your device's firmware is up-to-date.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
@thecode FYI.

## Proposed change

Add clarification to the Switcher documentation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
As in my case I was unable to control my device due to an old firmware, I find it may serve others in the same condition as I am.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
