### PR TITLE
Add synchronous download and authentication support to downloader integration

### DIFF
--- a/source/_integrations/downloader.markdown
+++ b/source/_integrations/downloader.markdown
@@ -35,12 +35,16 @@ Go to the "Developer Tools", then to "Call Service", and choose `downloader/down
 
 This will download the file from the given URL.
 
-| Service data attribute | Optional | Description                                    |
-| ---------------------- | -------- | ---------------------------------------------- |
-| `url`                  |       no | The URL of the file to download.               |
-| `subdir`               |      yes | Download into subdirectory of **download_dir** |
-| `filename`             |      yes | Determine the filename.                        |
-| `overwrite`            |      yes | Whether to overwrite the file or not, defaults to `false`. |
+| Service data attribute | Optional | Description                                                                   |
+|------------------------|----------|-------------------------------------------------------------------------------|
+| `url`                  | no       | The URL of the file to download.                                              |
+| `subdir`               | yes      | Download into subdirectory of **download_dir**                                |
+| `filename`             | yes      | Determine the filename.                                                       |
+| `overwrite`            | yes      | Whether to overwrite the file or not, defaults to `false`.                    |
+| `async`                | yes      | Whether to download in background without waiting or not, defaults to `true`. |
+| `auth_type`            | yes      | Authentication type: `none`, `basic` or `digest`, defaults to `None`.         |
+| `username`             | yes      | Username for authentication. Only required if **auth_type** is not `None`.    |
+| `password`             | yes      | Password for authentication. Only required if **auth_type** is not `None`.    |
 
 ### Download Status Events
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add support to `downloader` integration for:
- Synchronous download
- Authentication (Basic and Digest)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/61747
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://community.home-assistant.io/t/downloader-integration-lacks-authentication-options/344244

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
