### PR TITLE
2022.2.0: Removal version for iOS categories

### DIFF
--- a/source/_posts/2022-02-02-release-20222.markdown
+++ b/source/_posts/2022-02-02-release-20222.markdown
@@ -1005,7 +1005,7 @@ removed from your YAML configuration files.
 
 {% details "iOS" %}
 
-The Home Assistant iOS/macOS app supports notification actions defined [in the notification itself](https://companion.home-assistant.io/docs/notifications/actionable-notifications/); the old method of defining push categories in the iOS integration is now deprecated and will be removed in the future.
+The Home Assistant iOS/macOS app supports notification actions defined [in the notification itself](https://companion.home-assistant.io/docs/notifications/actionable-notifications/); the old method of defining push categories in the iOS integration is now deprecated and will be removed in 2022.4.
 
 ([@zacwest] - [#61078]) ([ios docs])
 


### PR DESCRIPTION
## Proposed change
Notes which version categories are going away in

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
