### PR TITLE
Reverse the placement of the phone mockup on mobile phones

### DIFF
--- a/sass/custom/_layout.scss
+++ b/sass/custom/_layout.scss
@@ -81,3 +81,11 @@ table {
         }
     }
   }
+
+@media only screen and (max-width: $palm-end) {
+     .hero {
+        img {
+            margin-bottom: 0px;
+        }
+    }
+}

--- a/sass/oscailte/helpers/_grid-fix.scss
+++ b/sass/oscailte/helpers/_grid-fix.scss
@@ -91,20 +91,4 @@
     -ms-flex-direction: column;
     flex-direction: column;
   }
-
-  .flex__item {
-    -webkit-box-ordinal-group: 1;
-    -moz-box-ordinal-group: 1;
-    -webkit-order: 0;
-    -ms-flex-order: 0;
-    order: 0;
-    -webkit-box-flex: 0;
-    -moz-box-flex: 0;
-    -webkit-flex: 0 1 auto;
-    -ms-flex: 0 1 auto;
-    flex: 0 1 auto;
-    -webkit-align-self: center;
-    -ms-flex-item-align: center;
-    align-self: center;
-  }
-}
+ }

--- a/sass/oscailte/helpers/_grid-fix.scss
+++ b/sass/oscailte/helpers/_grid-fix.scss
@@ -26,7 +26,69 @@
  *
  */
 
-@media only screen and (min-width: $lap-start){
+.flex__item {
+  -webkit-box-ordinal-group: 1;
+  -moz-box-ordinal-group: 1;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+/*
+* Css for seting orders
+* 
+*/
+
+.flex__item.order0 {
+  order: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+}
+
+.flex__item.order1 {
+  order: 1;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+}
+
+.flex__item.order2 {
+  order: 2;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+}
+
+.flex__item.order3 {
+  order: 3;
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+}
+
+.flex__item.order4 {
+  order: 4;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+}
+
+.flex__item.order5 {
+  order: 5;
+  -webkit-order: 5;
+  -ms-flex-order: 5;
+}
+
+/*
+ * Flexbox with 
+ *
+ */
+
+@media only screen and (min-width: $lap-start) {
   .flex {
     display: -webkit-box;
     display: -moz-box;
@@ -57,22 +119,6 @@
     -ms-flex-align: start;
     align-items: flex-start;
   }
-
-  .flex__item {
-    -webkit-box-ordinal-group: 1;
-    -moz-box-ordinal-group: 1;
-    -webkit-order: 0;
-    -ms-flex-order: 0;
-    order: 0;
-    -webkit-box-flex: 0;
-    -moz-box-flex: 0;
-    -webkit-flex: 0 1 auto;
-    -ms-flex: 0 1 auto;
-    flex: 0 1 auto;
-    -webkit-align-self: center;
-    -ms-flex-item-align: center;
-    align-self: center;
-  }
 }
 
 /*
@@ -80,15 +126,40 @@
  *
  */
 
-@media only screen and (max-width: $palm-end){
+@media only screen and (max-width: $palm-end) {
   .flex {
-    display: -webkit-box;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: -webkit-flex;
-    display: flex;
+    -webkit-box-direction: normal;
+    -moz-box-direction: normal;
+    -webkit-box-orient: vertical;
+    -moz-box-orient: vertical;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+    -webkit-box-pack: start;
+    -moz-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+    -webkit-align-content: stretch;
+    -ms-flex-line-pack: stretch;
+    align-content: stretch;
+    -webkit-box-align: start;
+    -moz-box-align: start;
+    -webkit-align-items: flex-start;
+    -ms-flex-align: start;
+    align-items: flex-start;
   }
- }
+
+  .flex.flexreverse {
+    -webkit-box-direction: reverse;
+    -moz-box-direction: reverse;
+    -webkit-box-orient: vertical;
+    -moz-box-orient: vertical;
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+  }
+}

--- a/sass/oscailte/helpers/_grid-fix.scss
+++ b/sass/oscailte/helpers/_grid-fix.scss
@@ -26,6 +26,33 @@
  *
  */
 
+ .flex {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-box-direction: normal;
+    -moz-box-direction: normal;
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+    -webkit-box-pack: start;
+    -moz-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+    -webkit-align-content: stretch;
+    -ms-flex-line-pack: stretch;
+    align-content: stretch;
+    -webkit-box-align: start;
+    -moz-box-align: start;
+    -webkit-align-items: flex-start;
+    -ms-flex-align: start;
+    align-items: flex-start;
+  }
+
+
 .flex__item {
   -webkit-box-ordinal-group: 1;
   -moz-box-ordinal-group: 1;
@@ -89,35 +116,13 @@
  */
 
 @media only screen and (min-width: $lap-start) {
+  
   .flex {
-    display: -webkit-box;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: -webkit-flex;
-    display: flex;
-    -webkit-box-direction: normal;
-    -moz-box-direction: normal;
     -webkit-box-orient: horizontal;
     -moz-box-orient: horizontal;
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
-    -webkit-flex-wrap: nowrap;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    -webkit-box-pack: start;
-    -moz-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-    -webkit-align-content: stretch;
-    -ms-flex-line-pack: stretch;
-    align-content: stretch;
-    -webkit-box-align: start;
-    -moz-box-align: start;
-    -webkit-align-items: flex-start;
-    -ms-flex-align: start;
-    align-items: flex-start;
   }
 }
 
@@ -128,34 +133,12 @@
 
 @media only screen and (max-width: $palm-end) {
   .flex {
-    display: -webkit-box;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: -webkit-flex;
-    display: flex;
-    -webkit-box-direction: normal;
-    -moz-box-direction: normal;
     -webkit-box-orient: vertical;
     -moz-box-orient: vertical;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
-    -webkit-flex-wrap: nowrap;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    -webkit-box-pack: start;
-    -moz-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-    -webkit-align-content: stretch;
-    -ms-flex-line-pack: stretch;
-    align-content: stretch;
-    -webkit-box-align: start;
-    -moz-box-align: start;
-    -webkit-align-items: flex-start;
-    -ms-flex-align: start;
-    align-items: flex-start;
+ 
   }
 
   .flex.palm-flexreverse {

--- a/sass/oscailte/helpers/_grid-fix.scss
+++ b/sass/oscailte/helpers/_grid-fix.scss
@@ -153,7 +153,7 @@
     align-items: flex-start;
   }
 
-  .flex.flexreverse {
+  .flex.palm-flexreverse {
     -webkit-box-direction: reverse;
     -moz-box-direction: reverse;
     -webkit-box-orient: vertical;

--- a/sass/oscailte/helpers/_grid-fix.scss
+++ b/sass/oscailte/helpers/_grid-fix.scss
@@ -128,6 +128,11 @@
 
 @media only screen and (max-width: $palm-end) {
   .flex {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
     -webkit-box-direction: normal;
     -moz-box-direction: normal;
     -webkit-box-orient: vertical;

--- a/sass/oscailte/helpers/_grid-fix.scss
+++ b/sass/oscailte/helpers/_grid-fix.scss
@@ -26,7 +26,7 @@
  *
  */
 
-@media only screen and (min-width: $lap-start){
+@media only screen and (min-width: $palm-start){
   .flex {
     display: -webkit-box;
     display: -moz-box;

--- a/sass/oscailte/helpers/_grid-fix.scss
+++ b/sass/oscailte/helpers/_grid-fix.scss
@@ -26,7 +26,7 @@
  *
  */
 
-@media only screen and (min-width: $palm-start){
+@media only screen and (min-width: $lap-start){
   .flex {
     display: -webkit-box;
     display: -moz-box;
@@ -56,6 +56,40 @@
     -webkit-align-items: flex-start;
     -ms-flex-align: start;
     align-items: flex-start;
+  }
+
+  .flex__item {
+    -webkit-box-ordinal-group: 1;
+    -moz-box-ordinal-group: 1;
+    -webkit-order: 0;
+    -ms-flex-order: 0;
+    order: 0;
+    -webkit-box-flex: 0;
+    -moz-box-flex: 0;
+    -webkit-flex: 0 1 auto;
+    -ms-flex: 0 1 auto;
+    flex: 0 1 auto;
+    -webkit-align-self: center;
+    -ms-flex-item-align: center;
+    align-self: center;
+  }
+}
+
+/*
+ * Setting a  use for flexbox on mobile too, instead of Row, items are now placed in Columns. This gives the possibility to set the order of items on mobile. 
+ *
+ */
+
+@media only screen and (max-width: $palm-end){
+  .flex {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
   }
 
   .flex__item {

--- a/source/_includes/site/hero_unit.html
+++ b/source/_includes/site/hero_unit.html
@@ -1,6 +1,6 @@
 <div class="hero">
   <div class="grid-wrapper">
-    <div class="grid flex">
+    <div class="grid flex palm-flexreverse">
       <div class="grid__item flex__item two-fifths palm-one-whole">
         <a href='https://demo.home-assistant.io/' target='_blank'>
           <img src="/images/hero_screenshot.png" alt="Home Assistant screenshot">


### PR DESCRIPTION
## Proposed change

Currently  on mobile phones in portrait mode, the phone image is displayed first and the "Awaken your home" text is displayed. This makes that the phone doesn't align to the edge of the blue section. Which it does do on desktop. It think it looks better when the phone is aligned below the blue section.

The current divs containing the content are using flexbox. With flexbox it is possible to set the order of the items. It is possible to reverse the order, which is suitable for this. 

I looked at the _grid-fix.scss file to make sure flexbox is applied to palm screens as well and set the order to column-reverse. I added classnames to make a generic solution. Next to that added a class in hero_unit.html and removed the margin on the phone image on palm screens. 


Current situation:

![](https://user-images.githubusercontent.com/43075793/135844792-55b64e85-9beb-4611-bd8e-dbd70f07a316.png)

Proposed:

![image](https://user-images.githubusercontent.com/43075793/135848002-2624394e-9a75-4343-8e4c-a17f7036038a.png)

See it live: https://deploy-preview-19596--home-assistant-docs.netlify.app/ in mobile view. 

## Type of change

*   [x] Spelling, grammar or other readability improvements (`current` branch).
*   [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
*   [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
    *   [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
*   [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
*   [ ] Removed stale or deprecated documentation.

## Additional information

*   Link to parent pull request in the codebase:
*   Link to parent pull request in the Brands repository:
*   This PR fixes or closes issue:

## Checklist

*   [x] This PR uses the correct branch, based on one of the following:
    *   I made a change to the existing documentation and used the `current` branch.
    *   I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
*   [x] The documentation follows the Home Assistant documentation [standards](https://developers.home-assistant.io/docs/documenting/standards).