### PR TITLE
Adding a full automation service call example

### DIFF
--- a/source/_integrations/nfandroidtv.markdown
+++ b/source/_integrations/nfandroidtv.markdown
@@ -131,7 +131,7 @@ Example of an automation with an service call, full configuration:
   - service: notify.living_room_tv
     data:
       title: "Thanks for the water!"
-      message: "Nigel is {{ states.sensor.nigel_moisture.state }}% moisture"
+      message: Nigel is {{ states('sensor.nigel_moisture') }}% moisture
       data:
         duration: 4
         position: "bottom-left"

--- a/source/_integrations/nfandroidtv.markdown
+++ b/source/_integrations/nfandroidtv.markdown
@@ -125,7 +125,7 @@ icon:
   auth: "digest"
 ```
 
-Example of automation serivce call, full cofiguration:
+Example of an automation with an service call, full configuration:
 
 ```yaml
   - service: notify.living_room_tv

--- a/source/_integrations/nfandroidtv.markdown
+++ b/source/_integrations/nfandroidtv.markdown
@@ -125,4 +125,20 @@ icon:
   auth: "digest"
 ```
 
+Example of automation serivce call, full cofiguration:
+
+```yaml
+  - service: notify.living_room_tv
+    data:
+      title: "Thanks for the water!"
+      message: "Nigel is {{ states.sensor.nigel_moisture.state }}% moisture"
+      data:
+        duration: 4
+        position: "bottom-left"
+        fontsize: "medium"
+        transparency: "80%"
+        color: "teal"
+        interrupt: 0
+ ```yaml
+
 Please note that `path` is validated against the `allowlist_external_dirs` in the `configuration.yaml`.

--- a/source/_integrations/nfandroidtv.markdown
+++ b/source/_integrations/nfandroidtv.markdown
@@ -127,18 +127,22 @@ icon:
 
 Example of an automation with an service call, full configuration:
 
+{% raw %}
+
 ```yaml
-  - service: notify.living_room_tv
-    data:
-      title: "Thanks for the water!"
-      message: Nigel is {{ states('sensor.nigel_moisture') }}% moisture
-      data:
-        duration: 4
-        position: "bottom-left"
-        fontsize: "medium"
-        transparency: "80%"
-        color: "teal"
-        interrupt: 0
- ```yaml
+service: notify.living_room_tv
+data:
+  title: "Thanks for the water!"
+  message: "Nigel is {{ states('sensor.nigel_moisture') }}% moisture"
+  data:
+    duration: 4
+    position: "bottom-left"
+    fontsize: "medium"
+    transparency: "80%"
+    color: "teal"
+    interrupt: 0
+```
+
+{% endraw %}
 
 Please note that `path` is validated against the `allowlist_external_dirs` in the `configuration.yaml`.


### PR DESCRIPTION
I did not realize I could add additional configurations by adding a second 'data' section.  May just be my ignorane but thought we could add a full example to help anyone else.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Simple change to demonstrate the addtion of the second 'data' section to leverage additional android features.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->


- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
