### PR TITLE
dlna_dmr: Document ability to browse and play media

### DIFF
--- a/source/_integrations/dlna_dmr.markdown
+++ b/source/_integrations/dlna_dmr.markdown
@@ -52,8 +52,8 @@ DLNA devices can support a range of features. Depending on the device itself, th
 
 ## Playing media
 
-Most DLNA DMR devices can play media from local HTTP servers. For best results, use HTTP instead of HTTPS, and refer to the server using an IP address instead of a host name, e.g. `http://192.168.1.1:8080/song.mp3`.
+Most DLNA DMR devices can play media from local HTTP servers. For best results, use HTTP instead of HTTPS, and refer to the server using an IP address instead of a hostname, e.g. `http://192.168.1.1:8080/song.mp3`.
 
 ### Media sources
 
-The `dlna_dmr` platform can browse any configured [media_source](/integrations/media_source/). Displayed media will be filtered based on the capabilities of the DLNA DMR device.
+The DLNA Digital Media Renderer integration can browse any configured [Media Source](/integrations/media_source/). Displayed media will be filtered based on the capabilities of the DLNA DMR device.

--- a/source/_integrations/dlna_dmr.markdown
+++ b/source/_integrations/dlna_dmr.markdown
@@ -52,7 +52,7 @@ DLNA devices can support a range of features. Depending on the device itself, th
 
 ## Playing media
 
-Most DLNA DMR devices can play media from local HTTP servers. For best results, use HTTP instead of HTTPS, and refer to the server using an IP address instead of a host name, e.g. `http://192.168.1.1:8123/song.mp3`.
+Most DLNA DMR devices can play media from local HTTP servers. For best results, use HTTP instead of HTTPS, and refer to the server using an IP address instead of a host name, e.g. `http://192.168.1.1:8080/song.mp3`.
 
 ### Media sources
 

--- a/source/_integrations/dlna_dmr.markdown
+++ b/source/_integrations/dlna_dmr.markdown
@@ -49,3 +49,11 @@ DLNA devices can support a range of features. Depending on the device itself, th
 * `media_player.shuffle_set`
 * `media_player.repeat_set`
 * `media_player.select_sound_mode`
+
+## Playing media
+
+Most DLNA DMR devices can play media from local HTTP servers. For best results, use HTTP instead of HTTPS, and refer to the server using an IP address instead of a host name, e.g. `http://192.168.1.1:8123/song.mp3`.
+
+### Media sources
+
+The `dlna_dmr` platform can browse any configured [media_source](/integrations/media_source/). Displayed media will be filtered based on the capabilities of the DLNA DMR device.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document support for `play_media` and `browse_media`.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66425
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
