### PR TITLE
update tplink docs for python-kasa rework

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -29,7 +29,7 @@ There is currently support for the following device types within Home Assistant:
 - **Sensor**
 
 In order to activate the support, you will have to enable the integration inside the configuration panel.
-The supported devices in your network are automatically discovered, but if you want to control devices residing in other networks you will need to configure them manually as shown below.
+The supported devices in your network are automatically discovered, but if you want to control devices residing in other networks you will need to add them manually.
 
 ## Supported Devices
 
@@ -38,19 +38,17 @@ The following devices are known to work with this component.
 
 ### Plugs
 
-Plugs are type `switch` when autodiscovery has been disabled.
-
 - HS100
 - HS103
 - HS105
-- HS110 (confirmed to support consumption sensors)
+- HS110 (supports consumption sensors)
 - KP105
-- KP115 (confirmed to support consumption sensors)
+- KP115 (supports consumption sensors)
 
 ### Strip (Multi-Plug)
 
 - HS107 (indoor 2-outlet)
-- HS300 (powerstrip 6-outlet) (confirmed to support consumption sensors)
+- HS300 (powerstrip 6-outlet) (supports consumption sensors)
 - KP303 (powerstrip 3-outlet)
 - KP400 (outdoor 2-outlet)
 - KP200 (indoor 2-outlet)
@@ -65,8 +63,6 @@ Plugs are type `switch` when autodiscovery has been disabled.
 
 ### Bulbs
 
-Other bulbs may also work, but with limited color temperatures. If you find a bulb isn't reaching the full-color temperature boundaries, submit a bug report. Bulbs do generally report some energy consumption information, see the entity state attributes to find out what information is available.
-
 - LB100
 - LB110
 - LB120
@@ -78,73 +74,4 @@ Other bulbs may also work, but with limited color temperatures. If you find a bu
 - KL130
 - KB130
 
-## Configuration
-
-```yaml
-# Example configuration.yaml
-tplink:
-```
-
-{% configuration %}
-discovery:
-  description: Whether to do automatic discovery of devices.
-  required: false
-  type: boolean
-  default: true
-light:
-  description: List of light devices.
-  required: false
-  type: list
-  keys:
-    host:
-      description: Hostname or IP address of the device.
-      required: true
-      type: string
-strip:
-  description: List of multi-outlet on/off switch devices.
-  required: false
-  type: list
-  keys:
-    host:
-      description: Hostname or IP address of the device.
-      required: true
-      type: string
-switch:
-  description: List of on/off switch devices.
-  required: false
-  type: list
-  keys:
-    host:
-      description: Hostname or IP address of the device.
-      required: true
-      type: string
-dimmer:
-  description: List of dimmable switch devices.
-  required: false
-  type: list
-  keys:
-    host:
-      description: Hostname or IP address of the device.
-      required: true
-      type: string
-{% endconfiguration %}
-
-## Manual configuration example
-
-```yaml
-# Example configuration.yaml entry with manually specified addresses
-tplink:
-  discovery: false
-  light:
-    - host: 192.168.200.1
-    - host: 192.168.200.2
-  switch:
-    - host: 192.168.200.3
-    - host: 192.168.200.4
-  dimmer:
-    - host: 192.168.200.5
-    - host: 192.168.200.6
-  strip:
-    - host: 192.168.200.7
-    - host: 192.168.200.8
-```
+Other bulbs may also work, but with limited color temperature range (2700-5000). If you find a bulb isn't reaching the full-color temperature boundaries, submit a bug report to [python-kasa](https://github.com/python-kasa/python-kasa).

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -28,8 +28,7 @@ There is currently support for the following device types within Home Assistant:
 - **Switch**
 - **Sensor**
 
-In order to activate the support, you will have to enable the integration inside the configuration panel.
-The supported devices in your network are automatically discovered, but if you want to control devices residing in other networks you will need to add them manually.
+{% include integrations/config_flow.md %}
 
 ## Supported Devices
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
TPLink integration is now fully configurable from the UI, so no more need to have manual configuration in the docs.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/56701
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
