### PR TITLE
proposed binary_sensor group

### DIFF
--- a/source/_integrations/binary_sensor.group.markdown
+++ b/source/_integrations/binary_sensor.group.markdown
@@ -1,0 +1,53 @@
+---
+title: "Binary Sensor Group"
+description: "Instructions for how to setup binary_sensor groups within Home Assistant."
+ha_category:
+  - Binary Sensor
+ha_release: 2021.10
+ha_iot_class: Local Push
+ha_quality_scale: internal
+ha_domain: group
+---
+
+The group binary_sensor platform lets you combine multiple binary_sensors into one entity. This integration presents itself as a single binary sensor in the UI. This allows the UI to use the text and icon of the type of sensor you are grouping. The sensor doesn't know what device class it should be, so this should be set to match the device class of the items in the group.
+
+## Group behavior
+
+By default when any member of a group is `on` then the group will also be `on`. If you set the `all` option to `true` though, this behavior is inverted and all members of the group have to be `on` for the group to turn on as well.
+
+To enable this platform in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+binary_sensor:
+    - platform: group
+      name: Patio Doors
+      device_class: opening
+      entities:
+        - binary_sensor.door_left_contact
+        - binary_sensor.door_right_contact
+```
+
+{% configuration %}
+entities:
+  description: A list of entities to be included in the group.
+  required: true
+  type: [string, list]
+name:
+  description: The name of the group. Defaults to "Binary Sensor Group".
+  required: false
+  type: string
+unique_id:
+  description: An ID that uniquely identifies this group. If two binary_sensors have the same unique ID, Home Assistant will raise an error.
+  required: false
+  type: string
+all:
+  description: Set this to `true` if the group state should only turn *on* if **all** grouped entities are *on*.
+  required: false
+  type: boolean
+  default: false
+device_class:
+  description: The type of the group (/integrations/binary_sensor).
+  required: true
+  type: string
+{% endconfiguration %}
+

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -59,23 +59,6 @@ icon:
   type: string
 {% endconfiguration %}
 
-One can also create `binary_sensor`, `light` and `media_player` groups which behave like a single entity. For `binary_sensor` the configuration should include the device class you want the group to appear as.
-```yaml
-binary_sensor:
-    - platform: group
-      name: Patio Doors
-      device_class: opening
-      entities:
-        - binary_sensor.door_left_contact
-        - binary_sensor.door_right_contact
-```
-{% configuration %}
-name:
-  description: Name of the group.
-  required: false
-  type: string
-{% endconfiguration %}
-
 ## Group behavior
 
 By default when any member of a group is `on` then the group will also be `on`. Similarly with a device tracker, when any member of the group is `home` then the group is `home`. If you set the `all` option to `true` though, this behavior is inverted and all members of the group have to be `on` for the group to turn on as well.

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -59,6 +59,23 @@ icon:
   type: string
 {% endconfiguration %}
 
+One can also create `binary_sensor`, `light` and `media_player` groups which behave like a single entity. For `binary_sensor` the configuration should include the device class you want the group to appear as.
+```yaml
+binary_sensor:
+    - platform: group
+      name: Patio Doors
+      device_class: opening
+      entities:
+        - binary_sensor.door_left_contact
+        - binary_sensor.door_right_contact
+```
+{% configuration %}
+name:
+  description: Name of the group.
+  required: false
+  type: string
+{% endconfiguration %}
+
 ## Group behavior
 
 By default when any member of a group is `on` then the group will also be `on`. Similarly with a device tracker, when any member of the group is `home` then the group is `home`. If you set the `all` option to `true` though, this behavior is inverted and all members of the group have to be `on` for the group to turn on as well.


### PR DESCRIPTION
https://github.com/home-assistant/core/pull/55365

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add binary sensor type which has a `device_class`


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/55365
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
