### PR TITLE
Add documentation on how to use IoTaWatt with energy management

### DIFF
--- a/source/_integrations/iotawatt.markdown
+++ b/source/_integrations/iotawatt.markdown
@@ -12,7 +12,7 @@ ha_codeowners:
 ha_platforms:
   - sensor
 ---
-A sensor platform for the [IoTaWatt](https://www.iotawatt.com/) Open WiFi Electricity Monitor. It
+Integration for the [IoTaWatt](https://www.iotawatt.com/) Open WiFi Electricity Monitor. It
 will collect data from the Current Transformer Clamps (Input CTs) and any Outputs that are defined on the IoTaWatt
 and create them as sensors in Home Assistant.
 

--- a/source/_integrations/iotawatt.markdown
+++ b/source/_integrations/iotawatt.markdown
@@ -12,8 +12,41 @@ ha_codeowners:
 ha_platforms:
   - sensor
 ---
-A sensor platform for the [IoTaWatt](https://www.iotawatt.com/) Open WiFi Electricity Monitor. It 
+A sensor platform for the [IoTaWatt](https://www.iotawatt.com/) Open WiFi Electricity Monitor. It
 will collect data from the Current Transformer Clamps (Input CTs) and any Outputs that are defined on the IoTaWatt
 and create them as sensors in Home Assistant.
 
 {% include integrations/config_flow.md %}
+
+## Energy management
+
+IoTaWatt does not provide the exact data that is needed for energy management. We're working with the IotaWatt team on resolving this.
+
+Until then, you can use these instructions to create the correct entities that work with energy management:
+
+### Configure IoTaWatt
+
+You will need to configure two new IoTaWatt output sensors:
+
+| Name | Unit | Formula
+| - | - | -
+| MainsConsumption|Watts|`(Main_In_Red + Main_In_White + Main_In_Blue) max 0`
+| MainsExport|Watts|`((Main_In_Red + Main_In_White + Main_In_Blue) min 0) abs`
+
+Replace `(Main_In_Red + Main_In_White + Main_In_Blue)` with the correct formula for your main feed.
+
+### Configure Home Assistant
+
+Add the following to your configuration.yaml file to convert the Watt measurements into kWh:
+
+```yaml
+sensor iotawatt:
+  - platform: integration
+    source: sensor.mainsexport
+    name: Total Grid Export
+    unit_prefix: k
+  - platform: integration
+    source: sensor.mainsconsumption
+    name: Total Grid Consumption
+    unit_prefix: k
+```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document how IoTaWatt can be used with energy management.

https://deploy-preview-19155--home-assistant-docs.netlify.app/integrations/iotawatt#energy-management

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
