### PR TITLE
Make note about new siren feature

### DIFF
--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -32,11 +32,11 @@ Turn the siren on.
 
 There are three optional input parameters that can be passed into the service call depending on whether or not your device supports them. Check the device's integration documentation for more details.
 
-| Parameter Name  | Input Type
-|---------------- |-------------------------
-| `tone`          | `string` or `integer`
-| `duration`      | `integer`
-| `volume_level`  | `float` between 0 and 1
+| Parameter Name  | Input Type              | Notes                                                                               |
+|---------------- |-------------------------|-------------------------------------------------------------------------------------|
+| `tone`          | `string` or `integer`   | When the `available_tones` property is a map, either the key or value can be used.  |
+| `duration`      | `integer`               |                                                                                     |
+| `volume_level`  | `float` between 0 and 1 |                                                                                     |
 
 ### Service `siren.turn_off`
 


### PR DESCRIPTION
## Proposed change
The `siren.available_tones` property can now be either a `list` (existing) or a `dict` (new). When the property is a dict, either the key or value can be used for the `siren.turn_on` service `tone` parameter. Making a note of that here.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/54198
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
