### PR TITLE
Update breaking changes for Hue

### DIFF
--- a/source/_posts/2021-12-11-release-202112.markdown
+++ b/source/_posts/2021-12-11-release-202112.markdown
@@ -813,7 +813,10 @@ To enable any (new) light entities for Hue groups:
 Open settings --> integrations --> Hue --> Entities --> Click one of the
 disabled entities and enable it.
 
-Existing Hue group lights will be migrated as enabled entities.
+Existing Hue group lights for rooms/zones will be migrated as enabled entities.
+
+Legacy Hue groups of type `LightGroup` (which are not visible in the official Hue
+app) will no longer be supported!
 
 **Entities for Hue scenes**
 


### PR DESCRIPTION
## Proposed change

With the introduction of the v2 Hue API legacy light groups are no longer exposed by the Hue API and therefore can no longer be supported in HA.

This is a breaking change.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: home-assistant/core#62610

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
