### PR TITLE
Add Picnic last_order_max_order_time sensor docs

### DIFF
--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -34,5 +34,6 @@ This integration provides the following sensors. Some sensors are disabled by de
 | Last order status              | Status of the last order, either `CURRENT`, `CANCELLED` or `COMPLETED`. Will only transition to `COMPLETED` after the invoice email has been sent.  |
 | Last order ETA start           | Start of the ETA window of the last order, will get more precise if the driver is underway.                                                         |
 | Last order ETA end             | End of the ETA window of the last order.                                                                                                            |
+| Last order max order time      | Maximum time it is/was still possible to add products to the last order.
 | Last order delivery time       | The delivery time of the last order, `unavailable` if not yet delivered.                                                                            |
 | Last order total price         | The total price of the last order.                                                                                                                  |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Whilst the Picnic integration already provided a sensor for the cut-off time to add groceries in an open order (in shopping cart), there was no sensor indicating how much time was left to add groceries to an existing order. This PR adds this sensor.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/63169
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
