### PR TITLE
Add documentation for Mazda electric vehicle sensors

### DIFF
--- a/source/_integrations/mazda.markdown
+++ b/source/_integrations/mazda.markdown
@@ -25,8 +25,9 @@ This integration requires an active Mazda Connected Services subscription and a 
 
 - Mazda3: 2019+
 - CX-30: 2020+
-- CX-9: 2021+
 - CX-5: 2021+
+- CX-9: 2021+
+- MX-30: 2020+
 
 {% include integrations/config_flow.md %}
 
@@ -39,10 +40,12 @@ This integration requires an active Mazda Connected Services subscription and a 
 ### Sensor
 
 The following sensor entities are available:
-- Fuel remaining
-- Fuel distance remaining
+- Fuel remaining (only for gas vehicles)
+- Fuel distance remaining (only for gas vehicles)
 - Odometer
 - Tire pressure (not available for CX-5 and CX-9 models)
+- Charge level (only for electric vehicles)
+- Remaining range (only for electric vehicles)
 
 ### Device tracker
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the two new Mazda electric vehicle sensors.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/64099
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
