### PR TITLE
Fixing errors created by 2021.10.x versions

### DIFF
--- a/source/_integrations/withings.markdown
+++ b/source/_integrations/withings.markdown
@@ -133,7 +133,7 @@ sensor:
       withings_weight_lbs_USER_PROFILE_NAME:
         friendly_name: "withings weight_lbs_USER_PROFILE_NAME"
         unit_of_measurement: "lbs"
-        value_template: "{{ (states('sensor.withings_weight_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        value_template: "{{ (states('sensor.withings_weight_kg_USER_PROFILE_NAME') | float(0) * 2.20462262185) | round(2, default=0) }}"
         icon_template: mdi:weight-pound
 
   - platform: template
@@ -141,7 +141,7 @@ sensor:
       withings_bone_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings bone_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: "lbs"
-        value_template: "{{ (states('sensor.withings_bone_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        value_template: "{{ (states('sensor.withings_bone_mass_kg_USER_PROFILE_NAME') | float(0) * 2.20462262185) | round(2, default=0) }}"
         icon_template: mdi:weight-pound
         
   - platform: template
@@ -149,7 +149,7 @@ sensor:
       withings_fat_free_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings fat_free_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: "lbs"
-        value_template: "{{ (states('sensor.withings_fat_free_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        value_template: "{{ (states('sensor.withings_fat_free_mass_kg_USER_PROFILE_NAME') | float(0) * 2.20462262185) | round(2, default=0) }}"
         icon_template: mdi:weight-pound
         
   - platform: template
@@ -157,7 +157,7 @@ sensor:
       withings_fat_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings fat_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: "lbs"
-        value_template: "{{ (states('sensor.withings_fat_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        value_template: "{{ (states('sensor.withings_fat_mass_kg_USER_PROFILE_NAME') | float(0) * 2.20462262185) | round(2, default=0) }}"
         icon_template: mdi:weight-pound
         
   - platform: template
@@ -165,7 +165,7 @@ sensor:
       withings_muscle_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings muscle_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: "lbs"
-        value_template: "{{ (states('sensor.withings_muscle_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        value_template: "{{ (states('sensor.withings_muscle_mass_kg_USER_PROFILE_NAME') | float(0) * 2.20462262185) | round(2, default=0) }}"
         icon_template: mdi:weight-pound
 ```
 


### PR DESCRIPTION
2020.10 throws errors if float() does not have a default, and if round() does not have a default

## Proposed change

Fix template to deal with new requirements in 2021.10.x


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
