### PR TITLE
Added info about Long term statistics

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -117,7 +117,7 @@ sensor:
       type: string
       default: None
     state_class:
-      description: "Defines the state class of the sensor, if any. Only possible value currently is `measurement`. Set this if your template sensor represents a measurement of the current value (so not a daily aggregate etc)."
+      description: "Defines the state class of the sensor, if any. Necessary to be set to 'measurement' to include in long term statistics. Only possible value currently is `measurement`. Set this if your template sensor represents a measurement of the current value (so not a daily aggregate etc)."
       required: false
       type: string
       default: None


### PR DESCRIPTION
## Proposed change

Added some info to the State class description. State class has to be set to `measurement` or `total_increasing` I read on [https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics.](https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics.) 

I am not sure if I am right here. But I think I got my template sensors working with setting `State_class: measurement`. 

I think a lot of users would like to know how to add their sensors to long term statistics, so some extra info on this page, by adding this line,  I would consider helpful . 

Also the question, it says only current possible value is `measurement`. Still the case for a template sensor or does this need updating as well?

## Type of change

*   [ ] Spelling, grammar or other readability improvements (`current` branch).
*   [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
*   [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
    *   [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
*   [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
*   [ ] Removed stale or deprecated documentation.

## Additional information

*   Link to parent pull request in the codebase:
*   Link to parent pull request in the Brands repository:
*   This PR fixes or closes issue:

## Checklist

*   [x] This PR uses the correct branch, based on one of the following:
    *   I made a change to the existing documentation and used the `current` branch.
    *   I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
*   [x] The documentation follows the Home Assistant documentation [standards](https://developers.home-assistant.io/docs/documenting/standards).