### PR TITLE
Add documentation on zwave_js automations

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -423,8 +423,6 @@ Z-Wave JS has support for device triggers and conditions. To use a device automa
 
 Z-Wave JS provides the `zwave_js.value_updated` trigger platform which can be used to trigger automations on any Z-Wave JS value update, including Z-Wave values that aren't supported in Home Assistant via entities. While they can't be authored from the automation UI, they can be authored in YAML directly in your `configuration.yaml`.
 
-{% raw %}
-
 ```yaml
 # Example automation trigger that fires whenever the `latchStatus` value changes from `closed` to `opened` on the three devices (devices will be derived from an entity ID).
 trigger:
@@ -436,18 +434,16 @@ trigger:
     - lock.back_door
   # `property` and `command_class` are required
   command_class: 98 # Door Lock CC
-  property: latchStatus
+  property: "latchStatus"
   # `property_key` and `endpoint` are optional
   property_key: null
   endpoint: 0
   # `from` and `to` will both accept lists of values and the trigger will fire if the value update matches any of the listed values
   from:
-    - closed
-    - jammed
-  to: opened
+    - "closed"
+    - "jammed"
+  to: "opened"
 ```
-
-{% endraw %}
 
 #### Available Trigger Data
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -413,6 +413,42 @@ action:
       entity_id: switch.in_wall_dual_relay_switch_2, switch.in_wall_dual_relay_switch_3
 ```
 
+## Automations
+
+### Device automations
+
+Z-Wave JS has support for device triggers and conditions. To use a device automation, use the automation UI to select the "Device" trigger/condition type, and then pick your Z-Wave JS device. Under trigger/condition types, you will see Z-Wave JS specific entries.
+
+### `zwave_js.value_updated` trigger
+
+Z-Wave JS provides the `zwave_js.value_updated` trigger platform which can be used to trigger automations on any Z-Wave JS value update, including Z-Wave values that aren't supported in Home Assistant via entities. While they can't be authored from the automation UI, they can be authored in YAML directly in your `configuration.yaml`.
+
+{% raw %}
+
+```yaml
+# Example automation trigger that fires whenever the `latchStatus` value changes from `closed` to `opened` on the three devices (devices will be derived from an entity ID).
+trigger:
+  platform: zwave_js.value_updated
+  # At least one `device_id` or `entity_id` must be provided
+  device_id: 45d7d3230dbb7441473ec883dab294d4  # Garage Door Lock device ID
+  entity_id:
+    - lock.front_lock
+    - lock.back_door
+  # `property` and `command_class` are required
+  command_class: 98 # Door Lock CC
+  property: latchStatus
+  # `property_key` and `endpoint` are optional
+  property_key: null
+  endpoint: 0
+  # `from` and `to` will both accept lists of values and the trigger will fire if the value update matches any of the listed values
+  from:
+    - closed
+    - jammed
+  to: opened
+```
+
+{% endraw %}
+
 ## Current Limitations
 
 - While support for the most common devices is working, some command classes are not yet (fully) implemented in Z-Wave JS. You can track the status [here](https://github.com/zwave-js/node-zwave-js/issues/6).

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -449,6 +449,26 @@ trigger:
 
 {% endraw %}
 
+#### Available Trigger Data
+
+In addition to the [standard automation trigger data](docs/automation/templating/#all), the `zwave_js.value_updated` trigger platform has additional trigger data available for use.
+
+| Template variable            | Data                                                                                       |
+|------------------------------|--------------------------------------------------------------------------------------------|
+| `trigger.device_id`          | Device ID for the device in the device registry.                                           |
+| `trigger.node_id`            | Z-Wave node ID.                                                                            |
+| `trigger.command_class`      | Command class ID.                                                                          |
+| `trigger.command_class_name` | Command class name.                                                                        |
+| `trigger.property`           | Z-Wave Value's property.                                                                   |
+| `trigger.property_name`      | Z-Wave Value's property name.                                                              |
+| `trigger.property_key`       | Z-Wave Value's property key.                                                               |
+| `trigger.property_key_name`  | Z-Wave Value's property key name.                                                          |
+| `trigger.endpoint`           | Z-Wave Value's endpoint.                                                                   |
+| `trigger.previous_value`     | The previous value for this Z-Wave value (translated to a state name when possible).       |
+| `trigger.previous_value_raw` | The raw previous value for this Z-Wave value (the key of the state when a state is named). |
+| `trigger.current_value`      | The current value for this Z-Wave value (translated to a state name when possible).        |
+| `trigger.current_value_raw`  | The raw current value for this Z-Wave value (the key of the state when a state is named).  |
+
 ## Current Limitations
 
 - While support for the most common devices is working, some command classes are not yet (fully) implemented in Z-Wave JS. You can track the status [here](https://github.com/zwave-js/node-zwave-js/issues/6).


### PR DESCRIPTION
## Proposed change
We are adding a new zwave_js automation trigger in https://github.com/home-assistant/core/pull/54897 so adding some documentation on automations.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/54897
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
