### PR TITLE
Add documentation on GE Home integration

### DIFF
--- a/source/_integrations/ge_home.markdown
+++ b/source/_integrations/ge_home.markdown
@@ -1,0 +1,38 @@
+---
+title: GE Home Appliances (SmartHQ)
+description: Instructions on how to integrate your GE Home appliances (SmartHQ) into Home Assistant.
+ha_category:
+  - Binary Sensor
+  - Sensor
+  - Switch
+  - Water Heater
+ha_release: 0.5.0
+ha_iot_class: Cloud Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@kevchu3'
+  - '@simbaja'
+ha_domain: ge_home
+ha_platforms:
+  - binary_sensor
+  - sensor
+  - switch
+  - water_heater
+ha_zeroconf: true
+---
+
+The `ge_home` implementation allows you to integrate your [GE Home Appliances](https://www.geappliances.com/) using the [SmartHQ API](https://smarthqsolutions.com/smarthq-platform-api) in Home Assistant.
+
+There is currently support for the following device types within Home Assistant:
+
+- Fridge
+- Oven
+- Dishwasher
+- Laundry (Washer/Dryer)
+- Whole Home Water Filter
+- A/C (Portable, Split, Window)
+- Range Hoods
+- Advantium
+
+{% include integrations/config_flow.md %}
+


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for a new integration for GE Home appliances (SmartHQ)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [X] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66220
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3152
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
