### PR TITLE
Make it clear when a connect bridge is required for august

### DIFF
--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -27,13 +27,17 @@ The `august` integration allows you to integrate your [August](https://august.co
 
 ## Known Working Devices
 
-- August Wi-Fi Smart Lock (Gen 4)
-- August Smart Lock Pro (Gen 3)
-- August Smart Lock (Gen 2)
-- August Doorbell Cam (Gen 1, Gen2)
-- August View
-- Yale Assure Locks with August/Yale Connect Module
-- Yale Conexis L1 with August/Yale Connect Module
+| --------------------------------- | ------------------------------------|
+| Device                            | Requires Connect Bridge or Doorbell |
+| --------------------------------- | ------------------------------------|
+| August Wi-Fi Smart Lock (Gen 4) | yes |
+| August Smart Lock Pro (Gen 3) | yes |
+| August Smart Lock (Gen 2) | yes |
+| August Smart Lock (Gen 1) | no |
+| August Doorbell Cam (Gen 1, Gen2) | no |
+| August View | no |
+| Yale Assure Locks with August/Yale Connect Module | yes |
+| Yale Conexis L1 with August/Yale Connect Module | yes |
 
 There is currently support for the following device types within Home Assistant:
 
@@ -44,7 +48,7 @@ There is currently support for the following device types within Home Assistant:
 - Lock
 
 <div class='note'>
-August Lock 2nd Gen will need either August Connect or Doorbell to connect to Home Assistant.
+Most devices will need either August Connect or Doorbell to connect to Home Assistant.
 </div>
 
 ## Known Unsupported Devices

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -28,7 +28,7 @@ The `august` integration allows you to integrate your [August](https://august.co
 ## Known Working Devices
 
 | --------------------------------- | ------------------------------------|
-| Device                            | Requires Connect Bridge or Doorbell |
+| Device                            | Requires (Connect Bridge)[https://august.com/products/august-connect/] or Doorbell |
 | --------------------------------- | ------------------------------------|
 | August Wi-Fi Smart Lock (Gen 4) | yes |
 | August Smart Lock Pro (Gen 3) | yes |
@@ -48,7 +48,7 @@ There is currently support for the following device types within Home Assistant:
 - Lock
 
 <div class='note'>
-Most devices will need either August Connect or Doorbell to connect to Home Assistant.
+Most devices will need either August (Connect Bridge)[https://august.com/products/august-connect/] or Doorbell to connect to Home Assistant.
 </div>
 
 ## Known Unsupported Devices


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Make it clear when a connect bridge is required for august


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/62702

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
