### PR TITLE
Add Tailscale integration

### DIFF
--- a/source/_integrations/tailscale.markdown
+++ b/source/_integrations/tailscale.markdown
@@ -1,0 +1,31 @@
+---
+title: Tailscale
+description: Instructions on how to integrate Tailscale within Home Assistant.
+ha_category:
+  - Binary Sensor
+  - Network
+ha_release: 2021.12
+ha_iot_class: Cloud Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@frenck'
+ha_domain: tailscale
+ha_platforms:
+  - binary_sensor
+ha_quality_scale: platinum
+---
+
+The Tailscale integration integrates the [Tailscale](https://www.tailscale.com) API
+with Home Assistant; giving you the possibility to monitor and automate on
+the state of the devices in your Tailscale VPN network (Tailnet).
+
+## Prerequisites
+
+To use the Tailscale integration, you will need to obtain an API key,
+you can create one in the [Tailscale Admin Panel](https://login.tailscale.com/admin/settings/authkeys).
+
+Additionally, you will need to know the Tailnet name of your Tailscale network.
+You can find it in the top left corner in the [Tailscale Admin Panel](https://login.tailscale.com/admin/settings/authkeys)
+(beside the Tailscale logo).
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds the Tailscale integration documentation

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/59764
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2951
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
