### PR TITLE
Add button platform to august to wake locks from a deep sleep

### DIFF
--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -2,8 +2,9 @@
 title: August
 description: Instructions on how to integrate your August devices into Home Assistant.
 ha_category:
-  - Doorbell
   - Binary Sensor
+  - Button
+  - Doorbell
   - Sensor
   - Camera
   - Lock
@@ -16,6 +17,7 @@ ha_domain: august
 ha_dhcp: true
 ha_platforms:
   - binary_sensor
+  - button
   - camera
   - lock
   - sensor
@@ -43,6 +45,7 @@ There is currently support for the following device types within Home Assistant:
 
 - Doorbell
 - Binary Sensor
+- Button
 - Sensor
 - Camera
 - Lock
@@ -68,6 +71,10 @@ If you have an August Doorbell, once you have enabled the August component, you 
 If you have an August Smart Lock with DoorSense, once you have enabled the August component, you should see the following sensors:
 
 - Door sensor
+
+## Button
+
+A button is created to wake the lock from a deep sleep. If your lock is not reporting a status, it may be in a deep sleep, and the button can be used to wake it. Locks are not automatically woken from deep sleep to preserve battery life.
 
 ## Camera
 

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -74,7 +74,7 @@ If you have an August Smart Lock with DoorSense, once you have enabled the Augus
 
 ## Button
 
-A button is created to wake the lock from a deep sleep. If your lock is not reporting a status, it may be in a deep sleep, and the button can be used to wake it. Locks are not automatically woken from deep sleep to preserve battery life.
+Buttons are created to wake locks from a deep sleep. If your lock is not reporting a status, it may be in a deep sleep, and the button can be used to wake it. Locks are not automatically woken from deep sleep to preserve battery life.
 
 ## Camera
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add button platform to august to wake locks from a deep sleep

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66343
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
