### PR TITLE
Correct type of MQTT optimistic configuration

### DIFF
--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -135,7 +135,7 @@ name:
 optimistic:
   description: Flag that defines if switch works in optimistic mode.
   required: false
-  type: string
+  type: boolean
   default: "`false` if state or position topic defined, else `true`."
 payload_available:
   description: The payload that represents the online state.

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -904,7 +904,7 @@ name:
 optimistic:
   description: Flag that defines if the light works in optimistic mode.
   required: false
-  type: string
+  type: boolean
   default: "`true` if no state topic or state template is defined, else `false`."
 payload_available:
   description: The payload that represents the available state.

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -122,7 +122,7 @@ name:
 optimistic:
   description: Flag that defines if lock works in optimistic mode.
   required: false
-  type: string
+  type: boolean
   default: "`true` if no `state_topic` defined, else `false`."
 payload_available:
   description: The payload that represents the available state.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Correct type of MQTT optimistic configuration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/home-assistant.io/issues/19263

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
