### PR TITLE
add advice to delete data via recorder services

### DIFF
--- a/source/_docs/backend/database.markdown
+++ b/source/_docs/backend/database.markdown
@@ -125,6 +125,6 @@ group.all_switches              8018
 
 ### Delete
 
-If you don't want to keep certain entities, you can delete them permanently by using the services provided by the recorder: https://www.home-assistant.io/integrations/recorder/#service-purge_entities
+If you don't want to keep certain entities, you can delete them permanently by using the [services provided by the recorder](/integrations/recorder/#service-purge_entities).
 
 For a more interactive way of working with the database, check the [Data Science Portal](https://data.home-assistant.io/).

--- a/source/_docs/backend/database.markdown
+++ b/source/_docs/backend/database.markdown
@@ -125,20 +125,6 @@ group.all_switches              8018
 
 ### Delete
 
-If you don't want to keep certain entities, you can delete them permanently:
-
-To do so, it is best to use the services provided by the recorder: https://www.home-assistant.io/integrations/recorder/#service-purge_entities
-
-Deleting data directly from the database might lead to a corrupted database, since the database isn't meant to be consumed like that:
-
-```bash
-sqlite> DELETE FROM states WHERE entity_id="sensor.cpu";
-```
-
-The `VACUUM` command cleans your database.
-
-```bash
-sqlite> VACUUM;
-```
+If you don't want to keep certain entities, you can delete them permanently by using the services provided by the recorder: https://www.home-assistant.io/integrations/recorder/#service-purge_entities
 
 For a more interactive way of working with the database, check the [Data Science Portal](https://data.home-assistant.io/).

--- a/source/_docs/backend/database.markdown
+++ b/source/_docs/backend/database.markdown
@@ -127,6 +127,10 @@ group.all_switches              8018
 
 If you don't want to keep certain entities, you can delete them permanently:
 
+To do so, it is best to use the services provided by the recorder: https://www.home-assistant.io/integrations/recorder/#service-purge_entities
+
+Deleting data directly from the database might lead to a corrupted database, since the database isn't meant to be consumed like that:
+
 ```bash
 sqlite> DELETE FROM states WHERE entity_id="sensor.cpu";
 ```


### PR DESCRIPTION


## Proposed change
<!-- 
I just trimmed my db (strictly) using this instruction. After
sqlite> DELETE FROM states WHERE entity_id="sensor.cpu";
sqlite> VACUUM;
and exiting with .quit, the db was marked corrupt and a fresh one was created.

I was wondering the corruption might have been caused by the HA service using the db while I was making changes to it and found out the database isn't meant to be consumed like that and one should use the services provided by the recorder instead.
https://github.com/home-assistant/home-assistant.io/issues/20440
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
