### PR TITLE
Clarify command_line runtime environment

### DIFF
--- a/source/_integrations/command_line.markdown
+++ b/source/_integrations/command_line.markdown
@@ -74,6 +74,16 @@ command_timeout:
   default: 15
 {% endconfiguration %}
 
+## Execution
+
+The `command` is executed within the [configuration directory](/docs/configuration/).
+
+<div class='note'>
+If you are using [Home Assistant operating system](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
+</div>
+
+With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the sensors value is not updated.
+
 ## Examples
 
 In this section you find some real-life examples of how to use this sensor.

--- a/source/_integrations/command_line.markdown
+++ b/source/_integrations/command_line.markdown
@@ -79,7 +79,9 @@ command_timeout:
 The `command` is executed within the [configuration directory](/docs/configuration/).
 
 <div class='note'>
+
 If you are using [Home Assistant operating system](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
+
 </div>
 
 With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the sensors value is not updated.

--- a/source/_integrations/command_line.markdown
+++ b/source/_integrations/command_line.markdown
@@ -80,7 +80,7 @@ The `command` is executed within the [configuration directory](/docs/configurati
 
 <div class='note'>
 
-If you are using [Home Assistant operating system](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
+If you are using [Home Assistant Operating System](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
 
 </div>
 

--- a/source/_integrations/sensor.command_line.markdown
+++ b/source/_integrations/sensor.command_line.markdown
@@ -56,6 +56,16 @@ json_attributes:
   type: [string, list]
 {% endconfiguration %}
 
+## Execution
+
+The `command` is executed within the [configuration directory](/docs/configuration/).
+
+<div class='note'>
+If you are using [Home Assistant operating system](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
+</div>
+
+With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the sensors value is not updated.
+
 ## Examples
 
 In this section you find some real-life examples of how to use this sensor.
@@ -189,3 +199,4 @@ sensor:
 ```
 
 {% endraw %}
+

--- a/source/_integrations/sensor.command_line.markdown
+++ b/source/_integrations/sensor.command_line.markdown
@@ -66,7 +66,7 @@ If you are using [Home Assistant operating system](https://github.com/home-assis
 
 </div>
 
-With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the sensors value is not updated.
+With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the value of the sensor is not updated.
 
 ## Examples
 

--- a/source/_integrations/sensor.command_line.markdown
+++ b/source/_integrations/sensor.command_line.markdown
@@ -61,7 +61,9 @@ json_attributes:
 The `command` is executed within the [configuration directory](/docs/configuration/).
 
 <div class='note'>
+
 If you are using [Home Assistant operating system](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
+
 </div>
 
 With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the sensors value is not updated.

--- a/source/_integrations/sensor.command_line.markdown
+++ b/source/_integrations/sensor.command_line.markdown
@@ -62,7 +62,7 @@ The `command` is executed within the [configuration directory](/docs/configurati
 
 <div class='note'>
 
-If you are using [Home Assistant operating system](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
+If you are using [Home Assistant Operating System](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
 
 </div>
 

--- a/source/_integrations/shell_command.markdown
+++ b/source/_integrations/shell_command.markdown
@@ -39,6 +39,16 @@ Any service data passed into the service call to activate the shell command will
 
 `stdout` and `stderr` output from the command are both captured and will be logged by setting the [log level](/integrations/logger/) to debug.
 
+## Execution
+
+The `command` is executed within the [configuration directory](/docs/configuration/).
+
+<div class='note'>
+If you are using [Home Assistant operating system](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
+</div>
+
+With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the sensors value is not updated.
+
 ## Examples
 
 ### Defining multiple shell commands

--- a/source/_integrations/shell_command.markdown
+++ b/source/_integrations/shell_command.markdown
@@ -47,7 +47,7 @@ The `command` is executed within the [configuration directory](/docs/configurati
 If you are using [Home Assistant operating system](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
 </div>
 
-With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the sensors value is not updated.
+With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the value of the sensor is not updated.
 
 ## Examples
 


### PR DESCRIPTION
A user should know in which environment his commands are executed and how the results of the command are processed.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

When using the integration for the first time I was a little lost because I did not know in which kind of environment my command is executed and how the results are processed. After trying out a bit and reading the code, it was clearer to me. I hope I got that right.

Now I think this would be useful to others starting with this integration.

To be honest, I wasn't quite sure where the text was properly located.

1. It is not clear to me whether you can simply open any chapters in the articles.
2. The details actually apply to all integrations of the component. I have now described it for sensor and binary_sensor. Should it be described for the others (cover, switch?) as well?
3. The copy & paste of the information is actually not good. Is there a central place where this can or should be documented?

- Link to parent pull request in the codebase: -
- Link to parent pull request in the Brands repository: -
- This PR fixes or closes issue: -

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
