### PR TITLE
Remove zwave_js device automation information

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -408,7 +408,7 @@ action:
       entity_id: switch.in_wall_dual_relay_switch_2, switch.in_wall_dual_relay_switch_3
 ```
 
-## Automation Trigger Platforms
+## Automations
 
 The `Z-Wave JS` integration provides its own trigger platforms which can be used in automations.
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -408,13 +408,9 @@ action:
       entity_id: switch.in_wall_dual_relay_switch_2, switch.in_wall_dual_relay_switch_3
 ```
 
-## Automations
+## Automation Trigger Platforms
 
-### Device automations
-
-Z-Wave JS has support for device triggers, conditions, and actions. To use a device automation, use the automation UI to select the "Device" trigger/condition/action type, and then pick your Z-Wave JS device. Under trigger/condition/action types, you will see Z-Wave JS specific entries.
-
-### `zwave_js.value_updated` trigger platform
+### `zwave_js.value_updated`
 
 This trigger platform can be used to trigger automations on any Z-Wave JS value update, including Z-Wave values that aren't supported in Home Assistant via entities. While they can't be authored from the automation UI, they can be authored in YAML directly in your `configuration.yaml`.
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -421,7 +421,7 @@ This trigger platform can be used to trigger automations on any Z-Wave JS value 
 #### Example automation trigger configuration
 
 ```yaml
-# Example automation trigger that fires whenever the `latchStatus` value changes from `closed` to `opened` on the three devices (devices will be derived from an entity ID).
+# Fires whenever the `latchStatus` value changes from `closed` to `opened` on the three devices (devices will be derived from an entity ID).
 trigger:
   platform: zwave_js.value_updated
   # At least one `device_id` or `entity_id` must be provided

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -410,6 +410,8 @@ action:
 
 ## Automation Trigger Platforms
 
+The `Z-Wave JS` integration provides its own trigger platforms which can be used in automations.
+
 ### `zwave_js.value_updated`
 
 This trigger platform can be used to trigger automations on any Z-Wave JS value update, including Z-Wave values that aren't supported in Home Assistant via entities. While they can't be authored from the automation UI, they can be authored in YAML directly in your `configuration.yaml`.

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -412,11 +412,11 @@ action:
 
 ### Device automations
 
-Z-Wave JS has support for device triggers and conditions. To use a device automation, use the automation UI to select the "Device" trigger/condition type, and then pick your Z-Wave JS device. Under trigger/condition types, you will see Z-Wave JS specific entries.
+Z-Wave JS has support for device triggers, conditions, and actions. To use a device automation, use the automation UI to select the "Device" trigger/condition/action type, and then pick your Z-Wave JS device. Under trigger/condition/action types, you will see Z-Wave JS specific entries.
 
-### `zwave_js.value_updated` trigger
+### `zwave_js.value_updated` trigger platform
 
-Z-Wave JS provides the `zwave_js.value_updated` trigger platform which can be used to trigger automations on any Z-Wave JS value update, including Z-Wave values that aren't supported in Home Assistant via entities. While they can't be authored from the automation UI, they can be authored in YAML directly in your `configuration.yaml`.
+This trigger platform can be used to trigger automations on any Z-Wave JS value update, including Z-Wave values that aren't supported in Home Assistant via entities. While they can't be authored from the automation UI, they can be authored in YAML directly in your `configuration.yaml`.
 
 ```yaml
 # Example automation trigger that fires whenever the `latchStatus` value changes from `closed` to `opened` on the three devices (devices will be derived from an entity ID).

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -418,6 +418,8 @@ Z-Wave JS has support for device triggers, conditions, and actions. To use a dev
 
 This trigger platform can be used to trigger automations on any Z-Wave JS value update, including Z-Wave values that aren't supported in Home Assistant via entities. While they can't be authored from the automation UI, they can be authored in YAML directly in your `configuration.yaml`.
 
+#### Example automation trigger configuration
+
 ```yaml
 # Example automation trigger that fires whenever the `latchStatus` value changes from `closed` to `opened` on the three devices (devices will be derived from an entity ID).
 trigger:


### PR DESCRIPTION
## Proposed change

- Removed the generic section on device automations which, per the review comments, is unnecessary
- Renamed the Automation section to Automation Trigger Platforms - right now we have one but I just submitted a PR for a second one:  62828


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
