### PR TITLE
Roku integration: Remove duplicated "Remote" section

### DIFF
--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -128,10 +128,6 @@ action:
       media_content_type: channel
 ```
 
-## Remote
-
-The `remote` platform allows you to send keypress commands to your device. Remote entities are automatically registered during the integration setup.
-
 ## Services
 
 ### Service `roku.search`


### PR DESCRIPTION
## Proposed change

Removes duplicated "Remote" section on Roku integration documentation page.
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Removed stale or deprecated documentation.


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
