### PR TITLE
Add example: write a 32-bit float value register

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -200,7 +200,7 @@ Description:
 
 ### Example: writing a float32 type register
 
-To write a float32 datatype register with value decimal 10 first determine the 32 bit float value (`10` decimal == `0x41200000` in float hexadecimal notation). Then call the modbus.write_register as such:
+To write a float32 datatype register use network format like `10.0` == `0x41200000` (network order float hexadecimal). Call the modbus.write_register:
 
 ```yaml
 service: modbus.write_register

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -200,7 +200,7 @@ Description:
 
 ### Example: writing a float32 type register
 
-To write a float32 datatype register use network format like `10.0` == `0x41200000` (network order float hexadecimal). Do:
+To write a float32 datatype register use network format like `10.0` == `0x41200000` (network order float hexadecimal). 
 
 ```yaml
 service: modbus.write_register

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -200,7 +200,7 @@ Description:
 
 ### Example: writing a float32 type register
 
-To write a float32 datatype register use network format like `10.0` == `0x41200000` (network order float hexadecimal). Call the modbus.write_register:
+To write a float32 datatype register use network format like `10.0` == `0x41200000` (network order float hexadecimal). Do:
 
 ```yaml
 service: modbus.write_register

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -198,6 +198,19 @@ Description:
 | value     | (write_register) A single value or an array of 16-bit values. Single value will call modbus function code 0x06. Array will call modbus function code 0x10. Values might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]`, this depend on the byte order of your CPU |
 | state     | (write_coil) A single boolean or an array of booleans. Single boolean will call modbus function code 0x05. Array will call modbus function code 0x0F |
 
+### Example: writing a float32 type register
+
+To write a float32 datatype register with value decimal 10 first determine the 32 bit float value (`10` decimal == `0x41200000` in float hexadecimal notation). Then call the modbus.write_register as such:
+
+```yaml
+service: modbus.write_register
+data:
+  address: <target register address>
+  unit: <target slave address>
+  hub: <hub name>
+  value: [0x4120, 0x0000]
+```
+
 # configure Modbus platforms
 
 Modbus platform entities are configured within the Modbus configuration.


### PR DESCRIPTION


## Proposed change

I propose to add this example. I've been trying to find information on how to write a multi-register float value on the forum and in the support docs but was unable to find valid information. It makes sense to add this example IMHO to save other people the time and effort to determine how to do this.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

none

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation 
