### PR TITLE
Add push_weather_data Service to Rainmachine

### DIFF
--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -79,7 +79,7 @@ Pause all watering activities for a number of seconds.
 
 Push Weather Data from Home Assistant to the RainMachine device.
 
-Local Weather Push service should be enabled from Settings > Weather > Developer tab for RainMachine to consider the values being sent. Units must be sent in metric; no conversions are performed by the integraion. Note: RAIN and QPF values shouldn't be send as cumulative values but the measured/forecasted values for each hour or day. The RainMachine Mixer will sum all RAIN or QPF values in the current day to have the day total RAIN or QPF.
+Local Weather Push service should be enabled from Settings > Weather > Developer tab for RainMachine to consider the values being sent. Units must be sent in metric; no conversions are performed by the integration. Note: RAIN and QPF values shouldn't be sent as cumulative values but the measured/forecasted values for each hour or day. The RainMachine Mixer will sum all RAIN or QPF values in the current day to have the day total RAIN or QPF.
 
 See details of RainMachine API Here: https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post
 

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -10,7 +10,7 @@ ha_release: 0.69
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:
-  - '@bachya'
+  - "@bachya"
 ha_domain: rainmachine
 ha_platforms:
   - binary_sensor
@@ -34,19 +34,20 @@ There is currently support for the following device types within Home Assistant:
 
 Services accept either device IDs or entity IDs, depending on the nature of the service:
 
-* Services that require a device ID as a target:
-    * `rainmachine.pause_watering`
-    * `rainmachine.stop_all`
-    * `rainmachine.unpause_watering`
-* Services that require an entity ID as a target (note that the correct entity ID type must be provided, such as a program for a program-related service)
-    * `rainmachine.disable_program`
-    * `rainmachine.disable_zone`
-    * `rainmachine.enable_program`
-    * `rainmachine.enable_zone`
-    * `rainmachine.start_program`
-    * `rainmachine.start_zone`
-    * `rainmachine.stop_program`
-    * `rainmachine.stop_zone`
+- Services that require a device ID as a target:
+  - `rainmachine.pause_watering`
+  - `rainmachine.push_weather_data`
+  - `rainmachine.stop_all`
+  - `rainmachine.unpause_watering`
+- Services that require an entity ID as a target (note that the correct entity ID type must be provided, such as a program for a program-related service)
+  - `rainmachine.disable_program`
+  - `rainmachine.disable_zone`
+  - `rainmachine.enable_program`
+  - `rainmachine.enable_zone`
+  - `rainmachine.start_program`
+  - `rainmachine.start_zone`
+  - `rainmachine.stop_program`
+  - `rainmachine.stop_zone`
 
 ### `rainmachine.disable_program`
 
@@ -70,9 +71,34 @@ Enable a RainMachine zone.
 
 Pause all watering activities for a number of seconds.
 
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `seconds`                   |      no  | The number of seconds to pause                              |
+| Service Data Attribute | Optional | Description                    |
+| ---------------------- | -------- | ------------------------------ |
+| `seconds`              | no       | The number of seconds to pause |
+
+### `rainmachine.push_weather_data`
+
+Push Weather Data from Home Assistant to the RainMachine device.
+
+Local Weather Push service should be enabled from Settings > Weather > Developer tab for RainMachine to consider the values being sent. Units must be sent in metric; no conversions are performed by the integraion. Note: RAIN and QPF values shouldn't be send as cumulative values but the measured/forecasted values for each hour or day. The RainMachine Mixer will sum all RAIN or QPF values in the current day to have the day total RAIN or QPF.
+
+See details of RainMachine API Here: https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post
+
+| Service Data Attribute | Optional | Description                                                                                                           |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `timestamp`            | no       | UNIX Timestamp for the Weather Data. If omitted, the RainMachine device's local time at the time of the call is used. |
+| `mintemp`              | no       | Minimum Temperature (°C)                                                                                              |
+| `maxtemp`              | no       | Maximum Temperature (°C)                                                                                              |
+| `temperature`          | no       | Current Temperature (°C)                                                                                              |
+| `wind`                 | no       | Wind Speed (m/s)                                                                                                      |
+| `solarrad`             | no       | Solar Radiation (MJ/m²/h)                                                                                             |
+| `et`                   | no       | Evapotranspiration (mm)                                                                                               |
+| `qpf`                  | no       | Quantitative Precipitation Forecast (mm), or QPF                                                                      |
+| `rain`                 | no       | Measured Rainfail (mm)                                                                                                |
+| `minrh`                | no       | Min Relative Humidity (%RH)                                                                                           |
+| `maxrh`                | no       | Max Relative Humidity (%RH)                                                                                           |
+| `condition`            | no       | Current weather condition code (WNUM)                                                                                 |
+| `pressure`             | no       | Barametric Pressure (kPa)                                                                                             |
+| `dewpoint`             | no       | Dew Point (°C)                                                                                                        |
 
 ### `rainmachine.start_program`
 
@@ -80,9 +106,9 @@ Pause all watering activities for a number of seconds.
 
 Start a RainMachine zone for a set number of seconds.
 
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `zone_run_time`             |      yes | The number of seconds to run; defaults to 60 seconds        |
+| Service Data Attribute | Optional | Description                                          |
+| ---------------------- | -------- | ---------------------------------------------------- |
+| `zone_run_time`        | yes      | The number of seconds to run; defaults to 60 seconds |
 
 ### `rainmachine.stop_all`
 

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -102,6 +102,8 @@ See details of RainMachine API Here: https://rainmachine.docs.apiary.io/#referen
 
 ### `rainmachine.start_program`
 
+Start a RainnMachine program.
+
 ### `rainmachine.start_zone`
 
 Start a RainMachine zone for a set number of seconds.

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -153,7 +153,7 @@ See details of RainMachine API Here: https://rainmachine.docs.apiary.io/#referen
 | `rain`                 | no       | Measured Rainfail (mm)                                                                                                |
 | `minrh`                | no       | Min Relative Humidity (%RH)                                                                                           |
 | `maxrh`                | no       | Max Relative Humidity (%RH)                                                                                           |
-| `condition`            | no       | Current weather condition code (WNUM)                                                                                 |
+| `condition`            | no       | Current weather condition code (WNUM). See [here][wnum reference] for options.                                        |
 | `pressure`             | no       | Barametric Pressure (kPa)                                                                                             |
 | `dewpoint`             | no       | Dew Point (°C)                                                                                                        |
 
@@ -170,3 +170,5 @@ After Home Assistant loads, new switches will be added for every enabled program
 - Zone On/Off: starts/stops a zone (using the `zone_run_time` parameter to determine how long to run for)
 
 Programs and zones are linked. While a program is running, you will see both the program and zone switches turned on; turning either one off will turn the other one off (just like in the web app).
+
+[wnum reference]: https://github.com/sprinkler/rainmachine-developer-resources/blob/d47e1ad59dee59e34094ad41636ae289275eb973/sdk-parsers/RMDataFramework/rmWeatherData.py#L13

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -81,7 +81,8 @@ Push Weather Data from Home Assistant to the RainMachine device.
 
 Local Weather Push service should be enabled from Settings > Weather > Developer tab for RainMachine to consider the values being sent. Units must be sent in metric; no conversions are performed by the integration. Note: RAIN and QPF values shouldn't be sent as cumulative values but the measured/forecasted values for each hour or day. The RainMachine Mixer will sum all RAIN or QPF values in the current day to have the day total RAIN or QPF.
 
-See details of RainMachine API Here: https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post
+See details of RainMachine API here: 
+<https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post>
 
 | Service Data Attribute | Optional | Description                                                                                                           |
 | ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -96,7 +96,7 @@ See details of RainMachine API Here: https://rainmachine.docs.apiary.io/#referen
 | `rain`                 | no       | Measured Rainfail (mm)                                                                                                |
 | `minrh`                | no       | Min Relative Humidity (%RH)                                                                                           |
 | `maxrh`                | no       | Max Relative Humidity (%RH)                                                                                           |
-| `condition`            | no       | Current weather condition code (WNUM)                                                                                 |
+| `condition`            | no       | Current weather condition code (WNUM). See [here][wnum reference] for options.                                        |
 | `pressure`             | no       | Barametric Pressure (kPa)                                                                                             |
 | `dewpoint`             | no       | Dew Point (°C)                                                                                                        |
 
@@ -126,38 +126,6 @@ Stop a RainMachine zone.
 
 Unpause all watering activities.
 
-<<<<<<< HEAD
-=======
-### `rainmachine.push_weather_data`
-
-Push Weather Data from Home Assistant to the RainMachine device.
-
-Some key notes:
-
-* Local Weather Push service should be enabled from Settings > Weather > Developer tab for RainMachine to consider the values being sent.
-* Units must be sent in metric; no conversions are performed by the integration.
-* Note: RAIN and QPF values shouldn't be send as cumulative values; instead, they should reflect the measured/forecasted values for each hour or day. The RainMachine Mixer will sum all RAIN or QPF values in the current day to have the day total RAIN or QPF.
-
-See details of RainMachine API Here: https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post
-
-| Service Data Attribute | Optional | Description                                                                                                           |
-| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| `timestamp`            | no       | UNIX Timestamp for the Weather Data. If omitted, the RainMachine device's local time at the time of the call is used. |
-| `mintemp`              | no       | Minimum Temperature (°C)                                                                                              |
-| `maxtemp`              | no       | Maximum Temperature (°C)                                                                                              |
-| `temperature`          | no       | Current Temperature (°C)                                                                                              |
-| `wind`                 | no       | Wind Speed (m/s)                                                                                                      |
-| `solarrad`             | no       | Solar Radiation (MJ/m²/h)                                                                                             |
-| `et`                   | no       | Evapotranspiration (mm)                                                                                               |
-| `qpf`                  | no       | Quantitative Precipitation Forecast (mm), or QPF                                                                      |
-| `rain`                 | no       | Measured Rainfail (mm)                                                                                                |
-| `minrh`                | no       | Min Relative Humidity (%RH)                                                                                           |
-| `maxrh`                | no       | Max Relative Humidity (%RH)                                                                                           |
-| `condition`            | no       | Current weather condition code (WNUM). See [here][wnum reference] for options.                                        |
-| `pressure`             | no       | Barametric Pressure (kPa)                                                                                             |
-| `dewpoint`             | no       | Dew Point (°C)                                                                                                        |
-
->>>>>>> d8d39f28b7 (Update source/_integrations/rainmachine.markdown)
 ## Switch
 
 The `rainmachine` switch platform allows you to control programs and zones within a [RainMachine smart Wi-Fi sprinkler controller](https://www.rainmachine.com/).

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -126,6 +126,38 @@ Stop a RainMachine zone.
 
 Unpause all watering activities.
 
+<<<<<<< HEAD
+=======
+### `rainmachine.push_weather_data`
+
+Push Weather Data from Home Assistant to the RainMachine device.
+
+Some key notes:
+
+* Local Weather Push service should be enabled from Settings > Weather > Developer tab for RainMachine to consider the values being sent.
+* Units must be sent in metric; no conversions are performed by the integration.
+* Note: RAIN and QPF values shouldn't be send as cumulative values; instead, they should reflect the measured/forecasted values for each hour or day. The RainMachine Mixer will sum all RAIN or QPF values in the current day to have the day total RAIN or QPF.
+
+See details of RainMachine API Here: https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post
+
+| Service Data Attribute | Optional | Description                                                                                                           |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `timestamp`            | no       | UNIX Timestamp for the Weather Data. If omitted, the RainMachine device's local time at the time of the call is used. |
+| `mintemp`              | no       | Minimum Temperature (°C)                                                                                              |
+| `maxtemp`              | no       | Maximum Temperature (°C)                                                                                              |
+| `temperature`          | no       | Current Temperature (°C)                                                                                              |
+| `wind`                 | no       | Wind Speed (m/s)                                                                                                      |
+| `solarrad`             | no       | Solar Radiation (MJ/m²/h)                                                                                             |
+| `et`                   | no       | Evapotranspiration (mm)                                                                                               |
+| `qpf`                  | no       | Quantitative Precipitation Forecast (mm), or QPF                                                                      |
+| `rain`                 | no       | Measured Rainfail (mm)                                                                                                |
+| `minrh`                | no       | Min Relative Humidity (%RH)                                                                                           |
+| `maxrh`                | no       | Max Relative Humidity (%RH)                                                                                           |
+| `condition`            | no       | Current weather condition code (WNUM)                                                                                 |
+| `pressure`             | no       | Barametric Pressure (kPa)                                                                                             |
+| `dewpoint`             | no       | Dew Point (°C)                                                                                                        |
+
+>>>>>>> d8d39f28b7 (Update source/_integrations/rainmachine.markdown)
 ## Switch
 
 The `rainmachine` switch platform allows you to control programs and zones within a [RainMachine smart Wi-Fi sprinkler controller](https://www.rainmachine.com/).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add service to Rainmachine to push weather data from Home Assistant to Rainmachine. This will allow users to send Home Assistant data to the Rain Machine Device to manage the amount of watering required, for example, weather from a local weather station feeding into Home Assistant.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57354
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
