### PR TITLE
Update BMW Connected Drive breaking changes

### DIFF
--- a/source/_posts/2021-12-11-release-202112.markdown
+++ b/source/_posts/2021-12-11-release-202112.markdown
@@ -600,6 +600,8 @@ using the My BMW API:
 - `lastchargingendresult`
 - `maxelectricrange`
 
+Attributes of `binary_sensor.doors` and `binary_sensor.windows` do not start with `door`/`window` anymore.
+
 `notify` requires a location attribute at `data.location`, as the MyBMW API
 only supports sending POI and not messages.
 

--- a/source/_posts/2021-12-11-release-202112.markdown
+++ b/source/_posts/2021-12-11-release-202112.markdown
@@ -605,6 +605,8 @@ Attributes of `binary_sensor.doors` and `binary_sensor.windows` do not start wit
 `notify` requires a location attribute at `data.location`, as the MyBMW API
 only supports sending POI and not messages.
 
+The `find_vehicle` service will **always** send the location of your HA instance to BMW.
+
 ([@rikroe] - [#59881]) ([bmw_connected_drive docs])
 
 {% enddetails %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updates BMW Connected Drive breaking changes for 2021.12.
- Attribute breaking change was missing (https://github.com/home-assistant/core/pull/59881)
- Changes to vehicle finder service (https://github.com/home-assistant/core/pull/60938)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
