### PR TITLE
Add bond button platform, deprecate services that have been converted to buttons

### DIFF
--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -2,6 +2,7 @@
 title: Bond
 description: Instructions on setting up Bond Bridge within Home Assistant.
 ha_category:
+  - Button
   - Hub
   - Cover
   - Fan
@@ -18,6 +19,7 @@ ha_config_flow: true
 ha_quality_scale: platinum
 ha_zeroconf: true
 ha_platforms:
+  - button
   - cover
   - fan
   - light
@@ -57,31 +59,6 @@ upgrade your firmware from Bond app before adding this integration.
 
 Firmware version 2.10.8 or newer is required for push updates. The integration
 will fallback to polling for 2.10.x versions lower than .8
-
-### Service `bond.start_increasing_brightness`
-
-Start increasing the light brightness.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings of `entity_id`s.
-
-### Service `bond.start_decreasing_brightness`
-
-Start decreasing the light brightness.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings of `entity_id`s.
-
-### Service `bond.stop`
-
-Stop any in-progress action and empty the queue. Calling this service will
-stop any increase or decrease in brightness that is in progress.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings of `entity_id`s.
 
 ### Service `bond.set_fan_speed_tracked_state`
 


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add bond button platform, deprecate services that have been converted to buttons

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/64725
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
