### PR TITLE
Add information about `select` platform for Xiaomi Miio fans

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -240,7 +240,6 @@ Supported devices:
   - `use_time`
   - `button_pressed`
   - `buzzer`
-  - `led_brightness`
   - `sleep_mode`
 - Sensor entities
 
@@ -367,7 +366,6 @@ This model uses newer MiOT communication protocol.
   - `led`
   - `use_time`
   - `buzzer`
-  - `led_brightness`
   - `fan_level`
 - Sensor entities
 
@@ -380,12 +378,17 @@ Sensor                  | Description
 `purify_volume`         | The volume of purified air in qubic meter
 `temperature`           | The current `temperature` measured
 
+- Select entities
+
+Select | Description
+--- | ---
+`led brightness` | Controls the brightness of the LEDs (bright, dim, off)
+
 ### Air Purifier V3 (zhimi.airpurifier.v3)
 
 - Power (on, off)
 - Operation modes (auto, silent, favorite, idle, medium, high, strong)
 - Child lock (on, off)
-- LED (on, off)
 - Attributes
   - `model`
   - `aqi`
@@ -421,6 +424,12 @@ Sensor                  | Description
 `motor_speed`           | The current `motor_speed` measured in rpm
 `motor2_speed`          | The current `motor2_speed` measured in rpm
 `purify_volume`         | The volume of purified air in qubic meter
+
+- Select entities
+
+Select | Description
+--- | ---
+`led brightness` | Controls the brightness of the LEDs (bright, dim, off)
 
 ### Air Humidifier (zhimi.humidifier.v1)
 
@@ -498,7 +507,6 @@ Clean mode and Motor speed can only be set when the device is turned on.
 - Operation modes (auto, silent, interval, low, middle, strong)
 - Buzzer (on, off)
 - Child lock (on, off)
-- LED (on, off), LED brightness (bright, dim, off)
 - Attributes
   - `model`
   - `aqi`
@@ -508,7 +516,6 @@ Clean mode and Motor speed can only be set when the device is turned on.
   - `co2`
   - `mode`
   - `led`
-  - `led_brightness`
   - `buzzer`
   - `child_lock`
   - `filter_life_remaining`
@@ -526,6 +533,12 @@ Sensor                  | Description
 `humidity`              | The current `humidity` measured
 `illuminance`           | The current `illuminance` measured
 `temperature`           | The current `temperature` measured
+
+- Select entities
+
+Select | Description
+--- | ---
+`led brightness` | Controls the brightness of the LEDs (bright, dim, off)
 
 ### Platform Services
 

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -426,12 +426,6 @@ Sensor                  | Description
 `motor2_speed`          | The current `motor2_speed` measured in rpm
 `purify_volume`         | The volume of purified air in qubic meter
 
-- Select entities
-
-Select | Description
---- | ---
-`led brightness` | Controls the brightness of the LEDs (bright, dim, off)
-
 ### Air Humidifier (zhimi.humidifier.v1)
 
 - On, Off

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -635,15 +635,6 @@ Set the LED brightness. Supported values are 'Bright', 'Dim', 'Off'.
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 | `option`                  |       no | Brightness option. Should be 'Bright', 'Dim' or 'Off'   |
 
-### Service `xiaomi_miio.fan_set_led_brightness` (Air Humidifiers, Air Purifier 2S and Air Purifier Pro excluded)
-
-Set the LED brightness. Supported values are 0 (Bright), 1 (Dim), 2 (Off).
-
-| Service data attribute    | Optional | Description                                             |
-|---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
-| `brightness`              |       no | Brightness, between 0 and 2.                            |
-
 ### Service `xiaomi_miio.fan_set_favorite_level` (Air Purifiers only)
 
 Set the favorite level of the operation mode "favorite".

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -389,6 +389,7 @@ Select | Description
 - Power (on, off)
 - Operation modes (auto, silent, favorite, idle, medium, high, strong)
 - Child lock (on, off)
+- LED (on, off)
 - Attributes
   - `model`
   - `aqi`
@@ -507,6 +508,7 @@ Clean mode and Motor speed can only be set when the device is turned on.
 - Operation modes (auto, silent, interval, low, middle, strong)
 - Buzzer (on, off)
 - Child lock (on, off)
+- LED (on, off)
 - Attributes
   - `model`
   - `aqi`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR:
- adds information about `select` platform for fans
- remove information about removed service `xiaomi_miio.fan_set_led_brightness`


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/54702
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
