### PR TITLE
Improve description of compensation integration 

### DIFF
--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -33,7 +33,7 @@ compensation:
 
 {% configuration %}
 source:
-  description: The entity to monitor.
+  description: The entity to monitor/compensate.
   required: true
   type: string
 data_points:
@@ -45,7 +45,7 @@ unique_id:
   required: false
   type: string
 attribute:
-  description: Attribute to monitor.
+  description: Attribute from the source to monitor/compensate. When omitted the state value of the source will be used.
   required: false
   type: string
 degree:


### PR DESCRIPTION
## Proposed change
Have the documentation of the compensation integration be more clear about the usage of the attribute option.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
This issue was first discussed https://github.com/home-assistant/core/issues/64774

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
