### PR TITLE
Add target_temp_step to generic_thermostat

### DIFF
--- a/source/_integrations/generic_thermostat.markdown
+++ b/source/_integrations/generic_thermostat.markdown
@@ -89,6 +89,11 @@ precision:
   required: false
   type: float
   default: "`0.1` for Celsius and `1.0` for Fahrenheit."
+target_temp_step:
+  description: "The desired step size for setting the target temperature. Supported values are `0.1`, `0.5` and `1.0`."
+  required: false
+  type: float
+  default: "equal to `precision`"
 {% endconfiguration %}
 
 Time for `min_cycle_duration` and `keep_alive` must be set as "hh:mm:ss" or it must contain at least one of the following entries: `days:`, `hours:`, `minutes:`, `seconds:` or `milliseconds:`. Alternatively, it can be an integer that represents time in seconds.

--- a/source/_integrations/generic_thermostat.markdown
+++ b/source/_integrations/generic_thermostat.markdown
@@ -93,7 +93,7 @@ target_temp_step:
   description: "The desired step size for setting the target temperature. Supported values are `0.1`, `0.5` and `1.0`."
   required: false
   type: float
-  default: "equal to `precision`"
+  default: "equal to `precision`."
 {% endconfiguration %}
 
 Time for `min_cycle_duration` and `keep_alive` must be set as "hh:mm:ss" or it must contain at least one of the following entries: `days:`, `hours:`, `minutes:`, `seconds:` or `milliseconds:`. Alternatively, it can be an integer that represents time in seconds.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding `target_temp_step` configuration option to `generic_thermostat`, while still keeping `precision` as the default step size to keep current behavior : fixing https://github.com/home-assistant/core/issues/46418


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/58691
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
