### PR TITLE
Add set_cover_tilt_position example

### DIFF
--- a/source/_integrations/cover.template.markdown
+++ b/source/_integrations/cover.template.markdown
@@ -233,6 +233,10 @@ cover:
           service: script.cover_group_position
           data:
             position: "{{position}}"
+        set_cover_tilt_position:
+          service: script.cover_group_tilt_position
+          data:
+            tilt: "{{tilt}}"
         value_template: "{{is_state('sensor.cover_group', 'open')}}"
         icon_template: >-
           {% if is_state('sensor.cover_group', 'open') %}


### PR DESCRIPTION
## Proposed change
This adds an example of how to define a `set_cover_tilt_position` in a template cover.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
This example is meaningful because it's not documented anywhere else on this page that the variable name to use in this action is `tilt` and not `tilt_position`.

This is a bit counter-intuitive as the variable name that is required in the  `cover.set_cover_tilt_position` service is `tilt_position`:
```
service: cover.set_cover_tilt_position
data:
  tilt_position: 7
target:
  entity_id: cover.cover_group
```

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
