### PR TITLE
Fix formatting of numbers in prefix warning box

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -677,7 +677,7 @@ automation 3:
 
 <div class='note warning'>
 
-Do not prefix numbers with a zero - using `'00'` instead of '0' for example will result in errors.
+Do not prefix numbers with a zero - using `'00'` instead of `'0'` for example will result in errors.
 
 </div>
 


### PR DESCRIPTION
## Proposed change
Consistently format numbers in the prefix warning box. Currently double 0 is marked with backticks, the single zero isn't so is inconsistent.

<img width="729" alt="Screenshot 2021-08-19 at 18 59 01" src="https://user-images.githubusercontent.com/67615/130120496-e4e3a209-fe60-4447-9fcd-b96e21751d79.png">

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
