### PR TITLE
Add mention of state_filter for notification

### DIFF
--- a/source/_lovelace/conditional.markdown
+++ b/source/_lovelace/conditional.markdown
@@ -31,15 +31,38 @@ conditions:
       required: false
       description: Entity state is unequal to this value.*
       type: string
+    state_filter:
+      required: false
+      description: List of strings representing states or `filter` objects, see below.
+      type: list
 card:
   required: true
   description: Card to display if all conditions match.
   type: map
 {% endconfiguration %}
 
-*one is required (`state` or `state_not`)
+*one is required (`state`, `state_not` or `state_filter`)
 
 Note: Conditions with more than one entity are treated as an 'and' condition. This means that for the card to show, *all* entities must meet the state requirements set.
+
+### Options For state_filter
+
+If you define state_filter as objects instead of strings (by adding `value:` before your state value), you can add more customization to your filter:
+
+{% configuration state_filter %}
+value:
+  required: true
+  description: String representing the state.
+  type: string
+operator:
+  required: false
+  description: Operator to use in the comparison. Can be `==`, `<=`, `<`, `>=`, `>`, `!=` or `regex`.
+  type: string
+attribute:
+  required: false
+  description: Attribute of the entity to use instead of the state.
+  type: string
+{% endconfiguration %}
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add mention of new state_filter support to conditional card.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/11539

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
