### PR TITLE
Documentation update for Signal Messenger integration for adding URL attachment support

### DIFF
--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -102,7 +102,7 @@ action:
   data:
     message: "Person detected on Front Camera!"
     data:
-      verifySsl: False
+      verify_ssl: false
       urls:
         - "http://homeassistant.local/api/frigate/notifications/<event-id>/thumbnail.jpg"
 ```

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -95,7 +95,7 @@ action:
 
 To attach files from outside of HomeAssistant, the URLs must be added to the [allowlist_external_urls](/docs/configuration/basic/#allowlist_external_urls) list.
 
-Note there is a 50mb size limit for attachments retrieved via URLs. You can also set `verify_ssl` to `False` to ignore SSL errors (default `True`)
+Note there is a 50MB size limit for attachments retrieved via URLs. You can also set `verify_ssl` to `false` to ignore SSL errors (default `true`).
 
 ```yaml
 ...

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -93,6 +93,8 @@ action:
 
 ### Text message with an attachment from a URL
 
+Note there is a 50mb size limit for attachments retrieved via URLs. You can set `verifyUrls` to `False` to ignore SSL errors (default `True`)
+
 ```yaml
 ...
 action:

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -93,7 +93,7 @@ action:
 
 ### Text message with an attachment from a URL
 
-To attach files from outside of HomeAssistant, the URLs must be added to the [allowlist_external_urls](https://www.home-assistant.io/docs/configuration/basic/#allowlist_external_urls) list.
+To attach files from outside of HomeAssistant, the URLs must be added to the [allowlist_external_urls](/docs/configuration/basic/#allowlist_external_urls) list.
 
 Note there is a 50mb size limit for attachments retrieved via URLs. You can also set `verify_ssl` to `False` to ignore SSL errors (default `True`)
 

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -93,7 +93,9 @@ action:
 
 ### Text message with an attachment from a URL
 
-Note there is a 50mb size limit for attachments retrieved via URLs. You can set `verifySsl` to `False` to ignore SSL errors (default `True`)
+To attach files from outside of HomeAssistant, the URLs must be added to the [allowlist_external_urls](https://www.home-assistant.io/docs/configuration/basic/#allowlist_external_urls) list.
+
+Note there is a 50mb size limit for attachments retrieved via URLs. You can also set `verify_ssl` to `False` to ignore SSL errors (default `True`)
 
 ```yaml
 ...

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -93,7 +93,7 @@ action:
 
 ### Text message with an attachment from a URL
 
-To attach files from outside of HomeAssistant, the URLs must be added to the [allowlist_external_urls](/docs/configuration/basic/#allowlist_external_urls) list.
+To attach files from outside of HomeAssistant, the URLs must be added to the [`allowlist_external_urls`](/docs/configuration/basic/#allowlist_external_urls) list.
 
 Note there is a 50MB size limit for attachments retrieved via URLs. You can also set `verify_ssl` to `false` to ignore SSL errors (default `true`).
 

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -100,6 +100,7 @@ action:
   data:
     message: "Person detected on Front Camera!"
     data:
-      urls:
+            verifyUrls: false
+            urls:
         - "http://homeassistant.local/api/frigate/notifications/<event-id>/thumbnail.jpg"
 ```

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -90,3 +90,16 @@ action:
       attachments:
         - "/tmp/surveillance_camera.jpg"
 ```
+
+### Text message with an attachment from a URL
+
+```yaml
+...
+action:
+  service: notify.NOTIFIER_NAME
+  data:
+    message: "Person detected on Front Camera!"
+    data:
+      urls:
+        - "http://homeassistant.local/api/frigate/notifications/<event-id>/thumbnail.jpg"
+```

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -102,7 +102,7 @@ action:
   data:
     message: "Person detected on Front Camera!"
     data:
-            verifyUrls: false
-            urls:
+      verifySsl: False
+      urls:
         - "http://homeassistant.local/api/frigate/notifications/<event-id>/thumbnail.jpg"
 ```

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -93,7 +93,7 @@ action:
 
 ### Text message with an attachment from a URL
 
-Note there is a 50mb size limit for attachments retrieved via URLs. You can set `verifyUrls` to `False` to ignore SSL errors (default `True`)
+Note there is a 50mb size limit for attachments retrieved via URLs. You can set `verifySsl` to `False` to ignore SSL errors (default `True`)
 
 ```yaml
 ...


### PR DESCRIPTION
Added documentation for a new feature I am proposing to this integration - https://github.com/home-assistant/core/pull/62311

## Proposed change
I am proposing a feature to the Signal Integration to allow sending of attachments in Signal messages from a URL.  This is the documentation update for this feature.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
https://github.com/home-assistant/core/pull/62311

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
