### PR TITLE
Fix broken link in TP-Link Kasa Smart

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -32,10 +32,6 @@ In order to activate the support, you will have to enable the integration inside
 The supported devices in your network are automatically discovered, but if you want to control devices residing in other networks you will need to configure them manually as shown below.
 
 ## Supported Devices
-
-This integration supports devices that are controllable with the [KASA app](https://play.google.com/store/apps/details?id=com.tplink.kasa_android).
-The following devices are known to work with this component.
-
 ### Plugs
 
 Plugs are type `switch` when autodiscovery has been disabled.

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -33,7 +33,7 @@ The supported devices in your network are automatically discovered, but if you w
 
 ## Supported Devices
 
-This integration supports devices that are controllable with the [KASA app](https://www.tp-link.com/us/kasa-smart/kasa.html).
+This integration supports devices that are controllable with the [KASA app](https://play.google.com/store/apps/details?id=com.tplink.kasa_android).
 The following devices are known to work with this component.
 
 ### Plugs

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -20,7 +20,7 @@ ha_platforms:
 ha_dhcp: true
 ---
 
-The `tplink` integration allows you to control your [TP-Link Smart Home Devices](https://www.tp-link.com/kasa-smart/) such as smart plugs and smart bulbs.
+The `tplink` integration allows you to control your [TP-Link Smart Home Devices](https://www.tp-link.com/kasa-smart/) such as smart plugs, smart wall switches and smart bulbs.
 
 There is currently support for the following device types within Home Assistant:
 

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -20,7 +20,7 @@ ha_platforms:
 ha_dhcp: true
 ---
 
-The `tplink` integration allows you to control your [TP-Link Smart Home Devices](https://www.tp-link.com/kasa-smart/) such as smart plugs, smart wall switches and smart bulbs.
+The `tplink` integration allows you to control your [TP-Link Smart Home Devices](https://www.tp-link.com/kasa-smart/) such as plugs, power strips, wall switches and bulbs.
 
 There is currently support for the following device types within Home Assistant:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

* Removed link to mobile App (no info found on https://www.kasasmart.com/us)
* Added smart wall switches to integration summery

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
