### PR TITLE
Remove outdated Ecowitt reference from Ambient PWS docs

### DIFF
--- a/source/_integrations/ambient_station.markdown
+++ b/source/_integrations/ambient_station.markdown
@@ -49,7 +49,7 @@ app_key:
 ## Local API Option
 
 This integration communicates with Ambient Weather PWS units via the Ambient Weather
-Cloud. Users wishing to explore a local option are encouraged to explore the
+Cloud. Users desiring a local option are encouraged to explore the
 [Ecowitt](https://www.ecowitt.com) family of devices, which are able to read RF signals
 directly from the PWS and transmit them to a variety of other applications, including
 [`ecowitt2mqtt`](https://github.com/bachya/ecowitt2mqtt) (which supports

--- a/source/_integrations/ambient_station.markdown
+++ b/source/_integrations/ambient_station.markdown
@@ -50,7 +50,7 @@ app_key:
 
 This integration communicates with Ambient Weather PWS units via the Ambient Weather
 Cloud. Users wishing to explore a local option are encouraged to explore the
-[Ecowitt GW1000](https://www.ecowitt.com/shop/goodsDetail/16), a small device that is
-able to read RF signals directly from the PWS and transmit them to a variety of
-other applications, including [`ecowitt2mqtt`](https://github.com/bachya/ecowitt2mqtt)
-(which supports [MQTT Discovery](/docs/mqtt/discovery)).
+[Ecowitt](https://www.ecowitt.com) family of devices, which are able to read RF signals
+directly from the PWS and transmit them to a variety of other applications, including
+[`ecowitt2mqtt`](https://github.com/bachya/ecowitt2mqtt) (which supports
+[MQTT Discovery](/docs/mqtt/discovery)).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR removes a reference to a no-longer-sold product from the Ambient PWS docs.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: https://github.com/home-assistant/home-assistant.io/issues/20640

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
