### PR TITLE
Allow area, device, and entity selectors to optionally support multiple selections like target selector

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -63,8 +63,7 @@ addon:
 
 ## Area selector
 
-The area selector shows an area finder that can pick a single area. The value
-of the input will be the area ID of the user-selected area.
+The area selector shows an area finder that can pick a single or multiple areas based on the selector configuration. The value of the input will be the area ID, or a list of area IDs, based on if 'multiple' is set to true.
 
 An area selector can filter the list of areas, based on properties of the devices
 and entities that are assigned to those areas. For example, the areas list could
@@ -131,6 +130,12 @@ entity:
         device class, for example, `motion` or `window`.
       type: device_class
       required: false
+multiple:
+  description: >
+    Allows selecting multiple areas.
+  type: boolean
+  default: false
+  required: false
 {% endconfiguration %}
 
 ### Example area selectors
@@ -152,6 +157,7 @@ integration.
 ```yaml
 area:
   device:
+    multiple: True
     integration: deconz
     manufacturer: IKEA of Sweden
     model: TRADFRI remote control
@@ -176,8 +182,7 @@ boolean:
 
 ## Device selector
 
-The device selector shows a device finder that can pick a single device.
-The value of the input will contain the device ID of the user-selected device.
+The device selector shows a device finder that can pick a single or multiple devices based on the selector configuration. The value of the input will contain the device ID or a list of device IDs, based on if 'multiple' is set to true.
 
 A device selector can filter the list of devices, based on things like the
 manufacturer or model of the device, the entities the device provides or based
@@ -237,6 +242,12 @@ entity:
         class, for example, `motion` or `window`.
       type: device_class
       required: false
+multiple:
+  description: >
+    Allows selecting multiple devices.
+  type: boolean
+  default: false
+  required: false
 {% endconfiguration %}
 
 ### Example device selector
@@ -261,8 +272,8 @@ device:
 
 ## Entity selector
 
-The entity selector shows an entity finder that can pick a single entity.
-The value of the input will contain the entity ID of user-selected entity.
+The entity selector shows an entity finder that can pick a single entity or a list of entities based on the selector configuration.
+The value of the input will contain the entity ID, or list of entity IDs, based on if 'multiple' is set to true.
 
 An entity selector can filter the list of entities, based on things like the
 class of the device, the domain of the entity or the domain that provided the
@@ -298,6 +309,12 @@ device_class:
     for example, `motion` or `window`.
   type: device_class
   required: false
+multiple:
+  description: >
+    Allows selecting multiple entities.
+  type: boolean
+  default: false
+  required: false
 {% endconfiguration %}
 
 ### Example entity selector
@@ -312,6 +329,7 @@ And this is what it looks like in YAML:
 
 ```yaml
 entity:
+  multiple: True
   integration: zha
   domain: binary_sensor
   device_class: motion


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Changes to the Area, Device, and Entity selectors to allow them to select multiple entities.
The user interface is similar to the Area, Device and Entity selector component of the target selector.
Single or multi select is configured with the optional multiple option on the selector configuration.
The selectors can now potentially return a list of area, device, or entity IDs.

This is motivated by the need to have multiple entity selector so a blueprint can trigger on multiple entities.
But brings a consistent UI for the Area, Device, Entity, and Target selector.
## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  [#62138](https://github.com/home-assistant/core/pull/63138) [#11059](https://github.com/home-assistant/frontend/pull/11059)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
