### PR TITLE
Various improvements to documentation for TP-Link LTE

### DIFF
--- a/source/_integrations/tplink_lte.markdown
+++ b/source/_integrations/tplink_lte.markdown
@@ -11,7 +11,7 @@ ha_platforms:
   - notify
 ---
 
-The TP-Link LTE integration for Home Assistant allows you to observe and control TP-Link LTE routers, currently only tested with TL-MR6400 (firmware 1.4.0).
+The TP-Link LTE integration for Home Assistant makes it possible to send SMS's from the TP-Link LTE router. Phone numbers have to be pre-defined as part of the YAML configuration, and each phone number will turn up as additional notify service in Home Assistant. The integration adds a new notify service for each adds a notification service to Home Assistant that can be used to send SMSs provides a notification service that will send an SMS. Tested only with TL-MR6400 v4.
 
 The integration provides a notification service that will send an SMS.
 
@@ -45,7 +45,7 @@ notify:
   required: false
   type: list
   keys:
-    target:
+    recipient:
       description: The phone number of a default recipient or a list with multiple recipients.
       required: true
       type: [string, list]


### PR DESCRIPTION
The documentation states that "allows you to observe.. //... your TP-Link LTE router", but no other part of the documentation indicates what could be observed or how. Neither have I been able to find anything like that when trying the integration out.
Separate from above, the example used "recipent" as parameter, whereas the parameter list used "target". "Recipient" worked out for me.

Also removed reference to firmware version, as there seems like TP-Link is not issuing any new firmwares for v4 devices. (I also have a v5 device that I hope to verify with soon).

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
