### PR TITLE
Mqtt light cmd template

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -130,6 +130,7 @@ Supported abbreviations:
     'flsh_tlng':           'flash_time_long',
     'flsh_tsht':           'flash_time_short',
     'fx_cmd_t':            'effect_command_topic',
+    'fx_cmd_tpl':          'effect_command_template',
     'fx_list':             'effect_list',
     'fx_stat_t':           'effect_state_topic',
     'fx_tpl':              'effect_template',

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -92,6 +92,7 @@ Supported abbreviations:
     'away_mode_stat_t':    'away_mode_state_topic',
     'b_tpl':               'blue_template',
     'bri_cmd_t':           'brightness_command_topic',
+    'bri_cmd_tpl':         'brightness_command_template',
     'bri_scl':             'brightness_scale',
     'bri_stat_t':          'brightness_state_topic',
     'bri_tpl':             'brightness_template',

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -190,6 +190,10 @@ effect_command_topic:
   description: "The MQTT topic to publish commands to change the light's effect state."
   required: false
   type: string
+effect_command_template:
+  description: "Defines a [template](/docs/configuration/templating/) to compose message which will be sent to `effect_command_topic`. Available variables: `value`."
+  required: false
+  type: string
 effect_list:
   description: The list of effects the light supports.
   required: false

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -90,6 +90,10 @@ brightness_command_topic:
   description: The MQTT topic to publish commands to change the light’s brightness.
   required: false
   type: string
+brightness_command_template:
+  description: "Defines a [template](/docs/configuration/templating/) to compose message which will be sent to `brightness_command_topic`. Available variables: `value`."
+  required: false
+  type: string
 brightness_scale:
   description: "Defines the maximum brightness value (i.e., 100%) of the MQTT device."
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added `brightness` and `effect` command template for MQTT light component. This is the same as the existing `color_temp_command_template`


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [PR#63361](https://github.com/home-assistant/core/pull/63361)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
