### PR TITLE
Document new area_id and area_name template functions

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -232,6 +232,28 @@ The same thing can also be expressed as a filter:
 
 {% endraw %}
 
+### Areas
+
+- `area_id(lookup_value)` returns the area ID for a given device ID, entity ID, or area name. Can also be used as a filter.
+
+#### Areas examples
+
+{% raw %}
+
+```text
+{{ area_id('Living Room') }}  # deadbeefdeadbeefdeadbeefdeadbeef
+```
+
+```text
+{{ area_id('my_device_id') }}  # deadbeefdeadbeefdeadbeefdeadbeef
+```
+
+```text
+{{ area_id('sensor.sony') }}  # deadbeefdeadbeefdeadbeefdeadbeef
+```
+
+{% endraw %}
+
 ### Time
 
 `now()` and `utcnow()` are not supported in [limited templates](#limited-templates).

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -234,7 +234,8 @@ The same thing can also be expressed as a filter:
 
 ### Areas
 
-- `area_id(lookup_value)` returns the area ID for a given device ID, entity ID, or area name. Can also be used as a filter. Note that if an area name is also a valid entity ID or device ID, the area ID for the area name will always be returned.
+- `area_id(lookup_value)` returns the area ID for a given device ID, entity ID, or area name. Can also be used as a filter.
+- `area_name(lookup_value)` returns the area name for a given device ID, entity ID, or area ID. Can also be used as a filter.
 
 #### Areas examples
 
@@ -250,6 +251,18 @@ The same thing can also be expressed as a filter:
 
 ```text
 {{ area_id('sensor.sony') }}  # deadbeefdeadbeefdeadbeefdeadbeef
+```
+
+```text
+{{ area_name('deadbeefdeadbeefdeadbeefdeadbeef') }}  # Living Room
+```
+
+```text
+{{ area_name('my_device_id') }}  # Living Room
+```
+
+```text
+{{ area_name('sensor.sony') }}  # Living Room
 ```
 
 {% endraw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -234,7 +234,7 @@ The same thing can also be expressed as a filter:
 
 ### Areas
 
-- `area_id(lookup_value)` returns the area ID for a given device ID, entity ID, or area name. Can also be used as a filter.
+- `area_id(lookup_value)` returns the area ID for a given device ID, entity ID, or area name. Can also be used as a filter. Note that if an area name is also a valid entity ID or device ID, the area ID for the area name will always be returned.
 
 #### Areas examples
 


### PR DESCRIPTION
## Proposed change
On a suggestion from someone in #templates on Discord, I added new template function/filters:
- `area_id`: Takes an entity ID, device ID, or area name and return an area ID if it can be found. 
- `area_name`: Takes an entity ID, device ID, or area ID and return an area name if it can be found. 



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/54248
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
