### PR TITLE
Update Discovery integration docs

### DIFF
--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -1,6 +1,6 @@
 ---
 title: Discovery
-description: Instructions on how to setup Home Assistant to discover new devices.
+description: Instructions on how to setup Home Assistant to discover new devices with the Discovery integration.
 ha_category:
   - Other
 ha_release: 0.7
@@ -10,36 +10,17 @@ ha_domain: discovery
 
 Home Assistant can discover and automatically configure [zeroconf](https://en.wikipedia.org/wiki/Zero-configuration_networking)/[mDNS](https://en.wikipedia.org/wiki/Multicast_DNS) and [UPnP](https://en.wikipedia.org/wiki/Universal_Plug_and_Play) devices on your network. Currently the `discovery` integration can detect:
 
- * [Apple TV](/integrations/apple_tv/)
- * [Belkin WeMo switches](/integrations/wemo/)
  * [Bluesound speakers](/integrations/bluesound)
  * [Bose Soundtouch speakers](/integrations/soundtouch)
- * [Denon network receivers](/integrations/denonavr/)
  * [DLNA DMR enabled devices](/integrations/dlna_dmr)
  * [Enigma2 media player](/integrations/enigma2)
  * [Frontier Silicon internet radios](/integrations/frontier_silicon)
+ * [LG Soundbars](/integrations/lg_soundbar)
  * [Linn / Openhome](/integrations/openhome)
- * [Logitech Harmony Hub](/integrations/harmony)
  * [Logitech Media Server (Squeezebox)](/integrations/squeezebox)
- * [NETGEAR routers](/integrations/netgear)
- * [Philips Hue](/integrations/hue)
  * [SABnzbd downloader](/integrations/sabnzbd)
- * [Samsung SyncThru Printer](/integrations/syncthru)
- * [Sonos speakers](/integrations/sonos)
  * [Telldus Live](/integrations/tellduslive/)
- * [Wink](/integrations/wink/)
  * [Yamaha media player](/integrations/yamaha)
- * [Yeelight Sunflower bulb](/integrations/yeelightsunflower/)
- * [Xiaomi Gateway (Aqara)](/integrations/xiaomi_aqara/)
-
-It will be able to add Belkin WeMo switches automatically,
-for Philips Hue it will require some configuration from the user.
-
-<div class='note'>
-
-Zeroconf discoverable integrations [Axis](/integrations/axis/)/[ESPHome](/integrations/esphome/)/[HomeKit](/integrations/homekit_controller/)/[Tradfri](/integrations/tradfri/)/[Google Cast](/integrations/cast/) have been migrated to use [zeroconf](/integrations/zeroconf) integration to initiate discovery.
-
-</div>
 
 To load this integration, add the following lines to your `configuration.yaml` file:
 
@@ -47,10 +28,10 @@ To load this integration, add the following lines to your `configuration.yaml` f
 # Example configuration.yaml entry
 discovery:
   ignore:
-    - sonos
-    - samsung_printer
+    - yamaha
+    - logitech_mediaserver
   enable:
-    - homekit
+    - dlna_dmr
 ```
 
 {% configuration discovery %}
@@ -66,28 +47,16 @@ enable:
 
 Valid values for ignore are:
 
- * `apple_tv`: Apple TV
- * `belkin_wemo`: Belkin WeMo switches
  * `bluesound`: Bluesound speakers
  * `bose_soundtouch`: Bose Soundtouch speakers
- * `denonavr`: Denon network receivers
  * `enigma2`: Enigma2 media players
  * `frontier_silicon`: Frontier Silicon internet radios
- * `harmony`: Logitech Harmony Hub
+ * `lg_smart_device`: LG Soundbars
  * `logitech_mediaserver`: Logitech Media Server (Squeezebox)
- * `netgear_router`: NETGEAR routers
- * `octoprint`: Octoprint
  * `openhome`: Linn / Openhome
- * `philips_hue`: Philips Hue
  * `sabnzbd`: SABnzbd downloader
- * `samsung_printer`: Samsung SyncThru Printer
- * `sonos`: Sonos speakers
- * `songpal` : Songpal
  * `tellstick`: Telldus Live
- * `wink`: Wink Hub
  * `yamaha`: Yamaha media player
- * `yeelight`: Yeelight lamps and bulbs (not only Yeelight Sunflower bulb)
- * `xiaomi_gw`: Xiaomi Aqara gateway
 
 Valid values for enable are:
 
@@ -118,7 +87,3 @@ There is currently a <a href='https://web.archive.org/web/20200623234241/https:/
 ### Could not install dependency netdisco
 
 If you see `Not initializing discovery because could not install dependency netdisco==0.6.1` in the logs, you will need to install the `python3-dev` or `python3-devel` package on your system manually (eg. `sudo apt-get install python3-dev` or `sudo dnf -y install python3-devel`). On the next restart of Home Assistant, the discovery should work. If you still get an error, check if you have a compiler (`gcc`) available on your system.
-
-### DSM and Synology
-
-For DSM/Synology, install via debian-chroot [see this forum post](https://community.home-assistant.io/t/error-starting-home-assistant-on-synology-for-first-time/917/15).

--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -18,6 +18,7 @@ Home Assistant can discover and automatically configure [zeroconf](https://en.wi
  * [LG Soundbars](/integrations/lg_soundbar)
  * [Linn / Openhome](/integrations/openhome)
  * [Logitech Media Server (Squeezebox)](/integrations/squeezebox)
+ * [NETGEAR routers](/integrations/netgear)
  * [SABnzbd downloader](/integrations/sabnzbd)
  * [Telldus Live](/integrations/tellduslive/)
  * [Yamaha media player](/integrations/yamaha)
@@ -53,6 +54,7 @@ Valid values for ignore are:
  * `frontier_silicon`: Frontier Silicon internet radios
  * `lg_smart_device`: LG Soundbars
  * `logitech_mediaserver`: Logitech Media Server (Squeezebox)
+ * `netgear_router`: NETGEAR routers
  * `openhome`: Linn / Openhome
  * `sabnzbd`: SABnzbd downloader
  * `tellstick`: Telldus Live


### PR DESCRIPTION
## Proposed change

- Remove migrated services/integrations
- Add missing LG Soundbars integration
- Remove zeroconf note
  - Integrations list is incomplete
  - This note also applies to mDNS and UPnP
  - Does not add useful information for Discovery integration users.
- Remove DSM/Synology section
  - Synology users now use Docker instead of the SynoCommunity package
- Update page description
- Update configuration.yaml example


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
