### PR TITLE
Add examples for selecting apps, favorites, channels and inputs

### DIFF
--- a/source/_integrations/philips_js.markdown
+++ b/source/_integrations/philips_js.markdown
@@ -136,11 +136,7 @@ overload the event bus in Home Assistant.
 
 ## Selecting apps, channels, or favorites
 
-Apps, channels, and favorites are exposed as media content to the integration. You can see which ones are available by clicking the media button in the media player more info card for your TV. To capture the `content_id` for the one you want to use in an automation or script, turn your logging on to debug level and tail the log while choosing the media content in the media player more info card. You will find a log message that looks like this when you choose the media:
-
-```txt
-2021-11-22 01:45:14 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=media_player, service=play_media, service_data=entity_id=media_player.philips936_tv, media_content_id=com.amazon.ignition.IgnitionActivity-com.amazon.amazonvideo.livingroom, media_content_type=app>
-```
+Apps, channels, and favorites are exposed as media content to the integration. You can see which ones are available by clicking the media button in the media player more info card for your TV. To capture the `content_id` for the one you want to use in an automation or script, watch the properties of the `media_content_id` attribute of the media_player entity as you launch different apps, and you can find the ones you use (some examples are included in the table below).
 
 Then you can turn that into a service call for the script or automation like the following, which can then open the app/channel/favorite automatically.
 

--- a/source/_integrations/philips_js.markdown
+++ b/source/_integrations/philips_js.markdown
@@ -133,3 +133,49 @@ Limits:
  - The integration does not expose current ambilight measured values since it would
 overload the event bus in Home Assistant.
  - There is no support to control the standard, non-expert, styles of the TV.
+
+## Selecting apps, channels, or favorites
+
+Apps, channels, and favorites are exposed as media content to the integration. You can see which ones are available by clicking the media button in the media player more info card for your TV. To capture the `content_id` for the one you want to use in an automation or script, turn your logging on to debug level and tail the log while choosing the media content in the media player more info card. You will find a log message that looks like this when you choose the media:
+
+```txt
+2021-11-22 01:45:14 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=media_player, service=play_media, service_data=entity_id=media_player.philips936_tv, media_content_id=com.amazon.ignition.IgnitionActivity-com.amazon.amazonvideo.livingroom, media_content_type=app>
+```
+
+Then you can turn that into a service call for the script or automation like the following, which can then open the app/channel/favorite automatically.
+
+```yaml
+service: media_player.play_media
+data:
+  media_content_id: com.amazon.ignition.IgnitionActivity-com.amazon.amazonvideo.livingroom
+  media_content_type: app
+target:
+  entity_id:
+    - media_player.philips936_tv
+```
+
+Here are some example media_content_id's for apps that have been discovered with this method. These might not be the same for every TV, so YMMV.
+
+| App Name         | Media Content ID                                                                                |
+| ---------------- | ----------------------------------------------------------------------------------------------- |
+| Hulu             | com.hulu.livingroomplus.WKFactivity-com.hulu.livingroomplus                                     |
+| Google Play      | com.google.android.videos.tv.presenter.activity.TvLauncherActivity-com.google.android.videos    |
+| TV1 Russia       | ru.kino1tv.android.tv.ui.activity.MainActivity-ru.tv1.android.tv                                |
+| YouTube          | com.google.android.apps.youtube.tv.activity.ShellActivity-com.google.android.youtube.tv         |
+| Curiosity Stream | com.curiosity.activities.OnboardingActivity-com.curiosity.curiositystream.androidtv             |
+| HBO Max          | com.hbo.go.LaunchActivity-com.hbo.hbonow                                                        |
+| PBS              | com.pbs.video.ui.main.activities.StartupActivity-com.pbs.video                                  |
+| Plex             | com.plexapp.plex.activities.SplashActivity-com.plexapp.android                                  |
+| PBS Kids         | org.pbskids.video.splash.ui.SplashScreenActivity-org.pbskids.video                              |
+
+## Selecting HDMI Input
+
+Selecting the HDMI Input on the TV is done as follows
+
+```yaml
+service: media_player.select_source
+data:
+  source: HDMI 4
+target:
+  entity_id: media_player.philips936_tv
+```


### PR DESCRIPTION
## Proposed change
<!-- 
There are a lot of things possible with this integration that are not described in the docs, like selecting apps, favorites, channels, and inputs, so this adds that.

Note that there was a [previous PR](https://github.com/home-assistant/home-assistant.io/pull/20810/commits) made against the 'current' branch which was rejected because for some reason I had to use 'next', so now I'm submitting against 'next'. 
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
