### PR TITLE
Add documentation for VeSync humidifiers

### DIFF
--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -121,43 +121,44 @@ VeSync air purifiers will expose the following details depending on the features
 | `night_light`           | The current status of the night light (Core200S/Core400s)                         | off             |
 | `child_lock`            | The current status of the child lock (Core200S/300s/400s)                         | off             |
 
-## Humidity Sensors
+## Humidifier Sensors
 
-VeSync humidifiers include humidity sensors. The measured humidity is exposed as a diagnostic sensor entity alongside the
-humidifier itself.
+Some information about VeSync humidifiers is exposed as diagnostic sensor entities:
 
-| Sensor                                      | Description                                     | Example |
-| ------------------------------------------- | ----------------------------------------------- | ------- |
-| `sensor.<humidifier name>_current_humidity` | The percent humidity measured by the humidifier | 43      |
+* Current humidity: the current percent humidity as measured by the humidifier (e.g. 43)
 
 ## Humidifier Settings
 
-VeSync humidifiers have settings other than just a target humidity, like a manual mist level and an on/off display toggle.
-These are exposed as configuration entities alongside the humidifier itself.
+VeSync humidifiers have settings other than just a target humidity. These are exposed as configuration entities
+alongside the humidifier itself.
 
-| Entity ID                                 | Description                                    |
-| ----------------------------------------- | ---------------------------------------------- |
-| `number.<humidifier name>_mist_level`     | The target mist level of the humidifier        |
-| `light.<humidifier name>_night_light`     | The brightness of the humidifier's night light |
-| `switch.<humidifier name>_display`        | The humidifier's display                       |
-| `switch.<humidifier name>_automatic_stop` | The humidifier's automatic stop feature        |
+### Number entities
+
+- Mist level: the target mist level of the humidifier
+
+### Light entities
+
+- Night light: the humidifier's night light
+
+### Switch entities
+
+- Display: the humidifier's display toggle
+- Automatic stop: the humidifier's automatic stop feature
 
 ## Humidifier Exposed Attributes
 
-VeSync humidifiers will expose the following details:
+VeSync humidifiers will expose the following details as attributes:
 
-| Attribute                     | Description                                             | Example             |
-| ----------------------------- | ------------------------------------------------------- | ------------------- |
-| `humidity`                    | The target humidity of the humidifier                   | 40                  |
-| `max_humidity`                | The minimum allowed target humidity of the humidifier   | 30                  |
-| `min_humidity`                | The maximum allowed target humidity of the humidifier   | 80                  |
-| `mode`                        | The current mode the humidifier is in                   | manual              |
-| `available_modes`             | The available list of modes supported by the humidifier | auto, manual, sleep |
-| `water_lacks`                 | Whether the humidifier lacks water                      | false               |
-| `humidity_high`               | Wether the humidifier detects high humidity             | true                |
-| `water_tank_lifted`           | Wether the water tank is lifted                         | true                |
-| `automatic_stop_reach_target` | Wether the automatic stop target has been reached       | false               |
-| `mist_level`                  | The level of mist being emitted by the humidifier       | 5                   |
+- `humidity`: the target humidity of the humidifier (e.g. 40)
+- `max_humidity`: the minimum allowed target humidity of the humidifier (e.g. 30)
+- `min_humidity`: the maximum allowed target humidity of the humidifier (e.g. 80)
+- `mode`: the current mode the humidifier is in (e.g. manual)
+- `available_modes`: the available list of modes supported by the humidifier (e.g. auto, manual, sleep)
+- `water_lacks`: whether the humidifier lacks water (e.g. false)
+- `humidity_high`: whether the humidifier detects high humidity (e.g. true)
+- `water_tank_lifted`: whether the water tank is lifted (e.g. true)
+- `automatic_stop_reach_target`: whether the automatic stop target has been reached (e.g. false)
+- `mist_level`: the level of mist being emitted by the humidifier (e.g. 5)
 
 ## Extracting Attribute data
 

--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -69,6 +69,9 @@ This integration supports devices controllable by the VeSync App.  The following
 ### Humidifiers
 
 - LEVOIT Classic 300S Ultrasonic Smart Humidifier
+- LEVOIT Classic 200S Smart Ultrasonic Cool Mist Humidifier
+- LEVOIT Dual 200S Smart Top-Fill Humidifier
+- LEVOIT LV600S Smart Hybrid Ultrasonic Humidifier
 
 ## Prerequisite
 
@@ -138,7 +141,7 @@ alongside the humidifier itself.
 
 ### Light entities
 
-- Night light: the humidifier's night light
+- Night light: the humidifier's night light (Classic300S, LV600S)
 
 ### Switch entities
 

--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -1,10 +1,12 @@
 ---
 title: VeSync
-description: Instructions on how to set up VeSync switches, outlets, and fans within Home Assistant.
+description: Instructions on how to set up VeSync switches, outlets, fans, and humidifiers within Home Assistant.
 ha_category:
   - Light
   - Switch
   - Fan
+  - Humidifier
+  - Number
 ha_release: 0.66
 ha_iot_class: Cloud Polling
 ha_config_flow: true
@@ -18,9 +20,11 @@ ha_platforms:
   - light
   - switch
   - sensor
+  - humidifier
+  - number
 ---
 
-The `vesync` integration enables you to control smart switches and outlets connected to the VeSync App.
+The `vesync` integration enables you to control smart switches, outlets, fans, and humidifiers connected to the VeSync App.
 
 The devices must be added to the VeSync App before this integration can discover them.
 
@@ -30,6 +34,8 @@ The following platforms are supported:
 - **switch**
 - **fan**
 - **sensor**
+- **humidifier**
+- **number**
 
 ## Supported Devices
 
@@ -59,6 +65,10 @@ This integration supports devices controllable by the VeSync App.  The following
 - Core 300S: Smart True HEPA Air Purifier
 - Core 400S: Smart True HEPA Air Purifier
 - LEVOIT Smart Wifi Air Purifier (LV-PUR131S)
+
+### Humidifiers
+
+- LEVOIT Classic 300S Ultrasonic Smart Humidifier
 
 ## Prerequisite
 
@@ -110,6 +120,44 @@ VeSync air purifiers will expose the following details depending on the features
 | `screen_status`         | The current status of the screen. (LV-PUR131S)                                    | on              |
 | `night_light`           | The current status of the night light (Core200S/Core400s)                         | off             |
 | `child_lock`            | The current status of the child lock (Core200S/300s/400s)                         | off             |
+
+## Humidity Sensors
+
+VeSync humidifiers include humidity sensors. The measured humidity is exposed as a diagnostic sensor entity alongside the
+humidifier itself.
+
+| Sensor                                      | Description                                     | Example |
+| ------------------------------------------- | ----------------------------------------------- | ------- |
+| `sensor.<humidifier name>_current_humidity` | The percent humidity measured by the humidifier | 43      |
+
+## Humidifier Settings
+
+VeSync humidifiers have settings other than just a target humidity, like a manual mist level and an on/off display toggle.
+These are exposed as configuration entities alongside the humidifier itself.
+
+| Entity ID                                 | Description                                    |
+| ----------------------------------------- | ---------------------------------------------- |
+| `number.<humidifier name>_mist_level`     | The target mist level of the humidifier        |
+| `light.<humidifier name>_night_light`     | The brightness of the humidifier's night light |
+| `switch.<humidifier name>_display`        | The humidifier's display                       |
+| `switch.<humidifier name>_automatic_stop` | The humidifier's automatic stop feature        |
+
+## Humidifier Exposed Attributes
+
+VeSync humidifiers will expose the following details:
+
+| Attribute                     | Description                                             | Example             |
+| ----------------------------- | ------------------------------------------------------- | ------------------- |
+| `humidity`                    | The target humidity of the humidifier                   | 40                  |
+| `max_humidity`                | The minimum allowed target humidity of the humidifier   | 30                  |
+| `min_humidity`                | The maximum allowed target humidity of the humidifier   | 80                  |
+| `mode`                        | The current mode the humidifier is in                   | manual              |
+| `available_modes`             | The available list of modes supported by the humidifier | auto, manual, sleep |
+| `water_lacks`                 | Whether the humidifier lacks water                      | false               |
+| `humidity_high`               | Wether the humidifier detects high humidity             | true                |
+| `water_tank_lifted`           | Wether the water tank is lifted                         | true                |
+| `automatic_stop_reach_target` | Wether the automatic stop target has been reached       | false               |
+| `mist_level`                  | The level of mist being emitted by the humidifier       | 5                   |
 
 ## Extracting Attribute data
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds documentation for VeSync humidifiers



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/62907
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
