### PR TITLE
corrections in reconnecting automation

### DIFF
--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -485,7 +485,8 @@ template:
   - binary_sensor:
       - name: "Homematic is sending updates"
         state: >-
-          {{ as_timestamp(now()) - as_timestamp(state_attr('sensor.office_voltage', 'last_changed'), 601) < 600 }}
+          {{ (now() - states.sensor['office_voltage'].last_changed).seconds < 600 }}
+
 
 automation:
   - alias: "Homematic Reconnect"

--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -485,7 +485,7 @@ template:
   - binary_sensor:
       - name: "Homematic is sending updates"
         state: >-
-          {{ (now() - states.sensor['office_voltage'].last_changed).seconds < 600 }}
+          {{ (now() - states.sensor.office_voltage.last_changed).seconds < 600 }}
 
 automation:
   - alias: "Homematic Reconnect"

--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -485,16 +485,16 @@ template:
   - binary_sensor:
       - name: "Homematic is sending updates"
         state: >-
-          {{ now() - as_timestamp(state_attr('sensor.office_voltage', 'last_changed'), 601) < 600 }}
+          {{ as_timestamp(now()) - as_timestamp(state_attr('sensor.office_voltage', 'last_changed'), 601) < 600 }}
 
 automation:
   - alias: "Homematic Reconnect"
     trigger:
       platform: state
-      entity_id: binary_sensor.homematic_up
+      entity_id: binary_sensor.homematic_is_sending_updates
       to: "off"
     action:
-      # Reconnect, if sensor has not been updated for over 3 hours
+      # Reconnect, if sensor has not been updated for over 10 minutes
       service: homematic.reconnect
 ```
 

--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -487,7 +487,6 @@ template:
         state: >-
           {{ (now() - states.sensor['office_voltage'].last_changed).seconds < 600 }}
 
-
 automation:
   - alias: "Homematic Reconnect"
     trigger:


### PR DESCRIPTION
## Proposed change
Fixed issues in the example reconnecting automation and the corresponding template

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
