### PR TITLE
Add description for Sleep Timer services of Yamaha MusicCast

### DIFF
--- a/source/_integrations/yamaha_musiccast.markdown
+++ b/source/_integrations/yamaha_musiccast.markdown
@@ -57,6 +57,35 @@ data:
   media_content_id: "presets:1"
   media_content_type: "music"
 ```
+
+## Sleep Timer services
+
+Some MusicCast devices support sleep timers. Sleep timers can be used to turn of the device after a given amount of minutes. 
+
+A sleep timer can be set to values from 30 to 120 minutes in steps of 30 minutes using the `yamaha_musiccast.set_sleep_timer` service. There is also a service `yamaha_musiccast.clear_sleep_timer` to disable the sleep timer. 
+
+The currently set sleep time is also available as state attribute `sleep_time` for sleep timer supporting devices. If the sleep timer is disabled, the value of `sleep_time` is set to 0.
+
+### Examples
+
+Set a sleep timer to 90 minutes:
+
+```yaml
+service: yamaha_musiccast.set_sleep_timer
+target:
+  entity_id: media_player.wohnzimmer_zone2
+data:
+  sleep_time: 90
+```
+
+Clear a sleep timer/disable it:
+
+```yaml
+service: yamaha_musiccast.clear_sleep_timer
+target:
+  entity_id: media_player.wohnzimmer_zone2
+```
+
 ## Troubleshooting
 
 In this section known problems and their resolution are documented.

--- a/source/_integrations/yamaha_musiccast.markdown
+++ b/source/_integrations/yamaha_musiccast.markdown
@@ -60,7 +60,7 @@ data:
 
 ## Sleep Timer services
 
-Some MusicCast devices support sleep timers. Sleep timers can be used to turn of the device after a given amount of minutes. 
+Some MusicCast devices support sleep timers. Sleep timers can be used to turn off the device after a given amount of minutes. 
 
 A sleep timer can be set to values from 30 to 120 minutes in steps of 30 minutes using the `yamaha_musiccast.set_sleep_timer` service. There is also a service `yamaha_musiccast.clear_sleep_timer` to disable the sleep timer. 
 
@@ -73,7 +73,7 @@ Set a sleep timer to 90 minutes:
 ```yaml
 service: yamaha_musiccast.set_sleep_timer
 target:
-  entity_id: media_player.wohnzimmer_zone2
+  entity_id: media_player.living_room_zone2
 data:
   sleep_time: 90
 ```
@@ -83,7 +83,7 @@ Clear a sleep timer/disable it:
 ```yaml
 service: yamaha_musiccast.clear_sleep_timer
 target:
-  entity_id: media_player.wohnzimmer_zone2
+  entity_id: media_player.living_room_zone2
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
In this PR we add the documentation of the sleep timer related services, introduced in the referenced PR.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57910
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
