### PR TITLE
Update zha.markdown Zigbee channel recommendation

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -253,13 +253,13 @@ zha:
       channels: [15, 20, 25]  # Channel mask
 ```
 
-This is a good reference for channel selection [Zigbee and Wifi Coexistance](https://support.metageek.com/hc/en-us/articles/203845040-ZigBee-and-WiFi-Coexistence).
+This is a good reference for channel selection for [Zigbee and WiFi coexistance](https://support.metageek.com/hc/en-us/articles/203845040-ZigBee-and-WiFi-Coexistence).
 
-Zigbee specification standard devides the 2.4Ghz band into 16 Zigbee channels (i.e. Zigbee radio frequencies). For all Zigbee devices to be able to communicate, they must support the same Zigbee channel (i.e. Zigbee radio frequency) that is set on the Zigbee Coordinator. Not all Zigbee devices support all Zigbee channels, it will usually depend on the hardware and firmware age as well as devices power ratings.
+The Zigbee specification standards divide the 2.4Ghz ISM radio band into 16 Zigbee channels (i.e. distinct radio frequencies for Zigbee). For all Zigbee devices to be able to communicate, they must support the same Zigbee channel (i.e. Zigbee radio frequency) that is set on the Zigbee Coordinator as the channel to use for its Zigbee network. Not all Zigbee devices support all Zigbee channels, it will usually depend on the hardware and firmware age as well as devices power ratings.
 
-The general recommedation is to only use channel 15, 20, or 25 in order to both avoid problems with devices that are limited to supporting ZLL (Zigbee Light Link) channels as well as lessen Wi-Fi networks interference with the Zigbee network. Note that using Zigbee channels 11, 24, 25, or 26 on your Zigbee Coordinator could mean it will not be accessible to older devices as those Zigbee channels are commonly only supported by relativly newer Zigbee hardware devices and/or newer Zigbee firmware.
+The general recommendation is to only use channels 15, 20, or 25 in order to avoid interoperability problems with Zigbee devices that are limited to only being compatible with the ZLL (Zigbee Light Link) channels as well as lessen the chance of Wi-Fi networks interfering too much with the Zigbee network. Note that especially using Zigbee channels 11, 24, 25, or 26 on your Zigbee Coordinator could mean it will probably not be accessible to older devices as those Zigbee channels are commonly only supported by relatively modern Zigbee hardware devices with newer Zigbee firmware.
 
-Regardless, note that the best practice recommendation is, however, not to change the Zigbee channel from default as not all Zigbee devices support all channels. If you have issues with overlapping frequencies, then it will generally be a better idea to change Wi-Fi channels on your Wi-Fi-router or Wi-Fi Access Points.
+Regardless, note that the best practice recommendation is, however, not to change the Zigbee channel from default as not all Zigbee devices support all channels. If you have issues with overlapping frequencies, then it will generally be a better idea to just change Wi-Fi channels on all your Wi-Fi Router or Wi-Fi Access Points instead.
 
 ### Modifying the device type
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -255,9 +255,11 @@ zha:
 
 This is a good reference for channel selection [Zigbee and Wifi Coexistance](https://support.metageek.com/hc/en-us/articles/203845040-ZigBee-and-WiFi-Coexistence).
 
-The general recommedation is to only use channel 15, 20, or 25 in order to both avoid problems with devices that are limited to supporting ZLL (Zigbee Light Link) channels as well as lessen Wi-Fi networks interference with the Zigbee network.
+Zigbee specification standard devides the 2.4Ghz band into 16 Zigbee channels (i.e. Zigbee radio frequencies). For all Zigbee devices to be able to communicate, they must support the same Zigbee channel (i.e. Zigbee radio frequency) that is set on the Zigbee Coordinator. Not all Zigbee devices support all Zigbee channels, it will usually depend on the hardware and firmware age as well as devices power ratings.
 
-Note that the best practice recommendation is, however, not to change the Zigbee channel from default as not all Zigbee devices support all channels. If you have issues with overlapping frequencies, then it will generally be a better idea to change Wi-Fi channels on your Wi-Fi-router or Wi-Fi Access Points.
+The general recommedation is to only use channel 15, 20, or 25 in order to both avoid problems with devices that are limited to supporting ZLL (Zigbee Light Link) channels as well as lessen Wi-Fi networks interference with the Zigbee network. Note that using Zigbee channels 11, 24, 25, or 26 on your Zigbee Coordinator could mean it will not be accessible to older devices as those Zigbee channels are commonly only supported by relativly newer Zigbee hardware devices and/or newer Zigbee firmware.
+
+Regardless, note that the best practice recommendation is, however, not to change the Zigbee channel from default as not all Zigbee devices support all channels. If you have issues with overlapping frequencies, then it will generally be a better idea to change Wi-Fi channels on your Wi-Fi-router or Wi-Fi Access Points.
 
 ### Modifying the device type
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -255,7 +255,9 @@ zha:
 
 This is a good reference for channel selection [Zigbee and Wifi Coexistance](https://support.metageek.com/hc/en-us/articles/203845040-ZigBee-and-WiFi-Coexistence).
 
-Note that the recommendation is, however, not to change the Zigbee channel from default as not all Zigbee devices support all channels. If you have issues with overlapping frequencies, then it will generally be a better idea to change Wi-Fi channels on your Wi-Fi-router or Wi-Fi Access Points.
+The general recommedation is to only use channel 11, 15, 20, or 25 in order to avoid problems with devices that are limited to supporting ZLL (Zigbee Light Link) channels.
+
+Note that the best practice recommendation is, however, not to change the Zigbee channel from default as not all Zigbee devices support all channels. If you have issues with overlapping frequencies, then it will generally be a better idea to change Wi-Fi channels on your Wi-Fi-router or Wi-Fi Access Points.
 
 ### Modifying the device type
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -259,7 +259,7 @@ The Zigbee specification standards divide the 2.4Ghz ISM radio band into 16 Zigb
 
 The general recommendation is to only use channels 15, 20, or 25 in order to avoid interoperability problems with Zigbee devices that are limited to only being compatible with the ZLL (Zigbee Light Link) channels as well as lessen the chance of Wi-Fi networks interfering too much with the Zigbee network. Note that especially using Zigbee channels 11, 24, 25, or 26 on your Zigbee Coordinator could mean it will probably not be accessible to older devices as those Zigbee channels are commonly only supported by relatively modern Zigbee hardware devices with newer Zigbee firmware.
 
-Regardless, note that the best practice recommendation is, however, not to change the Zigbee channel from default as not all Zigbee devices support all channels. If you have issues with overlapping frequencies, then it will generally be a better idea to just change Wi-Fi channels on all your Wi-Fi Router or Wi-Fi Access Points instead.
+Regardless, note that the best practice recommendation is, however, not to change the Zigbee channel from default as not all Zigbee devices support all channels. If you have issues with overlapping frequencies, then it will generally be a better idea to just change Wi-Fi channels on your Wi-Fi Router or all your Wi-Fi Access Points instead.
 
 ### Modifying the device type
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -255,7 +255,7 @@ zha:
 
 This is a good reference for channel selection [Zigbee and Wifi Coexistance](https://support.metageek.com/hc/en-us/articles/203845040-ZigBee-and-WiFi-Coexistence).
 
-The general recommedation is to only use channel 11, 15, 20, or 25 in order to avoid problems with devices that are limited to supporting ZLL (Zigbee Light Link) channels.
+The general recommedation is to only use channel 15, 20, or 25 in order to both avoid problems with devices that are limited to supporting ZLL (Zigbee Light Link) channels as well as lessen Wi-Fi networks interference with the Zigbee network.
 
 Note that the best practice recommendation is, however, not to change the Zigbee channel from default as not all Zigbee devices support all channels. If you have issues with overlapping frequencies, then it will generally be a better idea to change Wi-Fi channels on your Wi-Fi-router or Wi-Fi Access Points.
 


### PR DESCRIPTION
## Proposed change

Update Zigbee channel recommendation for ZHA by specifically mentioning using Zigbee channels 15, 20, or 25 to avoid problems with the limitation of devices only supporting ZZL (Zigbee Light Link) channels as well as for optimal Zigbee and Wi-Fi coexistence.

For reference; Zigbee2MQTT mention the ZZL (Zigbee Light Link) channels limitation as a comment in their Zigbee network config, see https://www.zigbee2mqtt.io/guide/configuration/zigbee-network.html#network-config but they forgot to also recommend not using Zigbee channel 11 which does not coexist well with Wi-Fi channel 1, see https://www.metageek.com/training/resources/zigbee-wifi-coexistence/  Also mention general recommendation not use Zigbee channels 11, 24, 25, or 26 if got old Zigbee devices, see https://www.digi.com/resources/documentation/digidocs/90001537/references/r_channels_zigbee.htm

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
