### PR TITLE
Add config flow to Stookalert

### DIFF
--- a/source/_integrations/stookalert.markdown
+++ b/source/_integrations/stookalert.markdown
@@ -8,31 +8,13 @@ ha_release: 0.104
 ha_iot_class: Cloud Polling
 ha_codeowners:
   - '@fwestenberg'
+  - '@frenck'
 ha_domain: stookalert
+ha_config_flow: true
 ha_platforms:
   - binary_sensor
 ---
 
-The `stookalert` sensor platform queries the [RIVM Stookalert](https://www.rivm.nl/stookalert) API for unfavorable weather conditions or poor air quality. With a Stookalert, the RIVM calls on people not to burn wood. This can prevent health problems in people in the area.
+The Stookalert integration queries the [RIVM Stookalert](https://www.rivm.nl/stookalert) API for unfavorable weather conditions or poor air quality. With a Stookalert, the RIVM calls on people not to burn wood. This can prevent health problems in people in the area.
 
-## Configuration
-
-To enable the platform, add the following lines to your `configuration.yaml` file:
-
-```yaml
-binary_sensor:
-  - platform: stookalert
-    province: YOUR_NL_PROVINCE
-```
-
-{% configuration %}
-province:
-  description: A province to use for the binary sensor's state. Currently only provinces in the Netherlands are supported. Valid values are `Drenthe`, `Flevoland`, `Friesland`, `Gelderland`, `Groningen`, `Limburg`, `Noord-Brabant`, `Noord-Holland`, `Overijssel`, `Utrecht`, `Zeeland` or `Zuid-Holland`.
-  required: true
-  type: string
-name:
-  description: The sensor name to use in the frontend.
-  required: false
-  default: "Stookalert"
-  type: string
-{% endconfiguration %}
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adjust the documentation for the added configuration flow to the Stookalert integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57119
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
