### PR TITLE
Minor typo in ecovacs.markdown

### DIFF
--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -70,7 +70,7 @@ logger:
     sucks: debug
 ```
 
-Warning: doing this will cause your authentication token to visible in your log files. Be sure to remove any tokens and other authentication details from your log before posting them in an issue.
+**Warning**: doing this will cause your authentication token to be visible in your log files. Be sure to remove any tokens and other authentication details from your log before posting them in an issue.
 
 
 ## Vacuum


### PR DESCRIPTION
## Proposed change

Fixing minor typo and beefing up the warning text a little bit.


## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.
