### PR TITLE
Fix "Previous state of an entity" YAML example

### DIFF
--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -108,7 +108,7 @@ Note that the SQL sensor state corresponds to the last row of the SQL result set
 
 Based on previous example with temperature, the query to get the former state is :
 ```sql
-SELECT * FROM (SELECT * FROM states WHERE entity_id = 'sensor.temperature_in' ORDER BY state_id DESC LIMIT 2) two_entity  ORDER BY state_id ASC LIMIT 1;
+SELECT * FROM (SELECT * FROM states WHERE entity_id = 'sensor.temperature_in' ORDER BY state_id DESC LIMIT 2) two_entity ORDER BY state_id ASC LIMIT 1;
 ```
 Thus in yaml
 ```yaml
@@ -117,7 +117,7 @@ sensor:
   - platform: sql
     queries:
       - name: Former_Temperature_In
-        query: "SELECT * FROM (SELECT state FROM states WHERE entity_id = 'sensor.temperature_in' ORDER BY state_id DESC LIMIT 2) two_entity  ORDER BY state_id ASC LIMIT 1;"
+        query: "SELECT * FROM (SELECT * FROM states WHERE entity_id = 'sensor.temperature_in' ORDER BY state_id DESC LIMIT 2) two_entity ORDER BY state_id ASC LIMIT 1;"
         column: "state"
 ```
 

--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -117,7 +117,7 @@ sensor:
   - platform: sql
     queries:
       - name: Former_Temperature_In
-        query: "SELECT * FROM (SELECT * FROM states WHERE entity_id = 'sensor.temperature_in' ORDER BY state_id DESC LIMIT 2) two_entity ORDER BY state_id ASC LIMIT 1;"
+        query: "SELECT * FROM (SELECT state, state_id FROM states WHERE entity_id = 'sensor.temperature_in' ORDER BY state_id DESC LIMIT 2) two_entity ORDER BY state_id ASC LIMIT 1;"
         column: "state"
 ```
 


### PR DESCRIPTION
In the YAML example of "Previous state of an entity" it's not enough to SELECT only 'state'. We need to choose at least 'state,state_id' for future sorting. Example with '*' add a bunch of attributes.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
