### PR TITLE
add reload events for Mqtt and Template

### DIFF
--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -55,20 +55,6 @@ This event has no additional data.
 
 Event `scene_reloaded` is fired when scenes have been reloaded and thus might have changed.
 
-This event has no additional data.
-
-## Event `event_mqtt_reloaded`
-
-Event `event_mqtt_reloaded` is fired when Manually configured MQTT entities have been reloaded and entities thus might have changed.
-
-This event has no additional data.
-
-## Event `event_template_reloaded`
-
-Event `event_template_reloaded` is fired when Template entities have been reloaded and entities thus might have changed.
-
-This event has no additional data.
-
 ## Event `platform_discovered`
 
 Event `platform_discovered` is fired when a new platform has been discovered by the [`discovery`](/integrations/discovery/) component.

--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -57,6 +57,18 @@ Event `scene_reloaded` is fired when scenes have been reloaded and thus might ha
 
 This event has no additional data.
 
+## Event `event_mqtt_reloaded`
+
+Event `event_mqtt_reloaded` is fired when Manually configured Mqtt entities have been reloaded and entities thus might have changed.
+
+This event has no additional data.
+
+## Event `event_template_reloaded`
+
+Event `event_template_reloaded` is fired when Template entities have been reloaded and entities thus might have changed.
+
+This event has no additional data.
+
 ## Event `platform_discovered`
 
 Event `platform_discovered` is fired when a new platform has been discovered by the [`discovery`](/integrations/discovery/) component.

--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -59,7 +59,7 @@ This event has no additional data.
 
 ## Event `event_mqtt_reloaded`
 
-Event `event_mqtt_reloaded` is fired when Manually configured Mqtt entities have been reloaded and entities thus might have changed.
+Event `event_mqtt_reloaded` is fired when Manually configured MQTT entities have been reloaded and entities thus might have changed.
 
 This event has no additional data.
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -64,3 +64,9 @@ mqtt:
 - [Birth and last will messages](/docs/mqtt/birth_will/)
 - [Testing your setup](/docs/mqtt/testing/)
 - [Logging](/docs/mqtt/logging/)
+
+## Event `event_mqtt_reloaded`
+
+Event `event_mqtt_reloaded` is fired when Manually configured MQTT entities have been reloaded and entities thus might have changed.
+
+This event has no additional data.

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -710,3 +710,9 @@ sensor:
         type: device_class
         default: None
 {% endconfiguration %}
+
+## Event `event_template_reloaded`
+
+Event `event_template_reloaded` is fired when Template entities have been reloaded and entities thus might have changed.
+
+This event has no additional data.


### PR DESCRIPTION
using the text we see when clicking the Quickbar for Reload on Template and Mqtt, to keep those texts consistent throughout the interface and documentation

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
