### PR TITLE
Clarify Daikin warning

### DIFF
--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -20,7 +20,7 @@ ha_platforms:
 ---
 
 <p class='note warning'>
-  Daikin has removed their local API in newer products. They offer a cloud API accessible only under NDA, which is incompatible with open source.
+  Daikin has removed their local API in newer products. They offer a cloud API accessible only under NDA, which is incompatible with open source. This affects units fitted with the BRP069C4x wifi adaptor. Units listed under Supported Hardwere below continue to have access to local control. Aditionally the older but comonly available BRP072A42 adaptor can be fitted to most if not all newer units for acces to local control. 
 </p>
 
 The `daikin` integration integrates Daikin air conditioning systems into Home Assistant.

--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -20,7 +20,7 @@ ha_platforms:
 ---
 
 <p class='note warning'>
-  Daikin has removed their local API in newer products. They offer a cloud API accessible only under NDA, which is incompatible with open source. This affects units fitted with the BRP069C4x wifi adaptor. Units listed under Supported Hardwere below continue to have access to local control. Aditionally the older but comonly available BRP072A42 adaptor can be fitted to most if not all newer units for acces to local control. 
+  Daikin has removed their local API in newer products. They offer a cloud API accessible only under NDA, which is incompatible with open source. This affects units fitted with the BRP069C4x wifi adapter. Units listed under Supported Hardware below continue to have access to local control. Additionally the older but commonly available BRP072A42 adapter can be fitted to most if not all newer units for access to local control. 
 </p>
 
 The `daikin` integration integrates Daikin air conditioning systems into Home Assistant.


### PR DESCRIPTION
There are many wifi adaptors that still have local control. Newer units can be fitted with the BRP072A42 for local control. This has been confirmed a few times on the forum. 
The warning was scaring users away from a device that still has valid local control options.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
