### PR TITLE
Additional hint in th recorder docs to statistics

### DIFF
--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -17,6 +17,12 @@ This integration constantly saves data. If you use the default configuration, th
 
 </div>
 
+<div class='note'>
+
+This integration does not affect the data, that is calculated and stored in the database by the [`statistics`](/integrations/statistics/) integration.
+
+</div>
+
 Home Assistant uses [SQLAlchemy](https://www.sqlalchemy.org/), which is an Object Relational Mapper (ORM). This means that you can use **any** SQL backend for the recorder that is supported by SQLAlchemy, like [MySQL](https://www.mysql.com/), [MariaDB](https://mariadb.org/), [PostgreSQL](https://www.postgresql.org/), or [MS SQL Server](https://www.microsoft.com/en-us/sql-server/).
 
 The default database engine is [SQLite](https://www.sqlite.org/) which does not require any configuration. The database is stored in your Home Assistant configuration directory ('/config/') and is named `home-assistant_v2.db`.


### PR DESCRIPTION
## Proposed change
When a user adds a new integration, he/she has to be careful, to not let the database get too big in size. Often, all the sensor values are recorded automatically. That is ok, normal recorder behavior.

My thing is, that I am always very unsure to change something in the recorder (e.g. in the exclude list) because I do not want to affect the data, that is shown in the energy dashboard. That data shall not be deleted (purged), because the historical view is the essence of the energy dashboard. And there is not way to reimport the energy data (the statistics) manually.

So, a user will perhaps struggle, to activate the recorder and that would leed to an ever growing database. I propose to make a note on the docs for the recorder and make clear, the the recorder 

* neither controls, which statistics are stored in the database
* nor purges the existing statistics

I know, it it not good practice to document "what not is", but in this cas, it would have helped me. And perhaps many others.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


## Checklist

- [x ] This PR uses the correct branch, based on one of the following:
  - x made a change to the existing documentation and used the `current` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
