### PR TITLE
Update link to Zwavejs2Mqtt quick-start

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -548,7 +548,7 @@ The Z-Wave network can be configured via the built-in Z-Wave JS control panel in
 
 **Option 3: The Zwavejs2Mqtt Docker container**
 
-This is the recommended approach if you're running Home Assistant Container. See the [Zwavejs2Mqtt documentation](https://zwave-js.github.io/Zwavejs2Mqtt/#/getting-started/quick-start) for instructions.
+This is the recommended approach if you're running Home Assistant Container. See the [Zwavejs2Mqtt documentation](https://zwave-js.github.io/zwavejs2mqtt/#/getting-started/quick-start) for instructions.
 
 This method provides the same server application and UI as the Zwavejs2Mqtt add-on. After installing the Docker image, make sure you enable the WS Server in the Home Assistant section of Settings page.
 


### PR DESCRIPTION
The orginal had captial Z and M where there shouldn't be.

## Proposed change
Update URL to Zwave2Mqtt quick-guide



## Type of change
Spelling mistake.

## Additional information
There should be no capital letters in the url.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
