### PR TITLE
Add device_class to commandline.sensor Issue #56631

### DIFF
--- a/source/_integrations/sensor.command_line.markdown
+++ b/source/_integrations/sensor.command_line.markdown
@@ -32,6 +32,10 @@ name:
   description: Name of the command sensor.
   required: false
   type: string
+device_class:
+  description: Sets the [class of the device](/integrations/sensor/), changing the device state and icon that is displayed on the frontend.
+  required: false
+  type: string
 unit_of_measurement:
   description: Defines the unit of measurement of the sensor, if any.
   required: false
@@ -71,6 +75,7 @@ Thanks to the [`proc`](https://en.wikipedia.org/wiki/Procfs) file system, variou
 sensor:
   - platform: command_line
     name: CPU Temperature
+    device_class: temperature
     command: "cat /sys/class/thermal/thermal_zone0/temp"
     # If errors occur, make sure configuration file is encoded as UTF-8
     unit_of_measurement: "°C"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adding `device_class` to the command line sensor

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#61506](https://github.com/home-assistant/core/pull/61506)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: [#56631](https://github.com/home-assistant/core/issues/56631)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
