### PR TITLE
Small updates with extra help - based on reviewing forums

### DIFF
--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -250,7 +250,7 @@ After completing the configuration flow, the Netatmo integration will be availab
 
 ### Receiving events
 
-To confirm your Home Assistant instance is receiving events via webhooks, you can listen to `netatmo_event` in {% developer_events title="Developer Tools -> Events" %}.
+To confirm your Home Assistant instance is receiving events via webhooks, you can listen to `netatmo_event` in {% my developer_events title="Developer Tools -> Events" %}.
 
 ### Light
 

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -250,7 +250,7 @@ After completing the configuration flow, the Netatmo integration will be availab
 
 ### Receiving events
 
-To confirm your Home Assistant instance is receiving events via webhooks, you can listen to `netatmo_event` in [Developer Tools --> Events](/docs/tools/dev-tools/#subscribe-to-an-event)
+To confirm your Home Assistant instance is receiving events via webhooks, you can listen to `netatmo_event` in {% developer_events title="Developer Tools -> Events" %}.
 
 ### Light
 

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -105,7 +105,7 @@ It is therefore recommended to use [an individual development account](#developm
 
 </div>
 
-To be able to receive events from [Netatmo](https://www.netatmo.com/en-gb/), your Home Assistant instance needs to be accessible from the web over port `80` or `443`. To achieve this you can either use your Nabu Casa account or for example Duck DNS ([Home Assistant instructions](/addons/duckdns/)). You also need to have the external URL configured in the Home Assistant [configuration](/docs/configuration/basic).
+To be able to receive events from [Netatmo](https://www.netatmo.com/en-gb/), your Home Assistant instance needs to be accessible from the web over port `443`. To achieve this you can either use your Nabu Casa account or for example Duck DNS ([Home Assistant instructions](/addons/duckdns/)). You also need to have the external URL configured in the Home Assistant [configuration](/docs/configuration/basic).
 
 Events coming in from Netatmo will be available as an event in Home Assistant and are fired as `netatmo_event`, along with their data. You can use these events to trigger automations.
 
@@ -213,6 +213,12 @@ to declare a new application in the [Netatmo Developer Page](https://dev.netatmo
 
 Sign in using your username and password from your regular Netatmo account.
 
+<div class='note warning'>
+ 
+In your Netatmo Application configuration, do not enter a 'redirect URI' or a 'webhook URI'.  The 'webhook URI' is automatically registered by this integration based on the external URL configured in the Home Assistant [configuration](/docs/configuration/basic).
+  
+</div>
+
 Next, add the following lines to your `configuration.yaml`:
 
 ```yaml
@@ -241,6 +247,10 @@ Click on the `+` sign to add an integration and click on **Netatmo**.
 After completing the configuration flow, the Netatmo integration will be available.
 
 ## Troubleshooting
+
+### Receiving events
+
+To confirm your Home Assistant instance is receiving events via webhooks, you can listen to `netatmo_event` in [Developer Tools --> Events](/docs/tools/dev-tools/#subscribe-to-an-event)
 
 ### Light
 


### PR DESCRIPTION
Port 80 no longer works with Netatmo
Example forum post: https://community.home-assistant.io/t/netatmo-cameras-no-events/281890/15

## Proposed change
Small improvements to the documentation.
Port 80 no longer works with Netatmo
Tackles issues from forum posts, example: https://community.home-assistant.io/t/netatmo-cameras-no-events/281890/15
Hope this helps :-)

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
