### PR TITLE
Add switch platform documentation for HomeWizard Energy

### DIFF
--- a/source/_integrations/homewizard.markdown
+++ b/source/_integrations/homewizard.markdown
@@ -57,7 +57,5 @@ The HomeWizard Energy API only exposes properties that are used within the HomeW
 
 The Wifi Energy Socket (`HWE-SKT`) outlet state can be controlled the switch platform. There are two switches:
 
-| Name | Description |
-| --- | --- |
-| Energy Socket | Controls the outlet state of the Energy Socket. |
-| Switch Lock | Forces the outlet state in the `on` position and disables the button. This option is useful when the socket is used for a device that must not be turned off, such as a refrigerator. |
+- **Switch**: Controls the outlet state of the Energy Socket. This switch is locked out when `Switch Lock` is turned on. 
+- **Switch Lock**: Forces the outlet state in the `on` position and disables the physical button. This option is useful when the socket is used for a device that must not be turned off, such as a refrigerator.

--- a/source/_integrations/homewizard.markdown
+++ b/source/_integrations/homewizard.markdown
@@ -19,7 +19,7 @@ Integration for the [HomeWizard Energy](https://www.homewizard.nl/energy) platfo
 **Supported devices**
 
 - [Wifi P1 Meter](https://www.homewizard.nl/p1-meter): Depending on the connected DSMR meter: sensors for power import/export, energy consumption (single or three phases) and gas. (Model: `HWE-P1`)
-- [Wifi Energy Socket](https://www.homewizard.nl/energy-socket): Sensors for power import/export and energy consumption. (model: `HWE-SKT`)
+- [Wifi Energy Socket](https://www.homewizard.nl/energy-socket): Sensors for power import/export and energy consumption and a switch for controlling the outlet (model: `HWE-SKT`)
 - [Wifi kWh Meter](https://www.homewizard.nl/kwh-meter): Sensors for power import/export and energy consumption. (Models: `SDM230-wifi`, `SDM630-wifi`)
 
 ## Enable the API
@@ -52,3 +52,12 @@ The HomeWizard Energy API only exposes properties that are used within the HomeW
 | Total Gas | m3 | HWE-P1 | Current gas import reading, only available when your smart meter is connected to a gas meter. |
 | DSMR Version | | HWE-P1 | The detected DSMR version. |
 | Smart Meter Model | | HWE-P1 | The detected smart meter model. |
+
+## Switches
+
+The Wifi Energy Socket (`HWE-SKT`) outlet state can be controlled the switch platform. There are two switches:
+
+| Name | Description |
+| --- | --- |
+| Energy Socket | Controls the outlet state of the Energy Socket. |
+| Switch Lock | Forces the outlet state in the `on` position and disables the button. This option is useful when the socket is used for a device that must not be turned off, such as a refrigerator. |

--- a/source/_integrations/homewizard.markdown
+++ b/source/_integrations/homewizard.markdown
@@ -19,7 +19,7 @@ Integration for the [HomeWizard Energy](https://www.homewizard.nl/energy) platfo
 **Supported devices**
 
 - [Wifi P1 Meter](https://www.homewizard.nl/p1-meter): Depending on the connected DSMR meter: sensors for power import/export, energy consumption (single or three phases) and gas. (Model: `HWE-P1`)
-- [Wifi Energy Socket](https://www.homewizard.nl/energy-socket): Sensors for power import/export and energy consumption and a switch for controlling the outlet (model: `HWE-SKT`)
+- [Wifi Energy Socket](https://www.homewizard.nl/energy-socket): Sensors for power import/export and energy consumption and switches for controlling the outlet (model: `HWE-SKT`)
 - [Wifi kWh Meter](https://www.homewizard.nl/kwh-meter): Sensors for power import/export and energy consumption. (Models: `SDM230-wifi`, `SDM630-wifi`)
 
 ## Enable the API


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for switch platform for HomeWizard Energy.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/64084
- Link to parent pull request in the Brands repository: -
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
