### PR TITLE
Kvm setup missing step to make the qemu guest agent work.

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -197,7 +197,11 @@ _All these can be extended if your usage calls for more resources._
     3. Choose “Generic Default” for the operating system
     4. Check the box for “Customize configuration before install”
     5. Select your bridge under “Network Selection”
-    6. Under customization select “Overview” -> “Firmware” -> “UEFI x86_64: …”.****
+    6. Under customization select “Overview” -> “Firmware” -> “UEFI x86_64: …”
+    7. Click "Add Hardware" (bottom left), and select "Channel"
+    8. Select device type: "unix"
+    9. Select name: "org.qemu.guest_agent.0"
+    10. Finally select "Begin Instalation" (upper left corner)
 
 {% if page.installation_type == 'windows' or page.installation_type == 'linux' %}
 


### PR DESCRIPTION
With the current guide I kept getting this error on startup that qemu guest agent can't start.
The setup was missing the channel for that, this is apparently not default so must be added.
reference: https://access.redhat.com/solutions/732773

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
