### PR TITLE
Sync flux_led model information with library

### DIFF
--- a/source/_integrations/flux_led.markdown
+++ b/source/_integrations/flux_led.markdown
@@ -63,57 +63,66 @@ This determines the transition between each color.
 
 ### Supported Models
 
-The following models have been tested with integration.
+The following models have been tested.
 
-| Model | Description                 | Notes                           |
-| ----- | --------------------------- | ------------------------------- |
-| 0x01  | Legacy RGB Controller       | Original protocol               |
-| 0x03  | Legacy CCT Controller       | Original protocol               |
-| 0x04  | UFO Controller RGBW         |                                 |
-| 0x06  | Controller RGBW             |                                 |
-| 0x07  | Controller RGBCW            |                                 |
-| 0x08  | Controller RGB with MIC     |                                 |
-| 0x0E  | Floor Lamp RGBCW            |                                 |
-| 0x10  | Christmas Light             |                                 |
-| 0x1A  | Christmas Light             |                                 |
-| 0x1C  | Table Light CCT             |                                 |
-| 0x21  | Bulb Dimmable               |                                 |
-| 0x25  | Controller RGB/WW/CW        | Supports RGB, RGBW, RGBWW, CW, DIM |
-| 0x33  | Controller RGB              |                                 |
-| 0x35  | Bulb RGBCW                  |                                 |
-| 0x41  | Controller Dimmable         |                                 |
-| 0x44  | Bulb RGBW                   |                                 |
-| 0x52  | Bulb CCT                    |                                 |
-| 0x54  | Downlight RGBW              |                                 |
-| 0x93  | Switch 1c                   |                                 |
-| 0x94  | Switch 1c Watt              |                                 |
-| 0x97  | Socket 1c                   |                                 |
-| 0xA1  | Addressable v1              | Supports UCS1903, SM16703, WS2811, WS2812B, SK6812, INK1003, WS2801, LB1914 |
-| 0xA2  | Addressable v2              | Supports UCS1903, SM16703, WS2811, WS2811B, SK6812, INK1003, WS2801, WS2815, APA102, TM1914, UCS2904B |
-| 0xA3  | Addressable v3              | Supports WS2812B, SM16703, SM16704, WS2811, UCS1903, SK6812, SK6812RGBW, INK1003, UCS2904B |
+| Model | Description                 | Microphone | Notes                           |
+| ----- | --------------------------- | ---------- | ------------------------------- |
+| 0x01  | Legacy RGB Controller       | no         | Original protocol               |
+| 0x03  | Legacy CCT Controller       | no         | Original protocol               |
+| 0x04  | UFO Controller RGBW         | no         |                                 |
+| 0x06  | Controller RGBW             | no         |                                 |
+| 0x07  | Controller RGBCW            | no         |                                 |
+| 0x08  | Controller RGB with MIC     | yes        |                                 |
+| 0x09  | Ceiling Light CCT           | no         |                                 |
+| 0x0E  | Floor Lamp RGBCW            | no         |                                 |
+| 0x10  | Christmas Light             | no         |                                 |
+| 0x16  | Magnetic Light CCT          | no         |                                 |
+| 0x17  | Magnetic Light Dimmable     | no         |                                 |
+| 0x1A  | Christmas Light             | no         |                                 |
+| 0x1C  | Table Light CCT             | no         |                                 |
+| 0x1E  | Ceiling Light RGBCW         | no         |                                 |
+| 0x21  | Bulb Dimmable               | no         |                                 |
+| 0x25  | Controller RGB/WW/CW        | no         | Supports RGB, RGBW, RGBWW, CW, DIM |
+| 0x33  | Controller RGB              | no         |                                 |
+| 0x35  | Bulb RGBCW                  | no         |                                 |
+| 0x41  | Controller Dimmable         | no         |                                 |
+| 0x44  | Bulb RGBW                   | no         |                                 |
+| 0x52  | Bulb CCT                    | no         |                                 |
+| 0x54  | Downlight RGBW              | no         |                                 |
+| 0x62  | Controller CCT              | no         |                                 |
+| 0x93  | Switch 1 Channel            | no         |                                 |
+| 0x97  | Socket                      | no         |                                 |
+| 0xA1  | Addressable v1              | no         | Supports UCS1903, SM16703, WS2811, WS2812B, SK6812, INK1003, WS2801, LB1914 |
+| 0xA2  | Addressable v2              | yes        | Supports UCS1903, SM16703, WS2811, WS2811B, SK6812, INK1003, WS2801, WS2815, APA102, TM1914, UCS2904B |
+| 0xA3  | Addressable v3              | yes        | Supports WS2812B, SM16703, SM16704, WS2811, UCS1903, SK6812, SK6812RGBW, INK1003, UCS2904B |
+| 0xA4  | Addressable v4              | no         | Supports WS2812B, SM16703, SM16704, WS2811, UCS1903, SK6812, SK6812RGBW, INK1003, UCS2904B |
+| 0xA6  | Addressable v6              | yes        | Supports WS2812B, SM16703, SM16704, WS2811, UCS1903, SK6812, SK6812RGBW, INK1003, UCS2904B |
+| 0xA7  | Addressable v7              | yes        | Supports WS2812B, SM16703, SM16704, WS2811, UCS1903, SK6812, SK6812RGBW, INK1003, UCS2904B |
+| 0xE1  | Ceiling Light CCT           | no         |                                 |
+| 0xE2  | Ceiling Light Assist        | no         | Auxiliary Switch not supported  |
+
+### Untested Models
+
+The following models have not been tested but may work.
+
+| Model | Description                 | Microphone | Notes                           |
+| ----- | --------------------------- | ---------- | ------------------------------- |
+| 0x02  | Legacy Dimmable Controller  | no         | Original protocol, discontinued |
 
 ### Unsupported Models
 
-The following models have not been tested with integration but may work.
+The following models are confirmed to be unsupported.
 
-| Model | Description                 | Notes                           |
-| ----- | --------------------------- | ------------------------------- |
-| 0x02  | Legacy Dimmable Controller  | Original protocol               |
-| 0x09  | Ceiling Light CCT           |                                 |
-| 0x16  | Magnetic Light CCT          |                                 |
-| 0x17  | Magnetic Light Dimmable     |                                 |
-| 0x19  | Socket 2 USB                |                                 |
-| 0x18  | Plant Light                 |                                 |
-| 0x1B  | Spray Light                 |                                 |
-| 0x1E  | Ceiling Light RGBCW         | Probably works & same as 0x35   |
-| 0x62  | Controller CCT              | May be discontinued             |
-| 0x95  | Switch 2c                   |                                 |
-| 0x96  | Switch 4c                   |                                 |
-| 0xD1  | Digital Light               |                                 |
-| 0xE1  | Ceiling Light               |                                 |
-| 0xE2  | Ceiling Light Assist        |                                 |
-| 0xA4  | Addressable v4              | Probably works & same as 0xA3   |
-| 0xA6  | Addressable v6              | Probably works & same as 0xA3   |
+| Model | Description                 | Microphone | Notes                           |
+| ----- | --------------------------- | ---------- | ------------------------------- |
+| 0x18  | Plant Grow Light            | no         |                                 |
+| 0x19  | Socket with 2 USB           | no         |                                 |
+| 0x1B  | Aroma Fragrance Lamp        | no         |                                 |
+| 0x1D  | Fill Light                  | no         |                                 |
+| 0x94  | Switch 1c Watt              | no         |                                 |
+| 0x95  | Switch 2 Channel            | no         |                                 |
+| 0x96  | Switch 4 Channel            | no         |                                 |
+| 0xD1  | Digital Time Lamp           | no         |                                 |
 
 ### Troubleshooting
 


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I recently built a device simulator that helped figure which devices will work and which ones one are not supported. We can now tell if any post 2013 device will work or not without having to actually have it in hand.  This led to a much more accurate supported list and we now have a known unsupported list.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
