### PR TITLE
Correct service names in lcn documentation

### DIFF
--- a/source/_integrations/lcn.markdown
+++ b/source/_integrations/lcn.markdown
@@ -497,7 +497,7 @@ The `lcn` switch platform allows the control of the following [LCN](https://www.
 ## Services
 
 In order to directly interact with the LCN system, and invoke commands which are not covered by the implemented platforms, the following service calls can be used.
-Refer to the (Services Calls)[/docs/scripts/service-calls] page for examples on how to use them.
+Refer to the [Services Calls](/docs/scripts/service-calls) page for examples on how to use them.
 
 ### Service `output_abs`
 
@@ -513,7 +513,7 @@ Set absolute brightness of output port in percent.
 Example:
 
 ```yaml
-service: output_abs
+service: lcn.output_abs
 data:
   address: myhome.0.7
   output: output1
@@ -535,7 +535,7 @@ Set relative brightness of output port in percent.
 Example:
 
 ```yaml
-service: output_rel
+service: lcn.output_rel
 data:
   address: myhome.0.7
   output: output1
@@ -555,7 +555,7 @@ Toggle output port.
 Example:
 
 ```yaml
-service: output_toggle
+service: lcn.output_toggle
 data:
   address: myhome.0.7
   output: output1
@@ -577,7 +577,7 @@ Example states:  `t---001-`
 Example:
 
 ```yaml
-service: relays
+service: lcn.relays
 data:
   address: myhome.0.7
   state: t---001-
@@ -595,7 +595,7 @@ Set the LED status.
 Example:
 
 ```yaml
-service: led
+service: lcn.led
 data:
   address: myhome.0.7
   led: led6
@@ -618,7 +618,7 @@ If `unit_of_measurement` is not defined, it is assumed to be `native`.
 Example:
 
 ```yaml
-service: var_abs
+service: lcn.var_abs
 data:
   address: myhome.0.7
   variable: var1
@@ -647,7 +647,7 @@ If `unit_of_measurement` is not defined, it is assumed to be `native`.
 Example:
 
 ```yaml
-service: var_rel
+service: lcn.var_rel
 data:
   address: myhome.0.7
   variable: var1
@@ -672,7 +672,7 @@ Reset value of variable or setpoint.
 Example:
 
 ```yaml
-service: var_reset:
+service: lcn.var_reset
 data:
   address: myhome.0.7
   variable: var1
@@ -697,7 +697,7 @@ If `state` is not defined, it is assumed to be `False`.
 Example:
 
 ```yaml
-service: lock_regulator
+service: lcn.lock_regulator
 data:
   address: myhome.0.7
   setpoint: r1varsetpoint
@@ -724,7 +724,7 @@ Examples:
 
 Send keys immediately:
 ```yaml
-service: send_keys
+service: lcn.send_keys
 data:
   address: myhome.0.7
   keys: a1a5d8
@@ -733,7 +733,7 @@ data:
 
 Send keys deferred:
 ```yaml
-service: send_keys
+service: lcn.send_keys
 data:
   address: myhome.0.7
   keys: a1a5d8
@@ -761,7 +761,7 @@ Examples:
 
 Lock keys forever:
 ```yaml
-service: lock_keys
+service: lcn.lock_keys
 data:
   address: myhome.0.7
   table: a
@@ -770,7 +770,7 @@ data:
 
 Lock keys for a specified time period:
 ```yaml
-service: lock_keys
+service: lcn.lock_keys
 data:
   address: myhome.0.7
   state: 1---t0--
@@ -794,7 +794,7 @@ Each row can be set independently and can store up to 60 characters (encoded in 
 Example:
 
 ```yaml
-service: dyn_text
+service: lcn.dyn_text
 data:
   address: myhome.0.7
   row: 1
@@ -813,7 +813,7 @@ Send arbitrary PCK command. Only the command part of the PCK command has to be s
 Example:
 
 ```yaml
-service: pck
+service: lcn.pck
 data:
   address: myhome.0.7
   pck: PIN4


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I noticed wrong service names in the examples of the LCN documentation.
Also there was a wrong link.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
