### PR TITLE
Remove deprecated server configuration instruction

### DIFF
--- a/source/_integrations/jellyfin.markdown
+++ b/source/_integrations/jellyfin.markdown
@@ -12,7 +12,7 @@ ha_domain: jellyfin
 ---
 
 The Jellyfin integration exposes a [Jellyfin](https://jellyfin.org/) server as a Media Source in Home Assistant.
-Support is currently limited to music libraries only. Other libraries will not appear in the Media Browser. This integration has been tested with Jellyfin server version 10.6.4, but should support older versions as well.
+Support is currently limited to music libraries only. Other libraries will not appear in the Media Browser. This integration has been tested with Jellyfin server version 10.6.4 and later.
 
 {% include integrations/config_flow.md %}
 
@@ -24,9 +24,3 @@ Username:
 Password:
   description: The password of the supplied user.
 {% endconfiguration_basic %}
-
-## Jellyfin server configuration
-
-The Jellyfin integration retrieves media items from your Jellyfin libraries using an Artist -> Album -> Track hierarchy. In order for the Media Browser to display thumbnails for artists and albums, Jellyfin has to include metadata for artists and albums. This is not enabled by default.
-
-To enable this, navigate to the Jellyfin dashboard and select Plugins. Choose which provider you would like to use for metadata retrieval (AudioDB and MusicBrainz are the two default providers) and select Settings. Enable the checkbox for "Enable this provider for metadata searches on artists and albums.".


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update the Jellyfin documentation to remove a deprecated instruction to configure the Jellyfin server for collecting artist and album images.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/home-assistant.io/issues/20657

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
