### PR TITLE
Total Connect: Add Sensor Activities and improve grammar

### DIFF
--- a/source/_integrations/totalconnect.markdown
+++ b/source/_integrations/totalconnect.markdown
@@ -1,6 +1,6 @@
 ---
 title: Total Connect
-description: Instructions on how to integrate TotalConnect alarms into Home Assistant.
+description: Integrate Resideo Total Connect 2.0-enabled alarm systems into Home Assistant.
 ha_category:
   - Alarm
   - Binary Sensor
@@ -15,13 +15,13 @@ ha_platforms:
   - binary_sensor
 ---
 
-The `totalconnect` integration provides connectivity with TotalConnect alarm systems used by many alarm companies.
+The `totalconnect` integration provides connectivity with Resideo Total Connect 2.0-enabled alarm systems.
 
 ## Prerequisites
 
-Log in to the [TotalConnect website](https://totalconnect2.com) and create a "standard" Total Connect user account specifically for use with Home Assistant. It should not have full administrative privileges.
+Log in to the [Total Connect website](https://totalconnect2.com) and create a "standard" Total Connect user account specifically for use with Home Assistant. It should not have full administrative privileges.
 
-Give the user access to your Location. Give the user a usercode, usually a 4 digit number.
+Give the user access to your Location, along with a user code, usually a 4 digit number.
 
 {% include integrations/config_flow.md %}
 
@@ -73,18 +73,18 @@ sudo apt install libxml2-dev libxmlsec1-dev
 
 ## Alarm Control Panel
 
-The integration provides an Alarm Control Panel for each TotalConnect location. It uses the name of your location from TotalConnect.  For example, if your location name in TotalConnect is "Home", then you will get `alarm_control_panel.home` in Home Assistant.
+The integration provides an Alarm Control Panel for each Total Connect location. It uses the name of your location from Total Connect.  For example, if your location name in Total Connect is "Home", Home Assistant will use `alarm_control_panel.home`.
 
-The alarm control panel supports the following services: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`. The integration also provides unique services for `totalconnect.arm_home_instant` and `totalconnect.arm_away_instant` which arm the system with zero entry delay, triggering the alarm instantly if someone opens a door.
+The alarm control panel supports the following services: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`. The integration also provides unique services for `totalconnect.arm_home_instant` and `totalconnect.arm_away_instant` which arms the system with zero entry delay, triggering the alarm instantly if an entry/exit zone is faulted.
 
 The `triggered` state also provides a state attribute called `triggered_source` giving more detail on what triggered the alarm:
 
-- `Police/Medical` is when sensors detected a burglar and/or a person pushed the Police or Medical button
-- `Fire/Smoke` is when fire or smoke is detected, or a person pushed the Fire button
+- `Police/Medical` is when sensors detected a burglar and/or the Police or Medical button was pressed
+- `Fire/Smoke` is when fire or smoke is detected, and/or the Fire button was pressed
 - `Carbon Monoxide` is when carbon monoxide is detected
 
 ## Binary Sensor
 
-The integration provides a Binary Sensor for each TotalConnect zone. To see zones in TotalConnect "fault" status, your TotalConnect account must have "Sensor Events" enabled. Your alarm monitoring company may charge an extra fee to enable this. If available, these can be found in the Total Connect 2 web portal at **Notifications** -> **Sensor Events**. Alternately, they can be found in the Total Connect iOS app at **More** -> **Settings** -> **Notifications** -> **Sensor Events**. Enable each zone you want to monitor. TotalConnect zones will display as `Closed` in Home Assistant unless the Sensor Event is enabled.
+The integration provides a Binary Sensor for each Total Connect zone. To see faulted zones in Home Assistant, your Total Connect account must have "Sensor Activities" enabled. Your alarm monitoring company may charge an extra fee to enable this. If available, these can be found in the Total Connect 2 web portal at **Notifications** -> **Sensor Activities**. Alternately, they can be found in the Total Connect mobile app at **More** -> **Settings** -> **Notifications** -> **Sensor Activities**. Enable each zone you want to monitor. Unmonitored zones will display as `Closed` in Home Assistant.
 
-The TotalConnect API has limited zone type information. Home Assistant device class `door` is assigned to TotalConnect door, window, perimeter, motion sensor, and most alarm panel buttons. The sensor will appear as `True` if the door is open (either fault or triggered in TotalConnect) and `False` otherwise. Device class `smoke` is assigned to TotalConnect smoke detectors and buttons with physical alarm panel "Response Type" setting of "Fire No Verification". The sensor will appear as `True` if smoke is detected.  Device class `gas` is assigned to TotalConnect carbon monoxide detectors. The sensor will appear as `True` if gas is detected.
+The Total Connect API has limited zone type information. Home Assistant device class `door` is assigned to Total Connect entry/exit, perimeter, and motion zones; along with most alarm panel buttons. The sensor will appear as `True` if the zone is opened (either fault or triggered in Total Connect) and `False` if closed. Device class `smoke` is assigned to Total Connect smoke detectors and alarm panel buttons set to a "Fire No Verification" response type. The sensor will appear as `True` if smoke is detected or the respective button is pressed.  Device class `gas` is assigned to Total Connect carbon monoxide detectors. The sensor will appear as `True` if carbon monoxide is detected.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR fixes the following:
* Total Connect Sensor Events are now known as Sensor Activities.
* According to Honeywell/Resideo, the official spelling of Total Connect is "Total Connect", not " TotalConnect".
* Improves variors grammatical errors to increase readability.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
