### PR TITLE
Update RainMachine service docs to reflect enable/disable changes

### DIFF
--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -42,32 +42,10 @@ Services accept either device IDs or entity IDs, depending on the nature of the 
   - `rainmachine.stop_all`
   - `rainmachine.unpause_watering`
 - Services that require an entity ID as a target (note that the correct entity ID type must be provided, such as a program for a program-related service)
-  - `rainmachine.disable_program`
-  - `rainmachine.disable_zone`
-  - `rainmachine.enable_program`
-  - `rainmachine.enable_zone`
   - `rainmachine.start_program`
   - `rainmachine.start_zone`
   - `rainmachine.stop_program`
   - `rainmachine.stop_zone`
-
-### `rainmachine.disable_program`
-
-Disable a RainMachine program. This will mark the program switch as
-`Unavailable` in the UI.
-
-### `rainmachine.disable_zone`
-
-Disable a RainMachine zone. This will mark the zone switch as
-`Unavailable` in the UI.
-
-### `rainmachine.enable_program`
-
-Enable a RainMachine program.
-
-### `rainmachine.enable_zone`
-
-Enable a RainMachine zone.
 
 ### `rainmachine.pause_watering`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR updates RainMachine docs to remove `enable_` and `disable_` services.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/59617
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
