### PR TITLE
Add name to example configuration.yaml

### DIFF
--- a/source/_integrations/apprise.markdown
+++ b/source/_integrations/apprise.markdown
@@ -22,6 +22,7 @@ To use Apprise supported notifications, add the following to your `configuration
 # Example configuration.yaml entry using URLs
 notify:
   - platform: apprise
+    name: apprise
     url: YOUR_APPRISE_URLS
 ```
 
@@ -32,6 +33,7 @@ You can also pre-define your own configuration files while storing them either r
 # Configuration Files/Sites:
 notify:
   - platform: apprise
+    name: apprise
     config: YOUR_APPRISE_CONFIG_URLS
 ```
 
@@ -41,6 +43,7 @@ There is no restriction on the number of URLs or Apprise Configuration locations
 # Example configuration.yaml entry using all options
 notify:
   - platform: apprise
+    name: apprise
     config: YOUR_APPRISE_CONFIG_URLS
     url: YOUR_APPRISE_URLS
 ```


### PR DESCRIPTION
name is required for the apprise platform to populate in the UI

## Proposed change
<!-- 
    the apprise platform would not populate in the UI until I had name in the configuration.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    N/A
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
