### PR TITLE
Add variable names for number and select

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -215,7 +215,7 @@ select:
       required: true
       type: action
     options:
-      description: Template for the select's available options.  The variable `option` will contain the option selected.
+      description: Template for the select's available options. The variable `option` will contain the option selected.
       required: true
       type: template
     optimistic:

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -179,7 +179,7 @@ number:
       required: true
       type: template
     set_value:
-      description: Defines an action to run when the number value changes.
+      description: Defines an action to run when the number value changes. The variable `value` will contain the number entered.
       required: true
       type: action
     step:
@@ -215,7 +215,7 @@ select:
       required: true
       type: action
     options:
-      description: Template for the select's available options.
+      description: Template for the select's available options.  The variable `option` will contain the option selected.
       required: true
       type: template
     optimistic:


### PR DESCRIPTION
Mention the template/Jinja variable names that will contain the user-entered values for `set_value` in the `number` platform and `select_option` in the `select` platform.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The documentation for the `set_value` and `select_option` actions don't currently mention how the entered/selected data is made available to the action.  This PR adds that information.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
