### PR TITLE
Add config flow to the Onkyo component 

### DIFF
--- a/source/_integrations/onkyo.markdown
+++ b/source/_integrations/onkyo.markdown
@@ -3,6 +3,7 @@ title: Onkyo & Pioneer Network Receivers
 description: Instructions on how to integrate Onkyo and some Pioneer receivers into Home Assistant.
 ha_category:
   - Media Player
+  - Number
 ha_release: 0.17
 ha_iot_class: Local Push
 ha_config_flow: true
@@ -11,6 +12,7 @@ ha_codeowners:
   - '@klaashoekstra94'
 ha_platforms:
   - media_player
+  - number
 ha_integration_type: integration
 ---
 
@@ -23,11 +25,13 @@ Please be aware that you need to enable "Network Standby" for this integration t
  If your receiver has second or third zone’s available, they are displayed as additional media players.
 
 {% configuration_basic %}
-max_volume:
-  description: The maximum volume of the receiver. For older receivers this was 80, newer receivers use 200. If you find the maximum volume of the receiver too loud, you can set this to a lower value to set Home Assistant's 100% volume to be that value. i.e., if your receiver has a maximum volume of 200 and you set this to 100, your receiver volume will be set to 50% when you set the volume in Home Assistant to 100%.
 sources:
   description: A list of mappings from source to source name to give custom names to the available sources. Unused sources may also be disabled.
 {% endconfiguration_basic %}
+
+## Maximum volume
+
+Different models of receivers have different volume ranges to set. Older receivers range from `0` to `80`, newer receivers to `200`. Since it's not possible to retrieve the range from de receiver, a number entity is created to set the maximum volume for each device. If you find the maximum volume of the receiver too loud, you can set this to a lower value to set Home Assistant's 100% volume to be that value. i.e., if your receiver has a maximum volume of `200` and you set the maximum volume number entity value to `100`, your receiver's actual volume will be set to 50% when you set the volume in Home Assistant to 100%.
 
 ## Playing media
 

--- a/source/_integrations/onkyo.markdown
+++ b/source/_integrations/onkyo.markdown
@@ -1,128 +1,47 @@
 ---
-title: Onkyo
+title: Onkyo & Pioneer Network Receivers
 description: Instructions on how to integrate Onkyo and some Pioneer receivers into Home Assistant.
 ha_category:
   - Media Player
 ha_release: 0.17
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
+ha_config_flow: true
 ha_domain: onkyo
+ha_codeowners:
+  - '@klaashoekstra94'
 ha_platforms:
   - media_player
 ha_integration_type: integration
 ---
 
-The `onkyo` platform allows you to control a [Onkyo](https://www.onkyo.com), [Integra](http://www.integrahometheater.com)
+The `onkyo` integration allows you to control [Onkyo](https://www.onkyo.com), [Integra](http://www.integrahometheater.com)
 and some recent [Pioneer](https://www.pioneerelectronics.com) receivers from Home Assistant.
 Please be aware that you need to enable "Network Standby" for this integration to work in your Hardware.
 
-## Configuration
+{% include integrations/config_flow.md %}
 
-To add an Onkyo or Pioneer receiver to your installation, add the following to your `configuration.yaml` file:
+ If your receiver has second or third zone’s available, they are displayed as additional media players.
 
-```yaml
-# Example configuration.yaml entry
-media_player:
-  - platform: onkyo
-    host: 192.168.1.2
-    name: receiver
-    sources:
-      pc: "HTPC"
-```
-
- If your receiver has second or third zone’s available, they are displayed as additional media players with the same functionality as the main zone.
-
-{% configuration %}
-host:
-  description: IP address of the device. Example:`192.168.1.2`. If not specified, the platform will load any discovered receivers.
-  required: false
-  type: string
-name:
-  description: Name of the device. (*Required if host is specified*)
-  required: false
-  type: string
+{% configuration_basic %}
 max_volume:
-  description: Maximum volume as a percentage. Often the maximum volume of the receiver is far too loud. Setting this will set Home Assistant's 100% volume to be this setting on the amp. i.e., if you set this to 50% when you set Home Assistant to be 100% then your receiver will be set to 50% of its maximum volume.
-  required: false
-  default: 100
-  type: integer
-receiver_max_volume:
-  description: The maximum volume of the receiver. For older Onkyo receivers this was 80, newer Onkyo receivers use 200.
-  required: false
-  default: 80
-  type: integer
+  description: The maximum volume of the receiver. For older receivers this was 80, newer receivers use 200. If you find the maximum volume of the receiver too loud, you can set this to a lower value to set Home Assistant's 100% volume to be that value. i.e., if your receiver has a maximum volume of 200 and you set this to 100, your receiver volume will be set to 50% when you set the volume in Home Assistant to 100%.
 sources:
-  description: A list of mappings from source to source name. Valid sources can be found below. A default list will be used if no source mapping is specified.
-  required: false
-  type: list
-{% endconfiguration %}
+  description: A list of mappings from source to source name to give custom names to the available sources. Unused sources may also be disabled.
+{% endconfiguration_basic %}
 
-List of source names:
+## Playing media
 
-- `video1`
-- `video2`
-- `video3`
-- `video4`
-- `video5`
-- `video6`
-- `video7`
-- `dvd`
-- `bd-dvd`
-- `tape1`
-- `tv-tape`
-- `tape2`
-- `phono`
-- `cd`
-- `tv-cd`
-- `fm`
-- `am`
-- `tuner`
-- `dlna`
-- `internet-radio`
-- `usb`
-- `network`
-- `universal-port`
-- `multi-ch`
-- `xm`
-- `sirius`
+The `play_media` service can be used in a script to play a radio station by preset number.
+Note that this does not work for NET radio.
 
-If your source is not listed above, and you want to figure out how to format that source name so you can map its entry, you can use the `onkyo-eiscp` Python module to discover the exact naming needed. First, change your receiver's source to the one that you need to define, and then run:
+### Examples
 
-```bash
-onkyo --host 192.168.0.100 source=query
-```
-
-To find your receivers max volume use the onkyo-eiscp Python module set the receiver to its maximum volume
-(don't do this whilst playing something!) and run:
-
-```bash
-onkyo --host 192.168.0.100 volume=query
-unknown-model: master-volume = 191
-```
-
-### Service `onkyo_select_hdmi_output`
-
-Changes HDMI output of your receiver
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of a single `entity_id` that will change output.
-| `hdmi_output` | no | The desired output code.
-
-Accepted values are:
-'no', 'analog', 'yes', 'out', 'out-sub', 'sub', 'hdbaset', 'both', 'up'
-which one to use seems to vary depending on model so you will have to try them out.
-( For model TX-NR676E it seems to be 'out' for main, 'out-sub' for sub, and 'sub' for both )
-
-### Example `play_media` script
-
-The `play_media` function can be used in script to play radio station by preset number.
-Not working for NET radio.
+This is an example service call that plays the radio station at preset 1.
 
 ```yaml
 # Example play_media script
-#
 script:
- radio1:
+  radio1:
     alias: "Radio 1"
     sequence:
       - service: media_player.turn_on
@@ -136,17 +55,37 @@ script:
           media_content_id: "1"
 ```
 
-### Example `onkyo_select_hdmi_output` script
+## Services
+
+The `onkyo` integration makes the following custom service available.
+
+### Service `select_hdmi_output`
+
+Changes HDMI output of your receiver
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String or list of a single `entity_id` that will change output.
+| `hdmi_output` | no | The desired output code.
+
+Accepted values are:
+`no`, `analog`, `yes`, `out`, `out-sub`, `sub`, `hdbaset`, `both` and `up`.
+which one to use seems to vary depending on model so you will have to try them out.
+(For model TX-NR676E it seems to be `out` for main, `out-sub` for sub, and `sub` for both).
+
+{% raw %}
 
 ```yaml
-# Example onkyo_select_hdmi_output script
-#
+# Example script to use select_hdmi_output service
 script:
- hdmi_sub:
-    alias: "Hdmi out projector"
+  hdmi_sub:
+    alias: "HDMI out projector"
     sequence:
-      - service: media_player.onkyo_select_hdmi_output
-        data:
+      - service: onkyo.select_hdmi_output
+        target:
           entity_id: media_player.onkyo
-          hdmi_output: out-sub
+        data:
+          hdmi_output: "out-sub"
 ```
+
+{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR updates the documentation for the Onkyo component according to the
new features added in the codebase.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#59518](https://github.com/home-assistant/core/pull/59518)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
