### PR TITLE
Update nest.markdown to define the expiry period

### DIFF
--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -184,7 +184,7 @@ and typically looks like `projects/sdm-prod/topics/EXAMPLE`.
 
 1. Lower the message retention duration to be something short (e.g., 10 minutes or under an hour) to avoid a large backlog of updates when Home Assistant is turned off.
 
-1. Select **Never expire** as the *Expiry Period*. To prevent the subscription you're creating being removed if for example your Home Assistant or the integration is offline for a while.
+1. Select **Never expire** as the *Expiry Period* to prevent the subscription you're creating being removed if for example your Home Assistant or the integration is offline for a while.
 
 1. Leave the rest of the defaults and click **Create**.
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -184,6 +184,8 @@ and typically looks like `projects/sdm-prod/topics/EXAMPLE`.
 
 1. Lower the message retention duration to be something short (e.g., 10 minutes or under an hour) to avoid a large backlog of updates when Home Assistant is turned off.
 
+1. Select **Never expire** as the *Expiry Period*
+
 1. Leave the rest of the defaults and click **Create**.
 
 1. Once created, copy the *Subscription name* which you will want to hold on to as your `subscriber_id` for configuring Home Assistant. This typically looks like `projects/MY-CLOUD-ID/subscriptions/EXAMPLE`.

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -184,7 +184,7 @@ and typically looks like `projects/sdm-prod/topics/EXAMPLE`.
 
 1. Lower the message retention duration to be something short (e.g., 10 minutes or under an hour) to avoid a large backlog of updates when Home Assistant is turned off.
 
-1. Select **Never expire** as the *Expiry Period*. To prevent the subscription you're creating being removed if for example your home assistant or the integration is offline for a while.
+1. Select **Never expire** as the *Expiry Period*. To prevent the subscription you're creating being removed if for example your Home Assistant or the integration is offline for a while.
 
 1. Leave the rest of the defaults and click **Create**.
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -184,7 +184,7 @@ and typically looks like `projects/sdm-prod/topics/EXAMPLE`.
 
 1. Lower the message retention duration to be something short (e.g., 10 minutes or under an hour) to avoid a large backlog of updates when Home Assistant is turned off.
 
-1. Select **Never expire** as the *Expiry Period*
+1. Select **Never expire** as the *Expiry Period*. To prevent the subscription you're creating being removed if for example your home assistant or the integration is offline for a while.
 
 1. Leave the rest of the defaults and click **Create**.
 


### PR DESCRIPTION
## Proposed change
the expiry period for a subscription by default is 31 days, which means if the integration is offline for any reason, when you bring it back it won't work as the subscription will have expired

updating the docs to make it clear this should be set to not expire
![image](https://user-images.githubusercontent.com/715120/139511328-ca57ac08-b5f5-45e3-bd5a-4cae64bedc05.png)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
