### PR TITLE
Add information about `number` platform for Xiaomi Miio fans

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -224,11 +224,9 @@ Supported devices:
 
 - Power (on, off)
 - Operation modes (Auto, Silent, Favorite, Idle)
-- Favorite Level (0...16)
 - Attributes
   - `model`
   - `mode`
-  - `favorite_level`
   - `sleep_time`
   - `sleep_mode_learn_count`
   - `extra_features`
@@ -236,6 +234,12 @@ Supported devices:
   - `use_time`
   - `button_pressed`
   - `sleep_mode`
+- Number entities
+
+Number                  | Description
+----------------------- | -----------------------
+Favorite Level          | Set the `favorite_level`
+
 - Sensor entities
 
 Sensor                  | Description
@@ -260,11 +264,9 @@ LED                     | Turn on/off `led`
 
 - Power (on, off)
 - Operation modes (Auto, Silent, Favorite)
-- Favorite Level (0...16)
 - Attributes
   - `model`
   - `mode`
-  - `favorite_level`
   - `sleep_time`
   - `sleep_mode_learn_count`
   - `extra_features`
@@ -272,7 +274,13 @@ LED                     | Turn on/off `led`
   - `auto_detect`
   - `use_time`
   - `button_pressed`
-  - `volume`
+- Number entities
+
+Number                  | Description
+----------------------- | -----------------------
+Favorite Level          | Set the `favorite_level`
+Volume                  | Set the `volume`
+
 - Sensor entities
 
 Sensor                  | Description
@@ -298,15 +306,19 @@ LED                     | Turn on/off `led`
 
 - Power (on, off)
 - Operation modes (Auto, Silent, Favorite)
-- Favorite Level (0...16)
 - Attributes
   - `model`
   - `mode`
-  - `favorite_level`
   - `extra_features`
   - `turbo_mode_supported`
   - `button_pressed`
-  - `volume`
+- Number entities
+
+Number                  | Description
+----------------------- | -----------------------
+Favorite Level          | Set the `favorite_level`
+Volume                  | Set the `volume`
+
 - Sensor entities
 
 Sensor                  | Description
@@ -331,14 +343,18 @@ LED                     | Turn on/off `led`
 
 - Power (on, off)
 - Operation modes (Auto, Silent, Favorite)
-- Favorite Level (0...16)
 - Attributes
   - `model`
   - `mode`
-  - `favorite_level`
   - `extra_features`
   - `turbo_mode_supported`
   - `button_pressed`
+- Number entities
+
+Number                  | Description
+----------------------- | -----------------------
+Favorite Level          | Set the `favorite_level`
+
 - Sensor entities
 
 Sensor                  | Description
@@ -363,14 +379,17 @@ This model uses newer MiOT communication protocol.
 
 - Power (on, off)
 - Operation modes (Auto, Silent, Favorite, Fan)
-- Favorite Level (0...16)
-- Fan Level (1...3)
 - Attributes
   - `model`
   - `mode`
-  - `favorite_level`
   - `use_time`
-  - `fan_level`
+- Number entities
+
+Number                  | Description
+----------------------- | -----------------------
+Fan Level               | Set the `fan_level`
+Favorite Level          | Set the `favorite_level`
+
 - Sensor entities
 
 Sensor                  | Description
@@ -661,33 +680,6 @@ Set the LED brightness. Supported values are 'Bright', 'Dim', 'Off'.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 | `option`                  |       no | Brightness option. Should be 'Bright', 'Dim' or 'Off'   |
-
-### Service `xiaomi_miio.fan_set_favorite_level` (Air Purifiers only)
-
-Set the favorite level of the operation mode "favorite".
-
-| Service data attribute    | Optional | Description                                             |
-|---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
-| `level`                   |       no | Level, between 0 and 16.                                |
-
-### Service `xiaomi_miio.fan_set_fan_level` (Air Purifiers only)
-
-Set the fan level for "fan" operation mode.
-
-| Service data attribute    | Optional | Description                                             |
-|---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |       no | Only act on a specific Xiaomi MiOT fan entity.          |
-| `level`                   |       no | Level, between 1 and 3.                                 |
-
-### Service `xiaomi_miio.fan_set_volume` (Air Purifier Pro only)
-
-Set the sound volume.
-
-| Service data attribute    | Optional | Description                                             |
-|---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
-| `volume`                  |       no | Volume, between 0 and 100.                              |
 
 ### Service `xiaomi_miio.fan_reset_filter` (Air Purifier 2 only)
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR:
- adds information about `number` platform for fans
- remove information about removed services


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/54977
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
