### PR TITLE
Add documentation for matrix.access_token support

### DIFF
--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -26,7 +26,9 @@ There is currently support for the following device types within Home Assistant:
 matrix:
   homeserver: https://matrix.org
   username: "@my_matrix_user:matrix.org"
+  # At least one of password or access_token is required.
   password: supersecurepassword
+  access_token: "access_token_of_my_device"
   rooms:
     - "#hasstest:matrix.org"
   commands:
@@ -40,9 +42,15 @@ username:
   required: true
   type: string
 password:
-  description: The password for your Matrix account.
-  required: true
+  description: The password for your Matrix account. At least one of password or access_token is required, and when access_token is configured and valid, the configured password will be ignored.
+  required: false
   type: string
+  default: empty
+access_token:
+  description: The access token associated with your device. At least one of password or access_token is required, and when access_token is configured and valid, the configured password will be ignored.
+  required: false
+  type: string
+  default: empty
 homeserver:
   description: "The full URL for your homeserver. If you use the default matrix.org homeserver, this is 'https://matrix.org'."
   required: true


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This adds the ability for the Matrix integration to support logging
in to your Matrix server by **using an access token** instead of a password.
Previously this integration would only allow you to specify a password
in the configuration. This means you can use an access token or a
password to log in to your Matrix server.

https://github.com/home-assistant/core/pull/63381

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
