### PR TITLE
Add Sonos shuffle and repeat template switch to docs

### DIFF
--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -241,13 +241,13 @@ switch:
           turn_on:
             service: media_player.repeat_set
             data:
-              repeat: 'all'
+              repeat: "all"
             target:
               entity_id: media_player.sonos_livingroom
           turn_off:
             service: media_player.repeat_set
             data:
-              repeat: 'off'
+              repeat: "off"
             target:
               entity_id: media_player.sonos_livingroom
 ```

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -177,3 +177,79 @@ The way media players are displayed in the frontend can be modified in the [cust
 - `tv`: Device is a television type device.
 - `speaker`: Device is speaker or stereo type device.
 - `receiver`: Device is audio video receiver type device taking audio and outputting to speakers and video to some display.
+
+### Control shuffle and repeat with a switch
+
+To have more visibility if the Sonos is shuffling or repeating items, you can also create one or multiple template switches to see the current status and also toggle these settings.
+
+```yaml
+# Example configuration.yaml entry to create a shuffle switch
+switch:
+  - platform: template
+      switches:
+        sonos_livingroom_shuffle:
+          friendly_name: "Sonos livingroom shuffle"
+          unique_id: "sonos_livingroom_shuffle"
+          icon_template: >-
+            {% if is_state_attr('media_player.sonos_livingroom', 'shuffle', true) %}
+                mdi:shuffle
+            {% else %}
+              mdi:shuffle-disabled
+            {% endif %}
+          value_template: >-
+            {% if is_state_attr('media_player.sonos_livingroom', 'shuffle', true) %}
+              on
+            {% else %}
+              off
+            {% endif %}
+          availability_template: "{{ not is_state('media_player.sonos_livingroom', 'unavailable') }}"
+          turn_on:
+            service: media_player.shuffle_set
+            data:
+              shuffle: true
+            target:
+              entity_id: media_player.sonos_livingroom
+          turn_off:
+            service: media_player.shuffle_set
+            data:
+              shuffle: false
+            target:
+              entity_id: media_player.sonos_livingroom
+```
+
+```yaml
+# Example configuration.yaml entry to create a repeat all switch
+switch:
+  - platform: template
+      switches:
+        sonos_livingroom_repeat_all:
+          friendly_name: "Sonos livingroom shuffle"
+          unique_id: "sonos_livingroom_shuffle"
+          icon_template: >-
+            {% if is_state_attr('media_player.sonos_livingroom', 'repeat', 'all') %}
+              mdi:repeat
+            {% else %}
+              mdi:repeat-off
+            {% endif %}
+          value_template: >-
+            {% if is_state_attr('media_player.sonos_livingroom', 'repeat', 'all') %}
+              on
+            {% else %}
+              off
+            {% endif %}
+          availability_template: "{{ not is_state('media_player.sonos_livingroom', 'unavailable') }}"
+          turn_on:
+            service: media_player.repeat_set
+            data:
+              repeat: 'all'
+            target:
+              entity_id: media_player.sonos_livingroom
+          turn_off:
+            service: media_player.repeat_set
+            data:
+              repeat: 'off'
+            target:
+              entity_id: media_player.sonos_livingroom
+```
+
+It is also possible to create a template switch which controls the one track shuffle, by changing `all` to `single`


### PR DESCRIPTION
## Proposed change
I wanted to have more control over Sonos shuffle and repeat all function, so I created a template switch for this purpose. I can imagine that more people find this useful, so I wanted to share this template switch in the docs so more people can use it in their configuration.
If you believe that this is not useful for anyone and will only confuse people, then please reject this PR 😉

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- In #20632 @frenck said that it used the old style platform sensor template, but this is a switch. I'm not aware that switch template is changed/has any old style. I do believe this is the right style.
- I adjusted the availability template code
- Added double quotes to the strings so it is compliant with [https://developers.home-assistant.io/docs/documenting/yaml-style-guide/](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/)

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards