### PR TITLE
Update docs page to include RAX50 in port 80 comms

### DIFF
--- a/source/_integrations/netgear.markdown
+++ b/source/_integrations/netgear.markdown
@@ -22,6 +22,7 @@ This platform allows you to detect presence by looking at connected devices to a
 {% include integrations/config_flow.md %}
 
 Most NETGEAR routers use port 5000 to communicate, however the following list of models are known to use port 80:
+- Nighthawk RAX50
 - Nighthawk X4S - AC2600 (R7800)
 - Orbi
 - XR500


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add a new device to the list of routers that use port 80 to communicate instead of 5000

Device: RAX50

Connecting with 5000:
<img width="449" alt="image" src="https://user-images.githubusercontent.com/34384474/150012881-9dade3f3-ffac-4baa-b56d-731b88ee53d6.png">

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
