### PR TITLE
MQTT climate preset_mode rework

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -79,18 +79,6 @@ availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
-away_mode_command_topic:
-  description: The MQTT topic to publish commands to change the away mode.
-  required: false
-  type: string
-away_mode_state_template:
-  description: A template to render the value received on the `away_mode_state_topic` with.
-  required: false
-  type: template
-away_mode_state_topic:
-  description: The MQTT topic to subscribe for changes of the HVAC away mode. If this is not set, the away mode works in optimistic mode (see below).
-  required: false
-  type: string
 current_temperature_template:
   description: A template with which the value received on `current_temperature_topic` will be rendered.
   required: false
@@ -176,26 +164,6 @@ fan_modes:
   required: false
   default: ['auto', 'low', 'medium', 'high']
   type: list
-hold_command_template:
-  description: A template to render the value sent to the `hold_command_topic` with.
-  required: false
-  type: template
-hold_command_topic:
-  description: The MQTT topic to publish commands to change the hold mode.
-  required: false
-  type: string
-hold_state_template:
-  description: A template to render the value received on the `hold_state_topic` with.
-  required: false
-  type: template
-hold_state_topic:
-  description: The MQTT topic to subscribe for changes of the HVAC hold mode. If this is not set, the hold mode works in optimistic mode (see below).
-  required: false
-  type: string
-hold_modes:
-  description: A list of available hold modes.
-  required: false
-  type: list
 initial:
   description: Set the initial target temperature.
   required: false
@@ -280,6 +248,27 @@ precision:
   required: false
   type: float
   default: 0.1 for Celsius and 1.0 for Fahrenheit.
+preset_mode_command_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to generate the payload to send to `preset_mode_command_topic`.
+  required: false
+  type: template
+preset_mode_command_topic:
+  description: The MQTT topic to publish commands to change the preset mode.
+  required: false
+  type: string
+preset_mode_state_topic:
+  description: The MQTT topic subscribed to receive climate speed based on presets. When preset 'none' is received or `None` the `preset_mode` will be reset.
+  required: false
+  type: string
+preset_mode_value_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the `preset_mode` value from the payload received on `preset_mode_state_topic`.
+  required: false
+  type: string
+preset_modes:
+  description: List of preset modes this climate is supporting. Common examples include `eco`, `away`, `boost`, `comfort`, `home`, `sleep` and `activity`.
+  required: false
+  type: [list]
+  default: []
 qos:
   description: The maximum QoS level to be used when receiving and publishing messages.
   required: false
@@ -434,7 +423,12 @@ climate:
       - "high"
       - "medium"
       - "low"
+    preset_modes:
+      - "eco"
+      - "sleep"
+      - "activity"
     power_command_topic: "study/ac/power/set"
+    preset_mode_command_topic: "study/ac/preset_mode/set"
     mode_command_topic: "study/ac/mode/set"
     temperature_command_topic: "study/ac/temperature/set"
     fan_mode_command_topic: "study/ac/fan/set"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add preset_mode settings for MQTT climate.
Remove hold and away mode config settings.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66062
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
