### PR TITLE
Change doorbird platform from switch to button

### DIFF
--- a/source/_integrations/doorbird.markdown
+++ b/source/_integrations/doorbird.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate your DoorBird video doorbell with 
 ha_category:
   - Doorbell
   - Camera
-  - Switch
+  - Button
 ha_release: 0.54
 ha_iot_class: Local Push
 ha_config_flow: true
@@ -15,7 +15,7 @@ ha_domain: doorbird
 ha_zeroconf: true
 ha_platforms:
   - camera
-  - switch
+  - button
 ---
 
 The `doorbird` implementation allows you to integrate your [DoorBird](https://www.doorbird.com/) device in Home Assistant.
@@ -23,7 +23,7 @@ The `doorbird` implementation allows you to integrate your [DoorBird](https://ww
 There is currently support for the following device types within Home Assistant:
 
 - [Camera](#camera) - View live and historical event based images.
-- [Switch](#switch) - Enable control of relays and camera night vision.
+- [Button](#button) - Enable control of relays and camera night vision.
 
 ## Setup
 
@@ -112,6 +112,6 @@ Note: Remember to complete the schedule assignment steps above for each event ty
 The `doorbird` implementation allows you to view the live video, the last doorbell ring image, and the last motion sensor image from your [DoorBird](https://www.doorbird.com/) device in Home Assistant.
 
 
-## Switch
+## Button
 
-The `doorbird` switch platform allows you to power connected relays and trigger the IR array in your [DoorBird](https://www.doorbird.com/) video doorbell device.
+The `doorbird` button platform allows you to power connected relays and trigger the IR array in your [DoorBird](https://www.doorbird.com/) video doorbell device.

--- a/source/_integrations/doorbird.markdown
+++ b/source/_integrations/doorbird.markdown
@@ -2,9 +2,9 @@
 title: DoorBird
 description: Instructions on how to integrate your DoorBird video doorbell with Home Assistant.
 ha_category:
-  - Doorbell
-  - Camera
   - Button
+  - Camera
+  - Doorbell
 ha_release: 0.54
 ha_iot_class: Local Push
 ha_config_flow: true
@@ -14,8 +14,8 @@ ha_codeowners:
 ha_domain: doorbird
 ha_zeroconf: true
 ha_platforms:
-  - camera
   - button
+  - camera
 ---
 
 The `doorbird` implementation allows you to integrate your [DoorBird](https://www.doorbird.com/) device in Home Assistant.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

With home-assistant/core#63995, the Doorbird integration is changed from having a switch to having a button. Update the documentation of the integration accordingly.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#63995
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
