### PR TITLE
fix link to Tautilli API ref

### DIFF
--- a/source/_integrations/tautulli.markdown
+++ b/source/_integrations/tautulli.markdown
@@ -71,7 +71,7 @@ monitored_users:
   required: false
   type: list
 monitored_conditions:
-  description: A list of attributes to expose for each Tautulli user you monitor, every key in the `session` [section here][tautulliapi] can be used.
+  description: A list of attributes to expose for each Tautulli user you monitor, every key in the `session` [section here](https://github.com/Tautulli/Tautulli/wiki/Tautulli-API-Reference#get_activity) can be used.
   required: false
   type: list
 {% endconfiguration %}
@@ -93,4 +93,3 @@ sensor:
 ```
 
 [tautulli]: https://tautulli.com
-[tautulliapi]: https://github.com/Tautulli/Tautulli/wiki/Tautulli-API-Reference#get_activity


### PR DESCRIPTION
It looks like reference-style links don't work in the configuration block.

## Proposed change
This replaces the literal text `[tautulliapi]` with a clickable link.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
I tried putting `[tautulliapi]: https://github.com/Tautulli/Tautulli/wiki/Tautulli-API-Reference#get_activity` inside the `{% configuration %}` block but that yielded:

```
  Liquid Exception: undefined method `downcase' for ["tautulliapi"]:Array in /home/peter/projects/home/home-assistant.io/source/_integrations/tautulli.markdown
             Error: undefined method `downcase' for ["tautulliapi"]:Array
             Error: Run jekyll build --trace for more information.
```

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
