### PR TITLE
Update Ness D8x/D16x ASCII protocol URL

### DIFF
--- a/source/_integrations/ness_alarm.markdown
+++ b/source/_integrations/ness_alarm.markdown
@@ -21,7 +21,7 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor: Reports on zone statuses
 - Alarm Control Panel: Reports on alarm status, and can be used to arm/disarm the system
 
-The module communicates via the [Ness D8x/D16x ASCII protocol](http://www.nesscorporation.com/Software/Ness_D8-D16_ASCII_protocol.pdf).
+The module communicates via the [Ness D8x/D16x ASCII protocol](https://ia601401.us.archive.org/34/items/ness-d-8x-d-16x-serial-interface.-ascii-protocol/Ness%20D8x%20D16x%20Serial%20Interface.%20ASCII%20Protocol.pdf).
 
 ## Configuration
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fix a broken link in the NESS Alarm integration. Updated the URL from an old 404 link to a permanent Archive.org URL of the original manual


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
