### PR TITLE
Update yeelight.markdown

### DIFF
--- a/source/_integrations/yeelight.markdown
+++ b/source/_integrations/yeelight.markdown
@@ -195,6 +195,8 @@ This integration is tested to work with the following models. If you have a diff
 | `mono`     | YLTD03YL     | Yeelight Serene Eye-Friendly Desk Lamp           |
 | `ceiling10`     | YLDL01YL     | Yeelight Meteorite Pendant Light            |
 | `ceiling13`     | YLXD01YL     | Yeelight LED Ceiling Light           |
+| ?     | YLXD013-B     | Yeelight Arwen Ceiling Light 450C           |
+| ?     | YLXD013-C     | Yeelight Arwen Ceiling Light 550C           |
 | `ceil26`   | YLXD76YL     | Yeelight Ceiling Light - Updated HomeKit 23w     |
 | `lamp` | MJTD02YL | Xiaomi Mijia Desk Lamp Pro |
 


### PR DESCRIPTION
Add YLXD013-B and YLXD013-C as supported

## Proposed change
Add YLXD013-B and YLXD013-C as supported. Yeelight integration worked for me.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
