### PR TITLE
Add information for configuring Amcrest channel

### DIFF
--- a/source/_integrations/amcrest.markdown
+++ b/source/_integrations/amcrest.markdown
@@ -141,6 +141,12 @@ control_light:
   required: false
   type: boolean
   default: true
+channel:
+  description: >
+    When using an Amcrest NVR for the camera feed, set the channel for the camera to use. For stand-alone cameras, the default channel will work correctly.
+  required: false
+  type: integer
+  default: 0
 {% endconfiguration %}
 
 **Note:** Amcrest cameras with newer firmware no longer have the ability to


### PR DESCRIPTION
## Proposed change

This adds the documentation linked to the addition to the Amcrest component to allow a channel to be specified to be able to use NVR devices.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/56515
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
