### PR TITLE
Add set_guest_wifi_password description

### DIFF
--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -59,6 +59,18 @@ A device is identified as stale when it's still present on Home Assistant but no
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | no       | Only act on a specific  router                                                                                 |
 
+#### Service `fritz.set_guest_wifi_password`
+
+Set a new password for the guest wifi.
+The password must be between 8 and 63 characters long.
+If no additional parameter is set, the password will be auto-generated with a length of 32 characters.
+
+| Service data attribute | Optional | Description                                                                                                    |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `device_id`            | no       | Only act on a specific  router                                                                                 |
+| `password`             | yes      | New password for the guest wifi                                                                                |
+| `length`               | yes      | Length of the new password. The password will be auto-generated, if no password is set.                        |
+
 ## Integration Options
 
 It is possible to change some behaviors through the integration options.

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -63,7 +63,7 @@ A device is identified as stale when it's still present on Home Assistant but no
 
 Set a new password for the guest wifi.
 The password must be between 8 and 63 characters long.
-If no additional parameter is set, the password will be auto-generated with a length of 12 characters.
+If no password is given, it will be auto-generated.
 
 | Service data attribute | Optional | Description                                                                                                    |
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -63,7 +63,7 @@ A device is identified as stale when it's still present on Home Assistant but no
 
 Set a new password for the guest wifi.
 The password must be between 8 and 63 characters long.
-If no additional parameter is set, the password will be auto-generated with a length of 32 characters.
+If no additional parameter is set, the password will be auto-generated with a length of 12 characters.
 
 | Service data attribute | Optional | Description                                                                                                    |
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -69,7 +69,7 @@ If no additional parameter is set, the password will be auto-generated with a le
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
 | `device_id`            | no       | Only act on a specific  router                                                                                 |
 | `password`             | yes      | New password for the guest wifi                                                                                |
-| `length`               | yes      | Length of the new password. The password will be auto-generated, if no password is set.                        |
+| `length`               | yes      | Length of the auto-generated password. (_default 12_)                        |
 
 ## Integration Options
 


### PR DESCRIPTION
Update docs for PR https://github.com/home-assistant/core/pull/62892

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- Add documentation for new service `set_guest_wifi_password` (https://github.com/home-assistant/core/pull/62892)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/62892
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
