### PR TITLE
remove "military" comment on time format

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -578,7 +578,7 @@ A string that represents a time to fire on each day. Can be specified as `HH:MM`
 automation:
   - trigger:
     - platform: time
-      # Military time format. This trigger will fire at 3:32 PM
+      # ISO 8601 time format. This trigger will fire at 3:32 PM
       at: "15:32:00"
 ```
 


### PR DESCRIPTION
## Proposed change
24 hour format isn't really military format, it's standard time format for most of the world and default for ISO 8601


## Type of change
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).