### PR TITLE
Add documentation for Nest Battery Cameras and Doorbells and WebRTC streams

### DIFF
--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -291,12 +291,11 @@ logger:
 
 ## Camera
 
-All Google Nest Cam models, Google Nest Doorbell models, Google Nest Hub Max expose a [CameraLiveStream](https://developers.google.com/nest/device-access/traits/device/camera-live-stream) via the SDM API, which either return an RTSP or WebRTC live stream which can be viewed from Home Assistant.
+All Google Nest Cam models, Google Nest Doorbell models, Google Nest Hub Max expose a [CameraLiveStream](https://developers.google.com/nest/device-access/traits/device/camera-live-stream) via the SDM API.
 
 Given a camera named `Front Yard` then the camera is created with a name such as `camera.front_yard`.
 
-See the [Nest SDM API: CameraLiveStream Schema](https://developers.google.com/nest/device-access/traits/device/camera-live-stream) for details on which models
-support which types of streams. WebRTC cameras do not support image previews or stream recording in Home Assistant as the stream communication is client side, directly from the browser to the device.
+Cameras either support an `RTSP` stream served via `HLS` by Home Assistant, or support a `WebRTC` stream. See the [Nest SDM API: CameraLiveStream Schema](https://developers.google.com/nest/device-access/traits/device/camera-live-stream) for details on which camera devices support which types of streams. WebRTC cameras do not support image previews or stream recording in Home Assistant as the stream communication is client side, directly from the browser to the device.
 
 ## Climate
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -295,7 +295,7 @@ All Google Nest Cam models, Google Nest Doorbell models, Google Nest Hub Max exp
 
 Given a camera named `Front Yard` then the camera is created with a name such as `camera.front_yard`.
 
-Cameras either support an `RTSP` stream served via `HLS` by Home Assistant, or support a `WebRTC` stream. See the [Nest SDM API: CameraLiveStream Schema](https://developers.google.com/nest/device-access/traits/device/camera-live-stream) for details on which camera devices support which types of streams. WebRTC cameras do not support image previews or stream recording in Home Assistant as the stream communication is client side, directly from the browser to the device.
+Cameras either support an `RTSP` stream served via `HLS` by Home Assistant, or support a `WebRTC` stream. See the [Nest SDM API: CameraLiveStream Schema](https://developers.google.com/nest/device-access/traits/device/camera-live-stream) for details on which camera devices support which types of streams. WebRTC cameras do not support image previews or stream recording in Home Assistant as the stream communication is client-side, directly from the browser to the device.
 
 ## Climate
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -51,7 +51,7 @@ Home Assistant is integrated with the following devices through the SDM API:
 - Display, Camera, and Doorbell Devices
   - The camera live stream is available as a `camera` entity
   - Device Triggers for use in automations such as Person detected, Motion detected and Doorbell pressed
-  - Example devices: All Google Nest Cam models, Google Nest Hello Video Doorbell, Google Nest Hub Max
+  - Example devices: All wired & battery Google Nest Cam models, wired & battery Nest Doorbells, and Google Nest Hub Max.
 
 You are in control of the information and capabilities exposed to Home Assistant. You can authorize a single device, multiple devices, or different levels of functionality such as motion events, live streams, for any particular device. The integration is flexible enough to adapt based on what you allow.
 
@@ -291,9 +291,12 @@ logger:
 
 ## Camera
 
-All Google Nest Cam models, Google Nest Hello Video Doorbell, Google Nest Hub Max expose a [CameraLiveStream](https://developers.google.com/nest/device-access/traits/device/camera-live-stream) via the SDM API, which returns a RTSP live stream which can be viewed from Home Assistant.
+All Google Nest Cam models, Google Nest Doorbell models, Google Nest Hub Max expose a [CameraLiveStream](https://developers.google.com/nest/device-access/traits/device/camera-live-stream) via the SDM API, which either return an RTSP or WebRTC live stream which can be viewed from Home Assistant.
 
 Given a camera named `Front Yard` then the camera is created with a name such as `camera.front_yard`.
+
+See the [Nest SDM API: CameraLiveStream Schema](https://developers.google.com/nest/device-access/traits/device/camera-live-stream) for details on which models
+support which types of streams. WebRTC cameras do not support image previews or stream recording in Home Assistant as the stream communication is client side, directly from the browser to the device.
 
 ## Climate
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation about support for Nest battery cameras that use WebRTC.

See https://github.com/home-assistant/architecture/discussions/640 for overall architecture issue and https://github.com/home-assistant/core/issues/55302 for `nest` specifics.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57299
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
