### PR TITLE
Update pulseaudio_loopback.markdown

### DIFF
--- a/source/_integrations/pulseaudio_loopback.markdown
+++ b/source/_integrations/pulseaudio_loopback.markdown
@@ -54,6 +54,6 @@ port:
 
 <div class='note warning'>
 
-This integration relies on raw TCP commands to PulseAudio. In order for PulseAudio to accept commands with this component, `module-native-protocol` must be loaded on the PulseAudio server.
+This integration relies on raw TCP commands to PulseAudio. In order for PulseAudio to accept commands with this component, `module-native-protocol-tcp auth-ip-acl=<homeassistant ip>` must be loaded on the PulseAudio server.
 
 </div>


### PR DESCRIPTION
There is no 'module-native-protocol' on its own, either module-native-protocol-tcp or module-native-protocol-unix. Also seems to need either 'auth-anonymous=true' or 'auth-ip-acl=<list of ips>'  option enabled to work.

Havent done this before,  sorry if I didnt do it right.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
