### PR TITLE
Document setting state trigger `to` or `from` to null

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -295,7 +295,7 @@ The `for` template(s) will be evaluated when an entity changes as specified.
 ## State trigger
 
 Fires when the state of any of given entities changes. If only `entity_id` is given, the trigger will fire for all state changes, even if only state attributes change.
-If only one of `from` or `to` are given, the trigger will fire on any matching state change, but not if only attributes change.
+If at least one of `from` or `to` are given, the trigger will fire on any matching state change, but not if only attributes change. To trigger on all state changes, but not on changed attributes, set at least one of `from` or `to` to `null`.
 
 <div class='note'>
 
@@ -329,7 +329,45 @@ automation:
       to: "error"
 ```
 
-### Holding a state
+Trigger on all state changes, but not attributes by setting `to` to `null`:
+
+```yaml
+automation:
+  trigger:
+    - platform: state
+      entity_id: vacuum.test
+      to:
+```
+
+### Triggering on attribute changes
+
+When the `attribute` option is specified, the trigger only fires
+when the specified attribut changes. Changes to other attributes or the
+state are ignored.
+
+For example, this trigger only fires when the boiler has been heating for 10 minutes:
+
+```yaml
+automation:
+  trigger:
+    - platform: state
+      entity_id: climate.living_room
+      attribute: hvac_action
+      to: "heating"
+      for: "00:10:00"
+```
+
+This trigger fires whenever the boiler's `hvac_action` attribute changes:
+
+```yaml
+automation:
+  trigger:
+    - platform: state
+      entity_id: climate.living_room
+      attribute: hvac_action
+```
+
+### Holding a state or attribute
 
 You can use `for` to have the state trigger only fire if the state holds for some time.
 
@@ -378,22 +416,6 @@ automation:
       entity_id: media_player.kitchen
       # The media player remained in its current state for 1 hour
       for: "01:00:00"
-```
-
-When the `attribute` option is specified, all of the above works, but only
-applies to the specific state value of that attribute. In this case the
-normal state value of the entity is ignored.
-
-For example, this trigger only fires if the boiler was heating for 10 minutes:
-
-```yaml
-automation:
-  trigger:
-    - platform: state
-      entity_id: climate.living_room
-      attribute: hvac_action
-      to: "heating"
-      for: "00:10:00"
 ```
 
 You can also use templates in the `for` option.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document setting state trigger `to` or `from` to `null` to trigger on all state changes


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/59713

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
