### PR TITLE
Add services to Renault integration

### DIFF
--- a/source/_integrations/renault.markdown
+++ b/source/_integrations/renault.markdown
@@ -53,7 +53,7 @@ Update charge schedule on vehicle.
   | Service data attribute | Required | Description | Example |
   | ---------------------- | -------- | ----------- | ------- |
   | `vehicle`| yes | device_id of the vehicle |
-  | `schedules` | yes | Schedule details. Can be a single schedule or a list of schedules | `[{'id':1,'activated':true,'monday':{'startTime':'T12:00Z','duration':15}},<br>{'id':2,'activated':false,'monday':{'startTime':'T12:00Z','duration':240}}<br>]` |
+  | `schedules` | yes | Schedule details. Can be a single schedule or a list of schedules | see [example below](#schedule_example) |
   
 Notes:
 
@@ -61,6 +61,23 @@ Notes:
 - the `id` is compulsory on each `schedule` (should be 1 to 5 depending on the vehicle)
 - the `activated` flag is an optional boolean. If it is not provided, then the existing flag will be kept as is.
 - the `monday` to `sunday` elements are optional. If they are not provided, then the existing settings will be kept for each day. If they are provided as None, then the existing setting will be cleared. If a value is provided, it must conform to this format `{'startTime':'T12:00Z','duration':15}` where start time is in UTC format and the duration is in minutes.
+
+<a name="schedule_example">Example</a>:
+
+```yaml
+[
+  { 
+    'id': 1, 
+    'activated': true, 
+    'monday': {'startTime':'T12:00Z', 'duration':15} 
+  }, 
+  { 
+    'id': 2, 
+    'activated': false, 
+    'monday': {'startTime':'T12:00Z', 'duration':240} 
+  },
+]
+```
 
 ### Service `renault.charge_start`
 

--- a/source/_integrations/renault.markdown
+++ b/source/_integrations/renault.markdown
@@ -25,3 +25,50 @@ You need two API keys: one for Gigya and one for Kamereon and they shouldn't be 
 {% include integrations/config_flow.md %}
 
 All vehicles linked to the account should then get added as devices, with sensors added as linked entity.
+
+## Services
+
+### Service `renault.ac_start`
+
+Start A/C on the specified vehicle by `vin`.
+
+  | Service data attribute | Required | Description |
+  | ---------------------- | -------- | ----------- |
+  | `vin` | yes | VIN of the vehicle |
+  | `temperature` | yes | Target A/C temperature in °C |
+  | `when` | no | Timestamp for the start of the A/C (optional - defaults to now) |
+
+### Service `renault.ac_cancel`
+
+Cancel A/C on the specified vehicle by `vin`.
+
+  | Service data attribute | Required | Description |
+  | ---------------------- | -------- | ----------- |
+  | `vin` | yes | VIN of the vehicle |
+
+### Service `renault.charge_set_mode`
+
+Set charge mode on the specified vehicle by `vin`.
+
+  | Service data attribute | Required | Description |
+  | ---------------------- | -------- | ----------- |
+  | `vin` | yes | VIN of the vehicle |
+  | `charge_mode` | yes | Charge mode to apply. Allowed values: `always`, `always_charging`, `schedule_mode` |
+
+### Service `renault.charge_set_schedules`
+
+Update charge schedule on the specified vehicle by `vin`.
+
+  | Service data attribute | Required | Description |
+  | ---------------------- | -------- | ----------- |
+  | `vin` | yes | VIN of the vehicle |
+  | `schedules` | yes | Schedule details. Can be a single schedule or a list of schedules |
+
+### Service `renault.charge_start`
+
+Start charge on the specified vehicle by `vin`.
+
+  | Service data attribute | Required | Description |
+  | ---------------------- | -------- | ----------- |
+  | `vin` | yes | VIN of the vehicle |
+

--- a/source/_integrations/renault.markdown
+++ b/source/_integrations/renault.markdown
@@ -30,45 +30,36 @@ All vehicles linked to the account should then get added as devices, with sensor
 
 ### Service `renault.ac_start`
 
-Start A/C on the specified vehicle by `vin`.
+Start A/C on vehicle.
 
   | Service data attribute | Required | Description |
   | ---------------------- | -------- | ----------- |
-  | `vin` | yes | VIN of the vehicle |
+  | `vehicle`| yes | device_id of the vehicle |
   | `temperature` | yes | Target A/C temperature in °C |
   | `when` | no | Timestamp for the start of the A/C (optional - defaults to now) |
 
 ### Service `renault.ac_cancel`
 
-Cancel A/C on the specified vehicle by `vin`.
+Cancel A/C on vehicle.
 
   | Service data attribute | Required | Description |
   | ---------------------- | -------- | ----------- |
-  | `vin` | yes | VIN of the vehicle |
-
-### Service `renault.charge_set_mode`
-
-Set charge mode on the specified vehicle by `vin`.
-
-  | Service data attribute | Required | Description |
-  | ---------------------- | -------- | ----------- |
-  | `vin` | yes | VIN of the vehicle |
-  | `charge_mode` | yes | Charge mode to apply. Allowed values: `always`, `always_charging`, `schedule_mode` |
+  | `vehicle`| yes | device_id of the vehicle |
 
 ### Service `renault.charge_set_schedules`
 
-Update charge schedule on the specified vehicle by `vin`.
+Update charge schedule on vehicle.
 
   | Service data attribute | Required | Description |
   | ---------------------- | -------- | ----------- |
-  | `vin` | yes | VIN of the vehicle |
+  | `vehicle`| yes | device_id of the vehicle |
   | `schedules` | yes | Schedule details. Can be a single schedule or a list of schedules |
 
 ### Service `renault.charge_start`
 
-Start charge on the specified vehicle by `vin`.
+Start charge on vehicle.
 
   | Service data attribute | Required | Description |
   | ---------------------- | -------- | ----------- |
-  | `vin` | yes | VIN of the vehicle |
+  | `vehicle`| yes | device_id of the vehicle |
 

--- a/source/_integrations/renault.markdown
+++ b/source/_integrations/renault.markdown
@@ -32,11 +32,11 @@ All vehicles linked to the account should then get added as devices, with sensor
 
 Start A/C on vehicle.
 
-  | Service data attribute | Required | Description |
-  | ---------------------- | -------- | ----------- |
-  | `vehicle`| yes | device_id of the vehicle |
-  | `temperature` | yes | Target A/C temperature in °C |
-  | `when` | no | Timestamp for the start of the A/C (optional - defaults to now) |
+  | Service data attribute | Required | Description | Example |
+  | ---------------------- | -------- | ----------- | ------- |
+  | `vehicle`| yes | device_id of the vehicle | |
+  | `temperature` | yes | Target A/C temperature in °C | |
+  | `when` | no | Timestamp for the start of the A/C (optional - defaults to now) | `2020-05-01T17:45:00` |
 
 ### Service `renault.ac_cancel`
 
@@ -50,10 +50,17 @@ Cancel A/C on vehicle.
 
 Update charge schedule on vehicle.
 
-  | Service data attribute | Required | Description |
-  | ---------------------- | -------- | ----------- |
+  | Service data attribute | Required | Description | Example |
+  | ---------------------- | -------- | ----------- | ------- |
   | `vehicle`| yes | device_id of the vehicle |
-  | `schedules` | yes | Schedule details. Can be a single schedule or a list of schedules |
+  | `schedules` | yes | Schedule details. Can be a single schedule or a list of schedules | `[{'id':1,'activated':true,'monday':{'startTime':'T12:00Z','duration':15}},<br>{'id':2,'activated':false,'monday':{'startTime':'T12:00Z','duration':240}}<br>]` |
+  
+Notes:
+
+- `schedules` can be in the form `{'id':1,...}` when updating a single schedules, or in the form `[{'id':1,...},{'id':2,...},...]` when updating multiple schedules within the same call
+- the `id` is compulsory on each `schedule` (should be 1 to 5 depending on the vehicle)
+- the `activated` flag is an optional boolean. If it is not provided, then the existing flag will be kept as is.
+- the `monday` to `sunday` elements are optional. If they are not provided, then the existing settings will be kept for each day. If they are provided as None, then the existing setting will be cleared. If a value is provided, it must conform to this format `{'startTime':'T12:00Z','duration':15}` where start time is in UTC format and the duration is in minutes.
 
 ### Service `renault.charge_start`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add services to Renault integration, as a follow up to #14383


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/54820
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
