### PR TITLE
Fix configuration block on the Scenes page

### DIFF
--- a/source/_docs/scene.markdown
+++ b/source/_docs/scene.markdown
@@ -32,7 +32,6 @@ scene:
 In the scene you define in your YAML files, please ensure you use
 all required parameters as listed below.
 
-```yaml
 {% configuration %}
 name: 
   description: Friendly name of the scene.
@@ -47,7 +46,6 @@ entities:
   required: true
   type: list
 {% endconfiguration %}
-```
 
 As you can see, there are two ways to define the states of each `entity_id`:
 


### PR DESCRIPTION
## Proposed change
The configuration part on the scenes page currently shows HTML. See https://www.home-assistant.io/docs/scene/.
This is due to the fact that it is inside a YAML block.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
