### PR TITLE
Add YLTD003 to supported models list

### DIFF
--- a/source/_integrations/yeelight.markdown
+++ b/source/_integrations/yeelight.markdown
@@ -172,6 +172,7 @@ This integration is tested to work with the following models. If you have a diff
 
 | Model ID   | Model number | Product name                                     |
 |------------|--------------|--------------------------------------------------|
+| `mono`     | YLTD03YL     | Yeelight Serene Eye-Friendly Desk Lamp           |
 | `mono1`    | YLDP01YL     | LED Bulb (White)                                 |
 | ?          | YLDP05YL     | LED Bulb (White) - 2nd generation                |
 | `color1`   | YLDP02YL     | LED Bulb (Color)                                 |
@@ -186,20 +187,20 @@ This integration is tested to work with the following models. If you have a diff
 | `bslamp1`  | MJCTD01YL    | Xiaomi Mijia Bedside Lamp - Wi-Fi Version!       |
 | `bslamp1`  | MJCTD02YL    | Xiaomi Mijia Bedside Lamp II                     |
 | `RGBW`     | MJDP02YL     | Mi LED smart Lamp - white and color Wi-Fi Version|
+| `lamp`     | MJTD02YL     | Xiaomi Mijia Desk Lamp Pro                       |
 | `lamp1`    | MJTD01YL     | Xiaomi Mijia Smart LED Desk Lamp (autodiscovery isn't possible because the device doesn't support mDNS due to the small amount of RAM) |
+| `lamp15`   | YLTD003      | Yeelight LED Screen Light Bar Pro                |
 | `ceiling1` | YLXD01YL     | Yeelight Ceiling Light                           |
 | `ceiling2` | YLXD03YL     | Yeelight Ceiling Light - Youth Version           |
 | ?          | YLXD62YI     | Yeelight Ceiling Light (Jiaoyue 260)             |
 | ?, may be `ceiling3` | YLXD04YL     | Yeelight Ceiling Light (Jiaoyue 450)   |
 | `ceiling3` | YLXD05YL     | Yeelight Ceiling Light (Jiaoyue 480)             |
 | `ceiling4` | YLXD02YL     | Yeelight Ceiling Light (Jiaoyue 650)             |
-| `mono`     | YLTD03YL     | Yeelight Serene Eye-Friendly Desk Lamp           |
-| `ceiling10`     | YLDL01YL     | Yeelight Meteorite Pendant Light            |
-| `ceiling13`     | YLXD01YL     | Yeelight LED Ceiling Light           |
-| ?     | YLXD013-B     | Yeelight Arwen Ceiling Light 450C           |
-| ?     | YLXD013-C     | Yeelight Arwen Ceiling Light 550C           |
+| `ceiling10`| YLDL01YL     | Yeelight Meteorite Pendant Light                 |
+| `ceiling13`| YLXD01YL     | Yeelight LED Ceiling Light                       |
 | `ceil26`   | YLXD76YL     | Yeelight Ceiling Light - Updated HomeKit 23w     |
-| `lamp` | MJTD02YL | Xiaomi Mijia Desk Lamp Pro |
+| ?          | YLXD013-B    | Yeelight Arwen Ceiling Light 450C                |
+| ?          | YLXD013-C    | Yeelight Arwen Ceiling Light 550C                |
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds the Yeelight LED Screen Light Bar Pro (YLTD003/`lamp15`) to the supported models list. Support for this model was added to the `python-yeelight` package in [v0.6.1](https://gitlab.com/stavros/python-yeelight/-/blob/master/CHANGELOG.md#v061-2021-04-20), which was added to home assistant in https://github.com/home-assistant/core/pull/49490.

Also rearranged some rows to group the model IDs together and made the formatting more consistent.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
