### PR TITLE
Added  services for bond integration state belief

### DIFF
--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -81,40 +81,40 @@ stop any increase or decrease in brightness that is in progress.
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings of `entity_id`s.
 
-### Service `bond.set_fan_speed_belief`
+### Service `bond.set_fan_speed_tracked_state`
 
-Set the believed speed of a fan. 
-Calling this service will change the believed speed of the fan but not transmit any signal to make the device change speed.
+Sets the tracked fan speed for a bond fan.
+Calling this service will change the tracked speed of the fan but not transmit any signal to make the device change speed.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings of `entity_id`s.
 | `speed` | no | Speed as a percentage.
 
-### Service `bond.set_switch_power_belief`
+### Service `bond.set_switch_power_tracked_state`
 
-Set the believed power state of a switch. 
-Calling this service will change the believed power state of any bond switch but not transmit any signal to make the device change its state.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings of `entity_id`s.
-| `power_state` | no | Boolean power state.
-
-### Service `bond.set_light_power_belief`
-
-Set the believed power state of a light. 
-Calling this service will change the believed power state of any bond light but not transmit any signal to make the device change its state.
+Sets the tracked power state of a bond switch.
+Calling this service will change the tracked power state of any bond switch but not transmit any signal to make the device change its state.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings of `entity_id`s.
 | `power_state` | no | Boolean power state.
 
-### Service `bond.set_light_brightness_belief`
+### Service `bond.set_light_power_tracked_state`
 
-Set the believed brightness state of a light. 
-Calling this service will change the believed brightness state of any bond light but not transmit any signal to make the device change its state.
+Sets the tracked power state of a bond light.
+Calling this service will change the tracked power state of any bond light but not transmit any signal to make the device change its state.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String or list of strings of `entity_id`s.
+| `power_state` | no | Boolean power state.
+
+### Service `bond.set_light_brightness_tracked_state`
+
+Sets the tracked brightness state of a bond light 
+Calling this service will change the tracked brightness state of any bond light but not transmit any signal to make the device change its state.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |

--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -83,7 +83,8 @@ stop any increase or decrease in brightness that is in progress.
 
 ### Service `bond.set_fan_speed_belief`
 
-Set the believed speed of a fan. Calling this service will change the believed speed of the fan but not transmit any signal to make the device change speed.
+Set the believed speed of a fan. 
+Calling this service will change the believed speed of the fan but not transmit any signal to make the device change speed.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -92,7 +93,8 @@ Set the believed speed of a fan. Calling this service will change the believed s
 
 ### Service `bond.set_switch_power_belief`
 
-Set the believed power state of a switch. Calling this service will change the believed power state of any bond switch but not transmit any signal to make the device change its state.
+Set the believed power state of a switch. 
+Calling this service will change the believed power state of any bond switch but not transmit any signal to make the device change its state.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -101,7 +103,8 @@ Set the believed power state of a switch. Calling this service will change the b
 
 ### Service `bond.set_light_power_belief`
 
-Set the believed power state of a light. Calling this service will change the believed power state of any bond light but not transmit any signal to make the device change its state.
+Set the believed power state of a light. 
+Calling this service will change the believed power state of any bond light but not transmit any signal to make the device change its state.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -110,9 +113,10 @@ Set the believed power state of a light. Calling this service will change the be
 
 ### Service `bond.set_light_brightness_belief`
 
-Set the believed brightness state of a light. Calling this service will change the believed brightness state of any bond light but not transmit any signal to make the device change its state.
+Set the believed brightness state of a light. 
+Calling this service will change the believed brightness state of any bond light but not transmit any signal to make the device change its state.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings of `entity_id`s.
-| `brightness` | no | Number (0-255)
+| `brightness` | no | brightness as an integer between 0 and 255

--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -81,3 +81,38 @@ stop any increase or decrease in brightness that is in progress.
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings of `entity_id`s.
 
+### Service `bond.set_fan_speed_belief`
+
+Set the believed speed of a fan. Calling this service will change the believed speed of the fan but not transmit any signal to make the device change speed.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String or list of strings of `entity_id`s.
+| `speed` | no | Speed as a percentage.
+
+### Service `bond.set_switch_power_belief`
+
+Set the believed power state of a switch. Calling this service will change the believed power state of any bond switch but not transmit any signal to make the device change its state.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String or list of strings of `entity_id`s.
+| `power_state` | no | Boolean power state.
+
+### Service `bond.set_light_power_belief`
+
+Set the believed power state of a light. Calling this service will change the believed power state of any bond light but not transmit any signal to make the device change its state.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String or list of strings of `entity_id`s.
+| `power_state` | no | Boolean power state.
+
+### Service `bond.set_light_brightness_belief`
+
+Set the believed brightness state of a light. Calling this service will change the believed brightness state of any bond light but not transmit any signal to make the device change its state.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String or list of strings of `entity_id`s.
+| `brightness` | no | Number (0-255)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added state belief documentation for https://github.com/home-assistant/core/pull/54735


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/54735
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
