### PR TITLE
Add link to addons page from compare table.

### DIFF
--- a/source/installation/index.html
+++ b/source/installation/index.html
@@ -224,7 +224,7 @@ toc: true
         <td>✅</td><td>❌</td><td>❌</td><td>✅</td>
     </tr>
     <tr>
-        <td>Add-ons</td>
+        <td><a href="/addons" target="_blank">Add-ons<a></td>
         <td>✅</td><td>❌</td><td>❌</td><td>✅</td>
     </tr>
     <tr>


### PR DESCRIPTION
## Proposed change
Add a link to addons documentation page from feature comparison table.  This mirrors what is done for integrations, automations, etc.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
