### PR TITLE
Docs: Add a way to use a value of an attribute in conditional card

### DIFF
--- a/source/_lovelace/conditional.markdown
+++ b/source/_lovelace/conditional.markdown
@@ -23,13 +23,17 @@ conditions:
       required: true
       description: Entity ID.
       type: string
+    attribute:
+      required: false
+      description: An attribute associated with the `entity`. Its value should be used instead of entity's state.
+      type: string
     state:
       required: false
-      description: Entity state is equal to this value.*
+      description: Entity state/attribute is equal to this value.*
       type: string
     state_not:
       required: false
-      description: Entity state is unequal to this value.*
+      description: Entity state/attribute is unequal to this value.*
       type: string
 card:
   required: true
@@ -50,6 +54,9 @@ conditions:
     state: "on"
   - entity: switch.decorative_lights
     state_not: "off"
+  - entity: light.ceiling
+    attribute: effect
+    state: sunset
 card:
   type: entities
   entities:

--- a/source/_lovelace/conditional.markdown
+++ b/source/_lovelace/conditional.markdown
@@ -56,7 +56,7 @@ conditions:
     state_not: "off"
   - entity: light.ceiling
     attribute: effect
-    state: sunset
+    state: "sunset"
 card:
   type: entities
   entities:

--- a/source/_lovelace/conditional.markdown
+++ b/source/_lovelace/conditional.markdown
@@ -25,7 +25,7 @@ conditions:
       type: string
     attribute:
       required: false
-      description: An attribute associated with the `entity`. Its value should be used instead of entity's state.
+      description: An attribute associated with the `entity`. Its value will be used instead of the entity's state.
       type: string
     state:
       required: false

--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -391,7 +391,7 @@ conditions:
       type: string
     attribute:
       required: false
-      description: An attribute associated with the `entity`. Its value should be used instead of entity's state.
+      description: An attribute associated with the `entity`. Its value will be used instead of the entity's state.
       type: string
     state:
       required: false

--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -389,13 +389,17 @@ conditions:
       required: true
       description: Entity ID.
       type: string
+    attribute:
+      required: false
+      description: An attribute associated with the `entity`. Its value should be used instead of entity's state.
+      type: string
     state:
       required: false
-      description: Entity state is equal to this value.*
+      description: Entity state/attribute is equal to this value.*
       type: string
     state_not:
       required: false
-      description: Entity state is unequal to this value.*
+      description: Entity state/attribute is unequal to this value.*
       type: string
 elements:
   required: true


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Added a new optional field: `attribute` to cards' configurations. When an attribute is provided, a value of given attribute is used instead of entity's state to calculate card's visibility.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch): 
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/10241
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
