### PR TITLE
Add configuration section to octoprint

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -57,6 +57,7 @@
     "nginx",
     "Nijhof",
     "Nmap",
+    "OctoPrint",
     "ohmconnect",
     "Onkyo",
     "OpenZWave",

--- a/source/_integrations/octoprint.markdown
+++ b/source/_integrations/octoprint.markdown
@@ -21,6 +21,37 @@ ha_platforms:
 
 {% include integrations/config_flow.md %}
 
+{% configuration_basic %}
+username:
+  description: Username for the server.
+  required: true
+  type: string
+host:
+  description: Address of the server, e.g., 192.168.1.32.
+  required: true
+  type: string
+port:
+  description:  Port of the server.
+  required: false
+  type: string
+  default: 80
+path:
+  description: URL path of the server
+  required: false
+  type: string
+  default: /
+ssl:
+  description: Whether to use SSL or not when communicating.
+  required: false
+  type: boolean
+  default: false
+verify ssl:
+  description: Should the SSL certificate be validated.
+  required: false
+  type: boolean
+  default: false
+{% endconfiguration_basic %}
+
 ### API Key
 
 The Octoprint integration will attempt to register itself via the [application keys plugin](https://docs.octoprint.org/en/master/bundledplugins/appkeys.html). After submitting the configuration UI in Home Assistant, open the Octoprint UI and click allow on the prompt.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding a configuration section for the octoprint documentation. Added an entry for the new verify_ssl parameter as part of this,


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/59213
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
