### PR TITLE
Remove documentation on disabled zone bypass switch feature

### DIFF
--- a/source/_integrations/envisalink.markdown
+++ b/source/_integrations/envisalink.markdown
@@ -25,7 +25,7 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor: Reports on zone status (Check the [type/class](/integrations/binary_sensor/#device-class) list for a possible visualization of your zone.)
 - Sensor: Emulates an alphanumeric keypad attached to the alarm panel
 - Alarm Control Panel: Reports on partition status, and can be used to arm/disarm the system
-- Switch: Bypass individual zones. Bypass switches are only available on DSC alarm panels due to limitations in the Honeywell interface.
+- Switch: Bypass individual zones. Bypass switches are only available on DSC alarm panels due to limitations in the Honeywell interface. Turn this feature on using the `create_zone_bypass_switches` configuration.
 
 This is a fully event-based component. Any event sent by the Envisalink device will be immediately reflected within Home Assistant.
 
@@ -47,6 +47,7 @@ envisalink:
   zonedump_interval: 30
   timeout: 10
   panic_type: Police
+  create_zone_bypass_switches: false
   zones:
     11:
       name: "Back Door"
@@ -133,6 +134,11 @@ partitions:
       description: Partition name
       required: true
       type: string
+create_zone_bypass_switches:
+  description: If enabled and the panel type is DSC then switches will be created to allow individual zones to be bypassed.  DO NOT enable this feature if your DSC panel is configured to require a code to bypass zones as it can prevent your physical keypads from working properly while the integration is running.
+  required: false
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 Supported services:

--- a/source/_integrations/envisalink.markdown
+++ b/source/_integrations/envisalink.markdown
@@ -5,7 +5,6 @@ ha_category:
   - Alarm
   - Binary Sensor
   - Sensor
-  - Switch
 ha_release: 0.23
 ha_iot_class: Local Push
 ha_domain: envisalink
@@ -13,7 +12,6 @@ ha_platforms:
   - alarm_control_panel
   - binary_sensor
   - sensor
-  - switch
 ---
 
 The `envisalink` integration will allow Home Assistant users who own either a DSC or Honeywell alarm panel to leverage their alarm system and its sensors to provide Home Assistant with rich information about their homes. Connectivity between Home Assistant and the alarm panel is accomplished through a device produced by Eyez On, known as the Envisalink. The Envisalink evl3 and evl4 boards provide a TCP/IP interface to the alarm panel, where it emulates an alarm keypad. This board also exposes a raw TCP/IP based API, upon which this integration is built. Currently, the Envisalink version 4 is the latest model. This integration supports both the evl3 and the evl4.
@@ -25,7 +23,6 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor: Reports on zone status (Check the [type/class](/integrations/binary_sensor/#device-class) list for a possible visualization of your zone.)
 - Sensor: Emulates an alphanumeric keypad attached to the alarm panel
 - Alarm Control Panel: Reports on partition status, and can be used to arm/disarm the system
-- Switch: Bypass individual zones. Bypass switches are only available on DSC alarm panels due to limitations in the Honeywell interface. Turn this feature on using the `create_zone_bypass_switches` configuration.
 
 This is a fully event-based component. Any event sent by the Envisalink device will be immediately reflected within Home Assistant.
 
@@ -47,7 +44,6 @@ envisalink:
   zonedump_interval: 30
   timeout: 10
   panic_type: Police
-  create_zone_bypass_switches: false
   zones:
     11:
       name: "Back Door"
@@ -134,11 +130,6 @@ partitions:
       description: Partition name
       required: true
       type: string
-create_zone_bypass_switches:
-  description: If enabled and the panel type is DSC then switches will be created to allow individual zones to be bypassed.  DO NOT enable this feature if your DSC panel is configured to require a code to bypass zones as it can prevent your physical keypads from working properly while the integration is running.
-  required: false
-  type: boolean
-  default: false
 {% endconfiguration %}
 
 Supported services:


### PR DESCRIPTION
## Proposed change
<!--
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the
    additional information section.
-->
Removing documentation on the DSC alarm panel zone bypass switches.  These switches have been temporarily disabled to address an issue with the feature causing serious issue with alarm panels that require a code to bypass zones.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66243
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
