### PR TITLE
Change Docker container name on locked_out page to be consistent

### DIFF
--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -23,13 +23,13 @@ Connect a keyboard and monitor to your device.
 
 #### To reset a user's password, via the container command line
 
-If you are running Home Assistant in a container, you can use the command line in the container with the `hass` command to change your password. The steps below refer to a Home Assistant container in Docker named `ha`. Note that while working in the container, commands will take a few moments to execute.
+If you are running Home Assistant in a container, you can use the command line in the container with the `hass` command to change your password. The steps below refer to a Home Assistant container in Docker named `homeassistant`. Note that while working in the container, commands will take a few moments to execute.
   
-1. `docker exec -it ha bash` to open to the container command line
+1. `docker exec -it homeassistant bash` to open to the container command line
 2. `hass` to create a default user, if this is your first time using the tool
 3. `hass --script auth --config /config change_password existing_user new_password` to change the password
 4. `exit` to exit the container command line
-5. `docker restart ha` to restart the container
+5. `docker restart homeassistant` to restart the container
 
 #### To reset a user's password, as an administrator via the web interface
 


### PR DESCRIPTION
## Proposed change
To avoid confusion: change Docker container name mentioned on the /locked_out page to be the same as that in the [install guide](https://www.home-assistant.io/installation/raspberrypi)

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - [x] I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
