### PR TITLE
Add navigate documentation in quickbar

### DIFF
--- a/source/_docs/tools/quick-bar.markdown
+++ b/source/_docs/tools/quick-bar.markdown
@@ -55,6 +55,7 @@ Run various commands from anywhere without having to navigate to another view.
 
 Type | Available |
 | ------------- | ------------- |
+| Navigate | All entries in the sidebar and settings |
 | Reload | All currently-supported "Reload {domain}" services.<br />*(E.g., "Reload Scripts")* |
 | Server | Restart/Stop |
 


### PR DESCRIPTION
## Proposed change
Trying the quickbar I found that it has 3 currently supported uses instead of the 2 documented here:
* Navigate (not documented)
* Reload
* Server
so I added the missing one to the docs.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
