### PR TITLE
Correction to release notes for Mazda integration

### DIFF
--- a/source/_posts/2022-02-02-release-20222.markdown
+++ b/source/_posts/2022-02-02-release-20222.markdown
@@ -392,6 +392,7 @@ This release adds support for long-term statistics to the following integrations
 - [GitHub][github docs] (thanks [@ludeeus])
 - [Hunter Douglas PowerView][hunterdouglas_powerview docs] (thanks [@bdraco])
 - [Kraken][kraken docs] (thanks [@eifinger])
+- [Mazda Connected Services][mazda docs] (thanks [@bdr99])
 - [Nexia/American Standard/Trane][nexia docs] (thanks [@bdraco])
 - [Pentair ScreenLogic][screenlogic docs] (thanks [@bdraco])
 - [Sensor.Community][luftdaten docs] (thanks [@frenck])
@@ -405,7 +406,6 @@ And the following integrations now have entity categories:
 - [GitHub][github docs] (thanks [@ludeeus])
 - [Hyperion][hyperion docs] (thanks [@starkillerOG])
 - [Kostal Plenticore Solar Inverter][kostal_plenticore docs] (thanks [@stegm])
-- [Mazda Connected Services][mazda docs] (thanks [@bdr99])
 - [Motion Blinds][motion_blinds docs] (thanks [@starkillerOG])
 - [NETGEAR][netgear docs] (thanks [@starkillerOG])
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Thanks for highlighting this change to the Mazda integration! However, the Mazda integration received support for long-term statistics, not entity categories.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
