### PR TITLE
Add information about purifiers `Use Time` sensor, Xiaomi Miio

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -252,15 +252,16 @@ Favorite Level          | Set the favorite level
 
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Filter Life Remaining   | The remaining life of the filter
-Filter Use              | Filter usage time in hours
-Humidity                | The current humidity measured
-Motor Speed             | The current motor speed measured in rpm
-PM2.5                   | The current particulate matter 2.5 measured
-Purify Volume           | The volume of purified air in qubic meter
-Temperature             | The current temperature measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -----------------------                                        | -----------------------
+Filter Life Remaining   | The remaining life of the filter                               | True
+Filter Use              | Filter usage time in hours                                     | True
+Humidity                | The current humidity measured                                  | True
+Motor Speed             | The current motor speed measured in rpm                        | True
+PM2.5                   | The current particulate matter 2.5 measured                    | True
+Purify Volume           | The volume of purified air in qubic meter                      | False
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
 
 - Switch entities
 
@@ -292,17 +293,18 @@ Volume                  | Set the volume
 
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Filter Life Remaining   | The remaining life of the filter
-Filter Use              | Filter usage time in hours
-Humidity                | The current humidity measured
-Illuminance             | The current illuminance measured
-Motor Speed             | The current motor speed measured in rpm
-PM2.5                   | The current particulate matter 2.5 measured
-Purify Volume           | The volume of purified air in qubic meter
-Second Motor Speed      | The current second motor speed measured in rpm
-Temperature             | The current temperature measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -----------------------                                        | -----------------------
+Filter Life Remaining   | The remaining life of the filter                               | True
+Filter Use              | Filter usage time in hours                                     | True
+Humidity                | The current humidity measured                                  | True
+Illuminance             | The current illuminance measured                               | True
+Motor Speed             | The current motor speed measured in rpm                        | True
+PM2.5                   | The current particulate matter 2.5 measured                    | True
+Purify Volume           | The volume of purified air in qubic meter                      | False
+Second Motor Speed      | The current second motor speed measured in rpm                 | True
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
 
 - Switch entities
 
@@ -329,16 +331,17 @@ Volume                  | Set the volume
 
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Filter Life Remaining   | The remaining life of the filter
-Filter Use              | Filter usage time in hours
-Humidity                | The current humidity measured
-Illuminance             | The current illuminance measured
-Motor Speed             | The current motor speed measured in rpm
-PM2.5                   | The current particulate matter 2.5 measured
-Second Motor Speed      | The current second motor speed measured in rpm
-Temperature             | The current temperature measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -----------------------                                        | -----------------------
+Filter Life Remaining   | The remaining life of the filter                               | True
+Filter Use              | Filter usage time in hours                                     | True
+Humidity                | The current humidity measured                                  | True
+Illuminance             | The current illuminance measured                               | True
+Motor Speed             | The current motor speed measured in rpm                        | True
+PM2.5                   | The current particulate matter 2.5 measured                    | True
+Second Motor Speed      | The current second motor speed measured in rpm                 | True
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
 
 - Switch entities
 
@@ -364,14 +367,15 @@ Favorite Level          | Set the favorite level
 
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Filter Life Remaining   | The remaining life of the filter
-Filter Use              | Filter usage time in hours
-Humidity                | The current humidity measured
-Motor Speed             | The current motor speed measured in rpm
-PM2.5                   | The current particulate matter 2.5 measured
-Temperature             | The current temperature measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -----------------------                                        | -----------------------
+Filter Life Remaining   | The remaining life of the filter                               | True
+Filter Use              | Filter usage time in hours                                     | True
+Humidity                | The current humidity measured                                  | True
+Motor Speed             | The current motor speed measured in rpm                        | True
+PM2.5                   | The current particulate matter 2.5 measured                    | True
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
 
 - Switch entities
 
@@ -405,15 +409,16 @@ LED Brightness          | Controls the brightness of the LEDs (bright, dim, off)
 
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Filter Life Remaining   | The remaining life of the filter
-Filter Use              | Filter usage time in hours
-Humidity                | The current humidity measured
-Motor Speed             | The current motor speed measured in rpm
-PM2.5                   | The current particulate matter 2.5 measured
-Purify Volume           | The volume of purified air in qubic meter
-Temperature             | The current temperature measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -----------------------                                        | -----------------------
+Filter Life Remaining   | The remaining life of the filter                               | True
+Filter Use              | Filter usage time in hours                                     | True
+Humidity                | The current humidity measured                                  | True
+Motor Speed             | The current motor speed measured in rpm                        | True
+PM2.5                   | The current particulate matter 2.5 measured                    | True
+Purify Volume           | The volume of purified air in qubic meter                      | False
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
 
 - Switch entities
 
@@ -435,12 +440,12 @@ LED Brihtness           | Set the LED brightness
 
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Filter Life Remaining   | The remaining life of the filter
-Filter Use              | Filter usage time in hours
-Motor Speed             | The current motor speed measured in rpm
-PM2.5                   | The current particulate matter 2.5 measured
+Sensor                  | Description                                  | Enabled by default
+----------------------- | -----------------------                      | -----------------------
+Filter Life Remaining   | The remaining life of the filter             | True
+Filter Use              | Filter usage time in hours                   | True
+Motor Speed             | The current motor speed measured in rpm      | True
+PM2.5                   | The current particulate matter 2.5 measured  | True
 
 - Switch entities
 
@@ -461,15 +466,16 @@ Child Lock              | Turn on/off the child lock
   - `button_pressed`
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-PM2.5                   | The current particulate matter 2.5 measured
-Illuminance             | The current illuminance measured
-Filter Life Remaining   | The remaining life of the filter
-Filter Use              | Filter usage time in hours
-Motor Speed             | The current motor speed measured in rpm
-Second Motor Speed      | The current second motor speed measured in rpm
-Purify Volume           | The volume of purified air in qubic meter
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -----------------------                                        | -----------------------
+PM2.5                   | The current particulate matter 2.5 measured                    | True
+Illuminance             | The current illuminance measured                               | True
+Filter Life Remaining   | The remaining life of the filter                               | True
+Filter Use              | Filter usage time in hours                                     | True
+Motor Speed             | The current motor speed measured in rpm                        | True
+Second Motor Speed      | The current second motor speed measured in rpm                 | True
+Purify Volume           | The volume of purified air in qubic meter                      | False
+Use Time                | The accumulative number of seconds the device has been in use  | False
 
 - Switch entities
 
@@ -488,15 +494,16 @@ LED                     | Turn on/off the LED
   - `extra_features`
 - Sensor entities
 
-Sensor                  | Description
------------------------ | -----------------------
-Carbon Dioxide          | The current carbon dioxide measured in ppm
-Filter Life Remaining   | The remaining life of the filter
-Filter Use              | Filter usage time in hours
-Humidity                | The current humidity measured
-Illuminance             | The current illuminance measured
-PM2.5                   | The current particulate matter 2.5 measured
-Temperature             | The current temperature measured
+Sensor                  | Description                                                    | Enabled by default
+----------------------- | -----------------------                                        | -----------------------
+Carbon Dioxide          | The current carbon dioxide measured in ppm                     | True
+Filter Life Remaining   | The remaining life of the filter                               | True
+Filter Use              | Filter usage time in hours                                     | True
+Humidity                | The current humidity measured                                  | True
+Illuminance             | The current illuminance measured                               | True
+PM2.5                   | The current particulate matter 2.5 measured                    | True
+Temperature             | The current temperature measured                               | True
+Use Time                | The accumulative number of seconds the device has been in use  | False
 
 - Select entities
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds inrormation about `Use Time` sensors.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57775
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
