### PR TITLE
Add breaking change note for Hue integration

### DIFF
--- a/source/_posts/2021-12-11-release-202112.markdown
+++ b/source/_posts/2021-12-11-release-202112.markdown
@@ -828,6 +828,26 @@ The following icons have been renamed:
 
 {% enddetails %}
 
+{% details "Hue" %}
+
+*Events for Hue remotes/switches*
+Philips/Signify streamlined the events that are emitted for remotes/switches, these are now no longer device specific but more generic.
+This means that if you're relying on the `hue_event` to trigger events emitted by these devices, the event_data will now be a slightly bit different.
+To easily identify what events get emitted by your Hue remotes, Open Developer Tools and subscribe to the `hue_event`.
+
+*Light entities for Hue rooms/zones*
+Entities for Hue groups (zones/rooms) will be imported but by default in a disabled state.
+The Integration option to enable Hue groups has been phased out in favor of the default Home Assistant functionality to enable/disable entities.
+To enable any (new) light entities for Hue groups: Open settings --> integrations --> Hue --> Entities --> Click one of the disabled entities and enable it.
+Existing Hue group lights will be migrated as enabled entities.
+
+*Entities for Hue scenes*
+If you create any scenes for your Hue zones/rooms, these will now be automatically imported to Home Assistant as scene entity, including support for the new Hue Dynamic Scenes. You can disable any scene entities you don't like to use in Home Assistant (or delete them in the Hue app).
+
+([@marcelveldt] - [#58996]) ([hue docs])
+
+{% enddetails %}
+
 ## Updates for custom integration developers
 
 If you are a custom integration developer, we have some updates in this
@@ -958,25 +978,6 @@ Dataclasses provided by discovery type:
 - SSDP: `SsdpServiceInfo` ([#59931])
 
 ([@epenet])
-
-{% enddetails %}
-
-{% details "Hue" %}
-
-*Events for Hue remotes/switches*
-Philips/Signify streamlined the events that are emitted for remotes/switches, these are now no longer device specific but more generic.
-This means that if you're relying on the `hue_event` to trigger events emitted by these devices, the event_data will now be a slightly bit different.
-To easily identify what events get emitted by your Hue remotes, Open Developer Tools and subscribe to the `hue_event`.
-
-*Light entities for Hue rooms/zones*
-Entities for Hue groups (zones/rooms) will be imported but by default in a disabled state.
-The Integration option to enable Hue groups has been phased out in favor of the default Home Assistant functionality to enable/disable entities.
-To enable any light entities for Hue groups: Open settings --> integrations --> Hue --> Entities --> Click one of the disabled entities and enable it.
-
-*Entities for Hue scenes*
-If you create any scenes for your Hue zones/rooms, these will now be automatically imported to Home Assistant as scene entity, including support for the new Hue Dynamic Scenes. You can disable any scene entities you don't like to use in Home Assistant (or delete them in the Hue app).
-
-([@marcelveldt]) ([hue docs])
 
 {% enddetails %}
 

--- a/source/_posts/2021-12-11-release-202112.markdown
+++ b/source/_posts/2021-12-11-release-202112.markdown
@@ -961,6 +961,25 @@ Dataclasses provided by discovery type:
 
 {% enddetails %}
 
+{% details "Hue" %}
+
+*Events for Hue remotes/switches*
+Philips/Signify streamlined the events that are emitted for remotes/switches, these are now no longer device specific but more generic.
+This means that if you're relying on the `hue_event` to trigger events emitted by these devices, the event_data will now be a slightly bit different.
+To easily identify what events get emitted by your Hue remotes, Open Developer Tools and subscribe to the `hue_event`.
+
+*Light entities for Hue rooms/zones*
+Entities for Hue groups (zones/rooms) will be imported but by default in a disabled state.
+The Integration option to enable Hue groups has been phased out in favor of the default Home Assistant functionality to enable/disable entities.
+To enable any light entities for Hue groups: Open settings --> integrations --> Hue --> Entities --> Click one of the disabled entities and enable it.
+
+*Entities for Hue scenes*
+If you create any scenes for your Hue zones/rooms, these will now be automatically imported to Home Assistant as scene entity, including support for the new Hue Dynamic Scenes. You can disable any scene entities you don't like to use in Home Assistant (or delete them in the Hue app).
+
+([@marcelveldt]) ([hue docs])
+
+{% enddetails %}
+
 ## Farewell to the following
 
 The following integrations are no longer available as of this release:

--- a/source/_posts/2021-12-11-release-202112.markdown
+++ b/source/_posts/2021-12-11-release-202112.markdown
@@ -830,18 +830,18 @@ The following icons have been renamed:
 
 {% details "Hue" %}
 
-*Events for Hue remotes/switches*
+### Events for Hue remotes/switches
 Philips/Signify streamlined the events that are emitted for remotes/switches, these are now no longer device specific but more generic.
 This means that if you're relying on the `hue_event` to trigger events emitted by these devices, the event_data will now be a slightly bit different.
 To easily identify what events get emitted by your Hue remotes, Open Developer Tools and subscribe to the `hue_event`.
 
-*Light entities for Hue rooms/zones*
+### Light entities for Hue rooms/zones
 Entities for Hue groups (zones/rooms) will be imported but by default in a disabled state.
 The Integration option to enable Hue groups has been phased out in favor of the default Home Assistant functionality to enable/disable entities.
 To enable any (new) light entities for Hue groups: Open settings --> integrations --> Hue --> Entities --> Click one of the disabled entities and enable it.
 Existing Hue group lights will be migrated as enabled entities.
 
-*Entities for Hue scenes*
+### Entities for Hue scenes
 If you create any scenes for your Hue zones/rooms, these will now be automatically imported to Home Assistant as scene entity, including support for the new Hue Dynamic Scenes. You can disable any scene entities you don't like to use in Home Assistant (or delete them in the Hue app).
 
 ([@marcelveldt] - [#58996]) ([hue docs])


### PR DESCRIPTION
## Proposed change
The release notes for the 2021.12 (beta) release currently does not contain the breaking changes on the Hue integration.
Not sure if we should also mention a bit more what's changed under the hood like that polling has been completely eliminated and that the hue_activate_scene is now in deprecation status for V2 bridges ?

More info about the new Hue API can be found here btw:
https://developers.meethue.com/new-hue-api/

Anyways, the breaking changes should be listed as I've already seen two reports from beta users.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
