### PR TITLE
Add documentation for new Unmanic integration

### DIFF
--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -252,6 +252,7 @@
         "Ubuntu",
         "UI",
         "UniFi",
+        "Unmanic",
         "unRAID",
         "UPnP",
         "UPS",

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -544,6 +544,7 @@ source/_integrations/ubus.markdown @noltari
 source/_integrations/unifi.markdown @Kane610
 source/_integrations/unifiled.markdown @florisvdk
 source/_integrations/unifiprotect.markdown @briis @AngellusMortis @bdraco
+source/_integrations/unmanic.markdown @JeffResc
 source/_integrations/upb.markdown @gwww
 source/_integrations/upc_connect.markdown @pvizeli @fabaff
 source/_integrations/upcloud.markdown @scop

--- a/source/_integrations/unmanic.markdown
+++ b/source/_integrations/unmanic.markdown
@@ -8,7 +8,7 @@ ha_iot_class: Local Polling
 ha_domain: unmanic
 ha_config_flow: true
 ha_codeowners:
-  - '@JeffResc'
+  - "@JeffResc"
 ha_platforms:
   - button
   - number
@@ -30,22 +30,22 @@ The Unmanic integration will add the following entities:
 
 ## Numbers
 
-- `number.unmanic_worker_count`: The configured number of workers.
 - `number.unmanic_concurrent_file_testers`: The configured number of concurrent file testers.
 - `number.unmanic_distributed_worker_count`: The configured number of distributed workers.
+- `number.unmanic_worker_count`: The configured number of workers.
 
 ## Sensors
 
 - `sensor.unmanic_active_workers`: The number of active workers.
-- `sensor.unmanic_total_workers`: The number of total workers.
-- `sensor.unmanic_pending_tasks`: The number of pending tasks in the queue.
 - `sensor.unmanic_completed_tasks`: The number of completed tasks in the history.
+- `sensor.unmanic_pending_tasks`: The number of pending tasks in the queue.
+- `sensor.unmanic_total_workers`: The number of total workers.
 
 ## Switches
 
-- `switch.unmanic_clear_all_pending_tasks_on_startup`: Whether Unmanic should clear all pending tasks on startup.
 - `switch.unmanic_debugging`: Whether debugging should be enabled on Unmanic.
 - `switch.unmanic_enable_periodic_library_scans`: Whether periodic library scans should be enabled.
 - `switch.unmanic_enable_the_library_file_monitor`: Whether the library file monitor should be enabled.
 - `switch.unmanic_follow_symlinks_on_library_scans`: Whether symlinks should be followed during library scans.
 - `switch.unmanic_run_a_one_off_library_scan_on_startup`: Whether a one-off library scan should be enabled on startup.
+- `switch.unmanic_clear_all_pending_tasks_on_startup`: Whether Unmanic should clear all pending tasks on startup.

--- a/source/_integrations/unmanic.markdown
+++ b/source/_integrations/unmanic.markdown
@@ -2,7 +2,7 @@
 title: Unmanic
 description: Instructions on how to integrate Unmanic with Home Assistant
 ha_category:
-  - Downloading
+  - Multimedia
 ha_release: 2022.1
 ha_iot_class: Local Polling
 ha_domain: unmanic

--- a/source/_integrations/unmanic.markdown
+++ b/source/_integrations/unmanic.markdown
@@ -10,10 +10,7 @@ ha_config_flow: true
 ha_codeowners:
   - "@JeffResc"
 ha_platforms:
-  - button
-  - number
   - sensor
-  - switch
 ---
 
 The `Unmanic` integration pulls data from a given [Unmanic](https://unmanic.app/) instance.
@@ -22,30 +19,9 @@ The `Unmanic` integration pulls data from a given [Unmanic](https://unmanic.app/
 
 The Unmanic integration will add the following entities:
 
-## Buttons
-
-- `button.unmanic_pause_all_workers`: Pauses all workers.
-- `button.unmanic_resume_all_workers`: Resumes all workers.
-- `button.unmanic_scan_library`: Triggers a library scan.
-
-## Numbers
-
-- `number.unmanic_concurrent_file_testers`: The configured number of concurrent file testers.
-- `number.unmanic_distributed_worker_count`: The configured number of distributed workers.
-- `number.unmanic_worker_count`: The configured number of workers.
-
 ## Sensors
 
 - `sensor.unmanic_active_workers`: The number of active workers.
 - `sensor.unmanic_completed_tasks`: The number of completed tasks in the history.
 - `sensor.unmanic_pending_tasks`: The number of pending tasks in the queue.
 - `sensor.unmanic_total_workers`: The number of total workers.
-
-## Switches
-
-- `switch.unmanic_debugging`: Whether debugging should be enabled on Unmanic.
-- `switch.unmanic_enable_periodic_library_scans`: Whether periodic library scans should be enabled.
-- `switch.unmanic_enable_the_library_file_monitor`: Whether the library file monitor should be enabled.
-- `switch.unmanic_follow_symlinks_on_library_scans`: Whether symlinks should be followed during library scans.
-- `switch.unmanic_run_a_one_off_library_scan_on_startup`: Whether a one-off library scan should be enabled on startup.
-- `switch.unmanic_clear_all_pending_tasks_on_startup`: Whether Unmanic should clear all pending tasks on startup.

--- a/source/_integrations/unmanic.markdown
+++ b/source/_integrations/unmanic.markdown
@@ -1,0 +1,51 @@
+---
+title: Unmanic
+description: Instructions on how to integrate Unmanic with Home Assistant
+ha_category:
+  - Downloading
+ha_release: 2022.1
+ha_iot_class: Local Polling
+ha_domain: unmanic
+ha_config_flow: true
+ha_codeowners:
+  - '@JeffResc'
+ha_platforms:
+  - button
+  - number
+  - sensor
+  - switch
+---
+
+The `Unmanic` integration pulls data from a given [Unmanic](https://unmanic.app/) instance.
+
+{% include integrations/config_flow.md %}
+
+The Unmanic integration will add the following entities:
+
+## Buttons
+
+- `button.unmanic_pause_all_workers`: Pauses all workers.
+- `button.unmanic_resume_all_workers`: Resumes all workers.
+- `button.unmanic_scan_library`: Triggers a library scan.
+
+## Numbers
+
+- `number.unmanic_worker_count`: The configured number of workers.
+- `number.unmanic_concurrent_file_testers`: The configured number of concurrent file testers.
+- `number.unmanic_distributed_worker_count`: The configured number of distributed workers.
+
+## Sensors
+
+- `sensor.unmanic_active_workers`: The number of active workers.
+- `sensor.unmanic_total_workers`: The number of total workers.
+- `sensor.unmanic_pending_tasks`: The number of pending tasks in the queue.
+- `sensor.unmanic_completed_tasks`: The number of completed tasks in the history.
+
+## Switches
+
+- `switch.unmanic_clear_all_pending_tasks_on_startup`: Whether Unmanic should clear all pending tasks on startup.
+- `switch.unmanic_debugging`: Whether debugging should be enabled on Unmanic.
+- `switch.unmanic_enable_periodic_library_scans`: Whether periodic library scans should be enabled.
+- `switch.unmanic_enable_the_library_file_monitor`: Whether the library file monitor should be enabled.
+- `switch.unmanic_follow_symlinks_on_library_scans`: Whether symlinks should be followed during library scans.
+- `switch.unmanic_run_a_one_off_library_scan_on_startup`: Whether a one-off library scan should be enabled on startup.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This adds documentation for the new Unmanic integraion.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [X] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [homeassistant/core#65352](https://github.com/home-assistant/core/pull/65352)
- Link to parent pull request in the Brands repository: [homeassistant/brands#3128](https://github.com/home-assistant/brands/pull/3128)
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
