### PR TITLE
Pioneer VSX 930 configuration.

### DIFF
--- a/source/_integrations/pioneer.markdown
+++ b/source/_integrations/pioneer.markdown
@@ -58,6 +58,37 @@ Under these lines, you can find some sample `sources` lists per receiver model. 
 
 Codes must be defined as strings (between single or double quotation marks) so that `05` is not implicitly transformed to `5`, which wouldn't be valid source code.
 
+#### VSX-930
+
+```yaml
+sources:
+  'BD': '25'
+  'DVD': '04'
+  'SAT': '06'
+  'HDMI3': '21'
+  'HDMI4': '22'
+  'HDMI5': '23'
+  'HDMI6 - MHL': '24'
+  'Ipod/USB': '17'
+  'BT': '33'
+  'Tuner': '02'
+  'TV': '05'
+  'CD': '01'
+  'Internet Radio': '38'
+  'Media Server': '44'
+  'Favourites': '45'
+  'Spotify': '53'
+```
+
+Note that some other functionalities are available, but may not be relevant to use from this integration. A non exhaustive list of them are:
+```yaml
+sources:
+#  Correspond to the HDMI button on the remote, which loops over `HDMI3`, `HDMI4`, `HDMI5` and `HDMI6 - MHL`
+  'HDMI': '31' 
+# Correspond to the NET button the remote, which loops over `Internet Radio`, `Media Server`, `Favourites` and `Spotify`
+  'NET': '26'
+```
+
 #### VSX-921
 
 ```yaml


### PR DESCRIPTION
## Proposed change

Documentation update of the Pioneer integration: add a new Pioneer model configuration to the list of already provided ones.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
I have not searched for an issue when writing this PR.
I have a model VSX 930 which is not covered by the current documentation.
I tested the onkyo integration which did not work, so I believed this integration would help. Looking at the available configurations, the VSX 930 has some extra features which were not part of the current ones.
Note that I provide some extra sources which I do not believe are useful for the integration in its current state: they enable to loop over multiple sources. I found these codes by doing a simple reverse engineering of the UI for the remote controller which uses two buttons to loop over a number of these sources. These are thus still added to the documentation but in a note.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
