### PR TITLE
Support connecting to ElkM1 over TLS 1.2

### DIFF
--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -58,6 +58,15 @@ Force arm away and stay are available in 5.3.0 or higher.
 
 Many features will work with lower versions of the ElkM1. Check the "ElkM1 RS232 Protocol" manual for details.
 
+### ELK-M1XEP Version
+
+The ELK-M1XEP is the Ethernet controller board for the ElkM1. If connecting the integration
+in secure mode the version of the ELK-M1XEP determines which secure protocol is supported.
+ELK-M1XEP versions less than 2.0.46 support TLS 1.0, while version 2.0.46 and above support
+TLS 1.2. When adding the ElkM1 integration in the user interface use `secure` for TLS 1.0 and
+use `TLS 1.2` for TLS 1.2. Note that ELK-M1XEP does not support auto-negotiation of the 
+version of the TLS protocol, the user must specify the TLS version to connect.
+
 ### Global Setting 35
 
 The ElkM1 integration tracks the user number and name of the last user name to
@@ -150,15 +159,15 @@ elkm1:
 
 {% configuration %}
 host:
-  description: Connection string to Elk of the form `<method>://<address>[:port]`. `<method>` is `elk` for non-secure connection, `elks` for secure connection, and `serial` for serial port connection. `<address>` is IP address or domain or for `serial` the serial port that the Elk is connected to. Optional `<port>` is the port to connect to on the Elk, defaulting to 2101 for `elk` and 2601 for `elks`. For `serial` method, _address_ is the path to the tty _/dev/ttyS1_ for example and `[:baud]` is the baud rate to connect with (Elk systems default to 115200 baud, but this can be changed during Elk system configuration).  You may have multiple host sections for connecting multiple controllers.
+  description: Connection string to Elk of the form `<method>://<address>[:port]`. `<method>` is `elk` for non-secure connection, `elks` for secure TLS 1.0 connection, `elksv1_2` for secure TLS 1.2 connection, and `serial` for serial port connection. `<address>` is IP address or domain or for `serial` the serial port that the Elk is connected to. Optional `<port>` is the port to connect to on the Elk, defaulting to 2101 for `elk` and 2601 for `elks` and `elksv1_2`. For `serial` method, _address_ is the path to the tty _/dev/ttyS1_ for example and `[:baud]` is the baud rate to connect with (Elk systems default to 115200 baud, but this can be changed during Elk system configuration).  You may have multiple host sections for connecting multiple controllers. See ELK-M1XEP section above for information on selecting the appropriate secure version.
   required: true
   type: string
 username:
-  description: Username to login to Elk. Only required if using `elks` connection method.
+  description: Username to login to Elk. Only required if using secure connection method.
   required: false
   type: string
 password:
-  description: Password to login to Elk. Only required if using `elks` connection method.
+  description: Password to login to Elk. Only required if using secure connection method.
   required: false
   type: string
 prefix:

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -159,15 +159,15 @@ elkm1:
 
 {% configuration %}
 host:
-  description: Connection string to Elk of the form `<method>://<address>[:port]`. `<method>` is `elk` for non-secure connection, `elks` for secure TLS 1.0 connection, `elksv1_2` for secure TLS 1.2 connection, and `serial` for serial port connection. `<address>` is IP address or domain or for `serial` the serial port that the Elk is connected to. Optional `<port>` is the port to connect to on the Elk, defaulting to 2101 for `elk` and 2601 for `elks` and `elksv1_2`. For `serial` method, _address_ is the path to the tty _/dev/ttyS1_ for example and `[:baud]` is the baud rate to connect with (Elk systems default to 115200 baud, but this can be changed during Elk system configuration).  You may have multiple host sections for connecting multiple controllers. See ELK-M1XEP section above for information on selecting the appropriate secure version.
+  description: Connection string to Elk of the form `<method>://<address>[:port]`. `<method>` is `elk` for non-secure connection, `elks` for secure TLS 1.0 connection, `elksv1_2` for secure TLS 1.2 connection, and `serial` for serial port connection. `<address>` is IP address or domain or for `serial` the serial port that the Elk is connected to. Optional `<port>` is the port to connect to on the Elk, defaulting to 2101 for `elk` and 2601 for `elks` and `elksv1_2`. For `serial` method, _address_ is the path to the tty _/dev/ttyS1_ for example and `[:baud]` is the baud rate to connect with (Elk systems default to 115200 baud, but this can be changed during Elk system configuration). See ELK-M1XEP section above for information on selecting the appropriate secure version. You may have multiple host sections for connecting multiple controllers.
   required: true
   type: string
 username:
-  description: Username to login to Elk. Only required if using secure connection method.
+  description: Username to login to Elk. Required if using a secure connection method.
   required: false
   type: string
 password:
-  description: Password to login to Elk. Only required if using secure connection method.
+  description: Password to login to Elk. Required if using a secure connection method.
   required: false
   type: string
 prefix:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The newest version of the ElkM1 Ethernet board software only support TLS 1.2 in secure mode. Unfortunately, Elk does not auto negotiate the TLS version and it must be specified. This PR allows for the integration to select the TLS version. The dependency was already added to HA earlier this week (elkm1-lib 1.0.0).

This is not a breaking change.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/56887
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
