### PR TITLE
Implement lock to yale_smart_alarm

### DIFF
--- a/source/_integrations/yale_smart_alarm.markdown
+++ b/source/_integrations/yale_smart_alarm.markdown
@@ -3,6 +3,7 @@ title: Yale Smart Living
 description: Instructions on how to integrate Yale Smart Alarms into Home Assistant.
 ha_category:
   - Alarm
+  - Lock
 ha_release: 0.78
 ha_iot_class: Cloud Polling
 ha_config_flow: true
@@ -11,17 +12,23 @@ ha_codeowners:
 ha_domain: yale_smart_alarm
 ha_platforms:
   - alarm_control_panel
+  - lock
 ---
 
 The Yale Smart Living integration provides connectivity with the Yale Smart Alarm systems and Smart Hub through Yale's API.
 
-This platform supports the following services: `alarm_arm_away`, `alarm_arm_home` and `alarm_disarm`.
-Currently only one alarm is supported.
+There is currently support for the following device types within Home Assistant:
+
+- Alarm
+- Lock
 
 {% include integrations/config_flow.md %}
 
-## Automation example
+## Alarm Control Panel
 
+Services provided are `armed_away`, `armed_home` and `disarmed`
+
+Example automation:
 ```yaml
 automation:
   - alias: "Alarm: Disarmed Daytime"
@@ -45,4 +52,22 @@ automation:
       service: scene.turn_on
       target:
         entity_id: scene.OnArmedAway
+```
+## Lock
+
+Lock platform requires a code for unlocking but no code for locking.
+The integration can be configured to provide a default code that is used if no code is supplied and the number of digits required for code.
+
+Example automation:
+```yaml
+automation:
+  - alias: "Unlock: Light Hallway"
+    trigger:
+      platform: state
+      entity_id: lock.enter
+      to: "unlocked"
+    action:
+      service: scene.turn_on
+      target:
+        entity_id: scene.LightHallway
 ```

--- a/source/_integrations/yale_smart_alarm.markdown
+++ b/source/_integrations/yale_smart_alarm.markdown
@@ -26,48 +26,13 @@ There is currently support for the following device types within Home Assistant:
 
 ## Alarm Control Panel
 
-Services provided are `armed_away`, `armed_home` and `disarmed`
+Services provided are `armed_away`, `armed_home` and `disarmed`.
 
-Example automation:
-```yaml
-automation:
-  - alias: "Alarm: Disarmed Daytime"
-    trigger:
-      platform: state
-      entity_id: alarm_control_panel.yale_smart_alarm
-      to: "disarmed"
-    condition:
-      condition: sun
-      before: sunset
-    action:
-      service: scene.turn_on
-      target:
-        entity_id: scene.OnDisarmedDaytime
-  - alias: "Alarm: Armed Away"
-    trigger:
-      platform: state
-      entity_id: alarm_control_panel.yale_smart_alarm
-      to: "armed_away"
-    action:
-      service: scene.turn_on
-      target:
-        entity_id: scene.OnArmedAway
-```
+No code is required to operate the alarm
+
+
 ## Lock
 
 Lock platform requires a code for unlocking but no code for locking.
-The integration can be configured to provide a default code that is used if no code is supplied and the number of digits required for code.
 
-Example automation:
-```yaml
-automation:
-  - alias: "Unlock: Light Hallway"
-    trigger:
-      platform: state
-      entity_id: lock.enter
-      to: "unlocked"
-    action:
-      service: scene.turn_on
-      target:
-        entity_id: scene.LightHallway
-```
+The integration can be configured to provide a default code that is used if no code is supplied and the number of digits required.

--- a/source/_integrations/yale_smart_alarm.markdown
+++ b/source/_integrations/yale_smart_alarm.markdown
@@ -26,13 +26,13 @@ There is currently support for the following device types within Home Assistant:
 
 ## Alarm Control Panel
 
-Services provided are `armed_away`, `armed_home` and `disarmed`.
+Services provided are `armed_away`, `armed_home`, and `disarmed`.
 
-No code is required to operate the alarm
+No code is required to operate the alarm.
 
 
 ## Lock
 
-Lock platform requires a code for unlocking but no code for locking.
+The lock platform requires a code for unlocking but no code for locking.
 
 The integration can be configured to provide a default code that is used if no code is supplied and the number of digits required.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update yale_smart_alarm markdown to implement lock platform


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/63643
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
