### PR TITLE
SSL options incompatible with local fulfillment

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -109,6 +109,10 @@ If you want to support active reporting of state to Google's server (configurati
 
 ### Enable Local Fulfillment
 
+<div class='note'>
+The [ssl_certificate option](https://www.home-assistant.io/integrations/http/#ssl_certificate) in `http` must not have a value or this feature won't work. This is because Google requires a valid certificate and the way it connects to Home Assistant for local fulfillment makes that impossible. Consider using a reverse proxy such as the [Nginx SSL](https://my.home-assistant.io/redirect/supervisor_addon/?addon=core_nginx_proxy) or [NGinx Proxy Manager](https://my.home-assistant.io/redirect/supervisor_addon/?addon=a0d7b954_nginxproxymanager) addons instead of directing external traffic directly to Home Assistant.
+</div>
+
 1. Open the project you created in the [Actions on Google console](https://console.actions.google.com/).
 2. Click `Develop` on the top of the page, then click `Actions` located in the hamburger menu on the top left.
 3. Upload [this Javascript file](/assets/integrations/google_assistant/app.js) for both Node and Chrome by clicking the `Upload Javascript files` button.

--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -113,7 +113,7 @@ If you want to support active reporting of state to Google's server (configurati
 
 The [`ssl_certificate` option](/integrations/http/#ssl_certificate) in the `http` integration must not have a value or this feature won't work.
 
-This is because Google requires a valid certificate and the way it connects to Home Assistant for local fulfillment makes that impossible. Consider using a reverse proxy such as the {% my addon="core_nginx_proxy" title="Nginx SSL" %} addon instead of directing external traffic directly to Home Assistant.
+This is because Google requires a valid certificate and the way it connects to Home Assistant for local fulfillment makes that impossible. Consider using a reverse proxy such as the {% my supervisor_addon addon="core_nginx_proxy" title="NGINX SSL" %} add-on instead of directing external traffic directly to Home Assistant.
 
 </div>
 

--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -110,7 +110,11 @@ If you want to support active reporting of state to Google's server (configurati
 ### Enable Local Fulfillment
 
 <div class='note'>
-The [ssl_certificate option](https://www.home-assistant.io/integrations/http/#ssl_certificate) in `http` must not have a value or this feature won't work. This is because Google requires a valid certificate and the way it connects to Home Assistant for local fulfillment makes that impossible. Consider using a reverse proxy such as the [Nginx SSL](https://my.home-assistant.io/redirect/supervisor_addon/?addon=core_nginx_proxy) or [NGinx Proxy Manager](https://my.home-assistant.io/redirect/supervisor_addon/?addon=a0d7b954_nginxproxymanager) addons instead of directing external traffic directly to Home Assistant.
+
+The [`ssl_certificate` option](/integrations/http/#ssl_certificate) in the `http` integration must not have a value or this feature won't work.
+
+This is because Google requires a valid certificate and the way it connects to Home Assistant for local fulfillment makes that impossible. Consider using a reverse proxy such as the {% my addon="core_nginx_proxy" title="Nginx SSL" %} addon instead of directing external traffic directly to Home Assistant.
+
 </div>
 
 1. Open the project you created in the [Actions on Google console](https://console.actions.google.com/).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Warn users that if the `ssl_certificate` option is set in the `http` integration then local fulfillment will not work. Provide a suggested alternative of a reverse proxy.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
