### PR TITLE
Document MQTT lock.open

### DIFF
--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -20,8 +20,6 @@ Optimistic mode can be forced, even if state topic is available. Try to enable i
 
 It's mandatory for locks to support `lock` and `unlock`. A lock may optionally support `open`, (e.g. to open the bolt in addition to the latch), in this case, `payload_open` is required in the configuration. If the lock is in optimistic mode, it will change states to `unlocked` when handling the `open` command.
 
-payload_open:
-
 To enable MQTT locks in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -18,6 +18,10 @@ When a `state_topic` is not available, the lock will work in optimistic mode. In
 
 Optimistic mode can be forced, even if state topic is available. Try to enable it, if experiencing incorrect lock operation.
 
+A simple lock only supports commands for lock and unlock. If in addition an open command is needed (e.g. to open the bolt in addition to the latch) a definition of `payload_open` is required in the configuration. In optimistic mode on an `payload_open` command the lock is in the unlocked state.
+
+payload_open:
+
 To enable MQTT locks in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -157,6 +161,11 @@ payload_unlock:
   required: false
   type: string
   default: UNLOCK
+payload_open:
+  description: The payload that requesta an open command. Only available if `payload_open` is explicitly specified.
+  required: false
+  type: string
+  default: OPEN
 qos:
   description: The maximum QoS level of the state topic.
   required: false

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -147,7 +147,7 @@ payload_available:
   type: string
   default: online
 payload_lock:
-  description: The payload that represents enabled/locked state.
+  description: The payload sent to the lock to lock it.
   required: false
   type: string
   default: LOCK
@@ -157,12 +157,12 @@ payload_not_available:
   type: string
   default: offline
 payload_unlock:
-  description: The payload that represents disabled/unlocked state.
+  description: The payload sent to the lock to unlock it.
   required: false
   type: string
   default: UNLOCK
 payload_open:
-  description: The payload sent to the lock to `open` it.
+  description: The payload sent to the lock to open it.
   required: false
   type: string
   default: OPEN
@@ -177,7 +177,7 @@ retain:
   type: boolean
   default: false
 state_locked:
-  description: The value that represents the lock to be in locked state
+  description: The payload sent to by the lock when it's locked.
   required: false
   type: string
   default: LOCKED
@@ -186,7 +186,7 @@ state_topic:
   required: false
   type: string
 state_unlocked:
-  description: The value that represents the lock to be in unlocked state
+  description: The payload sent to by the lock when it's unlocked.
   required: false
   type: string
   default: UNLOCKED

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -18,7 +18,7 @@ When a `state_topic` is not available, the lock will work in optimistic mode. In
 
 Optimistic mode can be forced, even if state topic is available. Try to enable it, if experiencing incorrect lock operation.
 
-It's mandatory for locks to support `lock` and `unlock`. A lock may optionally support `open`, (e.g. to open the bolt in addition to the latch), in this case `payload_open` is required in the configuration. If the lock is i optimistic mode, it will change states to `unlocked` when handling the `open` command.
+It's mandatory for locks to support `lock` and `unlock`. A lock may optionally support `open`, (e.g. to open the bolt in addition to the latch), in this case, `payload_open` is required in the configuration. If the lock is in optimistic mode, it will change states to `unlocked` when handling the `open` command.
 
 payload_open:
 

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -18,7 +18,7 @@ When a `state_topic` is not available, the lock will work in optimistic mode. In
 
 Optimistic mode can be forced, even if state topic is available. Try to enable it, if experiencing incorrect lock operation.
 
-A simple lock only supports commands for lock and unlock. If in addition an open command is needed (e.g. to open the bolt in addition to the latch) a definition of `payload_open` is required in the configuration. In optimistic mode on an `payload_open` command the lock is in the unlocked state.
+It's mandatory for locks to support `lock` and `unlock`. A lock may optionally support `open`, (e.g. to open the bolt in addition to the latch), in this case `payload_open` is required in the configuration. If the lock is i optimistic mode, it will change states to `unlocked` when handling the `open` command.
 
 payload_open:
 
@@ -162,7 +162,7 @@ payload_unlock:
   type: string
   default: UNLOCK
 payload_open:
-  description: The payload that requesta an open command. Only available if `payload_open` is explicitly specified.
+  description: The payload sent to the lock to `open` it.
   required: false
   type: string
   default: OPEN


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation changes for the pull request: Add missing MQTT lock.open #60022


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/60022
- Link to parent pull request in the Brands repository: -
- This PR fixes or closes issue: https://community.home-assistant.io/t/mqtt-lock-open/232823

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
