### PR TITLE
Update solaredge.markdown - add Category Energy

### DIFF
--- a/source/_integrations/solaredge.markdown
+++ b/source/_integrations/solaredge.markdown
@@ -3,6 +3,7 @@ title: SolarEdge
 description: Instructions on how to integrate SolarEdge sensor within Home Assistant.
 ha_category:
   - Sensor
+  - Energy
 ha_release: 0.85
 ha_iot_class: Cloud Polling
 ha_config_flow: true


### PR DESCRIPTION
Add Category Energy

## Proposed change

The [SolarEdge Integration](https://www.home-assistant.io/integrations/solaredge/) provides access to Cloud based polling for the SolarEdge Inverter, but is not currently listed in the [Energy Category](https://www.home-assistant.io/integrations/#energy).  This PR updates to include the SolarEdge Integration in the Energy category.

## Type of change

This PR updates to include the SolarEdge Integration in the Energy category.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
