### PR TITLE
Add info on trigger id's uniqueness requirement

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -24,7 +24,7 @@ An automation can be triggered by an event, with a certain entity state, at a gi
 
 ## Trigger id
 
-All triggers can be assigned an optional `id`. If the id is omitted, it will instead be set to the index of the trigger. The `id` can be referenced from trigger conditions. The `id` needs to be unique for each trigger (i.e. you can not use the `id` field to group triggers).
+All triggers can be assigned an optional `id`. If the id is omitted, it will instead be set to the index of the trigger. The `id` can be referenced from trigger conditions. The `id` should be unique for each trigger.
 
 ```yaml
 automation:

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -24,7 +24,7 @@ An automation can be triggered by an event, with a certain entity state, at a gi
 
 ## Trigger id
 
-All triggers can be assigned an optional `id`. If the id is omitted, it will instead be set to the index of the trigger. The `id` can be referenced from trigger conditions.
+All triggers can be assigned an optional `id`. If the id is omitted, it will instead be set to the index of the trigger. The `id` can be referenced from trigger conditions. The `id` needs to be unique for each trigger (i.e. you can not use the `id` field to group triggers).
 
 ```yaml
 automation:


### PR DESCRIPTION
## Proposed change
As per the comments on https://github.com/home-assistant/core/issues/56157 I'm proposing the included change to the automation trigger documentation to make it clear that trigger ids need to be unique, and can not be used to group triggers.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- This PR ~fixes or closes~ is related to issue: https://github.com/home-assistant/core/issues/56157

## Checklist
- [x] ? I believe I'm ok here, but just to be 100% adding the ? to the x for someone to verify I didn't misunderstand something -This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
