### PR TITLE
Reorganize RainMachine service docs

### DIFF
--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -32,39 +32,39 @@ There is currently support for the following device types within Home Assistant:
 
 ## Services
 
+Services accept either device IDs or entity IDs, depending on the nature of the service:
+
+* Services that require a device ID as a target:
+    * `rainmachine.pause_watering`
+    * `rainmachine.stop_all`
+    * `rainmachine.unpause_watering`
+* Services that require an entity ID as a target (note that the correct entity ID type must be provided, such as a program for a program-related service)
+    * `rainmachine.disable_program`
+    * `rainmachine.disable_zone`
+    * `rainmachine.enable_program`
+    * `rainmachine.enable_zone`
+    * `rainmachine.start_program`
+    * `rainmachine.start_zone`
+    * `rainmachine.stop_program`
+    * `rainmachine.stop_zone`
+
 ### `rainmachine.disable_program`
 
 Disable a RainMachine program. This will mark the program switch as
 `Unavailable` in the UI.
-
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `program_id  `              |      no  | The program to disable                                      |
 
 ### `rainmachine.disable_zone`
 
 Disable a RainMachine zone. This will mark the zone switch as
 `Unavailable` in the UI.
 
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `zone_id  `                 |      no  | The program to disable                                      |
-
 ### `rainmachine.enable_program`
 
 Enable a RainMachine program.
 
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `program_id  `              |      no  | The program to enable                                       |
-
 ### `rainmachine.enable_zone`
 
 Enable a RainMachine zone.
-
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `zone_id  `                 |      no  | The zone to enable                                          |
 
 ### `rainmachine.pause_watering`
 
@@ -76,19 +76,12 @@ Pause all watering activities for a number of seconds.
 
 ### `rainmachine.start_program`
 
-Start a RainMachine program.
-
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `program_id  `              |      no  | The program to start                                        |
-
 ### `rainmachine.start_zone`
 
 Start a RainMachine zone for a set number of seconds.
 
 | Service Data Attribute    | Optional | Description                                                 |
 |---------------------------|----------|-------------------------------------------------------------|
-| `zone_id`                   |      no  | The zone to start                                           |
 | `zone_run_time`             |      yes | The number of seconds to run; defaults to 60 seconds        |
 
 ### `rainmachine.stop_all`
@@ -99,17 +92,9 @@ Stop all watering activities.
 
 Stop a RainMachine program.
 
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `program_id  `              |      no  | The program to stop                                         |
-
 ### `rainmachine.stop_zone`
 
 Stop a RainMachine zone.
-
-| Service Data Attribute    | Optional | Description                                                 |
-|---------------------------|----------|-------------------------------------------------------------|
-| `zone_id  `                 |      no  | The zone to stop                                            |
 
 ### `rainmachine.unpause_watering`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR updates the RainMachine docs with some forthcoming service changes.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57145
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
