### PR TITLE
Description of newly added number entities

### DIFF
--- a/source/_integrations/yamaha_musiccast.markdown
+++ b/source/_integrations/yamaha_musiccast.markdown
@@ -57,6 +57,25 @@ data:
   media_content_id: "presets:1"
   media_content_type: "music"
 ```
+
+## Configuration/Diagnostic Entities
+
+Depending on the features supported by the device, several entities will be added for every MusicCast Device. Some of the entities are related to the MusicCast device and some are related to a zone of the device. All device and main zone related entities will be assigned to the Home Assistant device of the main zone. Entities related to other zones will be assigned to the Home Assistant device of the corresponding zone.
+
+### Number Entities
+
+The following entities will be added, if they are supported by the MusicCast device:
+- Equalizer (configuration, zone level)
+  - One number entity each is added for high, mid and low
+- Tone Control (configuration, zone level)
+  - One number entity each is added for bass and treble
+- Dialogue Level (configuration, zone level)
+  - Set the volume of dialogues in relation to the general volume
+- Dialogue Lift (configuration, zone level)
+  - Set the vertical position of the dialogues in the surround system
+- DTS Dialogue Control (configuration, zone level)
+  - Control the volume of dialogues for DTS:X content
+
 ## Troubleshooting
 
 In this section known problems and their resolution are documented.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
We started introducing configuration/diagnostic entities to the MusicCast integration. In the first step we added some number entities, but we already have additional entities in the pipeline. By adding these entities we want to enable the user to control all common settings of his/her MusicCast device using Home Asssistant.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/60093
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
