### PR TITLE
Fix indentation in homematic example code

### DIFF
--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -483,9 +483,9 @@ When the connection to your Homematic CCU or Homegear is lost, Home Assistant wi
 ```yaml
 template:
   - binary_sensor:
-    - name: "Homematic is sending updates"
-      state: >-
-        {{ now() - as_timestamp(state_attr('sensor.office_voltage', 'last_changed'), 601) < 600 }}
+      - name: "Homematic is sending updates"
+        state: >-
+          {{ now() - as_timestamp(state_attr('sensor.office_voltage', 'last_changed'), 601) < 600 }}
 
 automation:
   - alias: "Homematic Reconnect"


### PR DESCRIPTION
## Proposed change
Fix of the indentation as the VS Code integration autocorrects it and as is also used i.e. on https://www.home-assistant.io/integrations/template/

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
