### PR TITLE
Enphase_envoy: Add daily energy production template example

### DIFF
--- a/source/_integrations/enphase_envoy.markdown
+++ b/source/_integrations/enphase_envoy.markdown
@@ -21,3 +21,25 @@ A sensor platform for the [Enphase Envoy](https://enphase.com/en-us/products-and
 ### Obtaining the password
 
 For newer models, the username `envoy` without a password will grant access to the device. For older models, the password for the `installer` user can be obtained with this: [tool](https://thecomputerperson.wordpress.com/2016/08/28/reverse-engineering-the-enphase-installer-toolkit/).
+
+### Using Energy Dashboard with firmware <3.9
+
+Older firmware will round the value of lifetime energy production, sometimes to MWh. Unless you are an energy company, MWh will not offer enough precision; so you may wish to configure a template entity with the *daily energy production* measurement. Make sure to set `state_class` and `last_reset` so long-term statistics are supported.
+
+{% raw %}
+
+```yaml
+template:
+  - sensor:
+      - name: "My Daily Production"
+        state: "{{ states('sensor.envoy_today_s_energy_production') }}"
+        unique_id: "envoy_daily_energy_consumption_last_reset"
+        unit_of_measurement: Wh
+        icon: mdi:solar-power
+        device_class: energy
+        state_class: measurement
+        attributes:
+          last_reset: "{{ now().replace(hour=0, minute=0, second=0, microsecond=0).isoformat() }}"
+```
+
+{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

As discussed in https://github.com/home-assistant/core/issues/54553, it's required to use the daily production measurement instead of the lifetime production measurement with the energy dashboard on older envoy firmwares.

This PR adds the template snippet needed to set up an entity measuring the daily production with the necessary attributes for long-term statistics the energy dashboard requires.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
