### PR TITLE
Add Ohmpilot and energy dashboard recommendations to Fronius

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -56,7 +56,11 @@ Each device adds a set of sensors to Home Assistant.
 
 - `meter`
 
-  Detailed information about power, current and voltage, if supported split among the phases. Updated every minute interval.
+  Detailed information about power, current and voltage, if supported split among the phases. Updated every minute.
+
+- `ohmpilot`
+
+  Detailed information about energy, power, and temperature of your Ohmpilots. Updated every minute.
 
 - `storage`
 
@@ -67,6 +71,16 @@ The corresponding sensors are added to Home Assistant as entities as soon as the
 This means for example that when Home Assistant is started at night, there might be no sensor providing photovoltaic related data.
 This does not need to be problematic as the values will be added on sunrise, when the Fronius devices begins providing the needed data.
 When a device is not responding correctly the update interval will increase to 10 minutes (3 minutes for power flow) until valid data is received again.
+
+## Energy dashboard
+
+Recommended energy dashboard configuration for meter location in feed in path (`Meter location: 0`):
+
+- For `Grid consumption` use the meters `Energy real consumed` entity.
+- For `Return to grid` use the meters `Energy real produced` entity.
+- For `Solar production` add each inverters `Energy total` entity.
+- `Battery systems` aren't supported directly. Use [Riemann sum](/integrations/integration/) with negative values of `Power battery` entity (from power_flow endpoint found in your `SolarNet` device) for charging and positive values for discharging.
+- For `Devices` use the Ohmpilots `Energy consumed` entity.
 
 ## Note
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Ohmpilot and energy dashboard recommendations to Fronius


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/60765
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
