### PR TITLE
Better alt text on Etcher screenshots

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -87,7 +87,7 @@ If you prefer to use a live operating system, follow the instructions of your Li
 {% endif %}
 2. Download and start <a href="https://www.balena.io/etcher" target="_blank">Balena Etcher</a>
 3. Select "Flash from URL"
-![etcher_from_url](/images/installation/etcher1.png)
+![Screenshot of the Etcher software showing flash from URL selected.](/images/installation/etcher1.png)
 
 4. Get the URL for your {{site.installation.types[page.installation_type].board}}:
 {% if site.installation.types[page.installation_type].variants.size > 1 %}
@@ -121,15 +121,15 @@ If you prefer to use a live operating system, follow the instructions of your Li
 _Select and copy the URL or use the "copy" button that appear when you hover it._
 
 1. Paste the URL for your {{site.installation.types[page.installation_type].board}} into Balena Etcher and click "OK"
-![etcher_from_url_paste](/images/installation/etcher2.png)
+![Screenshot of the Etcher software showing the URL bar with a URL pasted in.](/images/installation/etcher2.png)
 6. Balena Etcher will now download the image, when that is done click "Select target"
-![etcher_select_target](/images/installation/etcher3.png)
+![Screenshot of the Etcher software showing the select target button highlighted.](/images/installation/etcher3.png)
 7. Select the {{site.installation.types[page.installation_type].installation_media}} you want to use for your {{site.installation.types[page.installation_type].board}}
-![etcher_select_target](/images/installation/etcher4.png)
+![Screenshot of the Etcher software showing teh targets available.](/images/installation/etcher4.png)
 8. Click on "Flash!" to start writing the image
-![etcher_select_target](/images/installation/etcher5.png)
+![Screenshot of the Etcher software showing the Flash button highlighted.](/images/installation/etcher5.png)
 9. When Balena Etcher is finished writing the image you will get this confirmation
-![etcher_select_target](/images/installation/etcher6.png)
+![Screenshot of the Etcher software showing that the installation has completed.](/images/installation/etcher6.png)
 
 ### Start up your {{site.installation.types[page.installation_type].board}}
 


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

To comply with WCAG, alt text needs to be descriptive.
Relates to https://www.home-assistant.io/installation/raspberrypi

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

See https://www.w3.org/WAI/WCAG21/Techniques/general/G95.html

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
