### PR TITLE
Improve Plex library sensor description and add automation example

### DIFF
--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -65,6 +65,29 @@ The activity sensor provides a count of users currently watching media from the 
 
 The library sensors show a count of items in each library. Depending on the library contents, the sensor will show extra detail in its attributes. For example, a library sensor for TV shows will represent the total number of episodes in the library and its attributes will also report the number of shows and seasons it contains.
 
+In addition to the item count, the last added media item (movie, album, or episode) and a timestamp showing when it was added are also provided with each library sensor.
+
+Example automation to use the `last_added_item` attribute on library sensors to notify when new media has been added:
+```yaml
+alias: Plex - New media added
+trigger:
+  - platform: state
+    entity_id: sensor.plex_library_movies
+    id: movie
+  - platform: state
+    entity_id: sensor.plex_library_music
+    id: album
+  - platform: state
+    entity_id: sensor.plex_library_tv_shows
+    id: episode
+
+action:
+  - service: notify.mobile_app_phone
+    data:
+      title: "New {{ trigger.id }} added"
+      message: "{{ trigger.to_state.attributes.last_added_item }}"
+```
+
 <div class='note info'>
   
 The library sensors are disabled by default, but can be enabled via the Plex integration page.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Improve the Plex library sensor documentation added in #19415 (which is still only in `next`) for a 2021.10.0 feature (https://github.com/home-assistant/core/pull/56235). Also adds an example automation which shows how to use the new sensor attributes.

This is intended to supersede #19649 which still targets `next`. This will create a small divergence between `current` and `next`, but this PR should take precedence. If a cleanup PR will be needed, please let me know.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/56235
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
