### PR TITLE
Made description of entity_id in the light and switch services consistent

### DIFF
--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -38,7 +38,7 @@ Most lights do not support all attributes. You can check the integration documen
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`s of lights. To target all the lights use `all` as `entity_id`.
+| `entity_id`  | no  | String or list of strings that point at `entity_id`s of lights. To target all lights, set `entity_id` to `all`.
 | `transition` | yes | Number that represents the time (in seconds) the light should take to transition to the new state.
 | `profile` | yes | String with the name of one of the [built-in profiles](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/light/light_profiles.csv) (relax, energize, concentrate, reading) or one of the custom profiles defined in `light_profiles.csv` in the current working directory. Light profiles define an xy color, brightness and a transition value (if no transition is desired, set to 0 or leave out the column entirely). If a profile is given, and a brightness is set, then the profile brightness will be overwritten.
 | `hs_color` | yes | A list containing two floats representing the hue and saturation of the color you want the light to be. Hue is scaled 0-360, and saturation is scaled 0-100.
@@ -107,7 +107,7 @@ Turns one or multiple lights off.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`s of lights. To target all the lights use all as `entity_id`.
+| `entity_id`  | no  | String or list of strings that point at `entity_id`s of lights. To target all lights, set `entity_id` to `all`.
 | `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds.
 
 ### Service `light.toggle`

--- a/source/_integrations/switch.markdown
+++ b/source/_integrations/switch.markdown
@@ -33,4 +33,4 @@ In the frontend open the sidebar. At the bottom, under **Developer Tools**, clic
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      no  | The entity ID of the switch to control. To target all switches, set the entity ID to `all`|
+| `entity_id`            |      no  | String or list of strings that point at `entity_id`s of switches. To target all switches, set `entity_id` to `all`.


### PR DESCRIPTION
## Proposed change
It was confusing (for me) that the switch services turn_on and turn_off only refer to one entity_id,
while for lights it says "string or list of strings describing an entity_id.
Therefore this PR makes the switch and light service description of entity_id consistent (with changes on both sides).



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

None

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
