### PR TITLE
Add RDW Vehicle information integration

### DIFF
--- a/source/_integrations/rdw.markdown
+++ b/source/_integrations/rdw.markdown
@@ -2,6 +2,7 @@
 title: RDW
 description: Instructions on how to integrate RDW vehicle information with Home Assistant.
 ha_category:
+  - Binary Sensor
   - Car
   - Sensor
 ha_release: 2021.12
@@ -12,6 +13,7 @@ ha_codeowners:
   - '@frenck'
 ha_domain: rdw
 ha_platforms:
+  - binary_sensor
   - sensor
 ---
 

--- a/source/_integrations/rdw.markdown
+++ b/source/_integrations/rdw.markdown
@@ -1,0 +1,30 @@
+---
+title: RDW
+description: Instructions on how to integrate RDW vehicle information with Home Assistant.
+ha_category:
+  - Car
+  - Sensor
+ha_release: 2021.12
+ha_iot_class: Cloud Poll
+ha_config_flow: true
+ha_quality_scale: platinum
+ha_codeowners:
+  - '@frenck'
+ha_domain: rdw
+ha_platforms:
+  - sensor
+---
+
+[RDW](https://www.rdw.nl) is the Netherlands Vehicle Authority. Their tasks
+are the licensing of vehicles and vehicle parts, supervision and enforcement,
+registration, information provision, and issuing documents.
+
+The RDW data is open data, available for public use. This integration looks
+up any dutch registered vehicle by its license plate and keeps that
+information in Home Assistant.
+
+This information, and the sensors provided, can be helpful, for example,
+by sending alerts when it is time to get your car checked for the
+required general periodic inspection (APK).
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds the RDW Vehicle information integration documentation.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
  - https://github.com/home-assistant/core/pull/59240
  - https://github.com/home-assistant/core/pull/59253
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2929
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
