### PR TITLE
explain how the light switch platfom generates entity IDs

### DIFF
--- a/source/_integrations/light.switch.markdown
+++ b/source/_integrations/light.switch.markdown
@@ -23,7 +23,15 @@ To enable this platform in your installation, add the following to your
 light:
   - platform: switch
     name: Christmas Tree Lights
-    entity_id: switch.christmas_tree_lights
+    entity_id: switch.christmas_tree_switch
+```
+
+This will create a new light entity. The entity ID for the generated light source will be based on the name defined here. So the ID of the entity defined above will be `light.christmas_tree_lights`. The new entity can then be used with a light platform service as shown in the following example:
+
+```yaml
+service: light.toggle
+target:
+  entity_id: light.christmas_tree_lights
 ```
 
 {% configuration %}


### PR DESCRIPTION
## Proposed change

It took me forever to figure out that the new entity's ID was generated based on the name rather than the previous entity ID. When they're the same I guess this is intuitive but in my case they weren't. I hope this clarification helps others realize how to use this feature more quickly.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
