### PR TITLE
update Harmony integration examples with new template sensor format

### DIFF
--- a/source/_integrations/harmony.markdown
+++ b/source/_integrations/harmony.markdown
@@ -185,15 +185,14 @@ Template sensors can be utilized to display current activity in the frontend.
 {% raw %}
 
 ```yaml
-sensor:
-  - platform: template
-    sensors:
-      family_room:
-        value_template: '{{ state_attr("remote.family_room", "current_activity") }}'
-        friendly_name: "Family Room"
-      bedroom:
-        value_template: '{{ state_attr("remote.bedroom", "current_activity") }}'
-        friendly_name: "bedroom"
+template:
+  - sensor:
+    - name: 'Family Room Harmony Remote'
+      state: >
+        {{ state_attr('remote.family_room', 'current_activity') }}
+    - name: 'Bedroom Harmony Remote'
+      state: >
+        {{ state_attr('remote.bedroom', 'current_activity') }}
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
template sensor configurations were changed in 2021.4 and the Harmony remote integration documents still reference the legacy format. just a quick update to correct that.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].
