### PR TITLE
Fritz deprecate services for button entities

### DIFF
--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -15,6 +15,7 @@ ha_codeowners:
 ha_iot_class: Local Polling
 ha_platforms:
   - binary_sensor
+  - button
   - device_tracker
   - sensor
   - switch
@@ -27,6 +28,7 @@ There is support for the following platform types within Home Assistant:
 
 - **Device tracker** - presence detection by looking at connected devices.
 - **Binary sensor** - connectivity status.
+- **Button** - reboot, reconnect, firmware_update.
 - **Sensor** - external IP address, uptime and network monitors.
 - **Switch** - call deflection, port forward, parental control and Wi-Fi networks.
 
@@ -44,28 +46,9 @@ The configuration in the UI asks for a username. Starting from FRITZ!OS 7.24 the
 
 Currently supported services are Platform specific:
 
-- `fritz.reconnect`
-- `fritz.reboot`
 - `fritz.cleanup`
 
 ### Platform Services
-
-#### Service `fritz.reboot`
-
-Reboot the router.
-
-| Service data attribute | Optional | Description                                                                                                    |
-| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific  router                                                                                 |
-
-#### Service `fritz.reconnect`
-
-Disconnect and reconnect the router to the Internet.
-If you have a dynamic IP address, most likely it will change.
-
-| Service data attribute | Optional | Description                                                                                                    |
-| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific  router                                                                                 |
 
 #### Service `fritz.cleanup`
 
@@ -75,8 +58,6 @@ A device is identified as stale when it's still present on Home Assistant but no
 | Service data attribute | Optional | Description                                                                                                    |
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | no       | Only act on a specific  router                                                                                 |
-
-**Note**: Services will be soon deprecated in favor of button entities, that have the same functionality.
 
 ## Integration Options
 
@@ -114,11 +95,11 @@ The following script can be used to easily add a reconnect button to your UI. If
 
 ```yaml
 fritz_box_reconnect:
-  alias: "Reconnect FRITZ!Box"
+  alias: "Reboot FRITZ!Box"
   sequence:
-    - service: fritz.reconnect
+    - service: button.press
       target:
-        entity_id: binary_sensor.fritzbox_7530_connection
+        entity_id: button.fritzbox_7530_reboot
 
 ```
 
@@ -126,14 +107,14 @@ fritz_box_reconnect:
 
 ```yaml
 automation:
-- alias: "System - Reconnect FRITZ!Box"
+- alias: "Reconnect FRITZ!Box"
   trigger:
     - platform: time
       at: "05:00:00"
   action:
-    - service: fritz.reconnect
+    - service: button.press
       target:
-        entity_id: binary_sensor.fritzbox_7530_connection
+        entity_id: button.fritzbox_7530_reconnect
 
 ```
 

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -76,6 +76,8 @@ A device is identified as stale when it's still present on Home Assistant but no
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | no       | Only act on a specific  router                                                                                 |
 
+**Note**: Services will be soon deprecated in favor of button entities, that have the same functionality.
+
 ## Integration Options
 
 It is possible to change some behaviors through the integration options.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Inform users that services will be soon deprecated in favor of new button entities.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/61483
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
