### PR TITLE
Make the web notification docs up-to-date & readable

### DIFF
--- a/source/_integrations/html5.markdown
+++ b/source/_integrations/html5.markdown
@@ -91,15 +91,13 @@ The `html5` platform can only function if all of the following requirements are 
 
 ### Configuring the platform
 
-1. Make sure you can access your Home Assistant installation from outside your network over HTTPS ([see documentation](/docs/configuration/remote/)) or can perform an alternative [Domain Name Verification Method](https://support.google.com/webmasters/answer/9008080#domain_name_verification) on the domain used by Home Assistant.
-2. Create a new project at [https://console.cloud.google.com/home/dashboard](https://console.cloud.google.com/home/dashboard), this project will be imported into Firebase later (alternatively, the project can also be created during step 4).
-3. Go to [https://console.cloud.google.com/apis/credentials/domainverification](https://console.cloud.google.com/apis/credentials/domainverification) and verify your domain via Google Webmaster Central / Search Console - [see below](#verify-your-domain).
-4. With the domain verified, go to [https://console.firebase.google.com](https://console.firebase.google.com), select import Google project and select the project you created.
-5. Then, click the cogwheel on top left and select "Project settings".
-6. Select the ['Cloud Messaging' tab](https://console.firebase.google.com/project/_/settings/cloudmessaging).
-7. Generate a new key pair under the Web configuration listing at the bottom of the page. To view the private key click the three dots to the right and 'Show private key'.
-8. Select the ['Service Accounts' tab](https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk).
-9. Get the email address for the project under the text that says "Firebase service account" for reference. This is not what you have to insert in `vapid_email`! You'll have to insert your Google account e-mail there.
+1. Create a new project at [https://console.cloud.google.com/home/dashboard](https://console.cloud.google.com/home/dashboard), this project will be imported into Firebase later (alternatively, the project can also be created in the next step).
+2. Go to [https://console.firebase.google.com](https://console.firebase.google.com), and click the "Add project" button
+3. Choose your Google Cloud project for the name field (or create a new one). Decline analytics.
+4. Then, click the cogwheel on top left and select "Project settings".
+5. Select the "Cloud Messaging" tab.
+6. Generate a new key pair in "Web configuration" at the bottom of the page. Add the public key as `vapid_pub_key` in the config, then choose the 3 dots, and copy the private key for `vapid_prv_key` in the config.
+7. Input your Google email as `vapid_email` in the config.
 
 ### Setting up your browser
 
@@ -108,10 +106,9 @@ Assuming you have already configured the platform:
 {% my profile badge %}
 
 1. Open Home Assistant in Chrome or Firefox and load profile page by clicking the My button above or by clicking on the badge next to the Home Assistant title in the sidebar. Assuming you have met all the [requirements](#requirements) above then you should see a new slider for Push Notifications. If the slider is greyed out, ensure you are viewing Home Assistant via its external HTTPS address (and that you have configured the `notify` HTML5 integration in Home Assistant). If the slider is not visible, ensure you are not in the user configuration (Sidebar, Configuration, Users, View User).
-2. Slide it to the on position.
-3. Name the device you're using in the alert that appears.
-4. Within a few seconds you should be prompted to allow notifications from Home Assistant.
-5. Assuming you accept, that's all there is to it!
+2. Turn on the slider, and name the device you're using in the alert that appears.
+3. Within a few seconds you should be prompted to allow notifications from Home Assistant.
+4. Assuming you accept, that's all there is to it!
 
 **Note:** If you aren't prompted for a device name when enabling notifications, open the `html5_push_registrations.conf` file in your configuration directory. You will see a new entry for the browser you just added. Rename it from `unnamed device` to a name of your choice, which will make it easier to identify later. _Do not change anything else in this file!_ You need to restart Home Assistant after making any changes to the file.
 
@@ -243,7 +240,7 @@ data:
 
 You can dismiss notifications by using service html5.dismiss like so:
 
-```json
+```yaml
 target: ['my phone']
 data:
   tag: notification_tag
@@ -337,28 +334,3 @@ If you still have the problem, even with mentioned rule, try to add this code:
     proxy_set_header Authorization $http_authorization;
     proxy_pass_header Authorization;
 ```
-
-#### Verify your domain
-
-If you need to verify domain ownership with Google Webmaster Central/Search Console while configuring this component, follow these steps:
-
-##### HTML file verification (only works for `/local` URLs)
-
-1. Enter your domain and add `/local` at the end, e.g., `https://example.com:8123/local`
-2. Select HTML file verification and download the google*.html file.
-3. Create a directory named `www` in your Home Assistant configuration directory (`/config/` share from Samba add-on).
-4. Place the downloaded `google*.html` file in the `www` directory.
-5. RESTART Home Assistant. **This is important!**
-6. Verify the file can be accessed in the browser, e.g., `https://example.com:8123/local/google123456789.html` (change filename). You should see a plain text message saying "google-site-verification: ...". If you see "404: Not Found" or something else, retry the above steps.
-7. Go back to Google Webmaster Central/Search Console and proceed with the verification.
-
-##### DNS verification (only if you control your DNS record or use DuckDNS)
-
-1. Enter your domain's base URL, like `https://example.com:8123/`
-2. Select DNS verification. If you're asked to choose your DNS provider, choose "Any DNS provider" or "Other".
-3. Add the TXT record to your DNS. If you use DuckDNS, use the format:
-   ```text
-   https://www.duckdns.org/update?domains={your Duck DNS subdomain (the part before .duckdns.org)}&token={your Duck DNS token}&txt={google-site-verification record}
-   ```
-4. Wait until the changes take effect. This can be anywhere from seconds to hours, so be patient. You can use [this site to test it](https://www.digwebinterface.com/).
-5. Go back to Google Webmaster Central/Search Console and proceed with the verification.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This updates the docs for the HTML5 Push Notification integration to be up to date, given that Google has changed the process since it was originally made.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
