### PR TITLE
Add troubleshooting note regarding Bonjour-HAP

### DIFF
--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -182,3 +182,7 @@ In these cases, HomeKit Controller will skip polling to avoid a buildup of back 
 ### I can't see any events generated for "stateless" accessories
 
 This is expected. The only way to use stateless accessories like some doorbells, buttons or remotes with Home Assistant is through device automations. Home Assistant doesn't create duplicate events for device automation triggers, so for example you won't be able to watch them with the events developer tools.
+
+### HomeAssistant can't see my homebridge device (≥2021.11.x)
+
+In your Homebridge settings/config, make sure you are using `ciao` and not `Bonjour-HAP`. `Bonjour-HAP` is no longer recommended by `homebridge` and is considered broken/unsupported. Using `Bonjour-HAP` will result in previously working devices/entities to become unavailable, and will result in a `Config flow not found` error prompt if attempting to add new devices.

--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -183,6 +183,6 @@ In these cases, HomeKit Controller will skip polling to avoid a buildup of back 
 
 This is expected. The only way to use stateless accessories like some doorbells, buttons or remotes with Home Assistant is through device automations. Home Assistant doesn't create duplicate events for device automation triggers, so for example you won't be able to watch them with the events developer tools.
 
-### Home Assistant can't see my homebridge device (≥2021.11.x)
+### Home Assistant can't see my Homebridge device(s)
 
-In your Homebridge settings/config, make sure you are using `ciao` and not `Bonjour-HAP`. `Bonjour-HAP` is no longer recommended by `homebridge` and is considered broken/unsupported. Using `Bonjour-HAP` will result in previously working devices/entities to become unavailable, and will result in a `Config flow not found` error prompt if attempting to add new devices.
+In your Homebridge settings/config, make sure you are using `ciao` and not `Bonjour-HAP`. `Bonjour-HAP` is no longer recommended by `homebridge` and is considered broken/unsupported.

--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -183,6 +183,6 @@ In these cases, HomeKit Controller will skip polling to avoid a buildup of back 
 
 This is expected. The only way to use stateless accessories like some doorbells, buttons or remotes with Home Assistant is through device automations. Home Assistant doesn't create duplicate events for device automation triggers, so for example you won't be able to watch them with the events developer tools.
 
-### HomeAssistant can't see my homebridge device (≥2021.11.x)
+### Home Assistant can't see my homebridge device (≥2021.11.x)
 
 In your Homebridge settings/config, make sure you are using `ciao` and not `Bonjour-HAP`. `Bonjour-HAP` is no longer recommended by `homebridge` and is considered broken/unsupported. Using `Bonjour-HAP` will result in previously working devices/entities to become unavailable, and will result in a `Config flow not found` error prompt if attempting to add new devices.


### PR DESCRIPTION
Addresses new issue encountered with homekit_controller when using Homebridge in ≥2021.11.x. Bonjour-HAP setting in homebridge (which is the default) no longer compatible.

## Proposed change

Adds note to troubleshooting section to steer users of `homekit_controller` and Homebridge to use `Caio` as the mDNS advertiser in Homebridge, as `Bonjour-HAP` no longer works with 2021.11.x

(Note from @Jc2k - Bonjour-hap has been unmaintained for over a year)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR ~~fixes or closes~~ addresses issue: [https://github.com/home-assistant/core/issues/59845](https://github.com/home-assistant/core/issues/59845)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
