### PR TITLE
Add documentation for Moonraker integration

### DIFF
--- a/source/_integrations/moonraker.markdown
+++ b/source/_integrations/moonraker.markdown
@@ -22,8 +22,6 @@ ha_platforms:
 
 There is currently support for the following device types within Home Assistant:
 
-- [Binary Sensor](#binary-sensor)
-- [Button](#button)
 - [Sensor](#sensor)
 
 {% include integrations/config_flow.md %}
@@ -31,21 +29,6 @@ There is currently support for the following device types within Home Assistant:
 ### API Key
 
 If you've configured an API key in Moonraker, you will be required to use that API key. The API key can usually be requested by an UIs you are using with Moonraker, such as [Fluidd](https://docs.fluidd.xyz) or [Mainsail](https://docs.mainsail.xyz). You may also request or change the API key directly with Moonraker, see the Moonraker [documentation](https://moonraker.readthedocs.io/en/latest/web_api/#get-the-current-api-key).
-
-## Binary Sensor
-
-The Moonraker integration provides the following binary sensors:
-
-- Print Status, indicating if the printer is currently printing.
-
-## Button
-
-The Moonraker integration provides the following buttons to control the printer:
-
-- Emergency Stop, stops the printer immediately and cancels the current print.
-- Host Restart, equivalent to running the `RESTART` command in Klipper
-- Firmware Restart, equivalent to running the `FIRMWARE_RESTART` command in Kipper
-- Cancel Print, equivalent to running the `CANCEL_PRINT` macro in Klipper. This macro will need to be defined in your Klipper configuration to work.
 
 ## Sensor
 

--- a/source/_integrations/moonraker.markdown
+++ b/source/_integrations/moonraker.markdown
@@ -1,0 +1,60 @@
+---
+title: Moonraker
+description: Integration between Moonraker and Home Assistant.
+ha_category:
+  - Binary Sensor
+  - Button
+  - Sensor
+ha_config_flow: true
+ha_release: 2021.11
+ha_codeowners:
+  - '@cmroche'
+ha_iot_class: Local Push
+ha_domain: moonraker
+ha_zeroconf: true
+ha_platforms:
+  - binary_sensor
+  - button
+  - sensor
+---
+
+[Moonraker](https://moonraker.readthedocs.io/en/latest/) is an HTTP and websocket interface for your 3D printer. This is the main integration to integrate Moonraker sensors.
+
+There is currently support for the following device types within Home Assistant:
+
+- [Binary Sensor](#binary-sensor)
+- [Button](#button)
+- [Sensor](#sensor)
+
+{% include integrations/config_flow.md %}
+
+### API Key
+
+If you've configured an API key in Moonraker, you will be required to use that API key. The API key can usually be requested by an UIs you are using with Moonraker, such as [Fluidd](https://docs.fluidd.xyz) or [Mainsail](https://docs.mainsail.xyz). You may also request or change the API key directly with Moonraker, see the Moonraker [documentation](https://moonraker.readthedocs.io/en/latest/web_api/#get-the-current-api-key).
+
+## Binary Sensor
+
+The Moonraker integration provides the following binary sensors:
+
+- Print Status, indicating if the printer is currently printing.
+
+## Button
+
+The Moonraker integration provides the following buttons to control the printer:
+
+- Emergency Stop, stops the printer immediately and cancels the current print.
+- Host Restart, equivalent to running the `RESTART` command in Klipper
+- Firmware Restart, equivalent to running the `FIRMWARE_RESTART` command in Kipper
+- Cancel Print, equivalent to running the `CANCEL_PRINT` macro in Klipper. This macro will need to be defined in your Klipper configuration to work.
+
+## Sensor
+
+The Moonraker integration provides the follow sensors for monitoring print progress.
+
+- Extruder Temperature
+- Extruder Target Temperature
+- Bed Temperature
+- Bed Target Temperature
+- Print Progress
+- Print Duration
+- Print File


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

- Adding documentation for a new integration, Moonraker.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2974
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
