### PR TITLE
Update bmw_connected_drive documentation for buttons

### DIFF
--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to setup your BMW Connected Drive account with 
 ha_category:
   - Car
   - Binary Sensor
+  - Button
   - Presence Detection
   - Lock
   - Sensor
@@ -17,6 +18,7 @@ ha_codeowners:
 ha_domain: bmw_connected_drive
 ha_platforms:
   - binary_sensor
+  - button
   - device_tracker
   - lock
   - notify
@@ -37,10 +39,10 @@ This integration provides the following platforms:
 
 - Binary Sensors: Doors, windows, condition based services, check control messages, parking lights, door lock state, charging status (electric cars) and connections status (electric cars).
 - Device tracker: The location of your car.
-- Lock: Control the lock of your car.
+- [Lock](/integrations/bmw_connected_drive/#lock): Control the lock of your car.
 - Sensors: Mileage, remaining range, remaining fuel, charging time remaining (electric cars), charging status (electric cars), remaining range electric (electric cars).
-- Notifications: Send Points of Interest (POI) to your car.
-- Services: Turn on air condition, sound the horn, flash the lights, update the vehicle location and update the state. More details can be found [here](/integrations/bmw_connected_drive/#services).
+- [Notifications](/integrations/bmw_connected_drive/#notifications): Send Points of Interest (POI) to your car.
+- [Buttons](/integrations/bmw_connected_drive/#buttons): Turn on air condition, sound the horn, flash the lights, update the vehicle location and update the state.
 
 ## Configuration
 
@@ -98,11 +100,7 @@ bmw_connected_drive:
 The `bmw_connected_drive` integration offers a notification service. Using this service you can send Points of Interest (POI) to your vehicle. In your vehicle you can select this POI and the navigation will automatically start using the POI as a destination.
 The name of the service is `notify.bmw_connected_drive_<your_vehicle>`.
 
-### Examples
-
-A few examples on how to use the notification service.
-
-#### Send a Point of Interest to your vehicle
+### Send a Point of Interest to your vehicle
 
 ```yaml
 ...
@@ -120,39 +118,37 @@ action:
         country: Country  # Optional
 ```
 
-## Services
+## Lock
 
-The `bmw_connected_drive` integration offers several services. In case you need to provide the vehicle identification number (VIN) as a parameter, you can see the VIN as attribute of all entities, e.g. (binary) sensors or the device tracker. The VIN is a 17 digit alphanumeric string, e.g., `WBANXXXXXX1234567`.
+The vehicle can be locked and unlocked via the lock integration that is created automatically for each vehicle. Before invoking, make sure it's safe to lock/unlock the vehicle in the current situation.
 
-Using these services will impact the state of your vehicle. So use these services with care!
+## Buttons
 
-### Locking and unlocking
+The `bmw_connected_drive` integration offers several buttons to trigger actions in your car. The buttons are automatically created and can be pressed/executed from the UI or using the `button.press` service. Please see the [button documentation](/integrations/button/) for more information.
 
-The vehicle can be locked and unlocked via the lock integration that is created automatically for each vehicle. Before invoking these services, make sure it's safe to lock/unlock the vehicle in the current situation.
+Using these buttons will impact the state of your vehicle. So use these services with care!
 
 ### Air condition
 
-The air condition of the vehicle can be activated with the service `bmw_connected_drive.activate_air_conditioning`.
+The air condition of the vehicle can be activated with the `button.<your_vehicle>_activate_air_conditioning` button.
 
 What exactly is started here depends on the type of vehicle. It might range from just ventilation over auxiliary heating to real air conditioning. If your vehicle is equipped with auxiliary heating, only trigger this service if the vehicle is parked in a location where it is safe to use it (e.g., not in an underground parking or closed garage).
 
-Some newer cars also support stopping an active air conditioning with the service `bmw_connected_drive.deactivate_air_conditioning`.
+Some newer cars also support stopping an active air conditioning with the `button.<your_vehicle>_deactivate_air_conditioning` button.
 
 This will only work if you have the option to stop the AC in the *MyBMW* app. If your car doesn't support this service, nothing will happen.
 
-The vehicle is identified via the parameter `vin`.
-
 ### Sound the horn
 
-The service `bmw_connected_drive.sound_horn` sounds the horn of the vehicle. This option is not available in some countries (among which  the UK). Use this feature responsibly, as it might annoy your neighbors. The vehicle is identified via the parameter `vin`.
+The `button.<your_vehicle>_sound_horn` button sounds the horn of the vehicle. This option is not available in some countries (among which  the UK). Use this feature responsibly, as it might annoy your neighbors.
 
 ### Flash the lights
 
-The service `bmw_connected_drive.light_flash` flashes the lights of the vehicle. The vehicle is identified via the parameter `vin`.
+The `button.<your_vehicle>_light_flash` button flashes the lights of the vehicle.
 
 ### Vehicle finder
 
-The service `bmw_connected_drive.find_vehicle` requests the vehicle to update the GPS location. This can be used for older vehicles which don't automatically send the updated GPS location. The vehicle is identified via the parameter `vin`.
+The `button.<your_vehicle>_find_vehicle` button requests the vehicle to update the GPS location. This can be used for older vehicles which don't automatically send the updated GPS location.
 
 <div class="note warning">
 
@@ -167,11 +163,9 @@ The service `bmw_connected_drive.find_vehicle` requests the vehicle to update th
 
 </div>
 
-### Update the state
+### Update the state / refresh from API
 
-The service `bmw_connected_drive.update_state` fetches the last state of the vehicles of all your accounts from the BMW server. This does *not* trigger an update from the vehicle; it gets the data from the BMW servers. So this service does *not* interact with your vehicles.
-
-This service does not require any attributes.
+The `button.<vehicle_model>_refresh_from_api` button fetches the last state of the vehicles of all your accounts from the BMW server. This does *not* trigger an update from the vehicle; it gets the data from the BMW servers. So this service does *not* interact with your vehicles.
 
 ## Disclaimer
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update BMW Connected Drive documentation for the new buttons.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/63136
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
