### PR TITLE
Update Control4 documentation to align with future PR

### DIFF
--- a/source/_integrations/control4.markdown
+++ b/source/_integrations/control4.markdown
@@ -20,15 +20,3 @@ The Control4 integration allows you to control and monitor lights from your loca
 Before setting up, you should assign a static IP address/DHCP reservation on your router to your Control4 controller. Home Assistant must be able to communicate with the controller over the local network; 4Sight remote access is not supported.
 
 {% include integrations/config_flow.md %}
-
-## Options
-
-The Control4 integration offers additional options in **Configuration** -> **Devices & Services** -> **Control4** -> **Options**:
-
-{% configuration %}
-Seconds between updates:
-  description: How often Home Assistant will poll the Control4 controller for state updates. Very frequent polling could cause the controller to lag, especially with many devices.
-  required: false
-  type: integer
-  default: 5
-{% endconfiguration %}

--- a/source/_integrations/control4.markdown
+++ b/source/_integrations/control4.markdown
@@ -3,7 +3,8 @@ title: Control4
 description: Instructions on adding a Control4 system to Home Assistant.
 ha_release: '0.114'
 ha_category: Light
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
+ha_quality_scale: silver
 ha_config_flow: true
 ha_codeowners:
   - '@lawtancool'


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Removes extra config options from documentation, as these options will be removed when https://github.com/home-assistant/core/pull/60465 is merged.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/60465
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
