### PR TITLE
Add list of services supported by DLNA DMR integration

### DIFF
--- a/source/_integrations/dlna_dmr.markdown
+++ b/source/_integrations/dlna_dmr.markdown
@@ -33,3 +33,19 @@ Event listener callback URL:
 Poll for device availability:
   description: "Periodically try to connect to the DLNA device, even if it is unavailable. Enable this if SSDP advertisements sent by the device are not received by Home Assistant, e.g. when IP multicast is broken on your network."
 {% endconfiguration_basic %}
+
+## Services
+
+DLNA devices can support a range of features. Depending on the device itself, the following [media_player](/integrations/media_player/#services) services may be supported:
+
+* `media_player.volume_up`, `media_player.volume_down`, and `media_player.volume_set`
+* `media_player.volume_mute`
+* `media_player.media_play`
+* `media_player.media_pause` and `media_player.media_play_pause`
+* `media_player.media_stop`
+* `media_player.media_next_track`
+* `media_player.media_previous_track`
+* `media_player.play_media`
+* `media_player.shuffle_set`
+* `media_player.repeat_set`
+* `media_player.select_sound_mode`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add a list of `media_player` services that *may* be supported for devices integrating via DLNA DMR.

This is "may be" because devices can vary quite a lot.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: #21159

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
