### PR TITLE
Homepage CSS changes alternative

### DIFF
--- a/sass/oscailte/homepage/_hero_unit.scss
+++ b/sass/oscailte/homepage/_hero_unit.scss
@@ -11,6 +11,7 @@
   margin-bottom: 1.5em;
   padding: 50px 0;
   position: relative;
+  z-index:999;
 
   // &::before {
   //   background: url("../images/matrix.png") 0 0 rgba(0, 0, 0, 0.35);
@@ -25,6 +26,11 @@
   > .grid-wrapper {
     position: relative;
     z-index: 7;
+  }
+  
+  .screenshotimage
+  {
+    display:block;
   }
 
   .credit {

--- a/sass/oscailte/homepage/_hero_unit.scss
+++ b/sass/oscailte/homepage/_hero_unit.scss
@@ -11,7 +11,6 @@
   margin-bottom: 1.5em;
   padding: 50px 0;
   position: relative;
-  z-index:999;
 
   // &::before {
   //   background: url("../images/matrix.png") 0 0 rgba(0, 0, 0, 0.35);

--- a/sass/oscailte/homepage/_hero_unit.scss
+++ b/sass/oscailte/homepage/_hero_unit.scss
@@ -30,7 +30,7 @@
   
   .screenshotimage
   {
-    display:block;
+     display:block;
   }
 
   .credit {

--- a/sass/oscailte/homepage/_home.scss
+++ b/sass/oscailte/homepage/_home.scss
@@ -4,7 +4,7 @@ ul.menu li {
     overflow: hidden;
 }
 
-ul.menu li.menuhasdropdown {
+ul.menu li.menuitemhasdropdown {
     overflow: visible;
 }
 

--- a/sass/oscailte/homepage/_home.scss
+++ b/sass/oscailte/homepage/_home.scss
@@ -1,3 +1,14 @@
+ul.menu li {
+    position: relative;
+    height: 68px;
+    overflow: hidden;
+}
+
+ul.menu li.menuhasdropdown {
+    overflow: visible;
+}
+
+
 .usp {
   text-align: center;
 

--- a/sass/oscailte/homepage/_home.scss
+++ b/sass/oscailte/homepage/_home.scss
@@ -8,7 +8,6 @@ ul.menu li.menuhasdropdown {
     overflow: visible;
 }
 
-
 .usp {
   text-align: center;
 

--- a/source/_includes/site/header.html
+++ b/source/_includes/site/header.html
@@ -23,7 +23,7 @@
         ></label>
         <ul class="menu pull-right">
           <li><a href="/getting-started/">Getting started</a></li>
-          <li>
+          <li class="menuitemhasdropdown">
             <a href="/docs/"
               >Documentation <i class="icon icon-caret-down"></i
             ></a>

--- a/source/_includes/site/hero_unit.html
+++ b/source/_includes/site/hero_unit.html
@@ -3,7 +3,7 @@
     <div class="grid flex">
       <div class="grid__item flex__item two-fifths palm-one-whole">
         <a href='https://demo.home-assistant.io/' target='_blank'>
-          <img src="/images/hero_screenshot.png" alt="Home Assistant screenshot">
+        <img src="/images/hero_screenshot.png" alt="Home Assistant screenshot" style="display:block;">
         </a>
       </div>
       <div class="grid__item flex__item three-fifths palm-one-whole">

--- a/source/_includes/site/hero_unit.html
+++ b/source/_includes/site/hero_unit.html
@@ -3,7 +3,7 @@
     <div class="grid flex">
       <div class="grid__item flex__item two-fifths palm-one-whole">
         <a href='https://demo.home-assistant.io/' target='_blank'>
-        <img src="/images/hero_screenshot.png" alt="Home Assistant screenshot" style="display:block;">
+        <img src="/images/hero_screenshot.png" alt="Home Assistant screenshot">
         </a>
       </div>
       <div class="grid__item flex__item three-fifths palm-one-whole">

--- a/source/_includes/site/hero_unit.html
+++ b/source/_includes/site/hero_unit.html
@@ -3,7 +3,7 @@
     <div class="grid flex">
       <div class="grid__item flex__item two-fifths palm-one-whole">
         <a href='https://demo.home-assistant.io/' target='_blank'>
-        <img src="/images/hero_screenshot.png" alt="Home Assistant screenshot">
+        <img src="/images/hero_screenshot.png" alt="Home Assistant screenshot" class="screenshotimage">
         </a>
       </div>
       <div class="grid__item flex__item three-fifths palm-one-whole">

--- a/source/index.html
+++ b/source/index.html
@@ -252,3 +252,7 @@ description:
   src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
   integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs="
   crossorigin="anonymous"></script>
+<script type="text/javascript">
+jQuery( "ul.menu li:has(ul)" ).addClass( "menuhasdropdown" );
+</script>
+

--- a/source/index.html
+++ b/source/index.html
@@ -248,11 +248,3 @@ description:
     </div>
   </div>
 </div>
-<script
-  src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
-  integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs="
-  crossorigin="anonymous"></script>
-<script type="text/javascript">
-jQuery( "ul.menu li:has(ul)" ).addClass( "menuhasdropdown" );
-</script>
-

--- a/source/index.html
+++ b/source/index.html
@@ -248,3 +248,7 @@ description:
     </div>
   </div>
 </div>
+<script
+  src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+  integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs="
+  crossorigin="anonymous"></script>


### PR DESCRIPTION
## Proposed change

Alternative for PR #18559

This one is CSS only and demands a class to be added manually to menu items with a dropdown list in the future. Which is not that bad I guess. At first, I assumed that the menu was being generated, not created from a html file. 

## Type of change

*   [x] Spelling, grammar or other readability improvements (`current` branch).
*   [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
*   [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
    *   [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
*   [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
*   [ ] Removed stale or deprecated documentation.

## Additional information

*   Link to parent pull request in the codebase:
*   Link to parent pull request in the Brands repository:
*   This PR fixes or closes issue:

## Checklist

*   [x] This PR uses the correct branch, based on one of the following:
    *   I made a change to the existing documentation and used the `current` branch.
    *   I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
*   [x] The documentation follows the Home Assistant documentation [standards](https://developers.home-assistant.io/docs/documenting/standards).