### PR TITLE
update docs to clarify the undocumented Code parameter

### DIFF
--- a/source/_integrations/simplisafe.markdown
+++ b/source/_integrations/simplisafe.markdown
@@ -36,6 +36,8 @@ There is currently support for the following device types within Home Assistant:
 
 {% include integrations/config_flow.md %}
 
+* Note: there is a "Code" parameter in the UI configuration. This is only used to protect the UI element and is not used in the arming/disarming flow. Setting this will break any Homekit integrations. *
+
 ## Services
 
 Note that the `system_id` parameter required by the below service calls can be discovered


### PR DESCRIPTION
## Proposed change
The current doc does not state what the Code param is used for in the UI. This can create confusion and break homekit.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
