### PR TITLE
Add documentation for xiaomi_miio's dmaker.airfresh.{a1,t2017} support

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -521,9 +521,9 @@ Auxiliary Heat          | Turn on/off `heater`
 
 - Button entities
 
-Button                  | Description                                | Enabled by default
------------------------ | ------------------------------------------ | ---------------------
-Reset dust filter       | Resets filter lifetime of the dust filter  | False
+Button                  | Description                                
+----------------------- | ------------------------------------------ 
+Reset dust filter       | Resets filter lifetime of the dust filter  
 
 ### Air Fresh VA2
 
@@ -596,10 +596,10 @@ Auxiliary Heat          | Turn on/off `heater`
 
 - Button entities
 
-Button                  | Description                                | Enabled by default
------------------------ | ------------------------------------------ | ---------------------
-Reset dust filter       | Resets filter lifetime of the dust filter  | False
-Reset upper filter      | Resets filter lifetime of the upper filter | False
+Button                  | Description                                
+----------------------- | ------------------------------------------ 
+Reset dust filter       | Resets filter lifetime of the dust filter  
+Reset upper filter      | Resets filter lifetime of the upper filter 
 
 ### Air Humidifier (zhimi.humidifier.v1)
 

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -503,7 +503,7 @@ Sensor                          | Description                                   
 ------------------------------- | -------------------------------------------------------------- | -----------------------
 Carbon Dioxide                  | The current carbon dioxide measured in ppm                     | True
 Dust filter life remaining      | The remaining life of the filter                               | True
-Dust filter life remaining days | Filter usage time in day                                       | True
+Dust filter life remaining days | The remaining life of the filter in day                        | True
 PM2.5                           | The current particulate matter 2.5 measured                    | True
 Temperature                     | The current outside temperature measured                       | True
 Control Speed                   | The current motor speed measured in rpm                        | True
@@ -569,9 +569,9 @@ Sensor                           | Description                                  
 -------------------------------- | -------------------------------------------------------------- | -----------------------
 Carbon Dioxide                   | The current carbon dioxide measured in ppm                     | True
 Dust filter life remaining       | The remaining life of the dust filter                          | True
-Dust filter life remaining days  | Dust filter usage time in day                                  | True
+Dust filter life remaining days  | The remaining life of the dust filter in day                   | True
 Upper filter life remaining      | The remaining life of the upper filter                         | True
-Upper filter life remaining days | Upper filter usage time in day                                 | True
+Upper filter life remaining days | The remaining life of the upper filter in day                  | True
 PM2.5                            | The current particulate matter 2.5 measured                    | True
 Temperature                      | The current outside temperature measured                       | True
 Control Speed                    | The current motor speed measured in rpm                        | True

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -508,7 +508,7 @@ PM2.5                           | The current particulate matter 2.5 measured   
 Temperature                     | The current outside temperature measured                       | True
 Control Speed                   | The current motor speed measured in rpm                        | True
 Favorite Speed                  | The favorite motor speed measured in rpm                       | True
-Ptc status                      | The heater status                                              | True
+Auxiliary Heat Status           | The heater status                                              | True
 
 - Switch entities
 
@@ -517,7 +517,7 @@ Switch                  | Description
 Buzzer                  | Turn on/off `buzzer`
 Child Lock              | Turn on/off `child lock`
 Display                 | Turn on/off `display`
-Ptc                     | Turn on/off `heater`
+Auxiliary Heat          | Turn on/off `heater`
 
 - Button entities
 
@@ -576,14 +576,14 @@ PM2.5                            | The current particulate matter 2.5 measured  
 Temperature                      | The current outside temperature measured                       | True
 Control Speed                    | The current motor speed measured in rpm                        | True
 Favorite Speed                   | The favorite motor speed measured in rpm                       | True
-Ptc status                       | The heater status                                              | True
+Auxiliary Heat Status            | The heater status                                              | True
 
 - Select entities
 
 Select                  | Description
 ----------------------- | -----------------------
 Display Orientation     | Controls the orientation of the display (forward, left, right)
-Ptc Level               | Controls the level of the heater (low, medium, high)
+Auxiliary Heat Level    | Controls the level of the heater (low, medium, high)
 
 - Switch entities
 
@@ -592,7 +592,7 @@ Switch                  | Description
 Buzzer                  | Turn on/off `buzzer`
 Child Lock              | Turn on/off `child lock`
 Display                 | Turn on/off `display`
-Ptc                     | Turn on/off `heater`
+Auxiliary Heat          | Turn on/off `heater`
 
 - Button entities
 

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -501,13 +501,13 @@ LED                     | Turn on/off the LED
 
 Sensor                          | Description                                                    
 ------------------------------- | -------------------------------------------------------------- 
-Carbon Dioxide                  | The current carbon dioxide measured in ppm                     
+Carbon Dioxide                  | The current carbon dioxide in ppm                     
 Dust filter life remaining      | The remaining life of the filter                              
 Dust filter life remaining days | The remaining life of the filter in day                        
-PM2.5                           | The current particulate matter 2.5 measured                    
-Temperature                     | The current outside temperature measured                      
-Control Speed                   | The current motor speed measured in rpm                       
-Favorite Speed                  | The favorite motor speed measured in rpm                       
+PM2.5                           | The current particulate matter 2.5                    
+Temperature                     | The current outside temperature                      
+Control Speed                   | The current motor speed in rpm                       
+Favorite Speed                  | The favorite motor speed in rpm                       
 
 - Switch entities
 
@@ -558,15 +558,15 @@ LED                     | Turn on/off `led`
 
 Sensor                           | Description                                                   
 -------------------------------- | -------------------------------------------------------------- 
-Carbon Dioxide                   | The current carbon dioxide measured in ppm                    
-Dust filter life remaining       | The remaining life of the dust filter                         
-Dust filter life remaining days  | The remaining life of the dust filter in day                   
+Carbon Dioxide                   | The current carbon dioxide in ppm                    
+Dust filter life remaining       | The remaining life of the dust filter                       
+Dust filter life remaining days  | The remaining life of the dust filter in days                   
 Upper filter life remaining      | The remaining life of the upper filter                         
-Upper filter life remaining days | The remaining life of the upper filter in day                  
-PM2.5                            | The current particulate matter 2.5 measured                    
-Temperature                      | The current outside temperature measured                       
-Control Speed                    | The current motor speed measured in rpm                        
-Favorite Speed                   | The favorite motor speed measured in rpm                       
+Upper filter life remaining days | The remaining life of the upper filter in days                  
+PM2.5                            | The current particulate matter 2.5                    
+Temperature                      | The current outside temperature                       
+Control Speed                    | The current motor speed in rpm                        
+Favorite Speed                   | The favorite motor speed in rpm                       
 
 - Switch entities
 

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -499,15 +499,15 @@ LED                     | Turn on/off the LED
 - Operation modes (Auto, Sleep, Favorite)
 - Sensor entities
 
-Sensor                          | Description                                                    | Enabled by default
-------------------------------- | -------------------------------------------------------------- | -----------------------
-Carbon Dioxide                  | The current carbon dioxide measured in ppm                     | True
-Dust filter life remaining      | The remaining life of the filter                               | True
-Dust filter life remaining days | The remaining life of the filter in day                        | True
-PM2.5                           | The current particulate matter 2.5 measured                    | True
-Temperature                     | The current outside temperature measured                       | True
-Control Speed                   | The current motor speed measured in rpm                        | True
-Favorite Speed                  | The favorite motor speed measured in rpm                       | True
+Sensor                          | Description                                                    
+------------------------------- | -------------------------------------------------------------- 
+Carbon Dioxide                  | The current carbon dioxide measured in ppm                     
+Dust filter life remaining      | The remaining life of the filter                              
+Dust filter life remaining days | The remaining life of the filter in day                        
+PM2.5                           | The current particulate matter 2.5 measured                    
+Temperature                     | The current outside temperature measured                      
+Control Speed                   | The current motor speed measured in rpm                       
+Favorite Speed                  | The favorite motor speed measured in rpm                       
 
 - Switch entities
 
@@ -556,17 +556,17 @@ LED                     | Turn on/off `led`
 - Operation modes (Auto, Sleep, Favorite)
 - Sensor entities
 
-Sensor                           | Description                                                    | Enabled by default
--------------------------------- | -------------------------------------------------------------- | -----------------------
-Carbon Dioxide                   | The current carbon dioxide measured in ppm                     | True
-Dust filter life remaining       | The remaining life of the dust filter                          | True
-Dust filter life remaining days  | The remaining life of the dust filter in day                   | True
-Upper filter life remaining      | The remaining life of the upper filter                         | True
-Upper filter life remaining days | The remaining life of the upper filter in day                  | True
-PM2.5                            | The current particulate matter 2.5 measured                    | True
-Temperature                      | The current outside temperature measured                       | True
-Control Speed                    | The current motor speed measured in rpm                        | True
-Favorite Speed                   | The favorite motor speed measured in rpm                       | True
+Sensor                           | Description                                                   
+-------------------------------- | -------------------------------------------------------------- 
+Carbon Dioxide                   | The current carbon dioxide measured in ppm                    
+Dust filter life remaining       | The remaining life of the dust filter                         
+Dust filter life remaining days  | The remaining life of the dust filter in day                   
+Upper filter life remaining      | The remaining life of the upper filter                         
+Upper filter life remaining days | The remaining life of the upper filter in day                  
+PM2.5                            | The current particulate matter 2.5 measured                    
+Temperature                      | The current outside temperature measured                       
+Control Speed                    | The current motor speed measured in rpm                        
+Favorite Speed                   | The favorite motor speed measured in rpm                       
 
 - Switch entities
 

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -213,7 +213,9 @@ Supported devices:
 | Air Purifier 3 (2019)  | zhimi.airpurifier.ma4  | |
 | Air Purifier 3H (2019) | zhimi.airpurifier.mb3  | |
 | Air Purifier 3C        | zhimi.airpurifier.mb4  | |
+| Air Fresh A1           | dmaker.airfresh.a1     | MJXFJ-150-A1 |
 | Air Fresh VA2          | zhimi.airfresh.va2     | |
+| Air Fresh T2017        | dmaker.airfresh.t2017  | MJXFJ-300-G1 |
 | Air Humidifier         | zhimi.humidifier.v1    | |
 | Air Humidifier CA1     | zhimi.humidifier.ca1   | |
 | Air Humidifier CA4     | zhimi.humidifier.ca4   | |
@@ -491,6 +493,38 @@ Buzzer                  | Turn on/off the buzzer
 Child Lock              | Turn on/off the child lock
 LED                     | Turn on/off the LED
 
+### Air Fresh A1 (dmaker.airfresh.a1)
+
+- Power (on, off)
+- Operation modes (Auto, Sleep, Favorite)
+- Sensor entities
+
+Sensor                          | Description                                                    | Enabled by default
+------------------------------- | -------------------------------------------------------------- | -----------------------
+Carbon Dioxide                  | The current carbon dioxide measured in ppm                     | True
+Dust filter life remaining      | The remaining life of the filter                               | True
+Dust filter life remaining days | Filter usage time in day                                       | True
+PM2.5                           | The current particulate matter 2.5 measured                    | True
+Temperature                     | The current outside temperature measured                       | True
+Control Speed                   | The current motor speed measured in rpm                        | True
+Favorite Speed                  | The favorite motor speed measured in rpm                       | True
+Ptc status                      | The heater status                                              | True
+
+- Switch entities
+
+Switch                  | Description
+----------------------- | -----------------------
+Buzzer                  | Turn on/off `buzzer`
+Child Lock              | Turn on/off `child lock`
+Display                 | Turn on/off `display`
+Ptc                     | Turn on/off `heater`
+
+- Button entities
+
+Button                  | Description                                | Enabled by default
+----------------------- | ------------------------------------------ | ---------------------
+Reset dust filter       | Resets filter lifetime of the dust filter  | False
+
 ### Air Fresh VA2
 
 - Power (on, off)
@@ -523,6 +557,49 @@ Switch                  | Description
 Buzzer                  | Turn on/off `buzzer`
 Child Lock              | Turn on/off `child lock`
 LED                     | Turn on/off `led`
+
+
+### Air Fresh T2017 (dmaker.airfresh.t2017)
+
+- Power (on, off)
+- Operation modes (Auto, Sleep, Favorite)
+- Sensor entities
+
+Sensor                           | Description                                                    | Enabled by default
+-------------------------------- | -------------------------------------------------------------- | -----------------------
+Carbon Dioxide                   | The current carbon dioxide measured in ppm                     | True
+Dust filter life remaining       | The remaining life of the dust filter                          | True
+Dust filter life remaining days  | Dust filter usage time in day                                  | True
+Upper filter life remaining      | The remaining life of the upper filter                         | True
+Upper filter life remaining days | Upper filter usage time in day                                 | True
+PM2.5                            | The current particulate matter 2.5 measured                    | True
+Temperature                      | The current outside temperature measured                       | True
+Control Speed                    | The current motor speed measured in rpm                        | True
+Favorite Speed                   | The favorite motor speed measured in rpm                       | True
+Ptc status                       | The heater status                                              | True
+
+- Select entities
+
+Select                  | Description
+----------------------- | -----------------------
+Display Orientation     | Controls the orientation of the display (forward, left, right)
+Ptc Level               | Controls the level of the heater (low, medium, high)
+
+- Switch entities
+
+Switch                  | Description
+----------------------- | -----------------------
+Buzzer                  | Turn on/off `buzzer`
+Child Lock              | Turn on/off `child lock`
+Display                 | Turn on/off `display`
+Ptc                     | Turn on/off `heater`
+
+- Button entities
+
+Button                  | Description                                | Enabled by default
+----------------------- | ------------------------------------------ | ---------------------
+Reset dust filter       | Resets filter lifetime of the dust filter  | False
+Reset upper filter      | Resets filter lifetime of the upper filter | False
 
 ### Air Humidifier (zhimi.humidifier.v1)
 

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -508,7 +508,6 @@ PM2.5                           | The current particulate matter 2.5 measured   
 Temperature                     | The current outside temperature measured                       | True
 Control Speed                   | The current motor speed measured in rpm                        | True
 Favorite Speed                  | The favorite motor speed measured in rpm                       | True
-Auxiliary Heat Status           | The heater status                                              | True
 
 - Switch entities
 
@@ -516,14 +515,6 @@ Switch                  | Description
 ----------------------- | -----------------------
 Buzzer                  | Turn on/off `buzzer`
 Child Lock              | Turn on/off `child lock`
-Display                 | Turn on/off `display`
-Auxiliary Heat          | Turn on/off `heater`
-
-- Button entities
-
-Button                  | Description                                
------------------------ | ------------------------------------------ 
-Reset dust filter       | Resets filter lifetime of the dust filter  
 
 ### Air Fresh VA2
 
@@ -576,14 +567,6 @@ PM2.5                            | The current particulate matter 2.5 measured  
 Temperature                      | The current outside temperature measured                       | True
 Control Speed                    | The current motor speed measured in rpm                        | True
 Favorite Speed                   | The favorite motor speed measured in rpm                       | True
-Auxiliary Heat Status            | The heater status                                              | True
-
-- Select entities
-
-Select                  | Description
------------------------ | -----------------------
-Display Orientation     | Controls the orientation of the display (forward, left, right)
-Auxiliary Heat Level    | Controls the level of the heater (low, medium, high)
 
 - Switch entities
 
@@ -591,15 +574,7 @@ Switch                  | Description
 ----------------------- | -----------------------
 Buzzer                  | Turn on/off `buzzer`
 Child Lock              | Turn on/off `child lock`
-Display                 | Turn on/off `display`
-Auxiliary Heat          | Turn on/off `heater`
 
-- Button entities
-
-Button                  | Description                                
------------------------ | ------------------------------------------ 
-Reset dust filter       | Resets filter lifetime of the dust filter  
-Reset upper filter      | Resets filter lifetime of the upper filter 
 
 ### Air Humidifier (zhimi.humidifier.v1)
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Add support for dmaker.airfresh.a1 and dmaker.airfresh.t2017 device to integration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:          
  1. https://github.com/home-assistant/core/pull/66331
  2. https://github.com/home-assistant/core/pull/66370

- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
