### PR TITLE
Add explanation about time zones to Docker instructions

### DIFF
--- a/source/_includes/installation/container.md
+++ b/source/_includes/installation/container.md
@@ -16,7 +16,7 @@ If you are using Docker then you need to be on at least version 19.03.9, ideally
 Installation with Docker is straightforward. Adjust the following command so that:
 
 * `/PATH_TO_YOUR_CONFIG` points at the folder where you want to store your configuration and run it.
-* `MY_TIME_ZONE` is [tz database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), like `TZ=America/Los_Angeles`.
+* `MY_TIME_ZONE` is a [tz database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), like `TZ=America/Los_Angeles`.
 
 {% endif %}
 

--- a/source/_includes/installation/container.md
+++ b/source/_includes/installation/container.md
@@ -13,7 +13,11 @@ If you are using Docker then you need to be on at least version 19.03.9, ideally
 
 ### Platform Installation
 
-Installation with Docker is straightforward. Adjust the following command so that `/PATH_TO_YOUR_CONFIG` points at the folder where you want to store your configuration and run it.
+Installation with Docker is straightforward. Adjust the following command so that:
+
+* `/PATH_TO_YOUR_CONFIG` points at the folder where you want to store your configuration and run it.
+* `MY_TIME_ZONE` is [tz database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), like `TZ=America/Los_Angeles`.
+
 {% endif %}
 
 {% if page.installation_type == 'raspberrypi' %}


### PR DESCRIPTION
## Proposed change

On the `docker run` installation instructions, add an example time zone value and a link to the list of time zones on Wikipedia.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

<!-- ## Additional information -->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - ✅ I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
