### PR TITLE
Update zha.markdown with note about changing Zigbee channel

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -211,7 +211,8 @@ Note: `cluster_id: 25` may also be `cluster_id: 0x0019`. The two are synonymous.
 
 ### Defining Zigbee channel to use
 
-ZHA prefers to use Zigbee channel 15 by default. You can change this using YAML configuration, however, note that changing the channel requires repairing all devices.
+ZHA prefers to use Zigbee channel 15 by default. You can change this using YAML configuration, but this only works
+if there's no existing network. To change the channel for an existing channel, radio has to be factory reset and a new network to be formed. This requires re-pairing of all the devices.
 
 ```yaml
 zha:

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -222,7 +222,7 @@ zha:
       channels: [15, 20, 25]  # Channel mask
 ```
 
-Tip: Reference this for channel selection [Zigbee and WiFi coexistence (using non-overlapping frequency-bands)](https://support.metageek.com/hc/en-us/articles/203845040-ZigBee-and-WiFi-Coexistence).
+This is a good reference for channel selection [Zigbee and Wifi Coexistance](https://support.metageek.com/hc/en-us/articles/203845040-ZigBee-and-WiFi-Coexistence)
 
 ### Modifying the device type
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -211,7 +211,7 @@ Note: `cluster_id: 25` may also be `cluster_id: 0x0019`. The two are synonymous.
 
 ### Defining Zigbee channel to use
 
-Zigbee network channel changes 15 will be used by default by ZHA but the Zigbee network channel can be changed via YAML, however note that changing Zigbee network channel changes requires repairing all already devices paired to ZHA.
+ZHA prefers to use Zigbee channel 15 by default. You can change this using YAML configuration, however, note that changing the channel requires repairing all devices.
 
 ```yaml
 zha:

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -212,7 +212,7 @@ Note: `cluster_id: 25` may also be `cluster_id: 0x0019`. The two are synonymous.
 ### Defining Zigbee channel to use
 
 ZHA prefers to use Zigbee channel 15 by default. You can change this using YAML configuration, but this only works
-if there's no existing network. To change the channel for an existing channel, radio has to be factory reset and a new network to be formed. This requires re-pairing of all the devices.
+if there's no existing network. To change the channel for an existing network, radio has to be factory reset and a new network to be formed. This requires re-pairing of all the devices.
 
 ```yaml
 zha:

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -211,6 +211,8 @@ Note: `cluster_id: 25` may also be `cluster_id: 0x0019`. The two are synonymous.
 
 ### Defining Zigbee channel to use
 
+Zigbee network channel changes 15 will be used by default by ZHA but the Zigbee network channel can be changed via YAML, however note that changing Zigbee network channel changes requires repairing all already devices paired to ZHA.
+
 ```yaml
 zha:
   zigpy_config:
@@ -219,7 +221,7 @@ zha:
       channels: [15, 20, 25]  # Channel mask
 ```
 
-This is a good reference for channel selection [Zigbee and Wifi Coexistance](https://support.metageek.com/hc/en-us/articles/203845040-ZigBee-and-WiFi-Coexistence)
+Tip: Reference this for channel selection [Zigbee and WiFi coexistence (using non-overlapping frequency-bands)](https://support.metageek.com/hc/en-us/articles/203845040-ZigBee-and-WiFi-Coexistence).
 
 ### Modifying the device type
 


### PR DESCRIPTION
## Proposed change

Update zha.markdown with a note about how changing Zigbee channel will require the user to re-pair devices in ZHA.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: NA
- Link to parent pull request in the Brands repository: NA
- This PR fixes or closes issue: NA

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards