### PR TITLE
Fix timestamp_custom example

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -691,7 +691,7 @@ The following overview contains a couple of options to get the needed values:
 # Timestamps
 {{ value_json.tst | timestamp_local }}
 {{ value_json.tst | timestamp_utc }}
-{{ value_json.tst | timestamp_custom('%Y' True) }}
+{{ value_json.tst | timestamp_custom('%Y', True) }}
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
Adding a missing comma to fix an example for the timestamp_custom function.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
NA

- Link to parent pull request in the codebase: NA
- Link to parent pull request in the Brands repository: NA
- This PR fixes or closes issue: NA

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
