### PR TITLE
Alarmdecoder chime status template example incorrect

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -132,10 +132,14 @@ Using a combination of the available services and attributes, you can create swi
       value_template: "{{ is_state_attr('alarm_control_panel.alarm_panel', 'chime', true) }}"
       turn_on:
         service: alarmdecoder.alarm_toggle_chime
+        target:
+          entity_id: alarm_control_panel.alarm_panel
         data:
           code: !secret alarm_code
       turn_off:
         service: alarmdecoder.alarm_toggle_chime
+        target:
+          entity_id: alarm_control_panel.alarm_panel
         data:
           code: !secret alarm_code
       icon_template: >-


### PR DESCRIPTION
## Proposed change
 I used the example from the alarmdecoder to create a template sensor and it generates an error because there is no target entity in the example.  This PR adds that so the example will work.


