### PR TITLE
Update the detecting lost connections

### DIFF
--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -447,7 +447,7 @@ When the connection to your Homematic CCU or Homegear is lost, Home Assistant wi
 - If you have a sensor which you know will be updated frequently (e.g., an outdoor temperature sensor, voltage sensor or light sensor) you could set up a helper binary sensor and an automation like this:
 
 {% raw %}
-
+Using old template sensor:
 ```yaml
 binary_sensor:
   - platform: template
@@ -459,7 +459,19 @@ binary_sensor:
           - sensor.time
         value_template: >-
           {{ as_timestamp(now()) - as_timestamp(state_attr('sensor.office_voltage', 'last_changed')) < 600 }}
+```
 
+Using new template sensor (prefered):
+```yaml
+template:
+  - sensor:
+      - name: "Homematic is sending updates"
+        state: >-
+          {{ as_timestamp(now()) - as_timestamp(states.sensor.outlet_washmachine_voltage.last_changed) < 600 }}
+```
+
+Add also the automation for it in the automations.yaml:
+```yaml
 automation:
   - alias: "Homematic Reconnect"
     trigger:
@@ -492,14 +504,21 @@ automation:
   3. Set up a template sensor in Home Assistant, which contains the value of the system variable:
 
      {% raw %}
-
+     Using new template sensor (prefered):
+     ```yaml
+     template:
+       - sensor:
+           - name: "raspberrymatic last reboot"
+             state: "{{ state_attr('homematic.raspberrymatic', 'V_Last_Reboot') or '01.01.1970 00:00:00' }}"
+     ```
+     Using old template sensor:
      ```yaml
      - platform: template
        sensors:
          v_last_reboot:
            value_template: "{{ state_attr('homematic.ccu2', 'V_Last_Reboot') or '01.01.1970 00:00:00' }}"
-           icon_template: "mdi:clock"
-           entity_id: homematic.ccu2
+           icon_template: "mdi:clock" #deprecated
+           entity_id: homematic.ccu2 #deprecated
      ```
 
      {% endraw %}


### PR DESCRIPTION
Update the detecting lost connections with the new template form and marked deprecated lines of old example (which are still working with raising errors and warnings)

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
