### PR TITLE
Update flux_led naming

### DIFF
--- a/source/_integrations/flux_led.markdown
+++ b/source/_integrations/flux_led.markdown
@@ -46,7 +46,7 @@ These devices have been sold under at least the following brands:
 - [Chichin](https://chichinlighting.com/)
 - Comoyda
 - dalattin
-- [DALS RGBW / Armacost Lighting](https://www.armacostlighting.com/)
+- [DALS RGBW / Armacost Lighting / MyLED](https://www.armacostlighting.com/)
 - DARKPROOF
 - [Daybetter](https://www.daybetter.com/)
 - deerdance
@@ -71,22 +71,21 @@ These devices have been sold under at least the following brands:
 - Magic Ambient
 - [Magic Home](http://www.zengge.com/appkzd)
 - [Magic Hue](http://www.magichue.com/)
-- Magic Light
+- [Magic Light](https://www.magiclightbulbs.com/)
 - Miheal
 - Mowelai
-- MyLED
 - Nexlux
 - OBSESS
-- Offdarks
+- [Offdarks](http://offdarks.net)
 - PH LED
 - PHOPOLLO
-- Pin Stadium (Pinball Lights)
+- [Pin Stadium Pinball Lights](https://pinstadium.com/)
 - POV Lamp
-- Rimikon
+- [Rimikon](https://www.rimikon.com/)
 - SMFX
-- Sumaote
-- Superhome
-- SuperlightingLED
+- [Sumaote](https://fvtled.com/)
+- [Superhome](https://superhome.com.cy/)
+- [SuperlightingLED](https://www.superlightingled.com/)
 - Svipear
 - Tommox
 - Vanance

--- a/source/_integrations/flux_led.markdown
+++ b/source/_integrations/flux_led.markdown
@@ -1,6 +1,6 @@
 ---
-title: Flux LED/MagicHome
-description: Instructions on how to setup Flux led/MagicHome/MagicLight within Home Assistant.
+title: Magic Home
+description: Instructions on how to setup Magic Home within Home Assistant.
 ha_category:
   - Light
   - Switch
@@ -17,13 +17,13 @@ ha_config_flow: true
 ha_dhcp: true
 ---
 
-The Flux LED integration supports several brands of switches, bulbs, and controllers that use the same protocol and have the HF-LPB100 chipset in common. Chances are high that your bulb or controller (eg. WiFi LED CONTROLLER) will work with this integration if you can control the device with the MagicHome app.
+The Magic Home integration supports several brands of switches, bulbs, and controllers that use the same protocol. Chances are high that your bulb or controller (eg. WiFi LED CONTROLLER) will work with this integration if you can control the device with the Magic Home app.
 
 This integration will provide local control over your LED lights/strips and can be configured to auto-scan your network for controllers or for you to manually configure individual lights by their IP address.
 
 Example of bulbs:
 
-- [Flux Smart Lighting](https://www.fluxsmartlighting.com/)
+- [Smart Lighting](https://www.fluxsmartlighting.com/)
 - [Flux WiFi Smart LED Light Bulb4](https://amzn.to/2X0dVwu)
 - [WIFI smart LED light Bulb1](https://amzn.to/2J2fksr)
 
@@ -32,11 +32,54 @@ Examples of controllers:
 - [Ledenet WiFi RGBW Controller](https://amzn.to/2WZKXNa)
 - [SUPERNIGHT WiFi Wireless LED Smart Controller](https://amzn.to/2WURx7w)
 
+These devices have been sold under at least the following brands:
 
+- Allkeys
+- Apobob
+- Arlux
+- Aubric
+- BERENNIS
+- BHGY
+- Bunpeon
+- Comoyda
+- dalattin
+- DARKPROOF
+- Daybetter
+- deerdance
+- Flux LED
+- FVTLED
+- GEYUEYA Home
+- GIDEALED
+- GIDERWEL
+- GMK
+- Goldwin
+- Hakkatronics
+- HaoDeng
+- HDDFL
+- INDARUN
+- iNextStation
+- LEDENET
+- Lytworx
+- Magic Hue
+- Magic Light
+- Miheal
+- Mowelai
+- Nexlux
+- OBSESS
+- Offdarks
+- PHOPOLLO
+- Sumaote
+- SuperlightingLED
+- Svipear
+- Vanance
+- Yetaida
+- YHW
+- Zengge
+- Zombber
 
 {% include integrations/config_flow.md %}
 
-After the devices have been added they can be configured with different effects listed below. These settings can be accessed by navigating to the integration settings in Configuration -> Integrations and selecting the "Flux Led/Magic Home" configuration for the bulb or controller. 
+After the devices have been added they can be configured with different effects listed below. These settings can be accessed by navigating to the integration settings in Configuration -> Integrations and selecting the "Magic Home" configuration for the bulb or controller. 
 
 
 **Custom Effect**\
@@ -48,7 +91,7 @@ This determines the transition between each color.
 
 ### Effects
 
-The Flux LED light offers a number of effects which are not included in other lighting packages. These can be selected from the front-end, or sent in the effect field of the `light.turn_on` command.
+The Magic Home light offers a number of effects which are not included in other lighting packages. These can be selected from the front-end, or sent in the effect field of the `light.turn_on` command.
 
 | Effect Name                                                                                                  | Description                                                        |
 |--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|

--- a/source/_integrations/flux_led.markdown
+++ b/source/_integrations/flux_led.markdown
@@ -34,47 +34,65 @@ Examples of controllers:
 
 These devices have been sold under at least the following brands:
 
-- Allkeys
+- Aislan
+- [Allkeys](http://allkeystech.com/)
 - Apobob
-- Arlux
+- [Arilux](https://www.ariluxworldwide.com/)
 - Aubric
 - BERENNIS
 - BHGY
+- [Brizled](https://www.brizled.com/)
 - Bunpeon
+- [Chichin](https://chichinlighting.com/)
 - Comoyda
 - dalattin
+- [DALS RGBW / Armacost Lighting](https://www.armacostlighting.com/)
 - DARKPROOF
-- Daybetter
+- [Daybetter](https://www.daybetter.com/)
 - deerdance
-- Flux LED
-- FVTLED
+- DIAMOND
+- [Diode Dynamics](https://www.diodedynamics.com/)
+- [Flux LED](https://www.fluxsmartlighting.com/)
+- [FVTLED](https://fvtled.com/)
+- [GEV LIG](https://www.gev.de/)
 - GEYUEYA Home
 - GIDEALED
-- GIDERWEL
+- [GIDERWEL](https://giderwel.com/)
 - GMK
 - Goldwin
 - Hakkatronics
-- HaoDeng
+- [HaoDeng](http://www.zengge.com/appkzd)
 - HDDFL
+- illume RGBW
 - INDARUN
 - iNextStation
 - LEDENET
 - Lytworx
-- Magic Hue
+- Magic Ambient
+- [Magic Home](http://www.zengge.com/appkzd)
+- [Magic Hue](http://www.magichue.com/)
 - Magic Light
 - Miheal
 - Mowelai
+- MyLED
 - Nexlux
 - OBSESS
 - Offdarks
+- PH LED
 - PHOPOLLO
+- Pin Stadium (Pinball Lights)
+- POV Lamp
+- Rimikon
+- SMFX
 - Sumaote
+- Superhome
 - SuperlightingLED
 - Svipear
+- Tommox
 - Vanance
 - Yetaida
 - YHW
-- Zengge
+- [Zengge](http://www.zengge.com/sy)
 - Zombber
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/flux_led.markdown
+++ b/source/_integrations/flux_led.markdown
@@ -23,7 +23,7 @@ This integration will provide local control over your LED lights/strips and can 
 
 Example of bulbs:
 
-- [Smart Lighting](https://www.fluxsmartlighting.com/)
+- [Flux Smart Lighting](https://www.fluxsmartlighting.com/)
 - [Flux WiFi Smart LED Light Bulb4](https://amzn.to/2X0dVwu)
 - [WIFI smart LED light Bulb1](https://amzn.to/2J2fksr)
 


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- Display the name of the integration as Magic Home (the brands logo already shows this)

- Flux LED is only one of many distributors of Magic
  Home (Zengge) products. Its confusing to highlight
  a single distributor since this integration works
  with at least 35 known brands of Magic Home
  devices.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/61187
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
