### PR TITLE
Remove obsolete information from modem_callerid

### DIFF
--- a/source/_integrations/modem_callerid.markdown
+++ b/source/_integrations/modem_callerid.markdown
@@ -17,13 +17,13 @@ The `modem_callerid` integration uses an available modem for collecting caller I
 
 When the sensor detects a new call, its state changes to 'ring' for each ring and 'callerid' when caller id information is received. It returns to 'idle' once ringing stops. The state event includes an attribute payload that includes the time of the call, name and number.
 
-This integration also offers two services. `modem_callerid.reject_call` to pick up and then hang up the call to properly reject a call (via ATA anf ATH). `modem_callerid.hangup_call` to hang up an existing call (via ATH).
+This integration also offers a service. `modem_callerid.reject_call` to pick up and then hang up the call to properly reject a call (via ATA anf ATH).
 
 {% include integrations/config_flow.md %}
 
 ## Examples
 
-Some example automations:
+An example automation:
 
 {% raw %}
 
@@ -60,19 +60,3 @@ automation:
 ```
 
 {% endraw %}
-
-## Extra instructions for the Home Assistant Core installation type
-
-To find the path of your USB modem, run:
-
-```bash
-ls /dev/ttyACM*
-```
-
-If Home Assistant (`hass`) runs with another user (e.g., `homeassistant`) give access to the stick with:
-
-```bash
-sudo usermod -a -G dialout homeassistant
-```
-
-Depending on what's plugged into your USB ports, the name found above may change. You can lock in a name, such as `/dev/modem`, by following [these instructions](http://hintshop.ludvig.co.nz/show/persistent-names-usb-serial-devices/).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Home Assistant now shows a list of available USB devices. Instructions for looking up a dev path is no longer needed.
Remove reference to non-existent service.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
