### PR TITLE
Remove custom WLED services

### DIFF
--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -106,27 +106,6 @@ Keep Master Light:
   description: Keep the master light, even if there is only 1 segment. This ensures the master light is always there, in case you are automating segments to appear and remove dynamically.
 {% endconfiguration_basic %}
 
-## Services
-
-Currently, the WLED integration provides one service for controlling effect.
-More services for other WLED features are expected to be added in the future.
-
-### Service `wled.effect`
-
-This service allows for controlling the WLED effect.
-
-| Service Data Attribute | Required | Description                                                                                                     |
-| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | A WLED entity ID, or list entity IDs, to apply the effect to. Use `entity_id: all` to target all WLED entities. |
-| `effect`               | no       | Name or ID of the WLED light effect.                                                                            |
-| `intensity`            | no       | Intensity of the effect. Number between `0` and `255`.                                                          |
-| `palette`              | no       | Name or ID of the WLED light palette.                                                                           |
-| `speed`                | no       | Speed of the effect. Number between `0` (slow) and `255` (fast).                                                |
-| `reverse`              | no       | Reverse the effect. Either `true` to reverse or `false` otherwise.                                              |
-
-A list of all available effects (and the behavior of the intensity for each
-effect) [is documented in the WLED Knowledge base](https://kno.wled.ge/features/effects-palettes/).
-
 ## Example Automations
 
 ### Activating Random Effect
@@ -136,7 +115,7 @@ You can automate changing the effect using a service call like this:
 {% raw %}
 
 ```yaml
-service: wled.effect
+service: light.turn_on
 target:
   entity_id: light.wled
 data:
@@ -147,28 +126,18 @@ data:
 
 ### Activating Random Palette
 
-Activating a random palette is a bit more complicated as there is currently no way to obtain a list of available palettes.
-To go around this issue, one solution is to leverage the fact that palettes can be activated by their IDs.
-As the IDs are based on an incrementing counter, picking a random number between zero and the number of palettes minus one works.
-
-To do this, the first step is to use [WLED's JSON API](https://kno.wled.ge/interfaces/json-api) find out how many palettes the device supports:
-
-```bash
-$ curl --silent http://<ip address of the wled device>/json | jq ".palettes | length"
-
-54
-```
-
-In this case (using WLED v0.11.0) there are 54 palettes, so the following service call will activate a random palette by its ID between 0 and 53:
+Activating a random palette is very similar to the above random effect,
+and can be done by selecting a random one from the available palette select
+entity.
 
 {% raw %}
 
 ```yaml
-service: wled.effect
+service: select.select_option
 target:
-  entity_id: light.wled
+  entity_id: select.wled_palette
 data:
-  palette: "{{ range(0,53) | random }}"
+  option: "{{ state_attr('select.wled_palette', 'options') | random }}"
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The `wled.effect` and `wled.preset` services have been removed.
For both services, full replacements are available as normal entities in Home Assistant.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/60537
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
