### PR TITLE
Add section about configuring macvtap multicast to HomeKit

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -543,6 +543,24 @@ You can also try to use `avahi-daemon` in reflector mode together with the optio
 
 Configure the network mode as `networkbridge`. Otherwise the Home Assistant Bridge won't be exposed to the network.
 
+#### `Home Assistant Bridge` doesn't appear in the Home App (for pairing) - Libvirt QEMU/KVM virtual machine with macvtap adapter
+
+By default, the macvtap adapter created by libvirt does not allow the guest to receive multicast traffic.
+
+Configure the virtual machine's macvtap adapter to accept multicast traffic by adding the `trustGuestRxFilters="yes"` setting in the adapter's XML. For example:
+
+```
+<interface type="direct" trustGuestRxFilters="yes">
+  <mac address="xx:xx:xx:xx:xx:xx"/>
+  <source dev="eno1" mode="bridge"/>
+  <model type="virtio"/>
+  <link state="up"/>
+  <address type="pci" domain="0x0000" bus="0x01" slot="0x00" function="0x0"/>
+</interface>
+```
+
+This only works with the `virtio` network adapter type and it is disabled by default for security reasons. See [the libvirt documentation](https://libvirt.org/formatdomain.html#elementsNICS) for more details.
+
 #### Pairing hangs - zeroconf error
 
 Pairing eventually fails, you might see the error message, `NonUniqueNameException`, you likely need to enable `default_interface: true` in the `zeroconf` integration configuration and set a unique name such as `name: MyHASS42`.

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -545,21 +545,7 @@ Configure the network mode as `networkbridge`. Otherwise the Home Assistant Brid
 
 #### Accessory does not appear in the Home App (for pairing) - Libvirt QEMU/KVM virtual machine with macvtap adapter
 
-By default, the macvtap adapter created by libvirt does not allow the guest to receive multicast traffic.
-
-Configure the virtual machine's macvtap adapter to accept multicast traffic by adding the `trustGuestRxFilters="yes"` setting in the adapter's XML. For example:
-
-```xml
-<interface type="direct" trustGuestRxFilters="yes">
-  <mac address="xx:xx:xx:xx:xx:xx"/>
-  <source dev="eno1" mode="bridge"/>
-  <model type="virtio"/>
-  <link state="up"/>
-  <address type="pci" domain="0x0000" bus="0x01" slot="0x00" function="0x0"/>
-</interface>
-```
-
-This only works with the `virtio` network adapter type and it is disabled by default for security reasons. See [the libvirt documentation](https://libvirt.org/formatdomain.html#elementsNICS) for more details.
+Please see the [zeroconf](/integrations/zeroconf/#troubleshooting) integration for more details.
 
 #### Pairing hangs - zeroconf error
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -543,7 +543,7 @@ You can also try to use `avahi-daemon` in reflector mode together with the optio
 
 Configure the network mode as `networkbridge`. Otherwise the Home Assistant Bridge won't be exposed to the network.
 
-#### `Home Assistant Bridge` doesn't appear in the Home App (for pairing) - Libvirt QEMU/KVM virtual machine with macvtap adapter
+#### Accessory does not appear in the Home App (for pairing) - Libvirt QEMU/KVM virtual machine with macvtap adapter
 
 By default, the macvtap adapter created by libvirt does not allow the guest to receive multicast traffic.
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -545,7 +545,7 @@ Configure the network mode as `networkbridge`. Otherwise the Home Assistant Brid
 
 #### Accessory does not appear in the Home App (for pairing) - Libvirt QEMU/KVM virtual machine with macvtap adapter
 
-Please see the [zeroconf](/integrations/zeroconf/#troubleshooting) integration for more details.
+Please see the [Zero-configuration networking](/integrations/zeroconf/#troubleshooting) integration for more details.
 
 #### Pairing hangs - zeroconf error
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -549,7 +549,7 @@ By default, the macvtap adapter created by libvirt does not allow the guest to r
 
 Configure the virtual machine's macvtap adapter to accept multicast traffic by adding the `trustGuestRxFilters="yes"` setting in the adapter's XML. For example:
 
-```
+```xml
 <interface type="direct" trustGuestRxFilters="yes">
   <mac address="xx:xx:xx:xx:xx:xx"/>
   <source dev="eno1" mode="bridge"/>

--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -32,12 +32,14 @@ IPv6 will automatically be enabled if one of the selected interfaces has an IPv6
 
 ## Troubleshooting
 
-### Integrations relying on zeroconf traffic are unresponsive
-Some integrations rely on zeroconf traffic to work, for example the [HomeKit](/integrations/homekit/) integration.
+### Integrations relying on Zeroconf traffic are unresponsive
+
+Some integrations rely on Zeroconf traffic to work, for example, the [HomeKit](/integrations/homekit/) integration.
 These integrations will not respond to traffic from other devices if the host device is not configured correctly.
 
 #### Libvirt virtual machine with macvtap adapter
-By default, the macvtap adapter created by libvirt does not allow the guest to receive zeroconf or multicast traffic.
+
+By default, the macvtap adapter created by libvirt does not allow the guest to receive Zeroconf or multicast traffic.
 
 Configure the virtual machine to accept this traffic by adding the `trustGuestRxFilters="yes"` setting in the adapter's XML. For example:
 

--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -29,3 +29,26 @@ zeroconf:
 Zeroconf chooses which interfaces to broadcast on based on the [Network](/integrations/network/) integration.
 
 IPv6 will automatically be enabled if one of the selected interfaces has an IPv6 address that is enabled via the Network integration.
+
+## Troubleshooting
+
+### Integrations relying on zeroconf traffic are unresponsive
+Some integrations rely on zeroconf traffic to work, for example the [HomeKit](/integrations/homekit/) integration.
+These integrations will not respond to traffic from other devices if the host device is not configured correctly.
+
+#### Libvirt virtual machine with macvtap adapter
+By default, the macvtap adapter created by libvirt does not allow the guest to receive zeroconf or multicast traffic.
+
+Configure the virtual machine to accept this traffic by adding the `trustGuestRxFilters="yes"` setting in the adapter's XML. For example:
+
+```xml
+<interface type="direct" trustGuestRxFilters="yes">
+  <mac address="xx:xx:xx:xx:xx:xx"/>
+  <source dev="eno1" mode="bridge"/>
+  <model type="virtio"/>
+  <link state="up"/>
+  <address type="pci" domain="0x0000" bus="0x01" slot="0x00" function="0x0"/>
+</interface>
+```
+
+This only works with the `virtio` network adapter type and it is disabled by default for security reasons. See [the libvirt documentation](https://libvirt.org/formatdomain.html#elementsNICS) for more details.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The HomeKit integration does not work by default for libvirt guests because multicast traffic never reaches it. Setting this flag seems to fix that.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
