### PR TITLE
Add description for state attributes of velux integration

### DIFF
--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -67,6 +67,26 @@ automation:
     - service: velux.reboot_gateway
 ```
 
+## Attributes
+
+Cover entity with integrated rain sensor has extra attributes to represent the state of the limitation sensor.
+
+| Name | Description |
+| ---- | ----------- |
+| `limitation_min` | Min limitation of window. `limitation_min` => 0 no rain; `limitation_min` => 93 the velux can only open for 7 % , so it means, its raining
+| `limitation_max` | Max limitation of window.
+
+The value can used as a `binary_sensor` for rain detection `True` or no rain `False`
+
+```yaml
+- platform: template
+  sensors:
+    rainsensor_kitchen:
+      device_class: moisture
+      value_template: >
+        {{ state_attr('cover.kitchen', 'limitation_min') >= 93 }}
+```
+
 ## Velux Active (KIX 300)
 
 The Velux Active (KIX 300) set is not supported by this integration. To integrate Velux Active (KIX 300) with Home Assistant, you can use the [HomeKit Controller](/integrations/homekit_controller) integration and get full control over your windows, curtains, covers, the air quality sensor KLA 300, etc.

--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -78,14 +78,19 @@ Cover entity with integrated rain sensor has extra attributes to represent the s
 
 The value can used as a `binary_sensor` for rain detection `True` or no rain `False`
 
+{% raw %}
+
 ```yaml
-- platform: template
-  sensors:
-    rainsensor_kitchen:
-      device_class: moisture
-      value_template: >
-        {{ state_attr('cover.kitchen', 'limitation_min') >= 93 }}
+binary_sensor:
+  - platform: template
+    sensors:
+      rainsensor_kitchen:
+        device_class: moisture
+        value_template: >
+          {{ state_attr('cover.kitchen', 'limitation_min') >= 93 }}
 ```
+
+{% endraw %}
 
 ## Velux Active (KIX 300)
 

--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -76,7 +76,7 @@ Cover entity with integrated rain sensor has extra attributes to represent the s
 | `limitation_min` | Min limitation of window. `limitation_min` => 0 no rain; `limitation_min` => 93 the window can only open for 7 % , so it means, its raining
 | `limitation_max` | Max limitation of window.
 
-The value can used as a `binary_sensor` for rain detection `True` or no rain `False`
+The value can be used as a `binary_sensor` for rain detection `True` or no rain `False`
 
 {% raw %}
 

--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -73,7 +73,7 @@ Cover entity with integrated rain sensor has extra attributes to represent the s
 
 | Name | Description |
 | ---- | ----------- |
-| `limitation_min` | Min limitation of window. `limitation_min` => 0 no rain; `limitation_min` => 93 the velux can only open for 7 % , so it means, its raining
+| `limitation_min` | Min limitation of window. `limitation_min` => 0 no rain; `limitation_min` => 93 the window can only open for 7 % , so it means, its raining
 | `limitation_max` | Max limitation of window.
 
 The value can used as a `binary_sensor` for rain detection `True` or no rain `False`


### PR DESCRIPTION
## Proposed change
Update docs for new state attribute for velux integration.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: [ Add limitation sensor for velux window #64628 ](https://github.com/home-assistant/core/pull/64628)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
