### PR TITLE
Remove "bash" highlighting for help output docs

### DIFF
--- a/source/_includes/common-tasks/commandline.md
+++ b/source/_includes/common-tasks/commandline.md
@@ -58,7 +58,7 @@ Replace x.y.z with the desired version like `--version {{current_version}}`
 
 You can get a better description of the CLI capabilities by typing `ha help`:
 
-```bash
+```txt
 The Home Assistant CLI is a small and simple command line utility that allows
 you to control and configure different aspects of Home Assistant
 
@@ -69,6 +69,7 @@ Available Commands:
   addons         Install, update, remove and configure Home Assistant add-ons
   audio          Audio device handling.
   authentication Authentication for Home Assistant users.
+  backups        Create, restore and remove backups
   banner         Prints the CLI Home Assistant banner along with some useful information
   cli            Get information, update or configure the Home Assistant cli backend
   core           Provides control of the Home Assistant Core
@@ -84,7 +85,6 @@ Available Commands:
   observer       Get information, update or configure the Home Assistant observer
   os             Operating System specific for updating, info and configuration imports
   resolution     Resolution center of Supervisor, show issues and suggest solutions
-  backups        Create, restore and remove backups
   supervisor     Monitor, control and configure the Home Assistant Supervisor
 
 Flags:


### PR DESCRIPTION
## Proposed change
The bash type highlighting highlighted every "for", "reboot" etc. which doesn't make sense for this kind of output.
Also rearranged the "backups" config entry to match the colsole output.

## Type of change
The bash type highlighting highlighted every "for", "reboot" etc.
- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
