### PR TITLE
Improve documentation for history-graph #19893

### DIFF
--- a/source/_lovelace/history-graph.markdown
+++ b/source/_lovelace/history-graph.markdown
@@ -59,7 +59,9 @@ name:
   type: string
 {% endconfiguration %}
 
-## Example
+Changing the units used to generate the graphs requires changing the entities' unit_of_measurement property, as it can't be overridden on the history-graph card. For more details, see [Customizing Entities](/docs/configuration/customizing-devices/#unit_of_measurement).
+
+## Examples
 
 Alternatively, the card can be configured using YAML:
 
@@ -70,4 +72,16 @@ entities:
   - sensor.outside_temperature
   - entity: media_player.lounge_room
     name: Main player
+```
+
+```yaml
+type: history-graph
+title: 'Temperatures in the last 48 hours'
+hours_to_show: 48
+entities:
+  - sensor.outside_temperature
+  - entity: sensor.lounge_temperature
+    name: Lounge
+  - entity: sensor.attic_temperature
+    name: Attic
 ```

--- a/source/_lovelace/history-graph.markdown
+++ b/source/_lovelace/history-graph.markdown
@@ -76,7 +76,7 @@ entities:
 
 ```yaml
 type: history-graph
-title: 'Temperatures in the last 48 hours'
+title: "Temperatures in the last 48 hours"
 hours_to_show: 48
 entities:
   - sensor.outside_temperature

--- a/source/_lovelace/history-graph.markdown
+++ b/source/_lovelace/history-graph.markdown
@@ -59,8 +59,6 @@ name:
   type: string
 {% endconfiguration %}
 
-Changing the units used to generate the graphs requires changing the entities' unit_of_measurement property, as it can't be overridden on the history-graph card. For more details, see [Customizing Entities](/docs/configuration/customizing-devices/#unit_of_measurement).
-
 ## Examples
 
 Alternatively, the card can be configured using YAML:
@@ -73,6 +71,8 @@ entities:
   - entity: media_player.lounge_room
     name: Main player
 ```
+
+Or with longer time frame, and multiple entities (as long as they share the same unit_of_measurement) in one graph:
 
 ```yaml
 type: history-graph

--- a/source/_lovelace/history-graph.markdown
+++ b/source/_lovelace/history-graph.markdown
@@ -81,7 +81,7 @@ hours_to_show: 48
 entities:
   - sensor.outside_temperature
   - entity: sensor.lounge_temperature
-    name: Lounge
+    name: "Lounge"
   - entity: sensor.attic_temperature
     name: "Attic"
 ```

--- a/source/_lovelace/history-graph.markdown
+++ b/source/_lovelace/history-graph.markdown
@@ -83,5 +83,5 @@ entities:
   - entity: sensor.lounge_temperature
     name: Lounge
   - entity: sensor.attic_temperature
-    name: Attic
+    name: "Attic"
 ```


### PR DESCRIPTION
## Proposed change

#19893 shows documentation for history-graph might be lacking. This change makes it more clear how to customize how history-graph (and many other cards) figure out how to display different entities.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: #19893 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
