### PR TITLE
Use correct default name of Ping binary sensor

### DIFF
--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -46,7 +46,7 @@ name:
   description: Let you overwrite the name of the device.
   required: false
   type: string
-  default: Binary sensor Ping [hostname]
+  default: Ping [hostname]
 {% endconfiguration %}
 
 The sensor exposes the different round trip times values measured by `ping` as attributes:


### PR DESCRIPTION
## Proposed change

As can be seen in [the source code for the Ping binary sensor](https://github.com/home-assistant/core/blob/dev/homeassistant/components/ping/binary_sensor.py#L70), the default name is, in-fact, not "Binary sensor Ping [hostname]" but simply "Ping [hostname]".

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to documentation page: https://www.home-assistant.io/integrations/ping/

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
