### PR TITLE
Add unique_id to modbus entities

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -265,6 +265,10 @@ slave:
   required: false
   type: integer
   default: 0
+unique_id:
+  description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+  required: false
+  type: string
 {% endconfiguration %}
 
 ### Configuring data_type and struct
@@ -314,6 +318,10 @@ swap:
   required: false
   default: none
   type: string
+unique_id:
+  description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+  required: false
+  type: string
 {% endconfiguration %}
 
 ## Configuring platform binary sensor
@@ -357,6 +365,10 @@ binary_sensors:
       description: type of address (discrete_input/coil)
       required: false
       default: coil
+      type: string
+    unique_id:
+      description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+      required: false
       type: string
 {% endconfiguration %}
 
@@ -435,6 +447,10 @@ climates:
       required: false
       type: string
       default: C
+    unique_id:
+      description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+      required: false
+      type: string
 {% endconfiguration %}
 
 ### Service `modbus.set-temperature`
@@ -524,6 +540,10 @@ covers:
       type: integer
     status_register_type:
       description: Modbus register type (holding, input), default holding.
+      required: false
+      type: string
+    unique_id:
+      description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
       required: false
       type: string
 {% endconfiguration %}
@@ -713,6 +733,10 @@ fans:
           required: false
           default: same as command_off
           type: integer
+        unique_id:
+          description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+          required: false
+          type: string
 {% endconfiguration %}
 
 ## Configuring platform light
@@ -802,6 +826,10 @@ lights:
           required: false
           default: same as command_off
           type: integer
+        unique_id:
+          description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+          required: false
+          type: string
 {% endconfiguration %}
 
 ## Configuring platform sensor
@@ -881,7 +909,11 @@ sensors:
     state_class:
       description: The [state_class](https://developers.home-assistant.io/docs/core/entity/sensor#available-state-classes) of the sensor.
       required: false
-      type: string
+    type: string
+      unique_id:
+        description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+        required: false
+        type: string
 {% endconfiguration %}
 
 <div class='note'>
@@ -1001,6 +1033,10 @@ switches:
           required: false
           default: same as command_off
           type: integer
+          unique_id:
+            description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+            required: false
+            type: string
 {% endconfiguration %}
 
 ## Opening an issue

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -733,10 +733,10 @@ fans:
           required: false
           default: same as command_off
           type: integer
-        unique_id:
-          description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
-          required: false
-          type: string
+    unique_id:
+      description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+      required: false
+      type: string
 {% endconfiguration %}
 
 ## Configuring platform light
@@ -826,10 +826,10 @@ lights:
           required: false
           default: same as command_off
           type: integer
-        unique_id:
-          description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
-          required: false
-          type: string
+    unique_id:
+      description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+      required: false
+      type: string
 {% endconfiguration %}
 
 ## Configuring platform sensor
@@ -909,11 +909,11 @@ sensors:
     state_class:
       description: The [state_class](https://developers.home-assistant.io/docs/core/entity/sensor#available-state-classes) of the sensor.
       required: false
-    type: string
-      unique_id:
-        description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
-        required: false
-        type: string
+      type: string
+    unique_id:
+      description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+      required: false
+      type: string
 {% endconfiguration %}
 
 <div class='note'>
@@ -1033,10 +1033,10 @@ switches:
           required: false
           default: same as command_off
           type: integer
-          unique_id:
-            description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
-            required: false
-            type: string
+        unique_id:
+          description: An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception.
+          required: false
+          type: string
 {% endconfiguration %}
 
 ## Opening an issue


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

update Doc for pull request "Add unique_id at modbus entity"


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/64634
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
