### PR TITLE
Add Daikin energy sensor text

### DIFF
--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -116,7 +116,7 @@ The `daikin` sensor platform integrates Daikin air conditioning systems into Hom
 <div class='note'>
 
 - The 'Today's total energy consumption' and 'Estimated power consumption' sensor is updated every time 100 Wh are consumed by all different operating modes summed together.
-- The 'Estimated power consumption' sensor is derived from the energy consumption and not provided by the AC directly. (Details see: https://bitbucket.org/mustang51/pydaikin/src/b3b7878c8f411b26c21c21dc08818cf8af5ec6c6/pydaikin/power.py#lines-160)
+- The 'Estimated power consumption' sensor is derived from the energy consumption and not provided by the AC directly.
 - The 'cool/heat' energy sensors are updated hourly with the previous hour energy consumption
   of a given mode and a given AC.
 - The 'cool' mode also includes the 'fan' and 'dehumidifier' modes' power consumption.

--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -101,7 +101,7 @@ The `daikin` sensor platform integrates Daikin air conditioning systems into Hom
 - Current total power consumption
 - Hourly energy consumption in cool mode
 - Hourly energy consumption in heat mode
-- Outside unit compressor frequency
+- Outside unit's compressor frequency
 - Today's total energy consumption (resets at 00:00)
 
 <div class='note'>
@@ -115,7 +115,8 @@ The `daikin` sensor platform integrates Daikin air conditioning systems into Hom
 
 <div class='note'>
 
-- The 'total' power and energy sensor is updated every time 100 Wh are consumed by all the AC summed together.
+- The 'total' power and energy sensor is updated every time 100 Wh are consumed by all different operating modes summed together.
+- The 'Current total power consumption' sensor is derived from the energy consumption and not provided by the AC directly. (Details see: https://bitbucket.org/mustang51/pydaikin/src/b3b7878c8f411b26c21c21dc08818cf8af5ec6c6/pydaikin/power.py#lines-160)
 - The 'cool/heat' energy sensors are updated hourly with the previous hour energy consumption
   of a given mode and a given AC.
 - The 'cool' mode also includes the 'fan' and 'dehumidifier' modes' power consumption.

--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -98,7 +98,7 @@ The `daikin` sensor platform integrates Daikin air conditioning systems into Hom
 - Inside temperature
 - Outside temperature
 - Inside humidity
-- Current total power consumption
+- Estimated power consumption
 - Hourly energy consumption in cool mode
 - Hourly energy consumption in heat mode
 - Outside unit's compressor frequency
@@ -115,8 +115,8 @@ The `daikin` sensor platform integrates Daikin air conditioning systems into Hom
 
 <div class='note'>
 
-- The 'total' power and energy sensor is updated every time 100 Wh are consumed by all different operating modes summed together.
-- The 'Current total power consumption' sensor is derived from the energy consumption and not provided by the AC directly. (Details see: https://bitbucket.org/mustang51/pydaikin/src/b3b7878c8f411b26c21c21dc08818cf8af5ec6c6/pydaikin/power.py#lines-160)
+- The 'Today's total energy consumption' and 'Estimated power consumption' sensor is updated every time 100 Wh are consumed by all different operating modes summed together.
+- The 'Estimated power consumption' sensor is derived from the energy consumption and not provided by the AC directly. (Details see: https://bitbucket.org/mustang51/pydaikin/src/b3b7878c8f411b26c21c21dc08818cf8af5ec6c6/pydaikin/power.py#lines-160)
 - The 'cool/heat' energy sensors are updated hourly with the previous hour energy consumption
   of a given mode and a given AC.
 - The 'cool' mode also includes the 'fan' and 'dehumidifier' modes' power consumption.

--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -98,23 +98,24 @@ The `daikin` sensor platform integrates Daikin air conditioning systems into Hom
 - Inside temperature
 - Outside temperature
 - Inside humidity
-- Total instant power consumption
+- Current total power consumption
 - Hourly energy consumption in cool mode
 - Hourly energy consumption in heat mode
-- Outside compressor frequency
+- Outside unit compressor frequency
+- Today's total energy consumption (resets at 00:00)
 
 <div class='note'>
 
 - Some models only report outside temperature when they are turned on.
-- Some models does not have humidity sensor.
-- Some models does not report the power/energy consumption.
-- Some models does not report the compressor frequency.
+- Some models do not have humidity sensor.
+- Some models do not report the power/energy consumption.
+- Some models do not report the compressor frequency.
 
 </div>
 
 <div class='note'>
 
-- The 'total' power sensor is updated every time 100 Wh are consumed by all the AC summed together.
+- The 'total' power and energy sensor is updated every time 100 Wh are consumed by all the AC summed together.
 - The 'cool/heat' energy sensors are updated hourly with the previous hour energy consumption
   of a given mode and a given AC.
 - The 'cool' mode also includes the 'fan' and 'dehumidifier' modes' power consumption.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This adds the new daily energy consumption sensor and fixes some typos


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/61617
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
