### PR TITLE
Xiaomi_miio - Add use_time sensor for humidifiers

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -541,11 +541,12 @@ LED Brightness          | Controls the brightness of the LEDs (bright, dim, off)
 
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Humidity                | The current humidity measured
-Temperature             | The current temperature measured
-Water Level             | The current water level percentage measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -------------------------------------------------------------- | ------------------
+Humidity                | The current humidity measured                                  | True
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
+Water Level             | The current water level percentage measured                    | True
 
 - Switch entities
 
@@ -583,11 +584,12 @@ LED Brightness          | Controls the brightness of the LEDs (bright, dim, off)
 
 - Sensor entities
 
-Sensor | Description
------------------------ | -----------------------
-Humidity                | The current humidity measured
-Temperature             | The current temperature measured
-Water Level             | The current water level percentage measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -------------------------------------------------------------- | ------------------
+Humidity                | The current humidity measured                                  | True
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
+Water Level             | The current water level percentage measured                    | True
 
 - Switch entities
 
@@ -632,12 +634,13 @@ LED Brightness          | Controls the brightness of the LEDs (bright, dim, off)
 
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Actual Speed            | The current motor speed measured in rpm
-Humidity                | The current humidity measured
-Temperature             | The current temperature measured
-Water Level             | The current water level percentage measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -------------------------------------------------------------- | ------------------
+Actual Speed            | The current motor speed measured in rpm                        | True
+Humidity                | The current humidity measured                                  | True
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
+Water Level             | The current water level percentage measured                    | True
 
 - Switch entities
 
@@ -681,11 +684,12 @@ LED Brightness          | Controls the brightness of the LEDs (bright, dim, off)
 
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Humidity                | The current humidity measured
-Temperature             | The current temperature measured
-Water Level             | The current water level percentage measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -------------------------------------------------------------- | ------------------
+Humidity                | The current humidity measured                                  | True
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
+Water Level             | The current water level percentage measured                    | True
 
 - Switch entities
 
@@ -719,10 +723,11 @@ Water Tank Empty        | Indicates whether the water tank is empty or not
 
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Humidity                | The current humidity measured
-Temperature             | The current temperature measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -------------------------------------------------------------- | ------------------
+Humidity                | The current humidity measured                                  | True
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
 
 - Switch entities
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
A new `Use Time` sensor is added for humidifiers. The sensor is not enable by default.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57560
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
