### PR TITLE
Remove reference to !secret in Todoist documentation

### DIFF
--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -64,7 +64,7 @@ Creating custom projects is super-easy and quite powerful. All you need to run t
 # Example configuration.yaml entry
 calendar:
   - platform: todoist
-    token: YOUR_API_TOKEN
+    token: !secret todoist_api_token
     custom_projects:
       - name: 'All Projects'
       - name: 'Due Today'

--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -64,7 +64,7 @@ Creating custom projects is super-easy and quite powerful. All you need to run t
 # Example configuration.yaml entry
 calendar:
   - platform: todoist
-    token: !secret todoist_api_token
+    token: YOUR_API_TOKEN
     custom_projects:
       - name: 'All Projects'
       - name: 'Due Today'
@@ -78,8 +78,6 @@ calendar:
           - Mathematical Structures II
           - Calculus II
 ```
-
-(See [here](/docs/configuration/secrets/) for more details about what that `!secret` does -- it's not exclusive to Todoist, and can help keep your API keys and passwords a little safer!)
 
 As you can see, there are 4 custom projects here:
 


### PR DESCRIPTION
The paragraph below references secrets, but there isn't a secret in the config.

We could also just remove the paragraph below since this introduces some inconsistency (saying "YOUR_API_TOKEN" above and "!secret todoist_api_token" here).

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
