### PR TITLE
mention helpers UI for timers

### DIFF
--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -19,6 +19,10 @@ When a timer finishes or gets canceled the corresponding events are fired. This 
 ## Configuration
 The preferred way to configure timer helpers is via the user interface. To add one, go to Configuration -> Helpers and click the add button; next choose the “Timer” option.
 
+You can also click the following button to be redirected to the Helpers page of your Home Assistant instance.
+
+[![Open your Home Assistant instance and show your helper entities.](https://my.home-assistant.io/badges/helpers.svg)](https://my.home-assistant.io/redirect/helpers/)
+
 To be able to add Helpers via the user interface you should have default_config: in your configuration.yaml, it should already be there by default unless you removed it. If you removed default_config: from your configuration, you must add timer: to your configuration.yaml first, then you can use the UI.
 
 Timers can also be configured via configuration.yaml:

--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -21,7 +21,7 @@ The preferred way to configure timer helpers is via the user interface. To add o
 
 You can also click the following button to be redirected to the Helpers page of your Home Assistant instance.
 
-[![Open your Home Assistant instance and show your helper entities.](https://my.home-assistant.io/badges/helpers.svg)](https://my.home-assistant.io/redirect/helpers/)
+{% my helpers badge %}
 
 To be able to add Helpers via the user interface you should have default_config: in your configuration.yaml, it should already be there by default unless you removed it. If you removed default_config: from your configuration, you must add timer: to your configuration.yaml first, then you can use the UI.
 

--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -17,7 +17,11 @@ When a timer finishes or gets canceled the corresponding events are fired. This 
 </div>
 
 ## Configuration
+The preferred way to configure timer helpers is via the user interface. To add one, go to Configuration -> Helpers and click the add button; next choose the “Timer” option.
 
+To be able to add Helpers via the user interface you should have default_config: in your configuration.yaml, it should already be there by default unless you removed it. If you removed default_config: from your configuration, you must add timer: to your configuration.yaml first, then you can use the UI.
+
+Timers can also be configured via configuration.yaml:
 To add a timer to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
## Proposed change
Timers can be setup from UI Helpers, there is no mention of this in the documentation.
This text has been copied from Input Boolean documentation page. With the necessary replaced words :)

Maybe adding a "my" link could be done too.  What do you think ?


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
