### PR TITLE
Fixing typo

### DIFF
--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -50,7 +50,7 @@ There are four options that can be configured for the SwitchBot entities. Settin
 - `Time between updates (seconds)`: Increase/Decrease the update interval for the device. (Could impact battery life)
 - `Retry count`: How many times to retry sending commands and retry polling your SwitchBot devices.
 - `Timeout between retries`: How long to wait before retries.
-- `How long to scan for advertisement data`: Bluetooth LE uses advertisement data for device statuses and/or attributes. This setting spesifies how long the scan should run.
+- `How long to scan for advertisement data`: Bluetooth LE uses advertisement data for device statuses and/or attributes. This setting specifies how long the scan should run.
 
 ### Error codes and troubleshooting
 


### PR DESCRIPTION
## Proposed change
A very small edit to correct a typo in an SwitchBot's documentation, which I happened to notice while reading. 



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
