### PR TITLE
Update modes.markdown

### DIFF
--- a/source/_docs/automation/modes.markdown
+++ b/source/_docs/automation/modes.markdown
@@ -23,7 +23,6 @@ number of runs that can be executing and/or queued up at a time. The default is 
 
 When `max` is exceeded (which is effectively 1 for `single` mode) a log message will be emitted to indicate this has happened. Configuration option `max_exceeded` controls the severity level of that log message. Set it to `silent` to ignore warnings or set it to a [log level](/integrations/logger/#log-levels). The default is `warning`.
 
-
 ## Example throttled automation
 
 Some automations you only want to run every 5 minutes. This can be achieved using the `single` mode and silencing the warnings when the automation is triggered while it's running.
@@ -52,7 +51,6 @@ automation:
     action:
       - ...
 ```
-
 
 When choosing the correct mode take into consideration that top level triggers only trigger once for any single instance of an automation. If your automation has until loops that rely on Trigger IDs consider using the restart mode. In this example if we set the mode to single the release trigger will not stop the light decreasing as the automation will be in the repeat loop. 
 

--- a/source/_docs/automation/modes.markdown
+++ b/source/_docs/automation/modes.markdown
@@ -23,6 +23,7 @@ number of runs that can be executing and/or queued up at a time. The default is 
 
 When `max` is exceeded (which is effectively 1 for `single` mode) a log message will be emitted to indicate this has happened. Configuration option `max_exceeded` controls the severity level of that log message. Set it to `silent` to ignore warnings or set it to a [log level](/integrations/logger/#log-levels). The default is `warning`.
 
+
 ## Example throttled automation
 
 Some automations you only want to run every 5 minutes. This can be achieved using the `single` mode and silencing the warnings when the automation is triggered while it's running.
@@ -50,4 +51,44 @@ automation:
       - ...
     action:
       - ...
+```
+
+
+When choosing the correct mode take into consideration that top level triggers only trigger once for any single instance of an automation. If your automation has until loops that rely on Trigger IDs consider using the restart mode. In this example if we set the mode to single the release trigger will not stop the light decreasing as the automation will be in the repeat loop. 
+
+## Example of restart
+
+```yaml
+alias: decrease light brightness
+description: ''
+trigger:
+  - device_id: 8621b4f2fce548a49da1d754a2c41bce
+    domain: zha
+    platform: device
+    type: remote_button_long_press
+    subtype: button
+    id: long press
+  - device_id: 8621b4f2fce548a49da1d754a2c41bce
+    domain: zha
+    platform: device
+    type: remote_button_long_release
+    subtype: button
+    id: press release
+condition: []
+action:
+  - repeat:
+      until:
+        - condition: trigger
+          id: press release
+      sequence:
+        - device_id: 3f7189b028a7f5b5007604f8ce44fa08
+          domain: light
+          entity_id: light.computer_room
+          type: brightness_decrease
+        - delay:
+            hours: 0
+            minutes: 0
+            seconds: 0
+            milliseconds: 500
+mode: restart
 ```


### PR DESCRIPTION
When trying to set up an process of allowing the lights to decrease while the bottom was pressed I interrupted the  single mode incorrectly and thoughts triggers for the Automation could still alter the behavior of the running instance of the automation if in single. This suggestion is to help any other user that might think the same.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
