### PR TITLE
Add GCE Eco-Devices integration

### DIFF
--- a/source/_integrations/ecodevices.markdown
+++ b/source/_integrations/ecodevices.markdown
@@ -1,0 +1,16 @@
+---
+title: GCE Eco-Devices
+description: Instructions on how to integrate GCE Eco-Devices within Home Assistant.
+ha_release: 2021.4
+ha_iot_class: Local Polling
+ha_category:
+  - Sensor
+ha_codeowners:
+  - '@Aohzan'
+ha_config_flow: true
+ha_domain: ecodevices
+---
+
+The `ecodevices` integration allows you to get information from [GCE Eco-Devices](http://gce-electronics.com/fr/carte-relais-ethernet-module-rail-din/409-teleinformation-ethernet-ecodevices.html).
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change

Add documentation for a new integration for GCE Eco-Devices: https://www.gce-electronics.com/fr/carte-relais-ethernet-module-rail-din/409-teleinformation-ethernet-ecodevices.html
From custom component https://github.com/Aohzan/ecodevices

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/55270
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2203
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
