### PR TITLE
Add `bytes` support to bitwise template filters

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -568,8 +568,8 @@ The numeric functions and filters will not fail if the input is not a valid numb
 - Filter `[x, y, ...] | max` will obtain the largest item in a sequence.
 - Filter `[x, y, ...] | min` will obtain the smallest item in a sequence.
 - Filter `[x, y, ...] | average` will return the average value of the sequence.
-- Filter `value_one|bitwise_and(value_two)` perform a bitwise and(&) operation with two values.
-- Filter `value_one|bitwise_or(value_two)` perform a bitwise or(\|) operation with two values.
+- Filter `value_one|bitwise_and(value_two, little_endian=False)` perform a bitwise and(&) operation with two values. If a value is a `bytes` object, it will be translated to an integer in Big-endian style (the first byte is contains the most significant bit). Set `little_endian` to `True` to parse `bytes` object in Little-endian style.
+- Filter `value_one|bitwise_or(value_two, little_endian=False)` perform a bitwise or(\|) operation with two values. If a value is a `bytes` object, it will be translated to an integer in Big-endian style (the first byte is contains the most significant bit). Set `little_endian` to `True` to parse `bytes` object in Little-endian style.
 - Filter `ord` will return for a string of length one an integer representing the Unicode code point of the character when the argument is a Unicode object, or the value of the byte when the argument is an 8-bit string.
 
 ### String filters


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add `bytes` support to the `bitwise_or` and `bitwise_and` template filters.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/60211
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
