### PR TITLE
'Monetary' missing from list of Device Classes

### DIFF
--- a/source/_integrations/sensor.markdown
+++ b/source/_integrations/sensor.markdown
@@ -22,7 +22,7 @@ The type of data a sensor returns impacts how it is displayed in the frontend. T
 - **energy**: Energy in Wh or kWh.
 - **humidity**: Percentage of humidity in the air.
 - **illuminance**: The current light level in lx or lm.
-- **monetary**: The monetary value
+- **monetary**: The monetary value.
 - **signal_strength**: Signal strength in dB or dBm.
 - **temperature**: Temperature in °C or °F.
 - **power**: Power in W or kW.

--- a/source/_integrations/sensor.markdown
+++ b/source/_integrations/sensor.markdown
@@ -22,6 +22,7 @@ The type of data a sensor returns impacts how it is displayed in the frontend. T
 - **energy**: Energy in Wh or kWh.
 - **humidity**: Percentage of humidity in the air.
 - **illuminance**: The current light level in lx or lm.
+- **monetary**: The monetary value
 - **signal_strength**: Signal strength in dB or dBm.
 - **temperature**: Temperature in °C or °F.
 - **power**: Power in W or kW.


### PR DESCRIPTION
'Monetary' missing from list of Device Classes

## Proposed change
Add 'Monetary' to list of Device Classes



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
'Monetary' was missing from list of Device Classes. Other device classes have a unit but I'm assuming monetary could be any currency from around the world so I didn't mention a unit.


## Checklist


- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
