### PR TITLE
Send telegram stickers by ID

### DIFF
--- a/source/_integrations/telegram_bot.markdown
+++ b/source/_integrations/telegram_bot.markdown
@@ -124,6 +124,7 @@ Send a sticker.
 |---------------------------|----------|--------------------------------------------------|
 | `url`                     |       no | Remote path to a static .webp or animated .tgs sticker. |
 | `file`                    |       no | Local path to a static .webp or animated .tgs sticker.  |
+| `sticker_id`              |       no | ID of a sticker that exists  on telegram servers. The ID can be found by sending a sticker to your bot and querying the telegram-api method [getUpdates](https://core.telegram.org/bots/api#getting-updates) or by using the [@idstickerbot](https://t.me/idstickerbot) |
 | `username`                |      yes | Username for a URL which requires HTTP authentication. |
 | `password`                |      yes | Password (or bearer token) for a URL which require HTTP authentication. |
 | `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication, or `bearer_token` for OAuth 2.0 bearer token authentication. Defaults to `basic`.  |


### PR DESCRIPTION
## Proposed change
Allow sending stickers that exists on telegram servers (sticker packs) via the stickers ID. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57482
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: #12249 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
