### PR TITLE
Advice using reserved or static IP with Zigbee gateways and bridges for ZHA

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -147,12 +147,12 @@ Press `Submit`. The success dialog will appear or an error will be displayed in 
 
 ### ZiGate or Sonoff ZBBridge Devices
 
-If you are use ZiGate or Sonoff ZBBridge you have to use some special usb_path configuration:
+If you are using ZiGate Ethernet/WiFi Gateway, Sonoff ZBBridge, or other network-attached Zigbee adapter you will have to use some special usb_path configuration. It is also strongly advised that you use a reserved or static IP Address is strongly by reserving the IP address in your router and/or configure a static IP address in your Zigbee gateway/bridge.
 
-- ZiGate USB TTL or DIN: `/dev/ttyUSB0` or `auto` to auto discover the zigate
-- PiZigate : `pizigate:/dev/ttyS0`
-- Wifi Zigate : `socket://[IP]:[PORT]` for example `socket://192.168.1.10:9999`
-- Sonoff ZBBridge : `socket://[IP]:[PORT]` for example `socket://192.168.1.11:8888`
+- ZiGate USB, USB-TTL or DIN: `/dev/ttyUSB0` or `auto` to auto discover the zigate
+- ZiGate PiZigate : `pizigate:/dev/ttyS0`
+- ZiGate Ethernet and WiFi Gateways : `socket://[IP]:[PORT]` for example `socket://192.168.1.10:9999`
+- ITead Sonoff ZBBridge : `socket://[IP]:[PORT]` for example `socket://192.168.1.11:8888`
 
 ### Discovery via USB or Zeroconf
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Advice using reserved or static IP with Zigbee gateways and bridges for ZHA. This is also recommended for Tube's Zigbee Gateways:

https://github.com/tube0013/tube_gateways/blob/main/README.md#getting-up-and-running

"_Using a Reserved or static IP Address is strongly advised. Reserve the address in the router or use a static ESPHome build with static ip_"

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
