### PR TITLE
Add RainMachine docs for `restrict_watering` and `unrestrict_watering` services

### DIFF
--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -49,7 +49,7 @@ Services accept either device IDs or entity IDs, depending on the nature of the 
 
 ### `rainmachine.pause_watering`
 
-Pause all watering activities for a number of seconds. After the pause is complete, the previous watering activities will resume.
+Pause all watering activities for a number of seconds. After the pause is complete, the previous watering activities will resume. Note that controllers can only be paused for a maximum of 12 hours.
 
 | Service Data Attribute | Optional | Description                    |
 | ---------------------- | -------- | ------------------------------ |

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -39,8 +39,10 @@ Services accept either device IDs or entity IDs, depending on the nature of the 
 - Services that require a device ID as a target:
   - `rainmachine.pause_watering`
   - `rainmachine.push_weather_data`
+  - `rainmachine.restrict_watering`
   - `rainmachine.stop_all`
   - `rainmachine.unpause_watering`
+  - `rainmachine.unrestrict_watering`
 - Services that require an entity ID as a target (note that the correct entity ID type must be provided, such as a program for a program-related service)
   - `rainmachine.start_program`
   - `rainmachine.start_zone`

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -49,7 +49,7 @@ Services accept either device IDs or entity IDs, depending on the nature of the 
 
 ### `rainmachine.pause_watering`
 
-Pause all watering activities for a number of seconds.
+Pause all watering activities for a number of seconds. After the pause is complete, the previous watering activities will resume.
 
 | Service Data Attribute | Optional | Description                    |
 | ---------------------- | -------- | ------------------------------ |
@@ -81,6 +81,14 @@ See details of RainMachine API here:
 | `pressure`             | no       | Barametric Pressure (kPa)                                                                                             |
 | `dewpoint`             | no       | Dew Point (°C)                                                                                                        |
 
+### `rainmachine.restrict_watering`
+
+Restrict any and all watering activities from staring for a time period.
+
+| Service Data Attribute | Optional | Description                    |
+| ---------------------- | -------- | ------------------------------ |
+| `duration`              | no       | The time period to restrict (e.g., "01:00:00") |
+
 ### `rainmachine.start_program`
 
 Start a RainnMachine program.
@@ -107,7 +115,11 @@ Stop a RainMachine zone.
 
 ### `rainmachine.unpause_watering`
 
-Unpause all watering activities.
+Unpause all paused watering activities.
+
+### `rainmachine.unrestrict_watering`
+
+Remove all watering restrictions enforced by `rainmachine.restrict_watering`.
 
 ## Switch
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds docs for two new forthcoming RainMachine services.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/64219
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
