### PR TITLE
Add Select Entities to MusicCast Documentation

### DIFF
--- a/source/_integrations/yamaha_musiccast.markdown
+++ b/source/_integrations/yamaha_musiccast.markdown
@@ -76,6 +76,25 @@ The following entities will be added, if they are supported by the MusicCast dev
 - DTS Dialogue Control (configuration, zone level)
   - Control the volume of dialogues for DTS:X content
 
+### Select Entities
+The following entities will be added, if they are supported by the MusicCast device:
+- Dimmer (configuration, device level)
+  - Set the display brightness
+- Surround Decoder Type (configuration, zone level)
+  - If sound program is set to surround decoder, the decoder type can be selected here
+- Sleep (configuration, zone level)
+  - Set a sleep timer for the device
+- Equalizer Mode (configuration, zone level)
+  - Some devices support multiple different equalizer modes
+- Tone Control Mode (configuration, zone level)
+  - Some devices support multiple different tone control modes
+- Link Audio Delay (configuration, zone level)
+  - Some devices let the user select, whether he prefers to have audio and video in sync or the audio of linked speakers in a group
+- Link Control (configuration, zone level)
+  - Some devices support compressed audio for groups
+- Link Audio Quality (configuration, zone level)
+  - Set the audio quality for grouped speakers
+
 ## Troubleshooting
 
 In this section known problems and their resolution are documented.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
After we already added number entities for configuration purposes some select entities will be made available for MusicCast devices supporting them.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/60645
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
