### PR TITLE
Update generic with no still_image_url option

### DIFF
--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -28,23 +28,23 @@ camera:
 
 {% configuration %}
 still_image_url:
-  description: "The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/topics/templating/)."
-  required: true
+  description: "The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/topics/templating/). At least one of still_image_url or stream_source must be provided."
+  required: true*
   type: string
 stream_source:
-  description: "The URL your camera serves the live stream on, e.g., `rtsp://192.168.1.21:554/`. Can be a [template](/topics/templating/)."
-  required: false
+  description: "The URL your camera serves the live stream on, e.g., `rtsp://user:pass@192.168.1.21:554/`. Can be a [template](/topics/templating/). Usernames and passwords must be embedded in the url. At least one of still_image_url or stream_source must be provided."
+  required: true*
   type: string
 name:
   description: This parameter allows you to override the name of your camera.
   required: false
   type: string
 username:
-  description: The username for accessing your camera.
+  description: The username for accessing your camera. Note that this username applies only to still_image_url and not to stream_source.
   required: false
   type: string
 password:
-  description: The password for accessing your camera.
+  description: The password for accessing your camera. Note that this password applies only to still_image_url and not to stream_source.
   required: false
   type: string
 authentication:
@@ -120,6 +120,7 @@ camera:
     name: Host instance camera feed
     still_image_url: https://127.0.0.5:8123/api/camera_proxy/camera.live_view
 ```
+
 ### Image from HTTP only camera
 
 To access a camera which is only available via HTTP, you must turn off SSL verification.
@@ -141,7 +142,18 @@ camera:
   - platform: generic
     name: Streaming Enabled
     still_image_url: http://194.218.96.92/jpg/image.jpg
-    stream_source: rtsp://194.218.96.92:554
+    username: user
+    password: pass
+    stream_source: rtsp://user:pass@194.218.96.92:554
+```
+
+If a camera only has a live stream URL and no snapshot url, the [stream](/integrations/stream/) component can also generate still images from the live stream URL.
+
+```yaml
+camera:
+  - platform: generic
+    name: Streaming
+    stream_source: rtsp://user:pass@194.218.96.92:554
 ```
 
 ### Secured access to the camera

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -32,7 +32,7 @@ still_image_url:
   required: false
   type: string
 stream_source:
-  description: "The URL your camera serves the live stream on, e.g., `rtsp://user:pass@192.168.1.21:554/`. Can be a [template](/topics/templating/). Usernames and passwords must be embedded in the url. At least one of still_image_url or stream_source must be provided."
+  description: "The URL your camera serves the live stream on, e.g., `rtsp://user:pass@192.168.1.21:554/`. Can be a [template](/topics/templating/). Usernames and passwords must be embedded in the URL. At least one of still_image_url or stream_source must be provided."
   required: false
   type: string
 name:
@@ -147,7 +147,7 @@ camera:
     stream_source: rtsp://user:pass@194.218.96.92:554
 ```
 
-If a camera only has a live stream URL and no snapshot url, the [stream](/integrations/stream/) component can also generate still images from the live stream URL.
+If a camera only has a live stream URL and no snapshot URL, the [stream](/integrations/stream/) component can also generate still images from the live stream URL.
 
 ```yaml
 camera:

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -29,11 +29,11 @@ camera:
 {% configuration %}
 still_image_url:
   description: "The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/topics/templating/). At least one of still_image_url or stream_source must be provided."
-  required: true*
+  required: false
   type: string
 stream_source:
   description: "The URL your camera serves the live stream on, e.g., `rtsp://user:pass@192.168.1.21:554/`. Can be a [template](/topics/templating/). Usernames and passwords must be embedded in the url. At least one of still_image_url or stream_source must be provided."
-  required: true*
+  required: false
   type: string
 name:
   description: This parameter allows you to override the name of your camera.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
https://github.com/home-assistant/core/pull/62611 Adds the ability for generic to grab still frames from Stream instead of from a still_image_url. This PR includes documentation for such a setup.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
