### PR TITLE
updating weather template example

### DIFF
--- a/source/_integrations/weather.template.markdown
+++ b/source/_integrations/weather.template.markdown
@@ -20,7 +20,7 @@ Another use case could be using temperature and humidity from one weather platfo
 
 To enable a Template Weather provider in your installation, add the following to your `configuration.yaml` file:
 
-(Note, be sure to update my_region in the forecast_template to an appropriate value for your setup).
+(Note, be sure to update my_region in the condition and forecast templates to an appropriate value for your setup).
 
 {% raw %}
 

--- a/source/_integrations/weather.template.markdown
+++ b/source/_integrations/weather.template.markdown
@@ -20,17 +20,19 @@ Another use case could be using temperature and humidity from one weather platfo
 
 To enable a Template Weather provider in your installation, add the following to your `configuration.yaml` file:
 
+(Note, be sure to update my_region in the forecast_template to an appropriate value for your setup).
+
 {% raw %}
 
 ```yaml
 # Example configuration.yaml entry
 weather:
   - platform: template
-    name: "my very own weather station"
-    condition_template: "sunny"
-    temperature_template: "{{ states('sensor.temperature') | float}}"
-    humidity_template: "{{ states('sensor.humidity')| float }}"
-    forecast_template: "{{ states.weather.my_region.attributes.forecast }}"
+    name: "My Weather Station"
+    condition_template: "{{ states('weather.my_region') }}"
+    temperature_template: "{{ states('sensor.temperature') | float }}"
+    humidity_template: "{{ states('sensor.humidity') | float }}"
+    forecast_template: "{{ state_attr('weather.my_region', 'forecast') }}"
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
marjor changes are:
* added `condition_template` that pulls state from a weather sensor rather than statically assigning it as *sunny*
* updated `forecast_template` to use `state_attr()` as recommended in [templating documentation](https://www.home-assistant.io/docs/configuration/templating/).


## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
