### PR TITLE
Updated Litter-Robot documentation for new select entity

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -27,14 +27,15 @@ The Feeder-Robot is not currently supported by this integration.
 
 The following entities are created for this component and identified by a single device per Litter-Robot unit:
 
-| Entity                | Domain   | Description                                                                      |
-| --------------------- | -------- | -------------------------------------------------------------------------------- |
-| Litter Box            | `vacuum` | Main entity that represents a Litter-Robot unit.                                 |
-| Night Light Mode      | `switch` | When turned on, automatically turns on the night light in darker settings.       |
-| Panel Lockout         | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
-| Sleep Mode Start Time | `sensor` | When sleep mode is enabled, displays the current or next sleep mode start time.  |
-| Sleep Mode End Time   | `sensor` | When sleep mode is enabled, displays the current or last sleep mode end time.    |
-| Waste Drawer          | `sensor` | Displays the current waste drawer level.                                         |
+| Entity                        | Domain   | Description                                                                      |
+| ----------------------------- | -------- | -------------------------------------------------------------------------------- |
+| Litter Box                    | `vacuum` | Main entity that represents a Litter-Robot unit.                                 |
+| Night Light Mode              | `switch` | When turned on, automatically turns on the night light in darker settings.       |
+| Panel Lockout                 | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
+| Sleep Mode Start Time         | `sensor` | When sleep mode is enabled, displays the current or next sleep mode start time.  |
+| Sleep Mode End Time           | `sensor` | When sleep mode is enabled, displays the current or last sleep mode end time.    |
+| Waste Drawer                  | `sensor` | Displays the current waste drawer level.                                         |
+| Clean Cycle Wait Time Minutes | `select` | View and select the clean cycle wait time for the Litter-Robot unit.             |
 
 ## Additional Attributes
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updated Litter-Robot documentation for new select entity added in core integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/58323
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
