### PR TITLE
Clarify target example in script service call documentation

### DIFF
--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -30,12 +30,13 @@ This is done with the `target` key.
 A `target` is a map that contains at least one of the following: `area_id`, `device_id`, `entity_id`.
 Each of these can be a list.
 
-When the service is called, the areas and devices will be resolved to entities.
+The following example uses a single service call to turn on the lights in the
+living room area, 2 additional light devices and 2 additional light entities:
 
 ```yaml
-service: homeassistant.turn_on
+service: light.turn_on
 target:
-  area_id: livingroom
+  area_id: living_room
   device_id:
     - ff22a1889a6149c5ab6327a8236ae704
     - 52c050ca1a744e238ad94d170651f96b


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Slightly adjusts the script service call documentation based on feedback provided in #19011

- Changes the service call from `homeassistant.turn_on` to `light.turn_on`. Especially when targeting areas, this might be a better example.
- Added a small text introducing/explaining the example.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: closes #19011

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
