### PR TITLE
Netgear Config Flow documentation

### DIFF
--- a/source/_integrations/netgear.markdown
+++ b/source/_integrations/netgear.markdown
@@ -8,70 +8,17 @@ ha_release: pre 0.7
 ha_domain: netgear
 ha_platforms:
   - device_tracker
+ha_config_flow: true
 ---
 
 This platform allows you to detect presence by looking at connected devices to a [NETGEAR](https://www.netgear.com/) device.
 
-<div class='note'>
+{% include integrations/config_flow.md %}
 
-A recent updates of Orbi APs introduced a bug which takes several hours to detects presence on your local network. The current workaround is to force this integration to use the Orbi's API v2 by adding the `accesspoints:` node to your configuration.
-
-</div>
-
-To use this device tracker in your installation, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-device_tracker:
-  - platform: netgear
-    password: YOUR_ADMIN_PASSWORD
-```
-
-{% configuration %}
-url:
-  description: The base URL, e.g., `http://routerlogin.com:5000` for example. If not provided `host` and `port` are used. If none provided autodetection of the URL will be used.
-  required: false
-  type: string
-host:
-  description: The IP address of your router, e.g., `192.168.1.1`.
-  required: false
-  type: string
-port:
-  description: The port your router communicates with.
-  required: false
-  default: 5000
-  type: integer
-username:
-  description: The username of a user with administrative privileges.
-  required: false
-  default: admin
-  type: string
-password:
-  description: The password for your given admin account.
-  required: true
-  type: string
-devices:
-  description: If provided only specified devices will be reported. Can be MAC address or the device name as reported in the NETGEAR UI.
-  required: false
-  type: list
-exclude:
-  description: Devices to exclude from the scan.
-  required: false
-  type: list
-accesspoints:
-  description: Also track devices on the specified APs. Only supports MAC address.
-  required: false
-  type: list
-{% endconfiguration %}
-
-When `accesspoints` is specified an extra device will be reported for each device connected to the APs specified here, as `MY-LAPTOP on RBS40`. `Router` will be reported as AP name for the main AP. Only tested with Orbi.
-
-The use of `devices` or `exclude` is recommended when using `accesspoints` to avoid having a lot of entries.
-
-List of models that are known to use port 80:
-
+Most Netgear routers use port 5000 to communicate, however the following list of models are known to use port 80:
 - Nighthawk X4S - AC2600 (R7800)
 - Orbi
 - XR500
+When setup through ssdp discovery the port schould be automatically detected.
 
-See the [device tracker integration page](/integrations/device_tracker/) for instructions how to configure the people to be tracked.
+The options flow of the netgear integration (in the sidebar of your HomeAssistant instance click on "Configuration" -> "Integrations" -> find the Netgear integration and click "Configure") allows you to specify the 'consider_home' time. This is the amount of seconds to wait till marking someone as not home after not being seen. This parameter is most useful for households with Apple iOS devices that go into sleep mode while still at home to conserve battery life. iPhones will occasionally drop off the network and then re-appear. consider_home helps prevent false alarms in presence detection.

--- a/source/_integrations/netgear.markdown
+++ b/source/_integrations/netgear.markdown
@@ -15,10 +15,10 @@ This platform allows you to detect presence by looking at connected devices to a
 
 {% include integrations/config_flow.md %}
 
-Most Netgear routers use port 5000 to communicate, however the following list of models are known to use port 80:
+Most NETGEAR routers use port 5000 to communicate, however the following list of models are known to use port 80:
 - Nighthawk X4S - AC2600 (R7800)
 - Orbi
 - XR500
 When setup through ssdp discovery the port schould be automatically detected.
 
-The options flow of the netgear integration (in the sidebar of your HomeAssistant instance click on "Configuration" -> "Integrations" -> find the Netgear integration and click "Configure") allows you to specify the 'consider_home' time. This is the amount of seconds to wait till marking someone as not home after not being seen. This parameter is most useful for households with Apple iOS devices that go into sleep mode while still at home to conserve battery life. iPhones will occasionally drop off the network and then re-appear. consider_home helps prevent false alarms in presence detection.
+The options flow of the NETGEAR integration (in the sidebar of your Home Assistant instance click on "Configuration" -> "Integrations" -> find the NETGEAR integration and click "Configure") allows you to specify the 'consider_home' time. This is the amount of seconds to wait till marking someone as not home after not being seen. This parameter is most useful for households with Apple iOS devices that go into sleep mode while still at home to conserve battery life. iPhones will occasionally drop off the network and then re-appear. consider_home helps prevent false alarms in presence detection.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for new config flow of the netgear integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/54479
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
