### PR TITLE
Update Litter-Robot documentation for new button entity

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -2,6 +2,10 @@
 title: Litter-Robot
 description: Instructions on how to integrate a Litter-Robot Wi-Fi-enabled, automatic, self-cleaning litter box to Home Assistant.
 ha_category:
+  - Button
+  - Select
+  - Sensor
+  - Switch
   - Vacuum
 ha_iot_class: Cloud Polling
 ha_release: 2021.3
@@ -10,6 +14,8 @@ ha_codeowners:
   - '@natekspencer'
 ha_domain: litterrobot
 ha_platforms:
+  - button
+  - select
   - sensor
   - switch
   - vacuum

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -35,7 +35,8 @@ The following entities are created for this component and identified by a single
 | Sleep Mode Start Time         | `sensor` | When sleep mode is enabled, displays the current or next sleep mode start time.  |
 | Sleep Mode End Time           | `sensor` | When sleep mode is enabled, displays the current or last sleep mode end time.    |
 | Waste Drawer                  | `sensor` | Displays the current waste drawer level.                                         |
-| Clean Cycle Wait Time Minutes | `select` | View and select the clean cycle wait time for the Litter-Robot unit.             |
+| Clean Cycle Wait Time Minutes | `select` | View and select the clean cycle wait time.                                       |
+| Reset Waste Drawer            | `button` | Button to reset the waste drawer level to 0%.                                    |
 
 ## Additional Attributes
 
@@ -56,16 +57,6 @@ Some entities have attributes in addition to the default ones that are available
 
 Services are utilized for additional functionality that is available in the Litter-Robot companion app. The following are currently available:
 
-### reset_waste_drawer
-
-Resets the waste drawer level on the Litter-Robot. This will reset the cycle count returned by the Litter-Robot API to `0` such that the waste drawer entity will report as `0.0 %`.
-
-```yaml
-service: litterrobot.reset_waste_drawer
-target:
-  entity_id: vacuum.litter_robot_litter_box
-```
-
 ### set_sleep_mode
 
 Enables (with `start_time` parameter) or disables sleep mode on the Litter-Robot.
@@ -85,22 +76,4 @@ data:
   enabled: true
   start_time: '23:30:00'
 
-```
-
-### set_wait_time
-
-Sets the wait time, in minutes, between when your cat uses the Litter-Robot and when the unit cycles automatically.
-
-| Parameter | Type | Required | Description                 |
-| --------- | ---- | -------- | --------------------------- |
-| minutes   | int  | yes      | Must be one of: 3, 7 or 15. |
-
-Example of setting the wait time to 3 minutes.
-
-```yaml
-service: litterrobot.set_wait_time
-target:
-  entity_id: vacuum.litter_robot_litter_box
-data:
-  minutes: 3
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update Litter-Robot documentation for new button entity
Remove references to deprecated services


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/59734
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
