### PR TITLE
Add additional garadget configuration

### DIFF
--- a/source/_integrations/garadget.markdown
+++ b/source/_integrations/garadget.markdown
@@ -127,10 +127,12 @@ For configuration of the garadget as a MQTT cover:
 cover:
   - platform: mqtt
     name: "Garage Door"
+    device_class: "garage"
     command_topic: "garadget/device_name/command"
     state_topic: "garadget/device_name/status"
     payload_open: "open"
     payload_close: "close"
+    payload_stop: "stop"
     value_template: "{{ value_json.status }}"
 ```
 


### PR DESCRIPTION
## Proposed change
Updates the documentation to set the device_class and payload_stop configurations in the mqtt example for Garadget.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
