### PR TITLE
Add notes on Sonos mic sensor, descriptions of additional entities

### DIFF
--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -28,13 +28,21 @@ The `sonos` integration allows you to control your [Sonos](https://www.sonos.com
 
 ## Feature controls & sensors
 
-Speaker-level features are exposed as `number` or `switch` entities which report current values and allow direct control.
+Speaker-level controls are exposed as `number` or `switch` entities. Additionally, various `sensor` and `binary_sensor` entities are provided.
 
-- **All devices**: Bass, Treble, Crossfade, Status Light, Touch Controls
-- **Home theater devices**: Night Sound, Speech Enhancement, Surround Enabled, Audio Input Format (read-only)
+### Controllable features
+
+- **All devices**: Alarms, Bass, Treble, Crossfade, Status Light, Touch Controls
+- **Home theater devices**: Night Sound, Speech Enhancement, Surround Enabled
 - **When paired with a sub**: Subwoofer Enabled
 
-## Battery support
+### Sensors
+
+- **Devices with battery**: Battery level, Power state
+- **Home theater devices**: Audio Input Format
+- **Voice-enabled devices**: Microphone Enabled
+
+### Battery support notes
 
 Battery sensors are fully supported for the `Sonos Roam` and `Sonos Move` devices on S2 firmware. `Sonos Move` speakers still on S1 firmware are supported but may update infrequently.
 
@@ -46,9 +54,13 @@ The battery sensors rely on working change events or updates will be delayed. S1
 
 </div>
 
-## Alarm support
+### Alarm support notes
 
 The Sonos integration adds one `switch` for each alarm set in the Sonos app. The alarm switches are detected, deleted and assigned automatically and come with several attributes that help to monitor Sonos alarms.
+
+### Microphone support notes
+
+The microphone can only be enabled/disabled from physical buttons on the Sonos device and cannot be controlled from Home Assistant. A `binary_sensor` reports its current state.
 
 ## Playing media
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds note on the new microphone `binary_sensor`. Explicitly splits descriptions of controllable feature entities & sensors.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/63097
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
