### PR TITLE
CSS added margin top to Sponsors box as in Press box

### DIFF
--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -240,8 +240,12 @@ $primary-color: #049cdb;
     }
   }
 
+  .sponsored-and-press
+  {
+    margin-top:24px;
+  }
+  
   .sponsored-by {
-    margin-top: 24px;
     
     img {
       border: 0;
@@ -255,7 +259,6 @@ $primary-color: #049cdb;
   }
   
   .seen-press {
-    margin-top: 24px;
 
     img {
       border: 0;

--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -240,13 +240,11 @@ $primary-color: #049cdb;
     }
   }
 
-  .sponsors-and-press
-  {
+  .sponsors-and-press {
     margin-top:24px;
   }
   
   .sponsored-by {
-    
     img {
       border: 0;
       border-radius: 0;

--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -240,7 +240,7 @@ $primary-color: #049cdb;
     }
   }
 
-  .sponsored-and-press
+  .sponsors-and-press
   {
     margin-top:24px;
   }

--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -241,8 +241,9 @@ $primary-color: #049cdb;
   }
 
   .sponsored-by {
-
-  img {
+    margin-top: 24px;
+    
+    img {
       border: 0;
       border-radius: 0;
       box-shadow: none;

--- a/source/index.html
+++ b/source/index.html
@@ -171,7 +171,7 @@ feedback: false
 
     <div class="sub-title">Features</div>
     {% include custom/features.html %}
-
+    <div class="grid sponsors-and-press">
     <div class="sponsored-by grid__item one-half lap-one-half palm-one-whole">
       <div class="material-card">
         <h1>Home Assistant is sponsored by</h1>
@@ -181,7 +181,6 @@ feedback: false
         /></a>
       </div>
     </div>
-
     <div class="seen-press grid__item one-half lap-one-half palm-one-whole">
       <div class="material-card">
         <h1>Home Assistant in the press</h1>
@@ -246,6 +245,7 @@ feedback: false
           target="_blank" rel="noopener"
           ><img alt="Ct logo" src="/images/press/ct.png"
         /></a>
+      </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Proposed change

After PR #19167 I noticed that a margin-top applied to the 'In the Press' box wasn't applied to the Sponsors box as a result of the changes. Sorry bout that.

Something I didn't noticed when submitting the PR, because I did the changes in Developer tools and wasn't able to check the end result in the end environment and must have forgotten this.

**Current**:

![](https://user-images.githubusercontent.com/43075793/132132535-bc55ca49-2162-498a-b74f-a8bb71a25a6e.png)

**After CSS change:**

![](https://user-images.githubusercontent.com/43075793/132132556-ff991c06-944a-4a24-8e64-50c0b5e859e9.png)

## Type of change

*   [x] Spelling, grammar or other readability improvements (`current` branch).
*   [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
*   [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
    *   [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
*   [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
*   [ ] Removed stale or deprecated documentation.

## Additional information

*   Link to parent pull request in the codebase:
*   Link to parent pull request in the Brands repository:
*   This PR fixes or closes issue:

## Checklist

*   [x] This PR uses the correct branch, based on one of the following:
    *   I made a change to the existing documentation and used the `current` branch.
    *   I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
*   [x] The documentation follows the Home Assistant documentation [standards](https://developers.home-assistant.io/docs/documenting/standards).