### PR TITLE
Add Todoist service assignee parameter documentation

### DIFF
--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -156,7 +156,7 @@ Here are two example JSON payloads resulting in the same task:
 
 - **labels** (*Optional*): Any labels you want to add to the task, separated by commas.
 
-- **assignee** (*Optional*): A members username of a shared project to assign this task to. You find the username formatted as bold text in the collaborator menu of a shared project. 
+- **assignee** (*Optional*): A member's username of a shared project to assign this task to. You find the username formatted as bold text in the collaborator menu of a shared project. 
 
 - **priority** (*Optional*): The priority of the task, from 1-4. Again, 1 means least important, and 4 means most important.
 

--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -156,6 +156,8 @@ Here are two example JSON payloads resulting in the same task:
 
 - **labels** (*Optional*): Any labels you want to add to the task, separated by commas.
 
+- **assignee** (*Optional*): A members username of a shared project to assign this task to. You find the username formatted as bold text in the collaborator menu of a shared project. 
+
 - **priority** (*Optional*): The priority of the task, from 1-4. Again, 1 means least important, and 4 means most important.
 
 - **due_date_string** (*Optional*): When the task should be due, in [natural language](https://get.todoist.help/hc/articles/205325931-Dates-and-Times). Mutually exclusive with `due_date`


### PR DESCRIPTION
## Proposed change
Added the new `assignee` parameter for the todoist service call, implemented in https://github.com/home-assistant/core/pull/63918



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/63918
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x ] This PR uses the correct branch, based on one of the following: next
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
