### PR TITLE
Remove groups organization advise from device configuration page

### DIFF
--- a/source/_docs/configuration/devices.markdown
+++ b/source/_docs/configuration/devices.markdown
@@ -59,25 +59,3 @@ switch 1:
 switch 2:
   platform: vera
 ```
-
-## Grouping entities
-
-Once you have several entities set up, it is time to organize them into groups.
-Each group consists of a name and a list of entity IDs. Entity IDs can be
-retrieved from the web interface by using the
-{% my developer_states title="States page in the Developer Tools" %}.
-
-```yaml
-# Example configuration.yaml entry
-group:
-  living_room:
-    entities:
-      - light.table_lamp
-      - switch.ac
-  bedroom:
-    entities:
-      - light.bedroom
-      - media_player.nexus_player
-```
-
-For more details please check the [Group](/integrations/group/) page.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Removes information/advice on grouping devices from the "Adding device to Home Assistant" page.

Besides it being confusing, as reported in #20536, it also no longer holds true. The groups part is a leftover from the old UI (in which it was needed for UI grouping).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #20536

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
