### PR TITLE
Adds prerequisite information

### DIFF
--- a/source/_integrations/mqtt_statestream.markdown
+++ b/source/_integrations/mqtt_statestream.markdown
@@ -8,7 +8,7 @@ ha_iot_class: Local Push
 ha_domain: mqtt_statestream
 ---
 
-The `mqtt_statestream` integration publishes state changes in Home Assistant to individual MQTT topics.
+The `mqtt_statestream` integration publishes state changes in Home Assistant to individual MQTT topics. [The MQTT integration](integrations/mqtt/) is a prerequisite for MQTT Statestream to work.
 
 ## Configuration
 

--- a/source/_integrations/mqtt_statestream.markdown
+++ b/source/_integrations/mqtt_statestream.markdown
@@ -8,7 +8,7 @@ ha_iot_class: Local Push
 ha_domain: mqtt_statestream
 ---
 
-The `mqtt_statestream` integration publishes state changes in Home Assistant to individual MQTT topics. [The MQTT integration](integrations/mqtt/) is a prerequisite for MQTT Statestream to work.
+The `mqtt_statestream` integration publishes state changes in Home Assistant to individual MQTT topics. [The MQTT integration](/integrations/mqtt/) is a prerequisite for MQTT Statestream to work.
 
 ## Configuration
 


### PR DESCRIPTION
## Proposed change
Adds information that the MQTT integration is a prerequisite for the MQTT statestream to work.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].
