### PR TITLE
Add reference to context in automation templating

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -9,11 +9,7 @@ The template variable `this` is also available when evaluating any `trigger_vari
 
 ## Available this Data
 
-`this` is a state object. [State Objects](/docs/configuration/state_object) provides a comprehensive description for the properties of `this` and `this.attributes`.
-
-## Available context Data
-
-Each of `this`, `to_state` and `from_state` have a context object, which includes information such as the user that caused the change. [Home Assistant Context](https://data.home-assistant.io/docs/context/t) provides more detail on contexts.
+`this` is a state object. [State Objects](/docs/configuration/state_object) provides a comprehensive description for the properties of `this` and `this.attributes`. State objects also contain context data, which can be used to identify the user that caused a script or automation to execute.
 
 ## Available Trigger Data
 

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -11,6 +11,10 @@ The template variable `this` is also available when evaluating any `trigger_vari
 
 `this` is a state object. [State Objects](/docs/configuration/state_object) provides a comprehensive description for the properties of `this` and `this.attributes`.
 
+## Available context Data
+
+Each of `this`, `to_state` and `from_state` have a context object, which includes information such as the user that caused the change. [Home Assistant Context](https://data.home-assistant.io/docs/context/t) provides more detail on contexts.
+
 ## Available Trigger Data
 
 The following tables show the available trigger data per platform.

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -9,7 +9,7 @@ The template variable `this` is also available when evaluating any `trigger_vari
 
 ## Available this Data
 
-`this` is a state object. [State Objects](/docs/configuration/state_object) provides a comprehensive description for the properties of `this` and `this.attributes`. State objects also contain context data, which can be used to identify the user that caused a script or automation to execute.
+Variable `this` is the [state object](/docs/configuration/state_object) of the automation. State objects also contain context data which can be used to identify the user that caused a script or automation to execute.
 
 ## Available Trigger Data
 

--- a/source/_docs/configuration/state_object.markdown
+++ b/source/_docs/configuration/state_object.markdown
@@ -39,12 +39,10 @@ When an attribute contains spaces, you can retrieve it like this: `state_attr('s
 
 ## Context
 
-Context is used to tie events and states together in Home Assistant. Whenever an automation or user interaction triggers a new change, a new context is assigned. This context will be attached to all events and states that happen as result of the change.
-
-The `user_id` in a context object may be useful in determining which user caused a script or automation to be executed.
+Context is used to tie events and states together in Home Assistant. Whenever an automation or user interaction causes states to change, a new context is assigned. This context will be attached to all events and states that happen as result of the change.
 
 | Field      | Description                                                         |
 | -----      | ------------------------------------------------------------------- |
 | context_id | Unique identifier for the context.                                  |
-| user_id    | Unique identifier of the user that started the change.              |
-| parent_id  | Unique identifier of the parent context_id that started the change. |
+| user_id    | Unique identifier of the user that started the change. Will be `None` if action was not started by a user (ie. started by an automation)               |
+| parent_id  | Unique identifier of the parent context that started the change, if available. For example, if an automation is triggered, the context of the trigger will be set as parent.  |

--- a/source/_docs/configuration/state_object.markdown
+++ b/source/_docs/configuration/state_object.markdown
@@ -19,6 +19,9 @@ All states will always have an entity id, a state and a timestamp when last upda
 | `state.last_updated` | Time the state was written to the state machine in UTC time. Note that writing the exact same state including attributes will not result in this field being updated. Example: `2017-10-28 08:13:36.715874+00:00`. |
 | `state.last_changed` | Time the state changed in the state machine in UTC time. This is not updated when there are only updated attributes. Example: `2017-10-28 08:13:36.715874+00:00`.                                                  |
 | `state.attributes`   | A dictionary with extra attributes related to the current state.                                                                                                                                                   |
+| `state.context`      | A dictionary with extra attributes related to the context of the state.                                                                                                                                                   |
+
+## Attributes
 
 The attributes of an entity are optional. There are a few attributes that are used by Home Assistant for representing the entity in a specific way. Each integration will also have its own attributes to represent extra state data about the entity. For example, the light integration has attributes for the current brightness and color of the light. When an attribute is not available, Home Assistant will not write it to the state.
 
@@ -33,3 +36,15 @@ When using templates, attributes will be available by their name. For example `s
 | `unit_of_measurement` | The unit of measurement the state is expressed in. Used for grouping graphs or understanding the entity. Example: `°C`.                       |
 
 When an attribute contains spaces, you can retrieve it like this: `state_attr('sensor.livingroom', 'Battery numeric')`.
+
+## Context
+
+Context is used to tie events and states together in Home Assistant. Whenever an automation or user interaction triggers a new change, a new context is assigned. This context will be attached to all events and states that happen as result of the change.
+
+The `user_id` in a context object may be useful in determining which user caused a script or automation to be executed.
+
+| Field      | Description                                                         |
+| -----      | ------------------------------------------------------------------- |
+| context_id | Unique identifier for the context.                                  |
+| user_id    | Unique identifier of the user that started the change.              |
+| parent_id  | Unique identifier of the parent context_id that started the change. |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Users aren't aware that they can discover the user ID of the user that triggered an automation. Adding this to the automation templating page to make this more obvious.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
