### PR TITLE
Adds webostv "force_volume_step_only" customization

### DIFF
--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -59,6 +59,11 @@ customize:
       description: List of hardware and webOS App inputs.
       required: false
       type: list
+    force_volume_step_only:
+      description: Forces volume stepping control only.
+      required: false
+      type: boolean
+      default: false
 {% endconfiguration %}
 
 ### Full configuration example
@@ -80,6 +85,7 @@ webostv:
       - youtube
       - makotv
       - netflix
+    force_volume_step_only: true
 
 media_player:
 
@@ -186,6 +192,14 @@ To change the sound output, the following service is available:
 | ---------------------- | -------- | --------------------------------------- |
 | `entity_id`            | no       | Target a specific webostv media player. |
 | `sound_output`         | no       | Name of the sound output to switch to.  |
+
+#### Force volume stepping only
+
+It is not possible to get or set the specific volume level with some types of external speaker connections (such as the ones connected via HMDI ARC), only to increase or decrese it.
+
+While the TV is off, it can't report the correct volume control features and that might cause problems with other integrations (such as Alexa).
+
+To avoid this problem, one can force to only use volume stepping, by using the `force_volume_step_only` setting.
 
 ### Generic commands and buttons
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Introduces a new `force_volume_step_only` setting for the LG webOS Smart TV integration, allowing for force volume stepping only.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/59782
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
