### PR TITLE
Added ZIV as working with the DSMR integration

### DIFF
--- a/source/_integrations/dsmr.markdown
+++ b/source/_integrations/dsmr.markdown
@@ -35,6 +35,7 @@ This integration is known to work for:
 - Kaifa E0026
 - Kamstrup 382JxC (DSMR 2.2)
 - Sagemcom XS210 ESMR5
+- Ziv E0058 ESMR5
 
 USB serial converters:
 


### PR DESCRIPTION
I own this meter and this integration works great with it. (It is this meter: https://www.enexis.nl/consument/aansluiting-en-meter/meter/slimme-meter/handleiding-en-uitleg/handleiding-slimme-meter/handleiding-elektriciteitsmeter-ziv-e0058-esmr5)

## Proposed change
Added the ZIV meter as working with this integration



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
