### PR TITLE
Add binary sensor platform to devolo Home Network

### DIFF
--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -23,9 +23,6 @@ Currently the following device types within Home Assistant are supported.
 
 ### Binary Sensors
 
-* Firmware availability
-  * Updates every 5 minutes
-  * Is enabled by default
 * Device attached to the router
   * Updates every 5 minutes
   * Is disabled by default because it typically rarely changes

--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -37,6 +37,7 @@ Currently the following device types within Home Assistant are supported.
 
 The list of supported devolo devices depends on the device firmware and the device features. The following devices were tested running firmware 5.6.0:
 
+<!-- textlint-disable -->
 * Magic 2 WiFi next
 * Magic 2 WiFi 2-1
 * Magic 1 WiFi mini
@@ -44,3 +45,4 @@ The list of supported devolo devices depends on the device firmware and the devi
 * dLAN 1200+ WiFi ac
 * dLAN 550+ Wifi
 * dLAN 550 WiFi
+<!-- textlint-enable -->

--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -38,6 +38,7 @@ Currently the following device types within Home Assistant are supported.
 The list of supported devolo devices depends on the device firmware and the device features. The following devices were tested running firmware 5.6.0:
 
 <!-- textlint-disable -->
+
 * Magic 2 WiFi next
 * Magic 2 WiFi 2-1
 * Magic 1 WiFi mini
@@ -45,4 +46,5 @@ The list of supported devolo devices depends on the device firmware and the devi
 * dLAN 1200+ WiFi ac
 * dLAN 550+ Wifi
 * dLAN 550 WiFi
+
 <!-- textlint-enable -->

--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -21,6 +21,15 @@ The devolo Home Network integration allows you to monitor your PLC network.
 
 Currently the following device types within Home Assistant are supported.
 
+### Binary Sensors
+
+* Firmware availability
+  * Updates every 5 minutes
+  * Is enabled by default
+* Device attached to the router
+  * Updates every 5 minutes
+  * Is disabled by default because it typically rarely changes
+
 ### Sensors
 
 * Number of connected wifi clients
@@ -44,3 +53,10 @@ The list of supported devolo devices depends on the device firmware and the devi
 * dLAN 1200+ WiFi ac
 * dLAN 550+ Wifi
 * dLAN 550 WiFi
+
+Since firmware 7.10 also the following device without Wifi can be used as long as the corresponding entities are supported:
+
+* Magic 2 LAN triple
+* Magic 2 DinRail
+* Magic 2 LAN 1-1
+* Magic 1 LAN 1-1

--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -37,8 +37,6 @@ Currently the following device types within Home Assistant are supported.
 
 The list of supported devolo devices depends on the device firmware and the device features. The following devices were tested running firmware 5.6.0:
 
-<!-- textlint-disable -->
-
 * Magic 2 WiFi next
 * Magic 2 WiFi 2-1
 * Magic 1 WiFi mini
@@ -46,5 +44,3 @@ The list of supported devolo devices depends on the device firmware and the devi
 * dLAN 1200+ WiFi ac
 * dLAN 550+ Wifi
 * dLAN 550 WiFi
-
-<!-- textlint-enable -->


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Describe the binary sensors that are newly added to the devolo Home Network integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/60301
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
