### PR TITLE
Statistics sensor documentation: Added names in example

### DIFF
--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -30,8 +30,10 @@ recorder:
 sensor:
   - platform: statistics
     entity_id: sensor.cpu
+    name: "CPU Statistics"
   - platform: statistics
     entity_id: binary_sensor.movement
+    name: "Movement Statistics"
 ```
 
 {% configuration %}


### PR DESCRIPTION

## Proposed change
It was not obvious to me that the sensor would be called "sensor.stats" and not contain anything from the entity_id field. Adding a name in the example config would probably make it easier for people to find the sensor when they set this up for the first time.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
