### PR TITLE
Add WalkingPad integration documentation

### DIFF
--- a/source/_integrations/walkingpad.markdown
+++ b/source/_integrations/walkingpad.markdown
@@ -16,7 +16,7 @@ The `walkingpad` integration allows you to control your WalkingPad treadmill wit
 - A1
 - A1 Pro
 
-## "International" version with bluetooth connection
+## "International" version with Bluetooth connection
 
 Before configuring "International" version of WalkingPad you need a Bluetooth backend. Depending on your operating system, you may have to configure the proper Bluetooth backend for your system:
 
@@ -26,7 +26,7 @@ Before configuring "International" version of WalkingPad you need a Bluetooth ba
   - Preferred solution: Install the `bluepy` library (via pip). When using a virtual environment, make sure to install the library in the right one.
   - Fallback solution: Install `gatttool` via your package manager. Depending on the distribution, the package name might be: `bluez`, `bluetooth`, `bluez-deprecated`
 
-Integration will automatically discover available devices bia bluetooth.
+Integration will automatically discover available devices bia Bluetooth.
 
 ## "Chinese" version with WiFi connection
 

--- a/source/_integrations/walkingpad.markdown
+++ b/source/_integrations/walkingpad.markdown
@@ -1,0 +1,35 @@
+---
+title: "WalkingPad Treadmill"
+description: "Instructions on how to integrate WalkingPad Treadmill into Home Assistant."
+ha_category: 
+  - Remote
+ha_release: 2021.11
+ha_iot_class: "Local Polling"
+ha_domain: walkingpad
+ha_config_flow: true
+ha_platforms:
+  - remote
+---
+
+The `walkingpad` integration allows you to control your WalkingPad treadmill with Home Assistant. Both "Chinese" and "International" versions are supported, with WiFi and Bluetooth connection types correspondingly.
+### Supported devices
+- A1
+- A1 Pro
+
+## "International" version with bluetooth connection
+
+Before configuring "International" version of WalkingPad you need a Bluetooth backend. Depending on your operating system, you may have to configure the proper Bluetooth backend for your system:
+
+- On [Home Assistant](/hassio/installation/): WalkingPad will work out of the box.
+- On [Home Assistant Container](/docs/installation/docker/): Works out of the box with `--net=host` and properly configured Bluetooth on the host.
+- On other Linux systems:
+  - Preferred solution: Install the `bluepy` library (via pip). When using a virtual environment, make sure to install the library in the right one.
+  - Fallback solution: Install `gatttool` via your package manager. Depending on the distribution, the package name might be: `bluez`, `bluetooth`, `bluez-deprecated`
+
+Integration will automatically discover available devices bia bluetooth.
+
+## "Chinese" version with WiFi connection
+
+To add device you need to configure it with Mi Home App first and find IP address and token. IP address can be found in router settings. To obtain token, please, follow instructions on this page https://python-miio.readthedocs.io/en/latest/discovery.html.  
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add WalkingPad integration documentation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/61677
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2978
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
