### PR TITLE
Fix anchors in configuration plugin for TOC generation. 

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -178,7 +178,7 @@ device_tracker:
     token: YOUR_TOKEN
 ```
 
-{% configuration %}
+{% configuration remote %}
 host:
   description: The IP address of your miio device.
   required: true
@@ -1049,7 +1049,7 @@ remote:
     token: YOUR_TOKEN
 ```
 
-{% configuration %}
+{% configuration repeater %}
 host:
   description: The IP of your remote.
   required: true


### PR DESCRIPTION
## Proposed change
Currently there is an ongoing problem where multiple configuration blocks generate duplicate anchors for toc and other saved links. Reported in: #16074 and #14784.

I found that if we use a parameter that is already set by many markdown pages today that we can append the parameter to the anchor for the configuration header to fix the TOCs. Additionally the individual variables can have `configuration-` prepended and the parameter again appended to resolve many duplicated anchors in variables.

Additionally I found that the anchors need to be added to the H3 rather than the link for jeckyll-toc to properly generate a link to the configuration block. In many examples I found it takes the html stripped text to generate a toc entry that doesn't function ("#-----configuration-variables--").

Last change in the configuration plugin I removed obsolete component and platform parameters to fit the config_name parameter, since component and platform is never used. The code dictates that you have "[component].[platform]". Platform is never used in code. Component is used in generating a link, but still is not used due to TYPE_LINKS not containing a component token to replace.

With this solution there are 75 integration docs that need to be fixed and 10 lovelace docs that can be optionally fixed due to no TOC. I can create an issue after merged to allow Hacktoberfest participants to help with commits or I can fix all if the HA team desires. 

### Alternative 
Instead of a parameter an easy fix can be using line_number available in tags/blocks already. This removes the need to fix all 75+10 files. It does however create a potential problem, what happens if someone bookmarks or references (in posts or personal git repos) saved links and then line numbers changes as integrations change. Anchors no longer become static and fail to work in this situation. Lets discuss in this PR.  

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: #16074 and #14784 

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
