### PR TITLE
Add Sonos shuffle and repeat template switch to docs

### DIFF
--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -273,3 +273,89 @@ sonos:
   media_player:
     advertise_addr: 192.0.2.1
 ```
+
+## Control shuffle and repeat with a switch
+
+To have more visibility if the Sonos is shuffling or repeating items, you can also create one or multiple template switches to see the current status and also toggle these settings.
+
+```yaml
+# Example configuration.yaml entry to create a shuffle switch
+switch:
+  - platform: template
+      switches:
+        sonos_livingroom_shuffle:
+          friendly_name: Sonos livingroom shuffle
+          unique_id: sonos_livingroom_shuffle
+          icon_template: >-
+            {% if is_state_attr('media_player.sonos_livingroom', 'shuffle', true) %}
+                mdi:shuffle
+            {% else %}
+              mdi:shuffle-disabled
+            {% endif %}
+          value_template: >-
+            {% if is_state_attr('media_player.sonos_livingroom', 'shuffle', true) %}
+              on
+            {% else %}
+              off
+            {% endif %}
+          availability_template: >-
+            {% if is_state('media_player.sonos_livingroom', 'unavailable') %}
+              unavailable
+            {% else %}
+              true
+            {% endif %}
+          turn_on:
+            service: media_player.shuffle_set
+            data:
+              shuffle: true
+            target:
+              entity_id: media_player.sonos_livingroom
+          turn_off:
+            service: media_player.shuffle_set
+            data:
+              shuffle: false
+            target:
+              entity_id: media_player.sonos_livingroom
+```
+
+```yaml
+# Example configuration.yaml entry to create a repeat all switch
+switch:
+  - platform: template
+      switches:
+        sonos_livingroom_repeat_all:
+          friendly_name: Sonos livingroom repeat all
+          unique_id: sonos_livingroom_repeat_all
+          icon_template: >-
+            {% if is_state_attr('media_player.sonos_livingroom', 'repeat', 'all') %}
+              mdi:repeat
+            {% else %}
+              mdi:repeat-off
+            {% endif %}
+          value_template: >-
+            {% if is_state_attr('media_player.sonos_livingroom', 'repeat', 'all') %}
+              on
+            {% else %}
+              off
+            {% endif %}
+          availability_template: >-
+            {% if is_state('media_player.sonos_livingroom', 'unavailable') %}
+              unavailable
+            {% else %}
+              true
+            {% endif %}
+          turn_on:
+            service: media_player.repeat_set
+            data:
+              repeat: 'all'
+            target:
+              entity_id: media_player.sonos_livingroom
+          turn_off:
+            service: media_player.repeat_set
+            data:
+              repeat: 'off'
+            target:
+              entity_id: media_player.sonos_livingroom
+```
+
+It is also possible to create a template switch which controls the one track shuffle, by changing `all` to `single`


### PR DESCRIPTION
## Proposed change
I wanted to have more control over Sonos shuffle and repeat all function, so I created a template switch for this purpose. I can imagine that more people find this useful, so I wanted to share this template switch in the docs so more people can use it in their configuration.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards