### PR TITLE
Update london_air template sensors examples

### DIFF
--- a/source/_integrations/london_air.markdown
+++ b/source/_integrations/london_air.markdown
@@ -70,7 +70,7 @@ template:
       state: '{{state_attr('sensor.merton', 'updated')}}'
     - name: "Merton PM10"
       state: '{{state_attr('sensor.merton', 'data')[0].pollutants[0].summary}}'
-    - name : "Westminster S02"
+    - name: "Westminster S02"
       state: '{{state_attr('sensor.westminster', 'data')[0].pollutants[3].summary}}'
 ```
 

--- a/source/_integrations/london_air.markdown
+++ b/source/_integrations/london_air.markdown
@@ -64,17 +64,14 @@ To explore the data available within the `data` attribute of a sensor use the `d
 
 ```yaml
 # Example template sensors
-- platform: template
-  sensors:
-    updated:
-      friendly_name: "Updated"
-      value_template: '{{state_attr('sensor.merton', 'updated')}}'
-    merton_pm10:
-      friendly_name: "Merton PM10"
-      value_template: '{{state_attr('sensor.merton', 'data')[0].pollutants[0].summary}}'
-    westminster_s02:
-      friendly_name: "Westminster S02"
-      value_template: '{{state_attr('sensor.westminster', 'data')[0].pollutants[3].summary}}'
+template:
+  - sensor:
+    - name: "Updated"
+      state: '{{state_attr('sensor.merton', 'updated')}}'
+    - name: "Merton PM10"
+      state: '{{state_attr('sensor.merton', 'data')[0].pollutants[0].summary}}'
+    - name : "Westminster S02"
+      state: '{{state_attr('sensor.westminster', 'data')[0].pollutants[3].summary}}'
 ```
 
 {% endraw %}

--- a/source/_integrations/london_air.markdown
+++ b/source/_integrations/london_air.markdown
@@ -67,11 +67,11 @@ To explore the data available within the `data` attribute of a sensor use the `d
 template:
   - sensor:
     - name: "Updated"
-      state: '{{state_attr('sensor.merton', 'updated')}}'
+      state: '{{ state_attr('sensor.merton', 'updated') }}'
     - name: "Merton PM10"
-      state: '{{state_attr('sensor.merton', 'data')[0].pollutants[0].summary}}'
+      state: '{{ state_attr('sensor.merton', 'data')[0].pollutants[0].summary }}'
     - name: "Westminster S02"
-      state: '{{state_attr('sensor.westminster', 'data')[0].pollutants[3].summary}}'
+      state: '{{ state_attr('sensor.westminster', 'data')[0].pollutants[3].summary }}'
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update london_air template sensors examples


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
