### PR TITLE
ZHA: deCONZ support for tcp forwarded serial ports

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -156,6 +156,39 @@ If you are use ZiGate or Sonoff ZBBridge you have to use some special usb_path c
 - Wifi Zigate : `socket://[IP]:[PORT]` for example `socket://192.168.1.10:9999`
 - Sonoff ZBBridge : `socket://[IP]:[PORT]` for example `socket://192.168.1.11:8888`
 
+### deCONZ Devices
+
+There are two options to connect to deCONZ devices. Those can be plugged into the local host system or a remote
+machine can be used as a serial port forwarder via TCP.
+
+#### Local device
+
+Set the serial device path to the serial port in `/dev/serial/by-id` as described above.
+
+#### Remote device
+
+**Note:** There are no security mechanisms. Anyone with access to your network can take control of your deCONZ device!
+
+Use a device path of the format `tcp://<host>:<port>` to connect to a serial device that is forwarded
+through a remote device. On the remote machine tools like `ser2net` or `socat` can be used to forward
+a serial device to a tcp socket.
+
+Example configuration steps:
+
+- Install `ser2net` from your distributions repository on the remote machine
+- Enable the service to automatically start (usually `sudo systemctl enable ser2net.service`)
+- Add the following single line to `/etc/ser2net.conf`:
+
+```text
+<port>:raw:0:/dev/serial/by-id/<your-serial-device>:38400 NONE 1STOPBIT -XONXOFF NOBREAK
+
+# example:
+23344:raw:0:/dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2457780-if00:38400 NONE 1STOPBIT -XONXOFF NOBREAK
+```
+
+- Restart ser2net (or reboot)
+- In the Home Assistant GUI configure a ZHA integration with a deCONZ device and the custom path `tcp://<remote machine hostname or IP>:23344`
+
 ### Discovery via USB or Zeroconf
 
 Some devices can be auto-discovered, which can simplify the ZHA setup process. The following devices have been tested with discovery and offer a quick setup experience:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This adds documentation and detailed usage instructions for the new configuration option in the ZHA integration. For deCONZ Zigbee devices a custom path format can be used to connect to remote devices forwarded via TCP.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: zigpy/zigpy-deconz#176
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
