### PR TITLE
Remove alternatives from version

### DIFF
--- a/source/_integrations/version.markdown
+++ b/source/_integrations/version.markdown
@@ -54,50 +54,5 @@ source:
 
 `default`, `qemux86`, `qemux86-64`, `qemuarm`, `qemuarm-64`, `generic-x86-64`, `raspberrypi`, `raspberrypi2`, `raspberrypi3`, `raspberrypi3-64`, `raspberrypi4`, `raspberrypi4-64`, `tinker`, `odroid-c2`, `odroid-n2`, `odroid-xu`
 
-## Alternatives for showing local version
 
-This sensor is an alternative to the existing solutions to achieve the same
-result through various platforms.
-Remember that you can easily get the installed version on the command line.
 
-```bash
-hass --version
-```
-
-Or go to the <img src='/images/screenshots/developer-tool-about-icon.png' alt='service developer tool icon' class="no-shadow" height="38" /> **Info** section of the **Developer Tools**.
-
-A [`command_line`](/integrations/sensor.command_line/) with
-[`hass`](/docs/tools/hass/) to display your current version.
-
-```yaml
-sensor:
-  - platform: command_line
-    name: Version
-    command: "/home/homeassistant/bin/hass --version"
-```
-
-It's also possible to read a file called `.HA_VERSION` which is located in your
-Home Assistant [configuration](/docs/configuration/) folder.
-
-```yaml
-sensor:
-  - platform: command_line
-    name: Version
-    command: "cat /home/homeassistant/.homeassistant/.HA_VERSION"
-```
-
-You might think that a [`rest` sensor](/integrations/rest) could work,
-too,
-but it will not as Home Assistant is not ready when the sensor gets initialized.
-
-{% raw %}
-
-```yaml
-sensor:
-  - platform: rest
-    resource: http://IP_ADDRESS:8123/api/config
-    name: Current Version
-    value_template: "{{ value_json.version }}"
-```
-
-{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Removes alternative examples from the version integration docs.
These should rather be in the forums, and the rest example has not worked since we added authentication.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
