### PR TITLE
Fix Xiaomi-miio humidifiers - correct modes and document attributes

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -416,32 +416,58 @@ This model uses newer MiOT communication protocol.
 ### Air Humidifier (zhimi.humidifier.v1)
 
 - On, Off
-- Operation modes (silent, medium, high, strong)
+- Operation modes (Silent, Medium, High, Strong)
 - Buzzer (on, off)
 - Child lock (on, off)
 - LED (on, off), LED brightness (bright, dim, off)
 - Target humidity (30, 40, 50, 60, 70, 80)
+- Attributes (humidifier platform)
+
+Attribute | Description
+--- | ---
+`humidity` | The current `target_humidity`
+`max_humidity` | The maximum settable `target_humidity`
+`min_humidity` | The minimum settable `target_humidity`
+`available_modes` | A list with the operation modes available
+`mode` | the current operation mode selected
+
 - Sensor entities
-  - `humidity`
-  - `temperature`
+
+Sensor | Description
+--- | ---
+`humidity` | The current `humidity` measured
+`temperature` | The current `temperature` measured
 
 ### Air Humidifier CA (zhimi.humidifier.ca1)
 
 - On, Off
-- Operation modes (silent, medium, high, auto)
+- Operation modes (Silent, Medium, High, Auto)
 - Buzzer (on, off)
 - Child lock (on, off)
 - LED brightness (bright, dim, off)
 - Target humidity (30, 40, 50, 60, 70, 80)
 - Dry mode (on, off)
+- Attributes (humidifier platform)
+
+Attribute | Description
+--- | ---
+`humidity` | The current `target_humidity`
+`max_humidity` | The maximum settable `target_humidity`
+`min_humidity` | The minimum settable `target_humidity`
+`available_modes` | A list with the operation modes available
+`mode` | the current operation mode selected
+
 - Sensor entities
-  - `humidity`
-  - `temperature`
+
+Sensor | Description
+--- | ---
+`humidity` | The current `humidity` measured
+`temperature` | The current `temperature` measured
 
 ### Air Humidifier CA (zhimi.humidifier.ca4)
 
 - On, Off
-- Operation modes (auto, low, medium, high)
+- Operation modes (Auto, Low, Medium, High)
 - Buzzer (on, off)
 - Child lock (on, off)
 - LED brightness (off, dim, bright)
@@ -449,11 +475,24 @@ This model uses newer MiOT communication protocol.
 - Clean mode (on, off)
 - Dry mode (on, off)
 - Motor speed rpm (200 - 2000)
+- Attributes (humidifier platform)
+
+Attribute | Description
+--- | ---
+`humidity` | The current `target_humidity`
+`max_humidity` | The maximum settable `target_humidity`
+`min_humidity` | The minimum settable `target_humidity`
+`available_modes` | A list with the operation modes available
+`mode` | the current operation mode selected
+
 - Sensor entities
-  - `actual_speed`
-  - `humidity`
-  - `temperature`
-  - `water_level`
+
+Sensor | Description
+--- | ---
+`actual_speed` | The current `moter_speed` measured in (rpm)
+`humidity` | The current `humidity` percentage measured
+`temperature` | The current `temperature` measured in degrees Celius
+`water_level` | The current `water_level` percentage measured
 
 <div class='note'>
 Clean mode and Motor speed can only be set when the device is turned on.
@@ -462,15 +501,28 @@ Clean mode and Motor speed can only be set when the device is turned on.
 ### Air Humidifier CB (zhimi.humidifier.cb1)
 
 - On, Off
-- Operation modes (silent, medium, high, auto)
+- Operation modes (Silent, Medium, High, Auto)
 - Buzzer (on, off)
 - Child lock (on, off)
 - LED (on, off), LED brightness (bright, dim, off)
 - Target humidity (30, 40, 50, 60, 70, 80)
 - Dry mode (on, off)
+- Attributes (humidifier platform)
+
+Attribute | Description
+--- | ---
+`humidity` | The current `target_humidity`
+`max_humidity` | The maximum settable `target_humidity`
+`min_humidity` | The minimum settable `target_humidity`
+`available_modes` | A list with the operation modes available
+`mode` | the current operation mode selected
+
 - Sensor entities
-  - `humidity`
-  - `temperature`
+
+Sensor | Description
+--- | ---
+`humidity` | The current `humidity` measured
+`temperature` | The current `temperature` measured
 
 ### Air Fresh VA2
 

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -489,7 +489,7 @@ Attribute | Description
 
 Sensor | Description
 --- | ---
-`actual_speed` | The current `moter_speed` measured in (rpm)
+`actual_speed` | The current `motor_speed` measured in (rpm)
 `humidity` | The current `humidity` percentage measured
 `temperature` | The current `temperature` measured in degrees Celius
 `water_level` | The current `water_level` percentage measured


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Small correction for Xiaomi-miio humidifiers
- Operation modes for humidifiers have a capital.
- Document attributes for humidfiers

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
