### PR TITLE
Update plex markdown to document PR#51180

### DIFF
--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -140,8 +140,19 @@ media_content_id: '{ "playlist_name": "The Best of Disco", "shuffle": "1" }'
 | Service data attribute | Description                                                                                                                                                                        |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | `entity_id` of the client                                                                                                                                                          |
-| `media_content_id`     | Quoted JSON containing:<br/><ul><li>`library_name` (Required)</li><li>`show_name` (Required)</li><li>`season_number`</li><li>`episode_number`</li><li>`shuffle` (0 or 1)</li></ul> |
+| `media_content_id`     | Quoted JSON containing:<br/><ul><li>`library_name` (Required)</li><li>`show_name` (Required)</li><li>`season_number`</li><li>`episode_number`</li><li>`shuffle` (0 or 1)</li><li>`continuous` (0 or 1)</li><li>`episode_resume_query`</li></ul> |
 | `media_content_type`   | `EPISODE`                                                                                                                                                                          |
+
+There are several optional keys in `media_content_id` JSON payload, which enable greater control over show playback. The optional key `episode_resume_query` supports the ability to resume shows based on any one of the following characteristcs:
+
+ - `ondeck`: select the show/season from the On Deck section (if it is listed there)
+ - `unfinished`: select the first or last unfinished episode in the show (or season)
+ - `unwatched`: select the first or last unwatched episode in the show (or season)
+ - `watched`: select the first or last watched episode in the show (or season)
+
+Each of the above characteristics can be used as a fallback in case the prior condition fails to find suitable episodes. Fallbacks are delimited by a "|". If all query conditions fail to find suitable media, the show or season will start from the beginning.
+
+The query characteristics may also be parameterized to get the 'first' or 'last' element among the results (e.g. `unwatched_first`, `unfinished_last`). Parameters are optional, and are delimited by an "\_". Default parameter is 'first'.
 
 ##### Examples:
 
@@ -154,6 +165,18 @@ media_content_id: '{ "library_name": "Adult TV", "show_name": "Rick and Morty", 
 entity_id: media_player.plex_player
 media_content_type: EPISODE
 media_content_id: '{ "library_name": "Kid TV", "show_name": "Sesame Street", "shuffle": "1" }'
+```
+
+The following example illustrates the use of `episode_resume_query`; the query `"episode_resume_query": "ondeck|unfinished_last|unwatched_first"` will attempt to:
+ 1. Select the show from On Deck, and if it's not listed then...
+ 2. Select the last unfinished episode, and if there are no unfinished episodes then...
+ 3. Select the first unwatched episode, and if there are no unwatched episodes then...
+ 4. Start from the beginning
+
+```yaml
+entity_id: media_player.plex_player
+media_content_type: EPISODE
+media_content_id: '{ "library_name": "Adult TV", "show_name": "Rick and Morty", "episode_resume_query": "ondeck|unfinished_last|unwatched_first"}'
 ```
 
 #### Movie


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Initial documentation draft for review, intended to be applied in tandem with [PR 51180](https://github.com/home-assistant/core/pull/51180). This PR documents the usage of `episode_resume_query` parameter.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/51180
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
