### PR TITLE
Config-flow options for DLNA integration

### DIFF
--- a/source/_integrations/dlna_dmr.markdown
+++ b/source/_integrations/dlna_dmr.markdown
@@ -8,6 +8,7 @@ ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:
   - '@StevenLooman'
+  - '@chishm'
 ha_domain: dlna_dmr
 ha_ssdp: true
 ha_platforms:

--- a/source/_integrations/dlna_dmr.markdown
+++ b/source/_integrations/dlna_dmr.markdown
@@ -32,34 +32,3 @@ Event listener callback URL:
 Poll for device availability:
   description: "Periodically try to connect to the DLNA device, even if it is unavailable. Enable this if SSDP advertisements sent by the device are not received by Home Assistant, e.g. when IP multicast is broken on your network."
 {% endconfiguration_basic %}
-
-## Manual Configuration
-
-Alternatively, you can add a DLNA DMR device to your installation, by adding the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-media_player:
-  - platform: dlna_dmr
-    url: http://192.168.0.10:9197/description.xml
-```
-
-{% configuration %}
-url:
-  description: The URL to the device description XML file, e.g., `http://192.168.0.10:9197/description.xml`.
-  required: true
-  type: string
-listen_port:
-  description: Port to listen on for events from the device.
-  required: false
-  default: 8301
-  type: integer
-name:
-  description: The name you would like to give to the device, e.g., `TV living room`.
-  required: false
-  type: string
-callback_url_override:
-  description: Override the advertised callback URL. In case the Home Assistant instance is not directly reachable (e.g., running in a Docker container without bridged-networking), advertise this callback URL for events.
-  required: false
-  type: string
-{% endconfiguration %}

--- a/source/_integrations/dlna_dmr.markdown
+++ b/source/_integrations/dlna_dmr.markdown
@@ -5,7 +5,11 @@ ha_category:
   - Media Player
 ha_release: 0.76
 ha_iot_class: Local Push
+ha_config_flow: true
+ha_codeowners:
+  - '@StevenLooman'
 ha_domain: dlna_dmr
+ha_ssdp: true
 ha_platforms:
   - media_player
 ---
@@ -14,9 +18,24 @@ The `dlna_dmr` platform allows you to control a [DLNA Digital Media Renderer](ht
 
 Please note that some devices, such as Samsung TVs, are rather picky about the source used to play from. The TTS service might not work in combination with these devices. If the play_media service does not work, please try playing from a DLNA/DMS (such as [MiniDLNA](https://sourceforge.net/projects/minidlna/)).
 
-## Configuration
+{% include integrations/config_flow.md %}
 
-To add a DLNA DMR device to your installation, add the following to your `configuration.yaml` file:
+## Options
+
+Options for DLNA DMR devices can be set going to **Configuration** -> **Integrations** -> **DLNA Digital Media Renderer** -> **Configuration**.
+
+{% configuration_basic %}
+Event listener port:
+  description: "Local port to listen on for events sent by the DLNA device. If this is not set, a random port will be allocated. Use this if you need a specific incoming port for firewall or NAT reasons."
+Event listener callback URL:
+  description: "Local URL destination for events sent by the DLNA device. It should be of the form `http://{host}:{port}/notify`, where keywords `{host}` and `{port}` will be automatically filled-in but can be set explicitly here, e.g. `http://192.88.99.1:5555/notify`. Use this if the local IP address or port seen by Home Assistant is not what the device should connect to, because of Network Address Translation (NAT)."
+Poll for device availability:
+  description: "Periodically try to connect to the DLNA device, even if it is unavailable. Enable this if SSDP advertisements sent by the device are not received by Home Assistant, e.g. when IP multicast is broken on your network."
+{% endconfiguration_basic %}
+
+## Manual Configuration
+
+Alternatively, you can add a DLNA DMR device to your installation, by adding the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -29,10 +48,6 @@ media_player:
 url:
   description: The URL to the device description XML file, e.g., `http://192.168.0.10:9197/description.xml`.
   required: true
-  type: string
-listen_ip:
-  description: IP to listen on for events from the device. Only set this when the IP is not detected properly.
-  required: false
   type: string
 listen_port:
   description: Port to listen on for events from the device.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds config-flow documentation for an upcoming `dlna_dmr` integration change.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/55267

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
