### PR TITLE
Microsoft tts defaults

### DIFF
--- a/source/_integrations/microsoft.markdown
+++ b/source/_integrations/microsoft.markdown
@@ -42,7 +42,7 @@ type:
   description: "The voice type you want to use. Accepted values are listed as the service name mapping [in the documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support#text-to-speech)."
   required: false
   type: string
-  default: "`ZiraRUS`"
+  default: "`JennyNeural`"
 rate:
   description: "Change the rate of speaking in percentage. Example values: `25`, `50`."
   required: false
@@ -72,6 +72,8 @@ region:
 <div class='note'>
 
 Not all Azure regions support high-quality neural voices. Use [this overview](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/regions#neural-and-standard-voices) to determine the availability of standard and neural voices by region/endpoint.
+ 
+New users ([any newly created Azure Speech resource after August 31st 2021](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/text-to-speech#migrate-to-neural-voice)) can only use neural voices.  Existing resources can continue using standard voices through August 31st, 2024.
 
 </div>
 
@@ -92,7 +94,7 @@ tts:
     api_key: YOUR_API_KEY
     language: en-gb
     gender: Male
-    type: George, Apollo
+    type: RyanNeural
     rate: 20
     volume: -50
     pitch: high

--- a/source/_integrations/microsoft.markdown
+++ b/source/_integrations/microsoft.markdown
@@ -73,7 +73,7 @@ region:
 
 Not all Azure regions support high-quality neural voices. Use [this overview](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/regions#neural-and-standard-voices) to determine the availability of standard and neural voices by region/endpoint.
  
-New users ([any newly created Azure Speech resource after August 31st 2021](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/text-to-speech#migrate-to-neural-voice)) can only use neural voices.  Existing resources can continue using standard voices through August 31st, 2024.
+New users ([any newly created Azure Speech resource after August 31st, 2021](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/text-to-speech#migrate-to-neural-voice)) can only use neural voices. Existing resources can continue using standard voices through August 31st, 2024.
 
 </div>
 


### PR DESCRIPTION
## Proposed change
Updating documentation for the code change to update the defaults for voice selection as  the current default ZiraRUS (Standard Voice) is no longer supported in eastus or any other region that has rolled out GA neural voices as Standard voices become deprecated.  This enables the microsoft tts defaults to work again.

This is due to a Microsoft policy change for new Azure Speech resources - new users ([any newly created Azure Speech resource after August 31st 2021](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/text-to-speech#migrate-to-neural-voice)) can only use neural voices.  Existing resources can continue using standard voices through August 31st, 2024.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/58499
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
