### PR TITLE
Implement binary sensor for yale_smart_alarm

### DIFF
--- a/source/_integrations/yale_smart_alarm.markdown
+++ b/source/_integrations/yale_smart_alarm.markdown
@@ -3,6 +3,7 @@ title: Yale Smart Living
 description: Instructions on how to integrate Yale Smart Alarms into Home Assistant.
 ha_category:
   - Alarm
+  - Binary Sensor
   - Lock
 ha_release: 0.78
 ha_iot_class: Cloud Polling
@@ -12,6 +13,7 @@ ha_codeowners:
 ha_domain: yale_smart_alarm
 ha_platforms:
   - alarm_control_panel
+  - binary_sensor
   - lock
 ---
 
@@ -20,6 +22,7 @@ The Yale Smart Living integration provides connectivity with the Yale Smart Alar
 There is currently support for the following device types within Home Assistant:
 
 - Alarm
+- Binary Sensor
 - Lock
 
 {% include integrations/config_flow.md %}
@@ -30,6 +33,9 @@ Services provided are `armed_away`, `armed_home`, and `disarmed`.
 
 No code is required to operate the alarm.
 
+## Binary Sensors
+
+Provides support for contact sensors for doors showing if door is open or closed
 
 ## Lock
 

--- a/source/_integrations/yale_smart_alarm.markdown
+++ b/source/_integrations/yale_smart_alarm.markdown
@@ -35,7 +35,7 @@ No code is required to operate the alarm.
 
 ## Binary Sensors
 
-Provides support for contact sensors for doors showing if door is open or closed
+Provides support for contact sensors for doors showing if door is open or closed.
 
 ## Lock
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Implement binary sensor in yale_smart_alarm


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/63937
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
