### PR TITLE
Update anchor link so it points to the correct paragraph

### DIFF
--- a/source/_integrations/sia.markdown
+++ b/source/_integrations/sia.markdown
@@ -25,7 +25,7 @@ To use this platform, you need to setup your alarm system to communicate using t
 3. Enable "Connect on demand".
 4. Place Account Id - 3-16 ASCII hex characters. For example AAA.
 5. Insert Home Assistant IP address. The hub must be able to reach this IP address. There is no cloud connection necessary.
-6. Insert Home Assistant listening port. This port must not be used by anything else on the machine Home Assistant is running on, see the notes on [port usage](###Portusage) below.
+6. Insert Home Assistant listening port. This port must not be used by anything else on the machine Home Assistant is running on, see the notes on [port usage](#port-usage) below.
 7. Select Preferred Network. Ethernet is preferred if hub and HA in same network. Multiple networks are not tested.
 8. Enable Periodic Reports. The interval with which the alarm systems reports to the monitoring station, default is 1 minute. This component adds 30 seconds before setting the alarm unavailable to deal with slights latencies between ajax and HA and the async nature of HA.
 9. Encryption is preferred but optional. Password is 16, 24 or 32 ASCII characters.


### PR DESCRIPTION
## Proposed change
I've noticed the anchor link to the "Port usage" paragraph is incorrect and this PR is to simply fix it.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
