### PR TITLE
Add example for ser2net 4.X.X

### DIFF
--- a/source/_integrations/dsmr.markdown
+++ b/source/_integrations/dsmr.markdown
@@ -86,7 +86,7 @@ DIY solutions (ESP8266 based):
 
 {% include integrations/config_flow.md %}
 
-Optional configuration example for ser2net:
+Optional configuration example for ser2net 3.x.x:
 
 ```sh
 # Example /etc/ser2net.conf for proxying USB/serial connections to DSMRv4 smart meters
@@ -96,6 +96,22 @@ or
 ```sh
 # Example /etc/ser2net.conf for proxying USB/serial connections to DSMRv2.2 smart meters
 2001:raw:600:/dev/ttyUSB0:9600 EVEN 1STOPBIT 7DATABITS XONXOFF LOCAL -RTSCTS
+```
+
+Optional configuration example for ser2net 4.x.x:
+
+```sh
+# Example /etc/ser2net.yaml for proxying USB/serial connections to DSMRv4 smart meters
+connection: &con0096
+    accepter: tcp,2001
+    enable: on
+    options:
+      banner: *banner
+      kickolduser: true
+      telnet-brk-on-sync: true
+    connector: serialdev,
+              /dev/ttyUSB0,
+              115200n81,local
 ```
 
 ### Technical overview


### PR DESCRIPTION
## Proposed change
I updated to Debian Bullseye and noticed no data was coming in. Ser2net got updated to 4.3.3.
Since ser2net 4.X.X the syntax has changed to ser2net.yaml. Added an example for that.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
