### PR TITLE
Refactor the SPI and ums info for the ODROID-N2+

### DIFF
--- a/source/_includes/common-tasks/flashing_n2_otg.md
+++ b/source/_includes/common-tasks/flashing_n2_otg.md
@@ -14,34 +14,41 @@ To flash your eMMC using Petitboot and OTG-USB, you will need the following item
 
 #### Enabling SPI boot mode
 
-Remove the case of your ODROID-N2+
+To enable the SPI boot mode:
 
-![Photo of the removed case](/images/hassio/screenshots/case-removed.jpg)
+1. Power off the ODROID-N2+ by unplugging the power cable.
+1. Remove the case.
 
-Next, locate the toggle for boot mode and switch it from MMC to SPI.
+   ![Photo of the removed case](/images/hassio/screenshots/case-removed.jpg)
 
-![Photo of the SPI toggle switch](/images/hassio/screenshots/toggle_spi.jpg)
+1. Locate the toggle for boot mode and switch it from MMC to SPI.
 
-Connect a USB keyboard and HDMI connected monitor to your ODROID-N2+, and then connect power.
+   ![Photo of the SPI toggle switch](/images/hassio/screenshots/toggle_spi.jpg)
+   
+1. Connect the ODROID-N2+ directly to your computer via the USB-OTG port located on the front of the board.
+1. Connect a USB keyboard and a monitor (using HDMI) to your ODROID-N2+.
+1. Plug in the power cable to power on the ODROID-N2+.
 
 #### Enabling USB drive mode
 
-The ODROID-N2+ will now boot into a terminal. Select `Exit to shell` from the menu.
+After The ODROID-N2+ is set to SPI boot mode and powered on, it boots into a terminal. To enable the USB drive mode:
 
-![Exit to shell](/images/hassio/screenshots/exit-shell.png)
+1. Select `Exit to shell` from the menu.
 
-Use the following command at the console to confirm the storage device node:
+   ![Exit to shell](/images/hassio/screenshots/exit-shell.png)
 
-```bash
-ls /dev/mmc*
-```
+1. Use the following command at the console to confirm the storage device node:
 
-Set the storage device on the ODROID-N2+ as a mass storage device using `ums` (USB Mass storage mode)
-This will configure the ODROID-N2+ and OTG to act as a memory card reader.
+   ```bash
+   ls /dev/mmc*
+   ```
 
-```bash
-ums /dev/mmcblk0
-```
+1. Set the storage device on the ODROID-N2+ as a mass storage device using the `ums` command (USB Mass storage mode).
+This will configure the ODROID-N2+ and OTG to act as a memory card reader:
+
+   ```bash
+   ums /dev/mmcblk0
+   ```
 
 #### Flashing Home Assistant
 


### PR DESCRIPTION

## Proposed change

Fix wrong order of steps of enabling SPI for the ODROID-N2+.
Also, turn the steps into a numbered list to improve the readability.

See:

- https://community.home-assistant.io/t/odroid-n2-ha-blue-unable-to-flash-ha/265840/3
- https://github.com/home-assistant/home-assistant.io/issues/19919

## Type of change


- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue:  https://github.com/home-assistant/home-assistant.io/issues/19919

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
