### PR TITLE
Add "gas" to the list of sensor.device_class

### DIFF
--- a/source/_integrations/sensor.markdown
+++ b/source/_integrations/sensor.markdown
@@ -23,6 +23,7 @@ The type of data a sensor returns impacts how it is displayed in the frontend. T
 - **carbon_monoxide**: Carbon Monoxide in CO (Gas CNG/LPG)
 - **current**: Current in A.
 - **energy**: Energy in Wh or kWh.
+- **gas**: Gasvolume in m³
 - **humidity**: Percentage of humidity in the air.
 - **illuminance**: The current light level in lx or lm.
 - **monetary**: The monetary value.

--- a/source/_integrations/sensor.markdown
+++ b/source/_integrations/sensor.markdown
@@ -23,7 +23,7 @@ The type of data a sensor returns impacts how it is displayed in the frontend. T
 - **carbon_monoxide**: Carbon Monoxide in CO (Gas CNG/LPG)
 - **current**: Current in A.
 - **energy**: Energy in Wh or kWh.
-- **gas**: Gasvolume in m³
+- **gas**: Gasvolume in m³.
 - **humidity**: Percentage of humidity in the air.
 - **illuminance**: The current light level in lx or lm.
 - **monetary**: The monetary value.


### PR DESCRIPTION
## Proposed change

Add "gas" to the list of available device_classes for sensors to make it easy for users to add gas meters to the new energy dashboard, see also here: Based on this forum topic: https://community.home-assistant.io/t/adding-gas-to-energy-dashboard-solved/334988

## Type of change
    Docu fix

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.