### PR TITLE
Add additional sketch that use v_percentage

### DIFF
--- a/source/_integrations/cover.mysensors.markdown
+++ b/source/_integrations/cover.mysensors.markdown
@@ -154,4 +154,4 @@ void receive(const MyMessage &message) {
 
 This sketch is ideally for star topology wiring. You can run up to 12 covers with a single Arduino Mega board and some relays. All you need to set is one line of parameters for one Cover. However, you can also use it for a single cover based on an Arduino Nano or even an ESP8266 board.
 
-[Check out the code on Github.](https://github.com/gryzli133/RollerShutterSplit)
+[Check out the code on GitHub.](https://github.com/gryzli133/RollerShutterSplit)

--- a/source/_integrations/cover.mysensors.markdown
+++ b/source/_integrations/cover.mysensors.markdown
@@ -149,3 +149,9 @@ void receive(const MyMessage &message) {
   }
 }
 ```
+
+## Sketch example with position measurement based on motor running time
+
+This sketch is ideally for star topology wiring. You can run up to 12 covers with a single Arduino Mega board and some releys. All you need to set is one line of parameters for one Cover. However you can also use it for a single cover based on an arduino nano or even ESP8266 board.
+
+https://github.com/gryzli133/RollerShutterSplit

--- a/source/_integrations/cover.mysensors.markdown
+++ b/source/_integrations/cover.mysensors.markdown
@@ -152,6 +152,6 @@ void receive(const MyMessage &message) {
 
 ## Sketch example with position measurement based on motor running time
 
-This sketch is ideally for star topology wiring. You can run up to 12 covers with a single Arduino Mega board and some releys. All you need to set is one line of parameters for one Cover. However you can also use it for a single cover based on an arduino nano or even ESP8266 board.
+This sketch is ideally for star topology wiring. You can run up to 12 covers with a single Arduino Mega board and some relays. All you need to set is one line of parameters for one Cover. However, you can also use it for a single cover based on an Arduino Nano or even an ESP8266 board.
 
 [Check out the code on github.](https://github.com/gryzli133/RollerShutterSplit)

--- a/source/_integrations/cover.mysensors.markdown
+++ b/source/_integrations/cover.mysensors.markdown
@@ -154,4 +154,4 @@ void receive(const MyMessage &message) {
 
 This sketch is ideally for star topology wiring. You can run up to 12 covers with a single Arduino Mega board and some releys. All you need to set is one line of parameters for one Cover. However you can also use it for a single cover based on an arduino nano or even ESP8266 board.
 
-https://github.com/gryzli133/RollerShutterSplit
+[Check out the code on github.](https://github.com/gryzli133/RollerShutterSplit)

--- a/source/_integrations/cover.mysensors.markdown
+++ b/source/_integrations/cover.mysensors.markdown
@@ -154,4 +154,4 @@ void receive(const MyMessage &message) {
 
 This sketch is ideally for star topology wiring. You can run up to 12 covers with a single Arduino Mega board and some relays. All you need to set is one line of parameters for one Cover. However, you can also use it for a single cover based on an Arduino Nano or even an ESP8266 board.
 
-[Check out the code on github.](https://github.com/gryzli133/RollerShutterSplit)
+[Check out the code on Github.](https://github.com/gryzli133/RollerShutterSplit)


### PR DESCRIPTION
I start developing this code some years ago. Now I use it since 3 years and it works well. I have over 30 covers running on 3 Arduino Mega boards. The biggest advantage is, that the local buttons works always, independent of the gateway or smart home server state/condition.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
