### PR TITLE
Replace Synology DSM services with buttons

### DIFF
--- a/source/_integrations/synology_dsm.markdown
+++ b/source/_integrations/synology_dsm.markdown
@@ -103,20 +103,37 @@ A switch is available to enable/disable the [Surveillance Station](https://www.s
 
 For each camera added in [Surveillance Station](https://www.synology.com/en-us/surveillance), a camera will be created in Home Assistant.
 
+## Buttons
+
+### Button `reboot`
+
+Reboot the NAS.
+
+### Button `shutdown`
+
+Shutdown the NAS.
+
 ## Services
+
+<div class='note warning'>
+
+The services `synology_dsm.reboot` and `synology_dsm.shutdown` are deprecated and will be removed in future release.
+Please use the new button entities.
+
+</div>
 
 ### Service `synology_dsm.reboot`
 
 Reboot the specified NAS by `serial`. If only one DSM is configured, `serial` is optional.
 
-  | Service data attribute | Required | Description |
-  | ---------------------- | -------- | ----------- |
-  | `serial` | yes, when multiple NAS are configured | serial of DSM |
+  | Service data attribute | Required                              | Description   |
+  | ---------------------- | ------------------------------------- | ------------- |
+  | `serial`               | yes, when multiple NAS are configured | serial of DSM |
 
 ### Service `synology_dsm.shutdown`
 
 Shutdown the specified NAS by `serial`. If only one DSM is configured, `serial` is optional.
 
-  | Service data attribute | Required | Description |
-  | ---------------------- | -------- | ----------- |
-  | `serial` | yes, when multiple NAS are configured | serial of DSM |
+  | Service data attribute | Required                              | Description   |
+  | ---------------------- | ------------------------------------- | ------------- |
+  | `serial`               | yes, when multiple NAS are configured | serial of DSM |

--- a/source/_integrations/synology_dsm.markdown
+++ b/source/_integrations/synology_dsm.markdown
@@ -112,28 +112,3 @@ Reboot the NAS.
 ### Button `shutdown`
 
 Shutdown the NAS.
-
-## Services
-
-<div class='note warning'>
-
-The services `synology_dsm.reboot` and `synology_dsm.shutdown` are deprecated and will be removed in future release.
-Please use the new button entities.
-
-</div>
-
-### Service `synology_dsm.reboot`
-
-Reboot the specified NAS by `serial`. If only one DSM is configured, `serial` is optional.
-
-  | Service data attribute | Required                              | Description   |
-  | ---------------------- | ------------------------------------- | ------------- |
-  | `serial`               | yes, when multiple NAS are configured | serial of DSM |
-
-### Service `synology_dsm.shutdown`
-
-Shutdown the specified NAS by `serial`. If only one DSM is configured, `serial` is optional.
-
-  | Service data attribute | Required                              | Description   |
-  | ---------------------- | ------------------------------------- | ------------- |
-  | `serial`               | yes, when multiple NAS are configured | serial of DSM |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The services `reboot` and `shutdown` are deprecated and will be removed in future release. Please use the new button entities.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core/pull/57352
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
