### PR TITLE
Add/Update command_line documentation for new yaml

### DIFF
--- a/source/_integrations/binary_sensor.command_line.markdown
+++ b/source/_integrations/binary_sensor.command_line.markdown
@@ -1,0 +1,172 @@
+---
+title: Legacy Command Line Binary Sensor
+description: Instructions on how to integrate command line binary sensors within Home Assistant.
+ha_category:
+  - Utility
+  - Binary Sensor
+ha_release: 0.12
+ha_iot_class: Local Polling
+ha_domain: command_line
+ha_platforms:
+  - binary_sensor
+  - cover
+  - notify
+  - sensor
+  - switch
+---
+
+The `command_line` binary sensor platform issues specific commands to get data.
+
+## Configuration
+
+_This format still works but is no longer recommended. [Use modern configuration](/integrations/command_line.binary_sensor/)._
+
+To use your Command binary sensor in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+binary_sensor:
+  - platform: command_line
+    command: "cat /proc/sys/net/ipv4/ip_forward"
+```
+
+<div class='note'>
+
+It's highly recommended to enclose the command in single quotes `'` as it ensures all characters can be used in the command and reduces the risk of unintentional escaping. To include a single quote in a command enclosed in single quotes, double it: `''`.
+
+</div>
+
+{% configuration %}
+command:
+  description: The action to take to get the value.
+  required: true
+  type: string
+name:
+  description: Let you overwrite the name of the device.
+  required: false
+  type: string
+  default: "*name* from the device"
+device_class:
+  description: Sets the [class of the device](/integrations/binary_sensor/), changing the device state and icon that is displayed on the frontend.
+  required: false
+  type: string
+payload_on:
+  description: The payload that represents enabled state.
+  required: false
+  type: string
+  default: 'ON'
+payload_off:
+  description: The payload that represents disabled state.
+  required: false
+  type: string
+  default: 'OFF'
+value_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
+  required: false
+  type: string
+scan_interval:
+  description: Defines number of seconds for polling interval.
+  required: false
+  type: integer
+  default: 60
+command_timeout:
+  description: Defines number of seconds for command timeout.
+  required: false
+  type: integer
+  default: 15
+unique_id:
+  description: An ID that uniquely identifies this binary sensor. Set this to a unique value to allow customization through the UI.
+  required: false
+  type: string
+{% endconfiguration %}
+
+## Execution
+
+The `command` is executed within the [configuration directory](/docs/configuration/).
+
+<div class='note'>
+
+If you are using [Home Assistant Operating System](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
+
+</div>
+
+With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the sensors value is not updated.
+
+## Examples
+
+In this section you find some real-life examples of how to use this sensor.
+
+### SickRage
+
+Check the state of an [SickRage](https://github.com/sickragetv/sickrage) instance.
+
+```yaml
+# Example configuration.yaml entry
+binary_sensor:
+  - platform: command_line
+    command: 'netstat -na | find "33322" | find /c "LISTENING" > nul && (echo "Running") || (echo "Not running")'
+    name: "sickragerunning"
+    device_class: moving
+    payload_on: "Running"
+    payload_off: "Not running"
+```
+
+### Check RasPlex
+
+Check if [RasPlex](https://github.com/RasPlex/RasPlex) is `online`.
+
+```yaml
+binary_sensor:
+  - platform: command_line
+    command: 'ping -c 1 rasplex.local | grep "1 received" | wc -l'
+    name: "is_rasplex_online"
+    device_class: connectivity
+    payload_on: 1
+    payload_off: 0
+```
+
+An alternative solution could look like this:
+
+```yaml
+binary_sensor:
+  - platform: command_line
+    name: Printer
+    command: 'ping -W 1 -c 1 192.168.1.10 > /dev/null 2>&1 && echo success || echo fail'
+    device_class: connectivity
+    payload_on: "success"
+    payload_off: "fail"
+```
+
+Consider to use the [ping sensor](/integrations/ping#binary-sensor) as an alternative to the samples above.
+
+### Check if a system service is running
+
+The services running is listed in `/etc/systemd/system` and can be checked with the `systemctl` command:
+
+```bash
+$ systemctl is-active home-assistant@rock64.service
+active
+$ sudo service home-assistant@rock64.service stop
+$ systemctl is-active home-assistant@rock64.service
+inactive
+```
+
+A binary command line sensor can check this:
+
+```yaml
+binary_sensor:
+  - platform: command_line
+    command: '/bin/systemctl is-active home-assistant@rock64.service'
+    payload_on: "active"
+    payload_off: "inactive"
+```
+
+## Services
+
+Available services: `reload`.
+
+### Service `command_line.reload`
+
+Reload all `command_line` entities.
+
+This service takes no service data attributes.

--- a/source/_integrations/binary_sensor.command_line.markdown
+++ b/source/_integrations/binary_sensor.command_line.markdown
@@ -9,10 +9,6 @@ ha_iot_class: Local Polling
 ha_domain: command_line
 ha_platforms:
   - binary_sensor
-  - cover
-  - notify
-  - sensor
-  - switch
 ---
 
 The `command_line` binary sensor platform issues specific commands to get data.

--- a/source/_integrations/command_line.binary_sensor.markdown
+++ b/source/_integrations/command_line.binary_sensor.markdown
@@ -1,0 +1,154 @@
+---
+title: Command Line Binary Sensor
+description: Instructions on how to integrate Command binary sensors within Home Assistant.
+ha_category:
+  - Utility
+  - Binary Sensor
+ha_release: 0.12
+ha_iot_class: Local Polling
+ha_domain: command_line
+---
+
+The `command_line` binary sensor platform issues specific commands to get data.
+
+## Configuration
+
+To use your Command binary sensor in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+command_line:
+  - binary_sensor:
+    - command: "cat /proc/sys/net/ipv4/ip_forward"
+```
+
+<div class='note'>
+
+It's highly recommended to enclose the command in single quotes `'` as it ensures all characters can be used in the command and reduces the risk of unintentional escaping. To include a single quote in a command enclosed in single quotes, double it: `''`.
+
+</div>
+
+{% configuration %}
+command:
+  description: The action to take to get the value.
+  required: true
+  type: string
+name:
+  description: Let you overwrite the name of the device.
+  required: false
+  type: string
+  default: "*name* from the device"
+device_class:
+  description: Sets the [class of the device](/integrations/binary_sensor/), changing the device state and icon that is displayed on the frontend.
+  required: false
+  type: string
+payload_on:
+  description: The payload that represents enabled state.
+  required: false
+  type: string
+  default: 'ON'
+payload_off:
+  description: The payload that represents disabled state.
+  required: false
+  type: string
+  default: 'OFF'
+value_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
+  required: false
+  type: string
+scan_interval:
+  description: Defines number of seconds for polling interval.
+  required: false
+  type: integer
+  default: 60
+command_timeout:
+  description: Defines number of seconds for command timeout.
+  required: false
+  type: integer
+  default: 15
+unique_id:
+  description: An ID that uniquely identifies this binary sensor. Set this to a unique value to allow customization through the UI.
+  required: false
+  type: string
+{% endconfiguration %}
+
+## Execution
+
+The `command` is executed within the [configuration directory](/docs/configuration/).
+
+<div class='note'>
+
+If you are using [Home Assistant Operating System](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
+
+</div>
+
+With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the sensors value is not updated.
+
+## Examples
+
+In this section you find some real-life examples of how to use this sensor.
+
+### SickRage
+
+Check the state of an [SickRage](https://github.com/sickragetv/sickrage) instance.
+
+```yaml
+# Example configuration.yaml entry
+command_line:
+  - binary_sensor:
+    - command: 'netstat -na | find "33322" | find /c "LISTENING" > nul && (echo "Running") || (echo "Not running")'
+      name: "sickragerunning"
+      device_class: moving
+      payload_on: "Running"
+      payload_off: "Not running"
+```
+
+### Check RasPlex
+
+Check if [RasPlex](https://github.com/RasPlex/RasPlex) is `online`.
+
+```yaml
+command_line:
+  - binary_sensor:
+    - command: 'ping -c 1 rasplex.local | grep "1 received" | wc -l'
+      name: "is_rasplex_online"
+      device_class: connectivity
+      payload_on: 1
+      payload_off: 0
+```
+
+An alternative solution could look like this:
+
+```yaml
+command_line:
+  - binary_sensor:
+    - name: Printer
+      command: 'ping -W 1 -c 1 192.168.1.10 > /dev/null 2>&1 && echo success || echo fail'
+      device_class: connectivity
+      payload_on: "success"
+      payload_off: "fail"
+```
+
+Consider to use the [ping sensor](/integrations/ping#binary-sensor) as an alternative to the samples above.
+
+### Check if a system service is running
+
+The services running is listed in `/etc/systemd/system` and can be checked with the `systemctl` command:
+
+```bash
+$ systemctl is-active home-assistant@rock64.service
+active
+$ sudo service home-assistant@rock64.service stop
+$ systemctl is-active home-assistant@rock64.service
+inactive
+```
+
+A binary command line sensor can check this:
+
+```yaml
+command_line:
+  - binary_sensor:
+    - command: '/bin/systemctl is-active home-assistant@rock64.service'
+      payload_on: "active"
+      payload_off: "inactive"
+```

--- a/source/_integrations/command_line.cover.markdown
+++ b/source/_integrations/command_line.cover.markdown
@@ -1,0 +1,90 @@
+---
+title: "Command Line Cover"
+description: "How to control a cover with the command line."
+ha_category:
+  - Cover
+ha_release: 0.14
+ha_iot_class: Local Polling
+ha_domain: command_line
+---
+
+A `command_line`cover platform that issues specific commands when it is moved up, down and stopped. It allows anyone to integrate any type of cover into Home Assistant that can be controlled from the command line.
+
+To enable a command line cover in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+command_line:
+  - cover:
+    - name: Garage Door
+      command_open: move_command up garage
+      command_close: move_command down garage
+      command_stop: move_command stop garage
+```
+
+{% configuration %}
+name:
+  description: The name of the cover.
+  required: false
+  type: string
+command_open:
+  description: The command to open the cover.
+  required: true
+  default: true
+  type: string
+command_close:
+  description: The action to close the cover.
+  required: true
+  default: true
+  type: string
+command_stop:
+  description: The action to stop the cover.
+  required: true
+  default: true
+  type: string
+command_state:
+  description: If given, this will act as a sensor that runs in the background and updates the state of the cover. If the command returns a `0` the indicates the cover is fully closed, whereas a 100 indicates the cover is fully open.
+  required: false
+  type: string
+value_template:
+  description: if specified, `command_state` will ignore the result code of the command but the template evaluating will indicate the position of the cover. For example, if your `command_state` returns a string "open", using `value_template` as in the example configuration above will allow you to translate that into the valid state `100`.
+  required: false
+  default: "'{% raw %}{{ value }}{% endraw%}'"
+  type: template
+command_timeout:
+  description: Defines number of seconds for command timeout.
+  required: false
+  type: integer
+  default: 15
+unique_id:
+  description: An ID that uniquely identifies this cover. Set this to a unique value to allow customization through the UI.
+  required: false
+  type: string
+{% endconfiguration %}
+
+## Examples
+
+In this section you find some real-life examples of how to use this sensor.
+
+### Full configuration
+
+{% raw %}
+
+```yaml
+# Example configuration.yaml entry
+command_line:
+  - cover:
+    - name: Garage Door
+      command_open: move_command up garage
+      command_close: move_command down garage
+      command_stop: move_command stop garage
+      command_state: state_command garage
+      value_template: >
+        {% if value == 'open' %}
+        100
+        {% elif value == 'closed' %}
+        0
+        {% endif %}
+```
+
+{% endraw %}

--- a/source/_integrations/command_line.markdown
+++ b/source/_integrations/command_line.markdown
@@ -1,9 +1,8 @@
 ---
 title: Command Line
-description: Instructions on how to integrate Command binary sensors within Home Assistant.
+description: Instructions on how to integrate Command line platform within Home Assistant.
 ha_category:
   - Utility
-  - Binary Sensor
 ha_release: 0.12
 ha_iot_class: Local Polling
 ha_domain: command_line
@@ -15,149 +14,31 @@ ha_platforms:
   - switch
 ---
 
-The `command_line` binary sensor platform issues specific commands to get data.
+The `command_line` domain issues specific commands to get data or set data.
 
 ## Configuration
 
-To use your Command binary sensor in your installation, add the following to your `configuration.yaml` file:
+To use the command line platform in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
-binary_sensor:
-  - platform: command_line
-    command: "cat /proc/sys/net/ipv4/ip_forward"
+command_line:
+  - sensor:
+    - name: cat ip forward
+      command: "cat /proc/sys/net/ipv4/ip_forward"
+  - switch:
+    - name: Kitchen Light:
+      command_on: switch_command on kitchen
+      command_off: switch_command off kitchen
 ```
 
-<div class='note'>
+## Platforms
 
-It's highly recommended to enclose the command in single quotes `'` as it ensures all characters can be used in the command and reduces the risk of unintentional escaping. To include a single quote in a command enclosed in single quotes, double it: `''`.
-
-</div>
-
-{% configuration %}
-command:
-  description: The action to take to get the value.
-  required: true
-  type: string
-name:
-  description: Let you overwrite the name of the device.
-  required: false
-  type: string
-  default: "*name* from the device"
-device_class:
-  description: Sets the [class of the device](/integrations/binary_sensor/), changing the device state and icon that is displayed on the frontend.
-  required: false
-  type: string
-payload_on:
-  description: The payload that represents enabled state.
-  required: false
-  type: string
-  default: 'ON'
-payload_off:
-  description: The payload that represents disabled state.
-  required: false
-  type: string
-  default: 'OFF'
-value_template:
-  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
-  required: false
-  type: string
-scan_interval:
-  description: Defines number of seconds for polling interval.
-  required: false
-  type: integer
-  default: 60
-command_timeout:
-  description: Defines number of seconds for command timeout.
-  required: false
-  type: integer
-  default: 15
-unique_id:
-  description: An ID that uniquely identifies this binary sensor. Set this to a unique value to allow customization through the UI.
-  required: false
-  type: string
-{% endconfiguration %}
-
-## Execution
-
-The `command` is executed within the [configuration directory](/docs/configuration/).
-
-<div class='note'>
-
-If you are using [Home Assistant Operating System](https://github.com/home-assistant/operating-system), the commands are executed in the `homeassistant` container context. So if you test or debug your script, it might make sense to do this in the context of this container to get the same runtime environment.
-
-</div>
-
-With a `0` exit code, the output (stdout) of the command is used as `value`. In case a command results in a non `0` exit code or is terminated by the `command_timeout`, the result is only logged to Home Assistant log and the sensors value is not updated.
-
-## Examples
-
-In this section you find some real-life examples of how to use this sensor.
-
-### SickRage
-
-Check the state of an [SickRage](https://github.com/sickragetv/sickrage) instance.
-
-```yaml
-# Example configuration.yaml entry
-binary_sensor:
-  - platform: command_line
-    command: 'netstat -na | find "33322" | find /c "LISTENING" > nul && (echo "Running") || (echo "Not running")'
-    name: "sickragerunning"
-    device_class: moving
-    payload_on: "Running"
-    payload_off: "Not running"
-```
-
-### Check RasPlex
-
-Check if [RasPlex](https://github.com/RasPlex/RasPlex) is `online`.
-
-```yaml
-binary_sensor:
-  - platform: command_line
-    command: 'ping -c 1 rasplex.local | grep "1 received" | wc -l'
-    name: "is_rasplex_online"
-    device_class: connectivity
-    payload_on: 1
-    payload_off: 0
-```
-
-An alternative solution could look like this:
-
-```yaml
-binary_sensor:
-  - platform: command_line
-    name: Printer
-    command: 'ping -W 1 -c 1 192.168.1.10 > /dev/null 2>&1 && echo success || echo fail'
-    device_class: connectivity
-    payload_on: "success"
-    payload_off: "fail"
-```
-
-Consider to use the [ping sensor](/integrations/ping#binary-sensor) as an alternative to the samples above.
-
-### Check if a system service is running
-
-The services running is listed in `/etc/systemd/system` and can be checked with the `systemctl` command:
-
-```bash
-$ systemctl is-active home-assistant@rock64.service
-active
-$ sudo service home-assistant@rock64.service stop
-$ systemctl is-active home-assistant@rock64.service
-inactive
-```
-
-A binary command line sensor can check this:
-
-```yaml
-binary_sensor:
-  - platform: command_line
-    command: '/bin/systemctl is-active home-assistant@rock64.service'
-    payload_on: "active"
-    payload_off: "inactive"
-```
+- [Binary Sensor](/integrations/command_line.binary_sensor/)
+- [Cover](/integrations/command_line.cover/)
+- [Notify](/integrations/notify.command_line/)
+- [Sensor](/integrations/command_line.sensor/)
+- [Switch](/integrations/command_line.switch/)
 
 ## Services
 
@@ -168,3 +49,9 @@ Available services: `reload`.
 Reload all `command_line` entities.
 
 This service takes no service data attributes.
+
+## Legacy Platform Config
+- [Legacy Binary Sensor](/integrations/binary_sensor.command_line/)
+- [Legacy Cover](/integrations/cover.command_line/)
+- [Legacy Sensor](/integrations/sensor.command_line/)
+- [Legacy Switch](/integrations/switch.command_line/)

--- a/source/_integrations/command_line.sensor.markdown
+++ b/source/_integrations/command_line.sensor.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Legacy Command Line Sensor"
+title: "Command Line Sensor"
 description: "Instructions on how to integrate command line sensors into Home Assistant."
 ha_category:
   - Utility
@@ -14,15 +14,13 @@ The `command_line` sensor platform simply issues specific commands to get its da
 
 ## Configuration
 
-_This format still works but is no longer recommended. [Use modern configuration](/integrations/command_line.sensor/)._
-
 To enable it, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
-  - platform: command_line
-    command: SENSOR_COMMAND
+command_line:
+  - sensor:
+    - command: SENSOR_COMMAND
 ```
 
 {% configuration %}
@@ -86,13 +84,13 @@ Thanks to the [`proc`](https://en.wikipedia.org/wiki/Procfs) file system, variou
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
-  - platform: command_line
-    name: CPU Temperature
-    command: "cat /sys/class/thermal/thermal_zone0/temp"
-    # If errors occur, make sure configuration file is encoded as UTF-8
-    unit_of_measurement: "°C"
-    value_template: "{{ value | multiply(0.001) | round(1) }}"
+command_line:
+  - sensor:
+    - name: CPU Temperature
+      command: "cat /sys/class/thermal/thermal_zone0/temp"
+      # If errors occur, make sure configuration file is encoded as UTF-8
+      unit_of_measurement: "°C"
+      value_template: "{{ value | multiply(0.001) | round(1) }}"
 ```
 
 {% endraw %}
@@ -103,10 +101,10 @@ If you'd like to know how many failed login attempts are made to Home Assistant,
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
-  - platform: command_line
-    name: badlogin
-    command: "grep -c 'Login attempt' /home/hass/.homeassistant/home-assistant.log"
+command_line:
+  - sensor:
+    - name: badlogin
+      command: "grep -c 'Login attempt' /home/hass/.homeassistant/home-assistant.log"
 ```
 
 Make sure to configure the [Logger integration](/integrations/logger) to monitor the [HTTP integration](/integrations/http/) at least the `warning` level.
@@ -124,10 +122,10 @@ logger:
 You can see directly in the frontend (**Developer tools** -> **About**) what release of Home Assistant you are running. The Home Assistant releases are available on the [Python Package Index](https://pypi.python.org/pypi). This makes it possible to get the current release.
 
 ```yaml
-sensor:
-  - platform: command_line
-    command: python3 -c "import requests; print(requests.get('https://pypi.python.org/pypi/homeassistant/json').json()['info']['version'])"
-    name: HA release
+command_line:
+  - sensor:
+    - command: python3 -c "import requests; print(requests.get('https://pypi.python.org/pypi/homeassistant/json').json()['info']['version'])"
+      name: HA release
 ```
 
 ### Read value out of a remote text file
@@ -135,10 +133,10 @@ sensor:
 If you own devices which are storing values in text files which are accessible over HTTP then you can use the same approach as shown in the previous section. Instead of looking at the JSON response we directly grab the sensor's value.
 
 ```yaml
-sensor:
-  - platform: command_line
-    command: python3 -c "import requests; print(requests.get('http://remote-host/sensor_data.txt').text)"
-    name: File value
+command_line:
+  - sensor:
+    - command: python3 -c "import requests; print(requests.get('http://remote-host/sensor_data.txt').text)"
+      name: File value
 ```
 
 ### Use an external script
@@ -165,10 +163,10 @@ To use the script you need to add something like the following to your `configur
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
-  - platform: command_line
-    name: Brightness
-    command: "python3 /path/to/script/arest-value.py"
+command_line:
+  - sensor:
+    - name: Brightness
+      command: "python3 /path/to/script/arest-value.py"
 ```
 
 ### Usage of templating in `command:`
@@ -179,11 +177,11 @@ sensor:
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
-  - platform: command_line
-    name: wind direction
-    command: "sh /home/pi/.homeassistant/scripts/wind_direction.sh {{ states('sensor.wind_direction') }}"
-    unit_of_measurement: "Direction"
+command_line:
+  - sensor:
+    - name: wind direction
+      command: "sh /home/pi/.homeassistant/scripts/wind_direction.sh {{ states('sensor.wind_direction') }}"
+      unit_of_measurement: "Direction"
 ```
 
 {% endraw %}
@@ -196,14 +194,14 @@ The example shows how you can retrieve multiple values with one sensor (where th
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
-  - platform: command_line
-    name: JSON time
-    json_attributes:
-      - date
-      - milliseconds_since_epoch
-    command: "python3 /home/pi/.homeassistant/scripts/datetime.py"
-    value_template: "{{ value_json.time }}"
+command_line:
+  - sensor:
+    - name: JSON time
+      json_attributes:
+        - date
+        - milliseconds_since_epoch
+      command: "python3 /home/pi/.homeassistant/scripts/datetime.py"
+      value_template: "{{ value_json.time }}"
 ```
 
 {% endraw %}

--- a/source/_integrations/command_line.switch.markdown
+++ b/source/_integrations/command_line.switch.markdown
@@ -1,0 +1,173 @@
+---
+title: "Command Line Switch"
+description: "Instructions on how to have switches call command line commands."
+ha_category:
+  - Switch
+ha_release: pre 0.7
+ha_iot_class: Local Polling
+ha_domain: command_line
+---
+
+The `command_line` switch platform issues specific commands when it is turned on
+and off. This might very well become our most powerful platform as it allows
+anyone to integrate any type of switch into Home Assistant that can be
+controlled from the command line, including calling other scripts!
+
+To enable it, add the following lines to your `configuration.yaml`:
+
+```yaml
+# Example configuration.yaml entry
+command_line:
+  - switch:
+    - name: Kitchen Light
+      command_on: switch_command on kitchen
+      command_off: switch_command off kitchen
+```
+
+{% configuration %}
+name:
+  description: The name of the switch.
+  required: false
+  type: string
+command_on:
+  description: The action to take for on.
+  required: true
+  type: string
+command_off:
+  description: The action to take for off.
+  required: true
+  type: string
+command_state:
+  description: "If given, this command will be run. Returning a result code `0` will indicate that the switch is on."
+  required: false
+  type: string
+value_template:
+  description: "If specified, `command_state` will ignore the result code of the command but the template evaluating to `true` will indicate the switch is on."
+  required: false
+  type: string
+friendly_name:
+  description: Use this if you want name in backend and frontend do differ.
+  required: false
+  type: string
+icon_template:
+  description: Defines a template for the icon of the entity.
+  required: false
+  type: template
+command_timeout:
+  description: Defines number of seconds for command timeout.
+  required: false
+  type: integer
+  default: 15
+unique_id:
+  description: An ID that uniquely identifies this switch. Set this to a unique value to allow customization through the UI.
+  required: false
+  type: string
+{% endconfiguration %}
+
+## Examples
+
+In this section you find some real-life examples of how to use this switch.
+
+### Change the icon when a state changes
+
+This example demonstrates how to use template to change the icon as its state changes. This icon is referencing its own state.
+
+{% raw %}
+
+```yaml
+command_line:
+  - switch:
+    - name: driveway_sensor_motion
+      friendly_name: Driveway buiten sensor
+      command_on: >
+        curl -X PUT -d '{"on":true}' "http://ip_address/api/sensors/27/config/"
+      command_off: >
+        curl -X PUT -d '{"on":false}' "http://ip_address/api/sensors/27/config/"
+      command_state: curl http://ip_address/api/sensors/27/
+        value_template: >
+          {{value_json.config.on}}
+        icon_template: >
+          {% if value_json.config.on == true %} mdi:toggle-switch
+          {% else %} mdi:toggle-switch-off
+          {% endif %}
+```
+
+{% endraw %}
+
+### aREST device
+
+The example below is doing the same as the
+[aREST switch](/integrations/arest#switch).
+The command line tool [`curl`](https://curl.haxx.se/) is used to toggle a pin
+which is controllable through REST.
+
+{% raw %}
+
+```yaml
+# Example configuration.yaml entry
+command_line:
+  - switch:
+    - name: arest_pin_four
+      command_on: "/usr/bin/curl -X GET http://192.168.1.10/digital/4/1"
+      command_off: "/usr/bin/curl -X GET http://192.168.1.10/digital/4/0"
+      command_state: "/usr/bin/curl -X GET http://192.168.1.10/digital/4"
+      value_template: '{{ value == "1" }}'
+      friendly_name: Kitchen Lightswitch
+```
+
+{% endraw %}
+
+### Shutdown your local host
+
+This switch will shutdown your system that is hosting Home Assistant.
+
+<div class='note warning'>
+This switch will shutdown your host immediately, there will be no confirmation.
+</div>
+
+```yaml
+# Example configuration.yaml entry
+command_line:
+  - switch:
+    - name: Home Assistant System Shutdown
+      command_off: "/usr/sbin/poweroff"
+```
+
+### Control your VLC player
+
+This switch will control a local VLC media player
+([Source](https://community.home-assistant.io/t/vlc-player/106)).
+
+```yaml
+# Example configuration.yaml entry
+command_line:
+  - switch:
+    - name: vlc
+      command_on: "cvlc 1.mp3 vlc://quit &"
+      command_off: "pkill vlc"
+```
+
+### Control Foscam Motion Sensor
+
+This switch will control the motion sensor of Foscam Webcams which Support CGI
+Commands ([Source](https://www.iltucci.com/blog/wp-content/uploads/2018/12/Foscam-IPCamera-CGI-User-Guide-V1.0.4.pdf)).
+This switch supports statecmd,
+which checks the current state of motion detection.
+
+{% raw %}
+
+```yaml
+# Example configuration.yaml entry
+command_line:
+  - switch:
+    - name: Foscam Motion
+      command_on: 'curl -k "https://ipaddress:443/cgi-bin/CGIProxy.fcgi?cmd=setMotionDetectConfig&isEnable=1&usr=admin&pwd=password"'
+      command_off: 'curl -k "https://ipaddress:443/cgi-bin/CGIProxy.fcgi?cmd=setMotionDetectConfig&isEnable=0&usr=admin&pwd=password"'
+      command_state: 'curl -k --silent "https://ipaddress:443/cgi-bin/CGIProxy.fcgi?cmd=getMotionDetectConfig&usr=admin&pwd=password" | grep -oP "(?<=isEnable>).*?(?=</isEnable>)"'
+      value_template: '{{ value == "1" }}'
+```
+
+{% endraw %}
+
+- Replace admin and password with an "Admin" privileged Foscam user
+- Replace ipaddress with the local IP address of your Foscam

--- a/source/_integrations/cover.command_line.markdown
+++ b/source/_integrations/cover.command_line.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Command Line Cover"
+title: "Legacy Command Line Cover"
 description: "How to control a cover with the command line."
 ha_category:
   - Cover
@@ -7,6 +7,8 @@ ha_release: 0.14
 ha_iot_class: Local Polling
 ha_domain: command_line
 ---
+
+_This format still works but is no longer recommended. [Use modern configuration](/integrations/command_line.cover/)._
 
 A `command_line`cover platform that issues specific commands when it is moved up, down and stopped. It allows anyone to integrate any type of cover into Home Assistant that can be controlled from the command line.
 

--- a/source/_integrations/notify.command_line.markdown
+++ b/source/_integrations/notify.command_line.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Command line Notify"
+title: "Command Line Notify"
 description: "Instructions on how to add command line notifications to Home Assistant."
 ha_category:
   - Notifications

--- a/source/_integrations/switch.command_line.markdown
+++ b/source/_integrations/switch.command_line.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Command line Switch"
+title: "Legacy Command Line Switch"
 description: "Instructions on how to have switches call command line commands."
 ha_category:
   - Switch
@@ -7,6 +7,8 @@ ha_release: pre 0.7
 ha_iot_class: Local Polling
 ha_domain: command_line
 ---
+
+_This format still works but is no longer recommended. [Use modern configuration](/integrations/command_line.switch/)._
 
 The `command_line` switch platform issues specific commands when it is turned on
 and off. This might very well become our most powerful platform as it allows

--- a/source/_redirects
+++ b/source/_redirects
@@ -129,7 +129,7 @@
 /components/binary_sensor.blink /integrations/blink
 /components/binary_sensor.bloomsky /integrations/bloomsky#binary-sensor
 /components/binary_sensor.bmw_connected_drive /integrations/bmw_connected_drive
-/components/binary_sensor.command_line /integrations/command_line
+/components/binary_sensor.command_line /integrations/binary_sensor.command_line
 /components/binary_sensor.concord232 /integrations/concord232#binary-sensor
 /components/binary_sensor.danfoss_air /integrations/danfoss_air#binary-sensor
 /components/binary_sensor.deconz /integrations/deconz#binary-sensor


### PR DESCRIPTION
## Proposed change
Adds command_line platform documentation for the new yaml configuration.
My approach is that each gets its own site like before but under the command_line domain.
The alternative would be to merge it all under command_line.markdown.
The new documentation is basically the legacy component documentation but with updated yaml configuration examples.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/63840
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
