### PR TITLE
Add input_button

### DIFF
--- a/source/_integrations/input_button.markdown
+++ b/source/_integrations/input_button.markdown
@@ -1,0 +1,88 @@
+---
+title: Input Button
+description: Instructions on how to use the Input Button helper with Home Assistant.
+ha_category:
+  - Automation
+ha_release: 2022.2
+ha_quality_scale: internal
+ha_codeowners:
+  - '@home-assistant/core'
+ha_domain: input_button
+---
+
+The Input Button helper integration allows you to define buttons that
+can be pressed via the user interface, and can be used to trigger things,
+like an automation.
+
+## Configuration
+
+The preferred way to configure button helpers is via the user interface.
+To add one, go to **{% my helpers title="Configuration -> Helpers" %}**
+and click the add button; next choose the "**Button**" option.
+
+To be able to add **Helpers** via the user interface you should have
+`default_config:` in your `configuration.yaml`, it should already be there by
+default unless you removed it. If you removed `default_config:` from your
+configuration, you must add `input_button:` to your `configuration.yaml` first,
+then you can use the UI.
+
+Input buttons can also be configured via `configuration.yaml`:
+
+```yaml
+# Example configuration.yaml entry
+input_button:
+  ring_bell:
+    name: Ring bell
+    icon: mdi:bell
+```
+
+{% configuration %}
+input_button:
+  description: Alias for the input. Multiple entries are allowed.
+  required: true
+  type: map
+  keys:
+    name:
+      description: Friendly name of the input.
+      required: false
+      type: string
+    icon:
+      description: Icon to display in front of the input element in the frontend.
+      required: false
+      type: icon
+{% endconfiguration %}
+
+## Automation Examples
+
+The `input_button` entity is stateless, as in, it cannot have a state like the
+`on` or `off` state that, for example, a normal switch entity has.
+
+Every input button entity does keep track of the timestamp of when the last time
+the input button entity has been pressed in the Home Assistant UI or pressed via
+a service call.
+
+Because the state of a input button entity in Home Assistant is a timestamp, it
+means we can use it in our automations. For example:
+
+```yaml
+trigger:
+  - platform: state
+    entity_id: button.my_button
+action:
+  - service: notify.frenck
+    data:
+      message: "My button has been pressed!"
+```
+
+## Services
+
+The input button entities exposes a single service:
+{% my developer_call_service service="input_button.press" %}
+
+This service can be called to trigger a button press for that entity.
+
+```yaml
+- service: input_button.press
+  target:
+    entity_id: input_button.my_button
+```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds documentation for the input_button entity / button helper.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/62008
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3014
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
