### PR TITLE
Add IntesisBox + IntesisHome local support

### DIFF
--- a/source/_integrations/intesishome.markdown
+++ b/source/_integrations/intesishome.markdown
@@ -54,6 +54,8 @@ password:
   type: string
 host:
   description: IP address or hostname for the IntesisBox and intesishome_local platforms.
+  required: false
+  type: string
 device:
   description: "`IntesisHome`, `anywair`, `airconwithme`, `IntesisBox` or `intesishome_local`"
   required: false

--- a/source/_integrations/intesishome.markdown
+++ b/source/_integrations/intesishome.markdown
@@ -11,9 +11,9 @@ ha_platforms:
   - climate
 ---
 
-The `IntesisHome` climate platform lets you control [IntesisHome](https://www.intesishome.com) and [Airconwithme](https://airconwithme.com) devices. IntesisHome provides integrations with air conditioners, including Panasonic, Daikin, Fujitsu, Toshiba, LG and more.
+The `IntesisHome` climate platform lets you control [IntesisHome](https://www.intesishome.com), [Airconwithme](https://airconwithme.com) and [IntesisBox](https://www.intesisbox.com) devices. IntesisHome provides integrations with air conditioners, including Panasonic, Daikin, Fujitsu, Toshiba, LG and more.
 
-Note: IntesisHome products are a separate product line to IntesisBox. This platform does not support IntesisBox devices (which can be controlled locally using the WMP protocol).
+The platform allows for local control of IntesisBox devices using the WMP protocol, and local control of some IntesisHome models which include an embedded webserver.
 
 ## Configuration
 
@@ -21,22 +21,41 @@ To set it up, add the following information to your `configuration.yaml` file:
 
 ```yaml
 climate:
+#   IntesisHome example
   - platform: intesishome
+    username: YOUR_USERNAME
+    password: YOUR_PASSWORD
+#   IntesisHome with integrated webserver example
+  - platform: intesishome
+    device: intesishome_local
+    username: YOUR_USERNAME
+    password: YOUR_PASSWORD
+    host: 192.168.1.50
+#   IntesisBox example
+  - platform: intesishome
+    device: IntesisBox
+    host: 192.168.1.50
+#   Airconwithme example
+  - platform: intesishome
+    device: airconwithme
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
 ```
 
+
 {% configuration %}
 username:
   description: "Your username for [IntesisHome.com](https://accloud.intesis.com) / [Airconwithme](https://airconwithme.com)"
-  required: true
+  required: false
   type: string
 password:
   description: Your password for IntesisHome
-  required: true
+  required: false
   type: string
+host:
+  description: IP address or hostname for the IntesisBox and intesishome_local platforms.
 device:
-  description: "`IntesisHome` or `airconwithme`."
+  description: "`IntesisHome`, `airconwithme`, `IntesisBox` or `intesishome_local`"
   required: false
   default: IntesisHome
   type: string
@@ -44,7 +63,6 @@ device:
 
 This component opens a TCP connection with the IntesisHome API to receive temperature and status updates, and to issue commands.
 By default, the component will be named using the friendly device name from the IntesisHome website or application.
-If internet connectivity is lost, the device will be marked as unavailable after 5 minutes.
 
 ### Supported services
 

--- a/source/_integrations/intesishome.markdown
+++ b/source/_integrations/intesishome.markdown
@@ -11,7 +11,7 @@ ha_platforms:
   - climate
 ---
 
-The `IntesisHome` climate platform lets you control [IntesisHome](https://www.intesishome.com), [Airconwithme](https://airconwithme.com) and [IntesisBox](https://www.intesisbox.com) devices. IntesisHome provides integrations with air conditioners, including Panasonic, Daikin, Fujitsu, Toshiba, LG and more.
+The `IntesisHome` climate platform lets you control [IntesisHome](https://www.intesishome.com) (including [Airconwithme](https://airconwithme.com) and Fujitsu anywAiR) and [IntesisBox](https://www.intesisbox.com) devices. IntesisHome provides integrations with air conditioners, including Panasonic, Daikin, Fujitsu, Toshiba, LG and more.
 
 The platform allows for local control of IntesisBox devices using the WMP protocol, and local control of some IntesisHome models which include an embedded webserver.
 
@@ -55,7 +55,7 @@ password:
 host:
   description: IP address or hostname for the IntesisBox and intesishome_local platforms.
 device:
-  description: "`IntesisHome`, `airconwithme`, `IntesisBox` or `intesishome_local`"
+  description: "`IntesisHome`, `anywair`, `airconwithme`, `IntesisBox` or `intesishome_local`"
   required: false
   default: IntesisHome
   type: string


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds configuration details for the IntesisHome platform to use with IntesisBox, and local control of some IntesisHome devices.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57883
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
