### PR TITLE
Add iif (immediate if) template function/filter

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -304,6 +304,8 @@ For example, return a "Yes" or "No" when the light is on or off.
 
 This can be written as:
 
+{% raw %}
+
 ```text
 {% if is_state('light.kitchen', 'on') %}
   Yes
@@ -312,11 +314,18 @@ This can be written as:
 {% endif %}
 ```
 
+{% endraw %}
+
 Or using a shorter syntax:
+
+
+{% raw %}
 
 ```text
 {{ 'Yes' if is_state('light.kitchen', 'on') else 'No' }}
 ```
+
+{% endraw %}
 
 Additionally, to the above, you can use the `iif` function/filter, which is
 an immediate if.
@@ -329,6 +338,8 @@ example, an empty string, mapping or list, will be considered false.
 
 Examples using `iif`:
 
+{% raw %}
+
 ```text
 {{ iif(is_state('light.kitchen', 'on'), 'Yes', 'No') }}
 
@@ -336,6 +347,8 @@ Examples using `iif`:
 
 {{ (state('light.kitchen') == 'on') | iif('Yes', 'No') }}
 ```
+
+{% endraw %}
 
 If the `if_none` parameter is omitted, the `if_false` value is used when
 the value 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -350,8 +350,9 @@ Examples using `iif`:
 
 {% endraw %}
 
-If the `if_none` parameter is omitted, the `if_false` value is used when
-the value 
+If the `if_none` parameter is used to define the return value
+of when `value` is `None`. If `if_none` is omitted, the `if_false` value is
+used when the value is `None`.
 
 ### Time
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -318,7 +318,6 @@ This can be written as:
 
 Or using a shorter syntax:
 
-
 {% raw %}
 
 ```text
@@ -330,11 +329,14 @@ Or using a shorter syntax:
 Additionally, to the above, you can use the `iif` function/filter, which is
 an immediate if.
 
-Syntax: `iif(value, if_true, if_false, if_none)`
+Syntax: `iif(condition, if_true, if_false, if_none)`
 
-It expects a value and can return a value if the condition returns true,
-false or `None`. The value is loosely compared if it is truthy or not. For
-example, an empty string, mapping or list, will be considered false. 
+`iif` returns the value of `if_true` if the condition is truthy, the value of `if_false` if it's `falsy` and the value of `if_none` if it's `None`.
+An empty string, an empty mapping or an an empty list, are all falsy, refer to [the Python documentation](https://docs.python.org/3/library/stdtypes.html#truth-value-testing) for an in depth explanation.
+
+`if_true` is optional, if it's omitted `True` is returned if the condition is truthy.
+`if_false` is optional, if it's omitted `False` is returned if the condition is falsy.
+`if_none` is optional, if it's omitted the value of `if_false` is returned if the condition is `None`.
 
 Examples using `iif`:
 
@@ -350,9 +352,6 @@ Examples using `iif`:
 
 {% endraw %}
 
-If the `if_none` parameter is used to define the return value
-of when `value` is `None`. If `if_none` is omitted, the `if_false` value is
-used when the value is `None`.
 
 ### Time
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -297,6 +297,49 @@ The same thing can also be expressed as a filter:
 
 {% endraw %}
 
+### Immediate if (iif)
+
+A common case is to conditionally return a value based on another value.
+For example, return a "Yes" or "No" when the light is on or off.
+
+This can be written as:
+
+```text
+{% if is_state('light.kitchen', 'on') %}
+  Yes
+{% else %}
+  No
+{% endif %}
+```
+
+Or using a shorter syntax:
+
+```text
+{{ 'Yes' if is_state('light.kitchen', 'on') else 'No' }}
+```
+
+Additionally, to the above, you can use the `iif` function/filter, which is
+an immediate if.
+
+Syntax: `iif(value, if_true, if_false, if_none)`
+
+It expects a value and can return a value if the condition returns true,
+false or `None`. The value is loosely compared if it is truthy or not. For
+example, an empty string, mapping or list, will be considered false. 
+
+Examples using `iif`:
+
+```text
+{{ iif(is_state('light.kitchen', 'on'), 'Yes', 'No') }}
+
+{{ is_state('light.kitchen', 'on') | iif('Yes', 'No') }}
+
+{{ (state('light.kitchen') == 'on') | iif('Yes', 'No') }}
+```
+
+If the `if_none` parameter is omitted, the `if_false` value is used when
+the value 
+
 ### Time
 
 `now()` and `utcnow()` are not supported in [limited templates](#limited-templates).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds documentation for the immediate if template filter/method (`iif`).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/61428
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
