### PR TITLE
Add note for macOS hosts

### DIFF
--- a/source/_includes/installation/container/cli.md
+++ b/source/_includes/installation/container/cli.md
@@ -4,6 +4,7 @@
   content: |
 
     ```bash
+    # on macOS hosts "--network=host" is not supported, replace it with "-p 8123:8123" 
     docker run -d \
       --name homeassistant \
       --privileged \
@@ -34,6 +35,7 @@
 
     ```bash
     # finally, start a new one
+    # on macOS hosts "--network=host" is not supported, replace it with "-p 8123:8123" 
     docker run -d \
       --name homeassistant \
       --restart=unless-stopped \


### PR DESCRIPTION

## Proposed change
The goal is to help future readers on macOS that will not be able to reach localhost:8123. `--network=host` is only supported by linux and there is no warning from the docker cli so this is not straightforward problem to debug.


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Not sure if this is the best way to include this note, fell free to move it around. 

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
