### PR TITLE
Add info on management for Shelly Valve

### DIFF
--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -5,6 +5,7 @@ ha_category:
   - Binary Sensor
   - Cover
   - Light
+  - Number
   - Sensor
   - Switch
 ha_release: 0.115
@@ -24,6 +25,7 @@ ha_platforms:
   - climate
   - cover
   - light
+  - number
   - sensor
   - switch
 ---
@@ -224,6 +226,16 @@ Trigger reboot of device.
 
 - Reboot
   - triggers the reboot
+
+## Shelly Thermostatic Radiator Valve (TRV)
+
+Shelly TRV generates 2 entities that can be used to control the device behavior: `climate` and `number`.
+The first will allow to specify a temperature, the second instead a percentage of the valve position.
+
+**Note**: that if you change the valve position then automatic temperature control
+ will be disabled.
+As soon as you change teh temperature, it gets enabled again.
+
 ## CoAP port (generation 1)
 
 In some cases, it may be needed to customize the CoAP port (default: `5683`) your Home Assistant instance is listening to.

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -230,11 +230,11 @@ Trigger reboot of device.
 ## Shelly Thermostatic Radiator Valve (TRV)
 
 Shelly TRV generates 2 entities that can be used to control the device behavior: `climate` and `number`.
-The first will allow to specify a temperature, the second instead a percentage of the valve position.
+The first will allow specifying a temperature, the second instead of a percentage of the valve position.
 
 **Note**: that if you change the valve position then automatic temperature control
  will be disabled.
-As soon as you change teh temperature, it gets enabled again.
+As soon as you change the temperature, it gets enabled again.
 
 ## CoAP port (generation 1)
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Introducing number platform there are now 2 way of managing a Shelly Valve.
This PR describes the difference.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/64207
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
