### PR TITLE
Update totalconnect.markdown

### DIFF
--- a/source/_integrations/totalconnect.markdown
+++ b/source/_integrations/totalconnect.markdown
@@ -66,7 +66,7 @@ sudo apt install libxml2-dev libxmlsec1-dev
 
 The integration provides an Alarm Control Panel for each TotalConnect location. It uses the name of your location from TotalConnect.  For example, if your location name in TotalConnect is "Home", then you will get `alarm_control_panel.home` in Home Assistant.
 
-The alarm control panel supports the following services: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`.  The integration also provides unique services for `arm_stay_instant` and `arm_away_instant` which arm the system with zero entry delay, triggering the alarm instantly if someone opens a door.
+The alarm control panel supports the following services: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`. The integration also provides unique services for `arm_stay_instant` and `arm_away_instant` which arm the system with zero entry delay, triggering the alarm instantly if someone opens a door.
 
 The `triggered` state also provides a state attribute called `triggered_source` giving more detail on what triggered the alarm:
 

--- a/source/_integrations/totalconnect.markdown
+++ b/source/_integrations/totalconnect.markdown
@@ -50,6 +50,15 @@ automation:
       service: scene.turn_on
       target:
         entity_id: scene.OnArmedAway
+  - alias: "Alarm: Arm Home Instant at Sunset"
+    trigger:
+      platform: sun
+      event: sunset
+      offset: '0'
+    action:
+      service: totalconnect.arm_home_instant
+      target:
+        entity_id: alarm_control_panel.total_connect
 ```
 
 {% details "Notes for Home Assistant Core Installations" %}
@@ -66,7 +75,7 @@ sudo apt install libxml2-dev libxmlsec1-dev
 
 The integration provides an Alarm Control Panel for each TotalConnect location. It uses the name of your location from TotalConnect.  For example, if your location name in TotalConnect is "Home", then you will get `alarm_control_panel.home` in Home Assistant.
 
-The alarm control panel supports the following services: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`. The integration also provides unique services for `arm_home_instant` and `arm_away_instant` which arm the system with zero entry delay, triggering the alarm instantly if someone opens a door.
+The alarm control panel supports the following services: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`. The integration also provides unique services for `totalconnect.arm_home_instant` and `totalconnect.arm_away_instant` which arm the system with zero entry delay, triggering the alarm instantly if someone opens a door.
 
 The `triggered` state also provides a state attribute called `triggered_source` giving more detail on what triggered the alarm:
 

--- a/source/_integrations/totalconnect.markdown
+++ b/source/_integrations/totalconnect.markdown
@@ -66,7 +66,7 @@ sudo apt install libxml2-dev libxmlsec1-dev
 
 The integration provides an Alarm Control Panel for each TotalConnect location. It uses the name of your location from TotalConnect.  For example, if your location name in TotalConnect is "Home", then you will get `alarm_control_panel.home` in Home Assistant.
 
-The alarm control panel supports the following services: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`. The integration also provides unique services for `arm_stay_instant` and `arm_away_instant` which arm the system with zero entry delay, triggering the alarm instantly if someone opens a door.
+The alarm control panel supports the following services: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`. The integration also provides unique services for `arm_home_instant` and `arm_away_instant` which arm the system with zero entry delay, triggering the alarm instantly if someone opens a door.
 
 The `triggered` state also provides a state attribute called `triggered_source` giving more detail on what triggered the alarm:
 

--- a/source/_integrations/totalconnect.markdown
+++ b/source/_integrations/totalconnect.markdown
@@ -66,7 +66,7 @@ sudo apt install libxml2-dev libxmlsec1-dev
 
 The integration provides an Alarm Control Panel for each TotalConnect location. It uses the name of your location from TotalConnect.  For example, if your location name in TotalConnect is "Home", then you will get `alarm_control_panel.home` in Home Assistant.
 
-The alarm control panel supports the following services: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night` and `alarm_disarm`.
+The alarm control panel supports the following services: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`.  The integration also provides unique services for `arm_stay_instant` and `arm_away_instant` which arm the system with zero entry delay, triggering the alarm instantly if someone opens a door.
 
 The `triggered` state also provides a state attribute called `triggered_source` giving more detail on what triggered the alarm:
 


### PR DESCRIPTION
Add info about the arm_away_instant and arm_stay_instant services

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/60156
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
