### PR TITLE
Update zha.markdown with "no longer recommend" comments for CC253x

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -83,8 +83,8 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
 - Texas Instruments based radios (via the [zigpy-znp](https://github.com/zigpy/zigpy-znp) library for zigpy)
   - [CC2652P/CC2652R/CC2652RB USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters)
   - [CC1352P/CC1352R USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters)
-  - [CC2538 USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters)
-  - [CC2530/CC2531 USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters) (not recommended for Zigbee networks with more than 20 devices)
+  - [CC2538 USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters) (no longer recommended as only got deprecated old end-of-life firmware)
+  - [CC2530/CC2531 USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/information/supported_adapters) (no longer recommended as uses deprecated hardware and very old end-of-life firmware, plus will not work properly at all if the whole Zigbee network has more than 15-20 devices)
 - Digi XBee Zigbee based radios (via the [zigpy-xbee](https://github.com/zigpy/zigpy-xbee) library for zigpy)
   - [Digi XBee Series 3 (xbee3-24)](https://www.digi.com/products/embedded-systems/digi-xbee/rf-modules/2-4-ghz-rf-modules/xbee3-zigbee-3) and [Digi XBee Series S2C](https://www.digi.com/products/embedded-systems/digi-xbee/rf-modules/2-4-ghz-rf-modules/xbee-zigbee) modules
     - Note! While not a must, [it is recommend to upgrade XBee Series 3 and S2C to newest firmware using XCTU](https://www.digi.com/resources/documentation/Digidocs/90002002/Default.htm#Tasks/t_load_zb_firmware.htm)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Zigbee Coordinator adapters based on CC253x chips are still supported but they are no longer recommended for new installations.

Update zha.markdown with "no longer recommend" comments as discouragment/determent to buyers in order to try to prevent new purchases of CC253x based adapters as still very common that new users and beginners buy those based on old obsolete hardware and firmware which will unfairly give those new users of ZHA a bad first Zigbee experience due to underpowered and older HW/FW.

ZHA integration is a native component of Home Assistant users will need to be informed/warned of this fact directly in the ZHA interaction documentation as there is no other upstream, external, or third-party documentation for the ZHA integration.

Note! They still work via the legacy support in zigpy-znp, but CC253x obsolete hardware and firmware is no longer recommended. Deprecate here mean Z-Stack Home 1.2 ZNP used by CC2530/CC2531 will still continue to work and there is no ETA when support for it will be removed, (although it would be great if log notifications were added regarding it but not in scope here).

Specifically:

CC2530 and CC2531 are no longer recommended as obsolete hardware and older deprecated end-of-life firmware since many years back, plus these will basically not work properly at all if the whole Zigbee network has more than 15-20 devices.

CC2538 is slightly newer but is also no longer recommended as unfortunately got old end-of-life firmware which Texas Instruments has no longer maintained since a few years back now, (though the hardware is otherwise still plenty fast enough on paper).

zigpy-znp does now note that these are "not recommended" -> https://github.com/zigpy/zigpy-znp#hardware-requirements

Texas Instruments who make the chip and firmware list CC2530/CC2531 as active but deprecated and do not maintain/update officially supported Z-Stack Home 1.2.x SDK / firmware for it since 6-years+ back -> https://www.ti.com/tool/Z-STACK-ARCHIVE

```
Z-STACK-HOME — ZigBee Home Automation Solutions
Version: 1.2.2a
Release date: 16-OCT-2015
```

Note! Should maybe be noted that this can be extra confusing for buyers as Texas Instruments still manufacture and sell all of these for legacy purposes. These recommendations above however specifically apply to using as a Zigbee Coordinator in ZHA.

PS: Zigbee2MQTT also lists these under "not recommended" -> https://www.zigbee2mqtt.io/information/supported_adapters.html

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
