### PR TITLE
Fix typo in documentation

### DIFF
--- a/source/_integrations/remember_the_milk.markdown
+++ b/source/_integrations/remember_the_milk.markdown
@@ -94,7 +94,7 @@ Here's an example for an automation that creates a new task whenever `sensor.mys
   action:
     - service: remember_the_milk.myaccount_create_task
       data:
-        name: "Please switch of {{trigger.entity_id}}"
+        name: "Please switch off {{trigger.entity_id}}"
         id: "{{trigger.entity_id}}"
 - id: mysensor_off
   trigger:


### PR DESCRIPTION
## Proposed change
This fixes a minor typo in the Remember The Milk integration example


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
