### PR TITLE
MQTT Alarm Control Panel - Remote code validation

### DIFF
--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -67,7 +67,7 @@ availability_topic:
   required: false
   type: string
 code:
-  description: If defined, specifies a code to enable or disable the alarm in the frontend. For remote code validation `REMOTE_CODE` or `REMOTE_CODE_TEXT` can configured as code to enable a numeric or text code dialog, this bypasses local code validation.
+  description: If defined, specifies a code to enable or disable the alarm in the frontend. For remote code validation `REMOTE_CODE` (numeric code) or `REMOTE_CODE_TEXT` (text code) can configured as code to enable a dialog, this bypasses local code validation. Use `command_template` to send the code to the backend. Example configurations [can be found here](./#configurations-with-remote-code-validation).
   required: false
   type: string
 code_arm_required:
@@ -211,3 +211,64 @@ value_template:
   required: false
   type: template
 {% endconfiguration %}
+
+## Examples
+
+In this section you find some real-life examples of how to use this alarm control panel.
+
+### Configuration with local code validation
+
+The example below shows a full configuration with local code validation.
+
+{% raw %}
+
+```yaml
+# Example using text based code with local validation configuration.yaml
+alarm_control_panel:
+  - platform: mqtt
+    name: "Alarm Panel With Numeric Keypad"
+    state_topic: "alarmdecoder/panel"
+    value_template: "{{value_json.state}}"
+    command_topic: "alarmdecoder/panel/set"
+    code: mys3cretc0de
+```
+
+{% endraw %}
+
+### Configurations with remote code validation
+
+The example below shows a full configuration with local code validation and `command_template`.
+
+{% raw %}
+
+```yaml
+# Example using text code with remote validation configuration.yaml
+alarm_control_panel:
+  - platform: mqtt
+    name: "Alarm Panel With Text Code Dialog"
+    state_topic: "alarmdecoder/panel"
+    value_template: "{{ value_json.state }}"
+    command_topic: "alarmdecoder/panel/set"
+    code: REMOTE_CODE_TEXT
+    command_template: "{ action: '{{ action }}', code: '{{ code }}'}"
+```
+
+```yaml
+# Example using numeric code with remote validation configuration.yaml
+alarm_control_panel:
+  - platform: mqtt
+    name: "Alarm Panel With Numeric Keypad"
+    state_topic: "alarmdecoder/panel"
+    value_template: "{{ value_json.state }}"
+    command_topic: "alarmdecoder/panel/set"
+    code: REMOTE_CODE
+    command_template: "{ action: '{{ action }}', code: '{{ code }}'}"
+```
+
+{% endraw %}
+
+<div class='note warning'>
+
+When your MQTT connection is not secured, this will send your secret code over the network unprotected!
+
+</div>

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -67,7 +67,7 @@ availability_topic:
   required: false
   type: string
 code:
-  description: If defined, specifies a code to enable or disable the alarm in the frontend. Note that the code is validated locally and blocks sending MQTT messages to the remote device. For remote code validation, the code can be configured to either of the special values `REMOTE_CODE` (numeric code) or `REMOTE_CODE_TEXT` (text code). In this case, local code validation is bypassed but the frontend will still show a numeric or text coe dialog.Use `command_template` to send the code to the remote device. Example configurations for remote code validation [can be found here](./#configurations-with-remote-code-validation).
+  description: If defined, specifies a code to enable or disable the alarm in the frontend. Note that the code is validated locally and blocks sending MQTT messages to the remote device. For remote code validation, the code can be configured to either of the special values `REMOTE_CODE` (numeric code) or `REMOTE_CODE_TEXT` (text code). In this case, local code validation is bypassed but the frontend will still show a numeric or text code dialog. Use `command_template` to send the code to the remote device. Example configurations for remote code validation [can be found here](./#configurations-with-remote-code-validation).
   required: false
   type: string
 code_arm_required:

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -67,7 +67,7 @@ availability_topic:
   required: false
   type: string
 code:
-  description: If defined, specifies a code to enable or disable the alarm in the frontend. Note that the code is validated locally and blocks sending MQTT messages to the remove device. For remote code validation, the code can be configured to either of the special values `REMOTE_CODE` (numeric code) or `REMOTE_CODE_TEXT` (text code). In this case, local code validation is bypassed but the frontend will still show a numeric or text coe dialog.Use `command_template` to send the code to the remote device. Example configurations for remote code validation [can be found here](./#configurations-with-remote-code-validation).
+  description: If defined, specifies a code to enable or disable the alarm in the frontend. Note that the code is validated locally and blocks sending MQTT messages to the remote device. For remote code validation, the code can be configured to either of the special values `REMOTE_CODE` (numeric code) or `REMOTE_CODE_TEXT` (text code). In this case, local code validation is bypassed but the frontend will still show a numeric or text coe dialog.Use `command_template` to send the code to the remote device. Example configurations for remote code validation [can be found here](./#configurations-with-remote-code-validation).
   required: false
   type: string
 code_arm_required:

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -67,7 +67,7 @@ availability_topic:
   required: false
   type: string
 code:
-  description: If defined, specifies a code to enable or disable the alarm in the frontend.
+  description: If defined, specifies a code to enable or disable the alarm in the frontend. For remote code validation `REMOTE_CODE` or `REMOTE_CODE_TEXT` can configured as code to enable a numeric or text code dialog, this bypasses local code validation.
   required: false
   type: string
 code_arm_required:

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -67,7 +67,7 @@ availability_topic:
   required: false
   type: string
 code:
-  description: If defined, specifies a code to enable or disable the alarm in the frontend. For remote code validation `REMOTE_CODE` (numeric code) or `REMOTE_CODE_TEXT` (text code) can configured as code to enable a dialog, this bypasses local code validation. Use `command_template` to send the code to the backend. Example configurations [can be found here](./#configurations-with-remote-code-validation).
+  description: If defined, specifies a code to enable or disable the alarm in the frontend. Note that the code is validated locally and blocks sending MQTT messages to the remove device. For remote code validation, the code can be configured to either of the special values `REMOTE_CODE` (numeric code) or `REMOTE_CODE_TEXT` (text code). In this case, local code validation is bypassed but the frontend will still show a numeric or text coe dialog.Use `command_template` to send the code to the remote device. Example configurations for remote code validation [can be found here](./#configurations-with-remote-code-validation).
   required: false
   type: string
 code_arm_required:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add support for remote code validation for a MQTT Alarm Code Panel.

The config variable `code` now supports to special values that will enable the a numeric or text base code dialog to enable remote authentication.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57764
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
