### PR TITLE
Add info about `index` config to notify documentation

### DIFF
--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -90,7 +90,6 @@ To use this notification platform in your installation, add the following to you
 notify:
   - name: NOTIFIER_NAME
     platform: ecobee
-    index: 0
 ```
 
 {% configuration %}

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -90,6 +90,7 @@ To use this notification platform in your installation, add the following to you
 notify:
   - name: NOTIFIER_NAME
     platform: ecobee
+    index: 0
 ```
 
 {% configuration %}
@@ -98,6 +99,11 @@ name:
   required: false
   default: "`notify`"
   type: string
+index:
+  description: If you have multiple thermostats, you can specify which one to send the notification to by setting an `index`. The index values assigned to the thermostats are consecutive integers, starting at 0.
+  required: false
+  default: 0
+  type: integer
 {% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).


### PR DESCRIPTION
## Proposed change
There is an undocumented `index` configuration in the `notify` section of the ecobee integration. For anyone with multiple Ecobee thermostats, you need to set the index for the notification to go to anything other than the 0th index thermostat (the default value). This PR adds documentation around this config.


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Link to undocumented `index` config in ecobee's `notify.py`: https://github.com/home-assistant/core/blob/0c04ca20c6571635860a4d1fc1618bf58b92797f/homeassistant/components/ecobee/notify.py#L10


## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
