### PR TITLE
Update Z-Wave integrations deprecation and migration status

### DIFF
--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -1,5 +1,5 @@
 ---
-title: OpenZWave (beta)
+title: OpenZWave (deprecated)
 description: Instructions on how to integrate OpenZWave with Home Assistant.
 ha_category:
   - Switch
@@ -22,14 +22,15 @@ ha_platforms:
   - switch
 ---
 
-This integration allows you to utilize OpenZWave's ozwdaemon to control a Z-Wave network over MQTT. 
-
 <div class='note warning'>
 
- As of mid-2021 this integration, as well as the upstream ozwdaemon project, are not currently maintained. If you're starting out with Z-Wave in Home Assistant, we recommend that you use [the Z-Wave JS integration](/integrations/zwave_js).
+ This integration is deprecated. We recommend using [the Z-Wave JS integration](/integrations/zwave_js).
+
+ The OpenZWave integration will no longer receive any updates. The technical dependencies may render this integration unusable in the future, at which time it may be removed.
 
 </div>
 
+This integration allows you to utilize OpenZWave's ozwdaemon to control a Z-Wave network over MQTT.
 
 ## Requirements
 

--- a/source/_integrations/zwave.markdown
+++ b/source/_integrations/zwave.markdown
@@ -33,7 +33,7 @@ ha_platforms:
 
 This integration is deprecated. We recommend using [the Z-Wave JS integration](/integrations/zwave_js).
 
-The Z-Wave integration will no longer receive any updates. It will not be removed unless it becomes incompatible with a future version of Python.
+The Z-Wave integration will no longer receive any updates. The technical dependencies may render this integration unusable in the future at which time it may be removed.
 
 </div>
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -493,15 +493,17 @@ You can keep track of the Roadmap for the Z-Wave JS integration [here](https://g
 
 If you're new to Home Assistant, use Z-Wave JS.
 
-The `zwave` integration has been marked as deprecated and will no longer receive any updates like new device files. The `ozw` integration will receive new device files if they are provided by upstream.
+The `zwave` and `ozw` integrations have been marked as deprecated and will no longer receive any updates.
 
 It is perfectly doable to switch over from one of the above mentioned previous integrations to the new Z-Wave JS integration. The good news is that your entire Z-Wave network is **stored on your stick** so you will not have to run through your house to recreate your network.
 
-If you are currently running the [`zwave`](/integrations/zwave/) or [`ozw`](/integrations/ozw/) Z-Wave integration and it works fine, there is **no need to switch over at this time** to Z-Wave JS. What is important to know is that all development focus currently goes to Z-Wave JS. The previous implementations are provided as-is. They will **NOT be removed** without proper notice but in time there *might* come technical dependencies that render one or both of those integrations unusable.
+If you are currently running the [`zwave`](/integrations/zwave/) or [`ozw`](/integrations/ozw/) Z-Wave integration we recommend you to migrate to Z-Wave JS. All development focus now goes to Z-Wave JS. The previous implementations are provided as-is. They will not be removed without proper notice but in time there might come technical dependencies that render one or both of those integrations unusable.
 
 ### Automatic migration wizard
 
 For the `zwave` integration there is a migration wizard that will help you set up the Z-Wave JS integration, remove the `zwave` integration and migrate the entities and devices that can be mapped from the `zwave` integration to the Z-Wave JS integration. Some entities may not be able to migrate automatically and you will need to rename the corresponding available Z-Wave JS entities manually, after the migration. Before completing the migration you will be shown a list of entities that could not be migrated automatically, and you'll have the option to abort or continue with the migration. The migration wizard is available from the `zwave` integration configuration panel in the GUI.
+
+There is no automatic migration wizard for the `ozw` integration. Please follow the manual migration path below if you want to migrate from `ozw` to Z-Wave JS.
 
 ### In a nutshell this is what the migration path looks like
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- Update deprecation and migration language for the three Z-Wave integrations. There's a parent PR in core.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57987
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
