### PR TITLE
Add "not recommended" note to CC2530 and C2531 in ZHA docs

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -82,7 +82,7 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
   - [CC2652P/CC2652R/CC2652RB USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters)
   - [CC1352P/CC1352R USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters)
   - [CC2538 USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters)
-  - [CC2530/CC2531 USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters)
+  - [CC2530/CC2531 USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters) (not recommended for Zigbee networks with more than 20 devices)
 - Digi XBee Zigbee based radios (via the [zigpy-xbee](https://github.com/zigpy/zigpy-xbee) library for zigpy)
   - [Digi XBee Series 3 (xbee3-24)](https://www.digi.com/products/embedded-systems/digi-xbee/rf-modules/2-4-ghz-rf-modules/xbee3-zigbee-3) and [Digi XBee Series S2C](https://www.digi.com/products/embedded-systems/digi-xbee/rf-modules/2-4-ghz-rf-modules/xbee-zigbee) modules
     - Note! While not a must, [it is recommend to upgrade XBee Series 3 and S2C to newest firmware using XCTU](https://www.digi.com/resources/documentation/Digidocs/90002002/Default.htm#Tasks/t_load_zb_firmware.htm)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add a "**_not recommended for Zigbee networks with more than 20 devices_**" note to CC2530/C2531 hardware adapter in ZHA docs.

The reason for adding this specific "not recommended" note is that Texas Instruments older less powerful hardware Zigbee adapter hardware are the least expensive and most commonly available so many people make the mistake of buying them and then having a bad experience with ZHA due to the CC2530/CC2531 hardware limitations.

This is the reason ZHA developers elected  in https://github.com/home-assistant/core/pull/55298 to not whitelist "TI CC2531" for USB adapter ZHA discovery.

zigpy developers now also list the same recommendation for CC2530/C2531 in zigpy-znp readme file:

https://github.com/zigpy/zigpy-znp#hardware-requirements

FYI, Zigbee2MQTT as well added "not recommended" notes to both CC2530 and CC2531 in their official supported adapters list:

https://www.zigbee2mqtt.io/information/supported_adapters

 - _Texas Instruments CC2531 (**not recommended**)_
 - _Texas Instruments CC2530 (**not recommended**)_

https://www.zigbee2mqtt.io/information/supported_adapters#notes

_Adapters based on the CC2530 or CC2531 chip are not powerful and not recommended for networks larger than 20 devices._

Also, Zigbee2MQTT / zigbee-herdsman developer Koenkk noted why Z-Stack 3.0.x firmware is not recommended on C2530/C2531:

https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator#im-using-a-cc2530-or-cc2531-which-firmware-should-i-use

### _I'm using a CC2530 or CC2531, which firmware should I use?_
_This depends:_
- _Zigbee 3.0 firmwares are **not** recommended for the CC2530 and CC2531 (since those are not powerful enough)_
- _If you have a network of 1 - 15 devices, the Z-Stack_Home_1.2 **default** firmware is recommended._
- _If you have a network of 15+ devices, the Z-Stack_Home_1.2 **source routing** firmware is recommended._
- _Note that the **source routing** firmware only supports 5 direct children, therefore you need to have routers in range of the coordinator._




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
