### PR TITLE
Update google_assistant JavaScript to support local query

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -113,12 +113,13 @@ If you want to support active reporting of state to Google's server (configurati
 2. Click `Develop` on the top of the page, then click `Actions` located in the hamburger menu on the top left.
 3. Upload [this Javascript file](/assets/integrations/google_assistant/app.js) for both Node and Chrome by clicking the `Upload Javascript files` button.
 4. Add device scan configuration:
-  1. Click `+ New scan config`
-  2. Select `MDNS`
-  3. set mDNS service name to `_home-assistant._tcp.local`
-5. `Save` your changes.
-6. Either wait for 30 minutes, or restart your connected Google device.
-7. Restart Home Assistant Core.
+   1. Click `+ New scan config`
+   2. Select `MDNS`
+   3. set mDNS service name to `_home-assistant._tcp.local`
+5. Check the box `Support local query` under `Add capabilities`.
+6. `Save` your changes.
+7. Either wait for 30 minutes, or restart your connected Google device.
+8. Restart Home Assistant Core.
 
 You can debug the setup by following [these instructions](https://developers.google.com/assistant/smarthome/develop/local#debugging_from_chrome)
 


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Enable local query for google_assistant, the functionality is identical to cloud query, so adding the functionality only requires updating the JavaScript that runs on the assistant devices and configuration change.

Also a fix to remove `onProxySelected`. This change was the only way I could make google_assistant local fulfilment work on any of my devices, but I would like to see others results with this. Two years ago this seemed to be a requirement, but none of Google's own docs or examples use it anymore.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

This is a little unclear which type of change because code is included in this documentation.
 I would like to longer term look at serving the JavaScript from Home Assistant itself. That will result in easier setup for users (just setting a URL in the Google Assistant developer panel, rather than uploading code) and more importantly code living with code not documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
This builds on https://github.com/home-assistant/core/pull/63218

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
