### PR TITLE
Mqtt add object_id

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -164,6 +164,7 @@ Supported abbreviations:
     'mode_stat_t':         'mode_state_topic',
     'modes':               'modes',
     'name':                'name',
+    'obj_id':              'object_id',
     'off_dly':             'off_delay',
     'on_cmd_type':         'on_command_type',
     'opt':                 'optimistic',
@@ -481,3 +482,19 @@ If the device supports gps coordinates then they can be sent to Home Assistant b
   "gps_accuracy": 1.2
  }
 ```
+
+### Used object_id to generate the entity id
+
+The entity identifier is generated from the device name. If you defined an object_id then it will be used instead.
+- Configuration topic: `homeassistant/sensor/devive1/config`
+- Example configuration payload:
+
+```json
+{
+  "name":"My Super Device",
+  "object_id":"device1",
+  "state_topic": "homeassistant/sensor/devive1/state",
+ }
+```
+This example should build the entity_id `sensor.device1` instead of `sensor.my_super_device`
+

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -488,14 +488,14 @@ If the device supports gps coordinates then they can be sent to Home Assistant b
 
 The entity id is automatically generated from the entity's name. All MQTT entity components optionally support providing an `object_id` which will be used instead if provided.
 
-- Configuration topic: `homeassistant/sensor/devive1/config`
+- Configuration topic: `homeassistant/sensor/device1/config`
 - Example configuration payload:
 
 ```json
 {
   "name":"My Super Device",
   "object_id":"device1",
-  "state_topic": "homeassistant/sensor/devive1/state",
+  "state_topic": "homeassistant/sensor/device1/state",
  }
 ```
 

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -483,7 +483,7 @@ If the device supports gps coordinates then they can be sent to Home Assistant b
  }
 ```
 
-### Used object_id to generate the entity id
+### Use object_id to influence the entity id
 
 
 The entity id is automatically generated from the entity's name. All MQTT entity components optionally support providing an `object_id` which will be used instead if provided.

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -485,7 +485,9 @@ If the device supports gps coordinates then they can be sent to Home Assistant b
 
 ### Used object_id to generate the entity id
 
-The entity identifier is generated from the device name. If you defined an object_id then it will be used instead.
+
+The entity id is automatically generated from the entity's name. All MQTT entity components optionally support providing an `object_id` which will be used instead if provided.
+
 - Configuration topic: `homeassistant/sensor/devive1/config`
 - Example configuration payload:
 
@@ -496,5 +498,6 @@ The entity identifier is generated from the device name. If you defined an objec
   "state_topic": "homeassistant/sensor/devive1/state",
  }
 ```
-This example should build the entity_id `sensor.device1` instead of `sensor.my_super_device`
+
+In the example above, the the entity_id will be `sensor.device1` instead of `sensor.my_super_device`.
 

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -157,6 +157,10 @@ name:
   required: false
   type: string
   default: MQTT Alarm
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 payload_arm_away:
   description: The payload to set armed-away mode on your Alarm Panel.
   required: false

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -140,6 +140,10 @@ name:
   required: false
   type: string
   default: MQTT Binary Sensor
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 off_delay:
   description: "For sensors that only send `on` state updates (like PIRs), this variable sets a delay in seconds after which the sensor's state will be updated back to `off`."
   required: false

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -119,6 +119,10 @@ name:
   description: The name of the camera.
   required: false
   type: string
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 topic:
   description: The MQTT topic to subscribe to.
   required: true

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -234,6 +234,10 @@ name:
   required: false
   type: string
   default: MQTT HVAC
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 payload_available:
   description: The payload that represents the available state.
   required: false

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -141,6 +141,10 @@ name:
   required: false
   type: string
   default: MQTT Cover
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 optimistic:
   description: Flag that defines if switch works in optimistic mode.
   required: false

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -165,6 +165,10 @@ name:
   description: The name of the MQTT device_tracker.
   required: false
   type: string
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 payload_available:
   description: The payload that represents the available state.
   required: false

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -132,6 +132,10 @@ name:
   required: false
   type: string
   default: MQTT Fan
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 optimistic:
   description: Flag that defines if fan works in optimistic mode
   required: false

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -148,6 +148,10 @@ name:
   required: false
   type: string
   default: MQTT humidifier
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 optimistic:
   description: Flag that defines if humidifier works in optimistic mode
   required: false

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -230,6 +230,10 @@ name:
   required: false
   type: string
   default: MQTT Light
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 on_command_type:
   description: "Defines when on the payload_on is sent. Using `last` (the default) will send any style (brightness, color, etc) topics first and then a `payload_on` to the `command_topic`. Using `first` will send the `payload_on` and then any style topics. Using `brightness` will only send brightness commands instead of the `payload_on` to turn the light on."
   required: false

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -592,6 +592,10 @@ name:
   required: false
   type: string
   default: MQTT JSON Light
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 optimistic:
   description: Flag that defines if the light works in optimistic mode.
   required: false
@@ -932,6 +936,10 @@ name:
   required: false
   type: string
   default: MQTT Template Light
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 optimistic:
   description: Flag that defines if the light works in optimistic mode.
   required: false

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -128,6 +128,10 @@ name:
   required: false
   type: string
   default: MQTT Lock
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 optimistic:
   description: Flag that defines if lock works in optimistic mode.
   required: false

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -131,6 +131,10 @@ name:
   description: The name of the Number.
   required: false
   type: string
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 optimistic:
   description: Flag that defines if number works in optimistic mode.
   required: false

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -73,6 +73,10 @@ name:
   required: false
   type: string
   default: MQTT Scene
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 payload_available:
   description: The payload that represents the available state.
   required: false

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -125,6 +125,10 @@ name:
   description: The name of the Select.
   required: false
   type: string
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 optimistic:
   description: Flag that defines if the select works in optimistic mode.
   required: false

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -137,6 +137,10 @@ name:
   required: false
   type: string
   default: MQTT Sensor
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 payload_available:
   description: The payload that represents the available state.
   required: false

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -128,6 +128,10 @@ name:
   required: false
   type: string
   default: MQTT Switch
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 optimistic:
   description: Flag that defines if switch works in optimistic mode.
   required: false

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -140,6 +140,10 @@ name:
   required: false
   type: string
   default: MQTT Vacuum
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 payload_available:
   description: The payload that represents the available state.
   required: false

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -399,6 +399,10 @@ name:
   required: false
   type: string
   default: MQTT Vacuum
+object_id:
+  description: Used instead of `name` for automatic generation of `entity_id`
+  required: false
+  type: string
 payload_available:
   description: The payload that represents the available state.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation of object_id in relation with with PR: https://github.com/home-assistant/core/pull/58728

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/58728
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
