### PR TITLE
Update torque.markdown

### DIFF
--- a/source/_integrations/torque.markdown
+++ b/source/_integrations/torque.markdown
@@ -28,8 +28,10 @@ Under the **Logging Preferences** header:
 Under the **Realtime Web Upload** header:
 
 - Check **Upload to web-server**.
-- Enter `http://HOST:PORT/api/torque?api_password=YOUR_PASSWORD` as the **Web-server URL**, where `HOST` and `PORT` are your externally accessible Home Assistant HTTP host and port and YOUR_PASSWORD is your Home Assistant's [API password](/integrations/http/). It highly recommended that you protect your Home Assistant instance with [SSL/TSL](/docs/ecosystem/certificates/).
-- Enter an email address in **User Email Address**.
+- Enter `https://HOST:PORT/api/torque` as the **Web-server URL**, where `HOST` and `PORT` are your externally accessible Home Assistant HTTP host. To use a Bearer Token, this has to be [SSL/TSL](/docs/ecosystem/certificates/).
+- Enable **Send https: Bearer Token**  (available since Torque Pro 1.12.46)
+- Paste a Long-Lived Access Token from any Home Assistant user in **Set Bearer Token** field.
+- Enter an email address in **User Email Address** (this can be any non empty string you like). 
 - Optionally set the **Web Logging Interval**. The 2-second default may quickly fill up the Home Assistant history database.
 
 ### Configuration
@@ -50,7 +52,7 @@ name:
   default: vehicle
   type: string
 email:
-  description: Email address configured in Torque application.
+  description: Value from the Email address field configured in Torque application. Doesn't have to be in email syntax.
   required: true
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
- Added information on how to configure a bearer access token in torque to successfully upload data to Home Assistant.
- clarify, that the email field can be any string and is not required to be an email address.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
