### PR TITLE
Rationalize command_line template usage

### DIFF
--- a/source/_integrations/command_line.markdown
+++ b/source/_integrations/command_line.markdown
@@ -38,7 +38,7 @@ It's highly recommended to enclose the command in single quotes `'` as it ensure
 command:
   description: The action to take to get the value.
   required: true
-  type: string
+  type: template
 name:
   description: Let you overwrite the name of the device.
   required: false
@@ -61,7 +61,7 @@ payload_off:
 value_template:
   description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
   required: false
-  type: string
+  type: template
 scan_interval:
   description: Defines number of seconds for polling interval.
   required: false

--- a/source/_integrations/cover.command_line.markdown
+++ b/source/_integrations/cover.command_line.markdown
@@ -38,21 +38,21 @@ covers:
           description: The command to open the cover.
           required: true
           default: true
-          type: string
+          type: template
         command_close:
           description: The action to close the cover.
           required: true
           default: true
-          type: string
+          type: template
         command_stop:
           description: The action to stop the cover.
           required: true
           default: true
-          type: string
+          type: template
         command_state:
           description: If given, this will act as a sensor that runs in the background and updates the state of the cover. If the command returns a `0` the indicates the cover is fully closed, whereas a 100 indicates the cover is fully open.
           required: false
-          type: string
+          type: template
         value_template:
           description: if specified, `command_state` will ignore the result code of the command but the template evaluating will indicate the position of the cover. For example, if your `command_state` returns a string "open", using `value_template` as in the example configuration above will allow you to translate that into the valid state `100`.
           required: false

--- a/source/_integrations/sensor.command_line.markdown
+++ b/source/_integrations/sensor.command_line.markdown
@@ -27,7 +27,7 @@ sensor:
 command:
   description: The action to take to get the value.
   required: true
-  type: string
+  type: template
 name:
   description: Name of the command sensor.
   required: false
@@ -39,7 +39,7 @@ unit_of_measurement:
 value_template:
   description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload."
   required: false
-  type: string
+  type: template
 scan_interval:
   description: Defines number of seconds for polling interval.
   required: false

--- a/source/_integrations/switch.command_line.markdown
+++ b/source/_integrations/switch.command_line.markdown
@@ -39,19 +39,19 @@ switches:
         command_on:
           description: The action to take for on.
           required: true
-          type: string
+          type: template
         command_off:
           description: The action to take for off.
           required: true
-          type: string
+          type: template
         command_state:
           description: "If given, this command will be run. Returning a result code `0` will indicate that the switch is on."
           required: false
-          type: string
+          type: template
         value_template:
           description: "If specified, `command_state` will ignore the result code of the command but the template evaluating to `true` will indicate the switch is on."
           required: false
-          type: string
+          type: template
         friendly_name:
           description: The name used to display the switch in the frontend.
           required: false


### PR DESCRIPTION
## Proposed change
Doc of https://github.com/home-assistant/core/pull/57536



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/57536
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
