### PR TITLE
icloud.markdown: remove app specific password

### DIFF
--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -39,18 +39,6 @@ To prevent excessive battery drainage, a dynamic interval is used for each indiv
 
 If two-step authentication is enabled for your iCloud account, some time after Home Assistant startup the integration will ask to enter the verification code you receive on your device via a notification in the Home Assistant UI. The duration of this authentication is determined by Apple, so you will need to verify your account every now and then.
 
-### App Specific Passwords
-Apple allows you to provide an [App Specific Password](https://support.apple.com/en-gb/HT204397), which **don't require two factor authentication**, and one could argue more secure than storing your iCloud password within Home Assistant.
-#### How to generate an app-specific password
-
-1. Sign in to your [Apple ID account page](https://appleid.apple.com/account/home).
-2. In the Security section, click Generate Password below App-Specific Passwords.
-3. Follow the steps on your screen.
-
-After you generate your app-specific password, enter or paste it into the password field of the integration.
-
-Any time you change or reset your primary Apple ID password, all your app-specific passwords are revoked automatically to protect the security of your account. You'll need to generate new app-specific passwords for any apps that you want to continue using.
-
 ## In case of troubleshooting
 
 Go into your Home Assistant configuration `.storage` folder and delete the "icloud" folder, then retry.


### PR DESCRIPTION
As said by @dsfaller in the below issue, Apple changed the login flow or rejects app-specific passwords completely now:
https://github.com/home-assistant/core/issues/53926#issuecomment-944491590

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
