### PR TITLE
updating utility_meter example to use new template format

### DIFF
--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -231,17 +231,25 @@ Additionally, you can add template sensors to compute daily and monthly total us
 {% raw %}
 
 ```yaml
-sensor:
-  - platform: template
-    sensors:
-      daily_energy:
-        friendly_name: Daily Energy
-        unit_of_measurement: kWh
-        value_template: "{{ states('sensor.daily_energy_offpeak')|float + states('sensor.daily_energy_peak')|float }}"
-      monthly_energy:
-        friendly_name: Monthly Energy
-        unit_of_measurement: kWh
-        value_template: "{{ states('sensor.monthly_energy_offpeak')|float + states('sensor.monthly_energy_peak')|float }}"
+template:
+  - sensor:
+    - name: 'Daily Energy Total'
+      device_class: energy
+      unit_of_measurement: kWh
+      state: >
+        {% set offpeak = states('sensor.daily_energy_offpeak') | float %}
+        {% set peak = states('sensor.daily_energy_peak') | float %}
+
+        {{ (offpeak + peak) }}
+
+    - name: 'Monthly Energy Total'
+      device_class: energy
+      unit_of_measurement: kWh
+      state: >
+        {% set offpeak = states('sensor.monthly_energy_offpeak') | float %}
+        {% set peak = states('sensor.monthly_energy_peak') | float %}
+
+        {{ (offpeak + peak) }}
 ```
 
 {% endraw %}

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -237,19 +237,19 @@ template:
       device_class: energy
       unit_of_measurement: kWh
       state: >
-        {% set offpeak = states('sensor.daily_energy_offpeak') | float %}
-        {% set peak = states('sensor.daily_energy_peak') | float %}
+        {% set offpeak = states('sensor.daily_energy_offpeak') %}
+        {% set peak = states('sensor.daily_energy_peak') %}
 
-        {{ (offpeak + peak) }}
+        {{ (offpeak + peak) | float }}
 
     - name: 'Monthly Energy Total'
       device_class: energy
       unit_of_measurement: kWh
       state: >
-        {% set offpeak = states('sensor.monthly_energy_offpeak') | float %}
-        {% set peak = states('sensor.monthly_energy_peak') | float %}
+        {% set offpeak = states('sensor.monthly_energy_offpeak') %}
+        {% set peak = states('sensor.monthly_energy_peak') %}
 
-        {{ (offpeak + peak) }}
+        {{ (offpeak + peak) | float }}
 ```
 
 {% endraw %}

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -228,7 +228,7 @@ utility_meter:
 
 Additionally, you can add template sensors to compute daily and monthly total usage. Important note, in these examples,
 we use the `is_number()` [function](/docs/configuration/templating/#numeric-functions-and-filters) to verify the values
-returned from the sensors are numeric. If this evalutes to false no value it returned.
+returned from the sensors are numeric. If this evalutes to false, `None` is returned.
 
 {% raw %}
 
@@ -241,6 +241,8 @@ template:
       state: >
         {% if is_number(states('sensor.daily_energy_offpeak')) and is_number(states('sensor.daily_energy_peak')) %}
           {{ (states('sensor.daily_energy_offpeak') + states('sensor.daily_energy_peak')) | float }}
+        {% else %}
+          None
         {% endif %}
 
     - name: 'Monthly Energy Total'
@@ -249,6 +251,8 @@ template:
       state: >
         {% if is_number(states('sensor.monthly_energy_offpeak')) and is_number(states('sensor.monthly_energy_peak')) %}
           {{ (states('sensor.monthly_energy_offpeak') + states('sensor.monthly_energy_peak')) | float }}
+        {% else %}
+          None
         {% endif %}
 ```
 

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -228,7 +228,7 @@ utility_meter:
 
 Additionally, you can add template sensors to compute daily and monthly total usage. Important note, in these examples,
 we use the `is_number()` [function](/docs/configuration/templating/#numeric-functions-and-filters) to verify the values
-returned from the sensors are numeric. If this evalutes to false the template sensor is set to: `unknown`.
+returned from the sensors are numeric. If this evalutes to false no value it returned.
 
 {% raw %}
 
@@ -241,8 +241,6 @@ template:
       state: >
         {% if is_number(states('sensor.daily_energy_offpeak')) and is_number(states('sensor.daily_energy_peak')) %}
           {{ (states('sensor.daily_energy_offpeak') + states('sensor.daily_energy_peak')) | float }}
-        {% else %}
-          unknown
         {% endif %}
 
     - name: 'Monthly Energy Total'
@@ -251,8 +249,6 @@ template:
       state: >
         {% if is_number(states('sensor.monthly_energy_offpeak')) and is_number(states('sensor.monthly_energy_peak')) %}
           {{ (states('sensor.monthly_energy_offpeak') + states('sensor.monthly_energy_peak')) | float }}
-        {% else %}
-          unknown
         {% endif %}
 ```
 

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -227,8 +227,8 @@ utility_meter:
 ```
 
 Additionally, you can add template sensors to compute daily and monthly total usage. Important note, in these examples,
-we use a [float filter](/docs/configuration/templating/#numeric-functions-and-filters) to
-return `Invalid Number` if `peak` or `offpeak` values returned are not numbers.
+we use the `is_number()` [function](/docs/configuration/templating/#numeric-functions-and-filters) to verify the values
+returned from the sensors are numeric. If this evalutes to false the template sensor is set to: `Invalid Number`.
 
 {% raw %}
 
@@ -239,17 +239,21 @@ template:
       device_class: energy
       unit_of_measurement: kWh
       state: >
-        {% set offpeak = float(states('sensor.daily_energy_offpeak'), default='Invalid Number') %}
-        {% set peak = float(states('sensor.daily_energy_peak'), default='Invalid Number') %}
-        {{ float((offpeak + peak), default='Invalid Number') }}
+        {% if is_number(states('sensor.daily_energy_offpeak')) and is_number(states('sensor.daily_energy_peak')) %}
+          {{ (states('sensor.daily_energy_offpeak') + states('sensor.daily_energy_peak')) | float }}
+        {% else %}
+          Invalid Number
+        {% endif %}
 
     - name: 'Monthly Energy Total'
       device_class: energy
       unit_of_measurement: kWh
       state: >
-        {% set offpeak = float(states('sensor.monthly_energy_offpeak'), default='Invalid Number') %}
-        {% set peak = float(states('sensor.monthly_energy_peak'), default='Invalid Number') %}
-        {{ float((offpeak + peak), default='Invalid Number') }}
+        {% if is_number(states('sensor.monthly_energy_offpeak')) and is_number(states('sensor.monthly_energy_peak')) %}
+          {{ (states('sensor.monthly_energy_offpeak') + states('sensor.monthly_energy_peak')) | float }}
+        {% else %}
+          Invalid Number
+        {% endif %}
 ```
 
 {% endraw %}

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -227,7 +227,7 @@ utility_meter:
 ```
 
 Additionally, you can add template sensors to compute daily and monthly total usage. Important note, in these examples,
-we use a [float filter](https://www.home-assistant.io/docs/configuration/templating/#numeric-functions-and-filters) to
+we use a [float filter](/docs/configuration/templating/#numeric-functions-and-filters) to
 return `Invalid Number` if `peak` or `offpeak` values returned are not numbers.
 
 {% raw %}

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -226,7 +226,9 @@ utility_meter:
     cycle: monthly
 ```
 
-Additionally, you can add template sensors to compute daily and monthly total usage.
+Additionally, you can add template sensors to compute daily and monthly total usage. Important note, in these examples,
+we use a [float filter](https://www.home-assistant.io/docs/configuration/templating/#numeric-functions-and-filters) to
+return `Invalid Number` if `peak` or `offpeak` values returned are not numbers.
 
 {% raw %}
 
@@ -237,19 +239,17 @@ template:
       device_class: energy
       unit_of_measurement: kWh
       state: >
-        {% set offpeak = states('sensor.daily_energy_offpeak') %}
-        {% set peak = states('sensor.daily_energy_peak') %}
-
-        {{ (offpeak + peak) | float }}
+        {% set offpeak = float(states('sensor.daily_energy_offpeak'), default='Invalid Number') %}
+        {% set peak = float(states('sensor.daily_energy_peak'), default='Invalid Number') %}
+        {{ float((offpeak + peak), default='Invalid Number') }}
 
     - name: 'Monthly Energy Total'
       device_class: energy
       unit_of_measurement: kWh
       state: >
-        {% set offpeak = states('sensor.monthly_energy_offpeak') %}
-        {% set peak = states('sensor.monthly_energy_peak') %}
-
-        {{ (offpeak + peak) | float }}
+        {% set offpeak = float(states('sensor.monthly_energy_offpeak'), default='Invalid Number') %}
+        {% set peak = float(states('sensor.monthly_energy_peak'), default='Invalid Number') %}
+        {{ float((offpeak + peak), default='Invalid Number') }}
 ```
 
 {% endraw %}

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -228,7 +228,7 @@ utility_meter:
 
 Additionally, you can add template sensors to compute daily and monthly total usage. Important note, in these examples,
 we use the `is_number()` [function](/docs/configuration/templating/#numeric-functions-and-filters) to verify the values
-returned from the sensors are numeric. If this evalutes to false the template sensor is set to: `Invalid Number`.
+returned from the sensors are numeric. If this evalutes to false the template sensor is set to: `unknown`.
 
 {% raw %}
 
@@ -242,7 +242,7 @@ template:
         {% if is_number(states('sensor.daily_energy_offpeak')) and is_number(states('sensor.daily_energy_peak')) %}
           {{ (states('sensor.daily_energy_offpeak') + states('sensor.daily_energy_peak')) | float }}
         {% else %}
-          Invalid Number
+          unknown
         {% endif %}
 
     - name: 'Monthly Energy Total'
@@ -252,7 +252,7 @@ template:
         {% if is_number(states('sensor.monthly_energy_offpeak')) and is_number(states('sensor.monthly_energy_peak')) %}
           {{ (states('sensor.monthly_energy_offpeak') + states('sensor.monthly_energy_peak')) | float }}
         {% else %}
-          Invalid Number
+          unknown
         {% endif %}
 ```
 


### PR DESCRIPTION
## Proposed change
updating `utility_meter` example to use new template format introduced in 2021.4. i also took the opportunity to demonstrate setting the appropriate `device_class` .


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
