### PR TITLE
[NMBS integration]: Mention full name

### DIFF
--- a/source/_integrations/nmbs.markdown
+++ b/source/_integrations/nmbs.markdown
@@ -1,6 +1,6 @@
 ---
 title: NMBS
-description: Instructions on how to integrate timetable data for traveling on the NMBS Belgian Railway within Home Assistant.
+description: Instructions on how to integrate timetable data for traveling on the NMBS/SNCB Belgian Railway within Home Assistant.
 ha_category:
   - Transport
 ha_iot_class: Cloud Polling
@@ -28,7 +28,7 @@ sensor:
     exclude_vias: true
 ```
 
-The stations can only be provided by their standard names and not ids. The list of stations can be checked on the NMBS/SCNB website but for most accurate results check them on the [iRail API page](https://api.irail.be/stations/) which this integration uses internally.
+The stations can only be provided by their standard names and not ids. The list of stations can be checked on the NMBS/SNCB website but for most accurate results check them on the [iRail API page](https://api.irail.be/stations/) which this integration uses internally.
 
 {% configuration %}
 station_from:


### PR DESCRIPTION
There was a typo in SNCB which made french-speaking persons not to find this integration.

I would also propose to add the full name that mentions the railway acronyms in both major national languages (NMBS/SNCB) instead of just NMBS in the title.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
- [X ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
