### PR TITLE
Fix solarlog unit of measurements

### DIFF
--- a/source/_integrations/solarlog.markdown
+++ b/source/_integrations/solarlog.markdown
@@ -68,10 +68,10 @@ The following sensors are available in the library:
 | consumption_total     | kWh    | Accumulated total consumption from all consumption meters. |
 | total_power           | Wp     | Installed generator power. |
 | alternator_loss       | W      | Altenator loss (equals to power_dc - power_ac) |
-| capacity              | %      | Capacity (equals to power_dc / total power) |
-| efficiency            | % W/Wp | Efficiency (equals to power_ac / power_dc |
+| capacity              | W/Wp   | Capacity (equals to power_dc / total power) |
+| efficiency            | %      | Efficiency (equals to power_ac / power_dc) |
 | power_available       | W      | Available power (equals to power_ac - consumption_ac) | 
-| usage                 |        | Usage (equals to consumption_ac / power_ac) |
+| usage                 | %      | Usage (equals to consumption_ac / power_ac) |
 
 <div class='note'>
 The solarlog integration is using the sunwatcher pypi package to get the data from your Solar-Log device. The last five sensors are not reported by your Solar-Log device directly, but are computed by the sunwatcher package.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Correction of the unit of measurement of three sensors, see https://github.com/home-assistant/core/pull/53946


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/53946
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
