### PR TITLE
Describe Sonos feature switches

### DIFF
--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -28,12 +28,12 @@ The `sonos` integration allows you to control your [Sonos](https://www.sonos.com
 
 Speaker-level features are exposed as `switch` entities which allow direct control and indicate if the features are currently enabled.
 
-* **All devices**: Crossfade, Status Light, Touch Controls
-* **Home theater devices**: Night Sound & Speech Enhancement
+- **All devices**: Crossfade, Status Light, Touch Controls
+- **Home theater devices**: Night Sound & Speech Enhancement
 
 <div class='note info'>
   
-The Crossfade, Status Light, and Touch Controls entities are disabled by default, but can be enabled via the Sonos integration page.
+The Crossfade, Status Light, and Touch Controls entities are disabled by default, but can be enabled via the Sonos device page.
   
 </div>
 

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -24,6 +24,19 @@ The `sonos` integration allows you to control your [Sonos](https://www.sonos.com
 
 {% include integrations/config_flow.md %}
 
+## Feature controls
+
+Speaker-level features are exposed as `switch` entities which allow direct control and indicate if the features are currently enabled.
+
+* **All devices**: Crossfade, Status Light, Touch Controls
+* **Home theater devices**: Night Sound & Speech Enhancement
+
+<div class='note info'>
+  
+The Crossfade, Status Light, and Touch Controls entities are disabled by default, but can be enabled via the Sonos integration page.
+  
+</div>
+
 ## Battery support
 
 Battery sensors are fully supported for the `Sonos Roam` and `Sonos Move` devices on S2 firmware. `Sonos Move` speakers still on S1 firmware are supported but may update infrequently.
@@ -179,21 +192,6 @@ Update an existing Sonos alarm.
 | `volume` | yes | Float for volume level.
 | `enabled` | yes | Boolean for whether or not to enable this alarm.
 | `include_linked_zones` | yes | Boolean that defines if the alarm also plays on grouped players.
-
-### Service `sonos.set_option`
-
-Set Sonos speaker options.
-
-Night Sound and Speech Enhancement modes are only supported when playing from the TV source of products like Sonos Playbar and Sonos Beam. Other speaker types will ignore these options.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of `entity_id`s that will have their options set.
-| `buttons_enabled` | yes | Boolean to control the functioning of hardware buttons on the device.
-| `crossfade` | yes | Boolean to control crossfading between songs.
-| `night_sound` | yes | Boolean to control Night Sound mode.
-| `speech_enhance` | yes | Boolean to control Speech Enhancement mode.
-| `status_light` | yes | Boolean to control the Status (LED) Light.
 
 ### Service `sonos.play_queue`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Describe the new Sonos feature `switch` entities, remove the `set_options` service.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/54502
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
