### PR TITLE
Updated imap_email_content docs to include proposed optional config parameters

### DIFF
--- a/source/_integrations/imap_email_content.markdown
+++ b/source/_integrations/imap_email_content.markdown
@@ -1,4 +1,4 @@
----
+git@github.com:smcpeck/home-assistant.io.git---
 title: IMAP Email Content
 description: Instructions on how to integrate IMAP email content sensor into Home Assistant.
 ha_category:
@@ -60,6 +60,13 @@ senders:
   description: A list of sender email addresses that are allowed to report state via email. Only emails received from these addresses will be processed.
   required: true
   type: string
+keep:
+  description: Keep existing message until another arrives. Default behavior will set sensor to `Unknown` next time the IMAP account is checked and no new message has arrived. This is useful if you want a sensor's value to persist based on the last received e-mail (like a date value).
+  required: false
+  default: false
+  type: boolean
+daysback:
+  description: Number of days back to look for e-mail. This is mainly intended to be used with `keep: true` so your last state is restored on a restart (like other sensors that "query" an existing entity and discover the proper state). It isn't perfect, but will offer some value. During normal operation, the last UID is tracked so older e-mails won't continuously be re-processed.
 value_template:
   description: If specified this template will be used to render the state of the sensor. If a template is not supplied the message subject will be used for the sensor value. The following attributes will be supplied to the template.
   required: false
@@ -89,6 +96,8 @@ sensor:
     port: 993
     username: MY_EMAIL_USERNAME
     password: MY_EMAIL_PASSWORD
+    keep: true
+    daysback: 5
     senders:
       - no-reply@smartconnect.apc.com
     value_template: >-


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding documentation to `imap_email_content` for new optional configuration values I'm proposing for that integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/64024
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
