### PR TITLE
Add config flow to Azure_event_hub integration documentation

### DIFF
--- a/source/_integrations/azure_event_hub.markdown
+++ b/source/_integrations/azure_event_hub.markdown
@@ -29,7 +29,7 @@ The final thing to consider is how often you want the integration to send messag
 
 {% include integrations/config_flow.md %}
 
-You can setup [filters](#filter-configuration) through the `configuration.yaml`, any other keys from the old configuration are forwarded to the config flow and stored by Home Assistant and can be deleted from your configuration.
+You can setup [filters](#filter-configuration) through the `configuration.yaml`.
 
 <div class='note warning'>
 Not filtering domains or entities will send every event to Azure Event Hub, thus taking up a lot of space and bandwidth.

--- a/source/_integrations/azure_event_hub.markdown
+++ b/source/_integrations/azure_event_hub.markdown
@@ -25,7 +25,7 @@ Once you have the name of your namespace, instance, Shared Access Policy and the
 
 The alternative approach is to use a connection string and instance name, this can be retrieved in the same way as the Shared Access Policy and this can also be gotten for a device in an IoT Hub (Event Hub-compatible connection string). In the case of IoT Hub, you need to put the Device ID as the instance name.
 
-The final thing to consider is how often you want the integration to send messages in a batch to your hub, this is set with the `send_interval`, with a default of 5 seconds. Since this component runs in an asynchronous way there is no guarantee that the sending happens exactly on time, and because your home assistant might be very busy with lots of events happening it might discard several events that are older then 20 seconds plus the `send_interval`.
+The final thing to consider is how often you want the integration to send messages in a batch to your hub, this is set with the `send_interval`, with a default of 5 seconds. Since this component runs in an asynchronous way there is no guarantee that the sending happens exactly on time, and because your Home Assistant might be very busy with lots of events happening it might discard several events that are older then 20 seconds plus the `send_interval`.
 
 ## Configuration
 

--- a/source/_integrations/azure_event_hub.markdown
+++ b/source/_integrations/azure_event_hub.markdown
@@ -27,11 +27,9 @@ The alternative approach is to use a connection string and instance name, this c
 
 The final thing to consider is how often you want the integration to send messages in a batch to your hub, this is set with the `send_interval`, with a default of 5 seconds. Since this component runs in an asynchronous way there is no guarantee that the sending happens exactly on time, and because your Home Assistant might be very busy with lots of events happening it might discard several events that are older then 20 seconds plus the `send_interval`.
 
-## Configuration
-
-The configuration will move to a hybrid of yaml and config flow starting with 2022.2, where the filters can be set in the `configuration.yaml` and the other pieces are done through a config flow.
-
 {% include integrations/config_flow.md %}
+
+You can setup [filters](#filter-configuration) through the `configuration.yaml`, any other keys from the old configuration are forwarded to the config flow and stored by Home Assistant and can be deleted from your configuration.
 
 <div class='note warning'>
 Not filtering domains or entities will send every event to Azure Event Hub, thus taking up a lot of space and bandwidth.
@@ -41,7 +39,7 @@ Not filtering domains or entities will send every event to Azure Event Hub, thus
 Event Hubs have a retention time of at most 7 days, if you do not capture or use the events they are deleted automatically from the Event Hub, the default retention is 1 day.
 </div>
 
-### Configure Filter
+### Filter Configuration
 
 By default, no entity will be excluded. To limit which entities are being exposed to `Azure Event Hub`, you can use the `filter` parameter.
 
@@ -78,8 +76,8 @@ Filters are applied as follows:
 
 {% configuration %}
 filter:
-  description: Filter domains and entities for Event Hub. ([Configure Filter](#configure-filter))
-  required: true
+  description: Filter domains and entities for Event Hub.
+  required: false
   type: map
   default: Includes all entities from all domains
   keys:

--- a/source/_integrations/azure_event_hub.markdown
+++ b/source/_integrations/azure_event_hub.markdown
@@ -8,6 +8,7 @@ ha_iot_class: Cloud Push
 ha_codeowners:
   - '@eavanvalkenburg'
 ha_domain: azure_event_hub
+ha_config_flow: true
 ---
 
 The `Azure Event Hub` integration allows you to hook into the Home Assistant event bus and send events to [Azure Event Hub](https://azure.microsoft.com/en-us/services/event-hubs/) or to an [Azure IoT Hub](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin).
@@ -24,57 +25,58 @@ Once you have the name of your namespace, instance, Shared Access Policy and the
 
 The alternative approach is to use a connection string and instance name, this can be retrieved in the same way as the Shared Access Policy and this can also be gotten for a device in an IoT Hub (Event Hub-compatible connection string). In the case of IoT Hub, you need to put the Device ID as the instance name.
 
-The final thing to consider is how often you want the integration to send messages in a batch to your hub, this is set with the `send_interval`, with a default of 5 seconds. The other thing to look at is what the maximum delay you want to use, since this component runs in an asynchronous way there is no guarantee that the sending happens exactly on time, so depending on your semantics you might want messages discarded. The actual check of the time happens with `max_delay` plus `send_interval`, so that even with a long `send_interval` the semantics are the same.
+The final thing to consider is how often you want the integration to send messages in a batch to your hub, this is set with the `send_interval`, with a default of 5 seconds. Since this component runs in an asynchronous way there is no guarantee that the sending happens exactly on time, and because your home assistant might be very busy with lots of events happening it might discard several events that are older then 20 seconds plus the `send_interval`.
 
 ## Configuration
 
-Add the following lines to your `configuration.yaml` file:
+The configuration will move to a hybrid of yaml and config flow starting with 2022.2, where the filters can be set in the `configuration.yaml` and the other pieces are done through a config flow.
+
+{% include integrations/config_flow.md %}
+
+<div class='note warning'>
+Not filtering domains or entities will send every event to Azure Event Hub, thus taking up a lot of space and bandwidth.
+</div>
+
+<div class='note warning'>
+Event Hubs have a retention time of at most 7 days, if you do not capture or use the events they are deleted automatically from the Event Hub, the default retention is 1 day.
+</div>
+
+### Configure Filter
+
+By default, no entity will be excluded. To limit which entities are being exposed to `Azure Event Hub`, you can use the `filter` parameter.
 
 ```yaml
-# Example configuration.yaml entry
+# Example filter to include specified domains and exclude specified entities
 azure_event_hub:
-  event_hub_namespace: NAMESPACE_NAME
-  event_hub_instance_name: EVENT_HUB_INSTANCE_NAME
-  event_hub_sas_policy: SAS_POLICY_NAME
-  event_hub_sas_key: SAS_KEY
   filter:
     include_domains:
-    - homeassistant
-    - light
-    - media_player
+      - alarm_control_panel
+      - light
+    include_entity_globs:
+      - binary_sensor.*_occupancy
+    exclude_entities:
+      - light.kitchen_light
 ```
 
+Filters are applied as follows:
+
+1. No includes or excludes - pass all entities
+2. Includes, no excludes - only include specified entities
+3. Excludes, no includes - only exclude specified entities
+4. Both includes and excludes:
+   - Include domain and/or glob patterns specified
+      - If domain is included, and entity not excluded or match exclude glob pattern, pass
+      - If entity matches include glob pattern, and entity does not match any exclude criteria (domain, glob pattern or listed), pass
+      - If domain is not included, glob pattern does not match, and entity not included, fail
+   - Exclude domain and/or glob patterns specified and include does not list domains or glob patterns
+      - If domain is excluded and entity not included, fail
+      - If entity matches exclude glob pattern and entity not included, fail
+      - If entity does not match any exclude criteria (domain, glob pattern or listed), pass
+   - Neither include or exclude specifies domains or glob patterns
+      - If entity is included, pass (as #2 above)
+      - If entity include and exclude, the entity exclude is ignored
+
 {% configuration %}
-event_hub_namespace:
-  description: The name of your Event Hub namespace.
-  required: exclusive
-  type: string
-event_hub_instance_name:
-  description: The name of your Event Hub instance.
-  required: true
-  type: string
-event_hub_sas_policy:
-  description: The name of your Shared Access Policy.
-  required: exclusive
-  type: string
-event_hub_sas_key:
-  description: The key for the Shared Access Policy.
-  required: exclusive
-  type: string
-event_hub_connection_string:
-  description: The connection string to your event hub.
-  required: exclusive
-  type: string
-send_interval:
-  description: The interval in seconds should events be sent to the Event Hub.
-  required: false
-  type: integer
-  default: 5
-max_delay:
-  description: The time in seconds after which a message is to be discarded.
-  required: false
-  type: integer
-  default: 30
 filter:
   description: Filter domains and entities for Event Hub. ([Configure Filter](#configure-filter))
   required: true
@@ -106,66 +108,6 @@ filter:
       required: false
       type: list
 {% endconfiguration %}
-
-<div class='note warning'>
-Not filtering domains or entities will send every event to Azure Event Hub, thus taking up a lot of space.
-</div>
-
-<div class='note warning'>
-Event Hubs have a retention time of at most 7 days, if you do not capture or use the events they are deleted automatically from the Event Hub, the default retention is 1 day.
-</div>
-
-### Configure Filter
-
-By default, no entity will be excluded. To limit which entities are being exposed to `Azure Event Hub`, you can use the `filter` parameter.
-
-```yaml
-# Example filter to include specified domains and exclude specified entities
-azure_event_hub:
-  event_hub_namespace: NAMESPACE_NAME
-  event_hub_instance_name: EVENT_HUB_INSTANCE_NAME
-  event_hub_sas_policy: SAS_POLICY_NAME
-  event_hub_sas_key: SAS_KEY
-  filter:
-    include_domains:
-      - alarm_control_panel
-      - light
-    include_entity_globs:
-      - binary_sensor.*_occupancy
-    exclude_entities:
-      - light.kitchen_light
-```
-
-Filters are applied as follows:
-
-1. No includes or excludes - pass all entities
-2. Includes, no excludes - only include specified entities
-3. Excludes, no includes - only exclude specified entities
-4. Both includes and excludes:
-   - Include domain and/or glob patterns specified
-      - If domain is included, and entity not excluded or match exclude glob pattern, pass
-      - If entity matches include glob pattern, and entity does not match any exclude criteria (domain, glob pattern or listed), pass
-      - If domain is not included, glob pattern does not match, and entity not included, fail
-   - Exclude domain and/or glob patterns specified and include does not list domains or glob patterns
-      - If domain is excluded and entity not included, fail
-      - If entity matches exclude glob pattern and entity not included, fail
-      - If entity does not match any exclude criteria (domain, glob pattern or listed), pass
-   - Neither include or exclude specifies domains or glob patterns
-      - If entity is included, pass (as #2 above)
-      - If entity include and exclude, the entity exclude is ignored
-
-### Advanced configuration
-
-This is what the configuration will look like when using a connection string directly, instead of the four parameters. It also shows how to set the send_interval and max_delay to something other than the default. This means once every minute the integration will connect to your hub and send messages, but the messages have to be less than 65 seconds old at the time of sending for them to be counted (send_interval + max_delay).
-
-```yaml
-# Connection string config with non-defaults for send_interval and max_delay
-azure_event_hub:
-  event_hub_connection_string: CONNECTION_STRING
-  event_hub_instance_name: EVENT_HUB_INSTANCE_NAME
-  send_interval: 60
-  max_delay: 5
-```
 
 ## Using the data in Azure
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I implemented a config flow for the azure event hub integration, so that needs to be reflected in the docs.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/61155
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
