### PR TITLE
Updated zamg to use config flow

### DIFF
--- a/source/_integrations/zamg.markdown
+++ b/source/_integrations/zamg.markdown
@@ -7,6 +7,7 @@ ha_category:
 ha_release: 0.35
 ha_iot_class: Cloud Polling
 ha_domain: zamg
+ha_config_flow: true
 ha_platforms:
   - sensor
   - weather
@@ -18,109 +19,28 @@ Only observations for capital cities are publicly available. You can check the l
 
 There is currently support for the following device types within Home Assistant:
 
-- **[Weather](#weather)** - Easier to configure but less customizable and doesn't have support for conditions which is a key feature of the `weather` platforms.
+- **Weather** - It displays the current temperature, humidity, pressure and wind speed, but it doesn't have support for conditions which is a key feature of the `weather` platforms.
 - **[Sensor](#sensor)**
-
-## Weather
-
-To add ZAMG weather platform to your installation, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-weather:
-  - platform: zamg
-```
-
-{% configuration %}
-station_id:
-  description: The ID number for a supported ZAMG station.
-  required: false
-  type: string
-name:
-  description: A name for the weather platform.
-  required: false
-  type: string
-latitude:
-  description: "Latitude coordinate to monitor weather of (required if **longitude** is specified)."
-  required: false
-  type: float
-  default: "Defaults to coordinates defined in your `configuration.yaml` file."
-longitude:
-  description: "Longitude coordinate to monitor weather of (required if **latitude** is specified)."
-  required: false
-  type: float
-  default: "Defaults to coordinates defined in your `configuration.yaml` file."
-{% endconfiguration %}
 
 ## Sensor
 
-To add ZAMG sensor platform to your installation, add the following to your `configuration.yaml` file:
+This integration provides the following sensors:
 
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: zamg
-```
-
-{% configuration %}
-station_id:
-  required: false
-  description: The ID number for a supported ZAMG station.
-  type: string
-name:
-  required: false
-  description: Additional name for the sensors. Defaults to platform name.
-  default: zamg
-  type: string
-latitude:
-  required: false
-  description: "Latitude coordinate to monitor weather of (required if **longitude** is specified)."
-  default: "Defaults to coordinates defined in your `configuration.yaml` file."
-  type: float
-longitude:
-  required: false
-  description: "Longitude coordinate to monitor weather of (required if **latitude** is specified)."
-  default: "Defaults to coordinates defined in your `configuration.yaml` file."
-  type: float
-monitored_conditions:
-  required: false
-  description: Conditions to display in the frontend.
-  type: list
-  default: temperature
-  keys:
-    pressure:
-      description: Pressure at station level
-    pressure_sealevel:
-      description: Pressure at sea Level
-    humidity:
-      description: Humidity
-    wind_speed:
-      description: Wind speed
-    wind_bearing:
-      description: Wind bearing
-    wind_max_speed:
-      description: Top wind speed
-    wind_max_bearing:
-      description: Top wind bearing
-    sun_last_hour:
-      description: Sun last hour percentage
-    temperature:
-      description: Temperature
-    precipitation:
-      description: Precipitation
-    dewpoint:
-      description: Dew point
-{% endconfiguration %}
-
-A full configuration example:
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: zamg
-    station_id: 11035
-    name: Wien
-    monitored_conditions:
-      - temperature
-      - humidity
-```
+|Name|Description|
+|----|-----------|
+|Temperature|Temperature in °C|
+|Humidity|Humidity in %|
+|Dew Point|Dew point in °C|
+|Pressure|Station pressure in hPa|
+|Pressure at Sea Level|Sea level pressure in hPa|
+|Wind Speed|Wind speed in km/h|
+|Top Wind Speed|Max wind speed in km/h|
+|Wind Bearing|Wind bearing in °|
+|Top Wind Bearing|Wind bearing at max speed in °|
+|Sun Last Hour|Sunshine in the last hour in %|
+|Precipitation|Precipitation in 1/m²|
+|Station Name|Station name|
+|Station Elevation|The station elevation in m|
+|Update Date|Update date of last read data|
+|Update Time|Update time of last read data|
+|Station id|The station id|

--- a/source/_integrations/zamg.markdown
+++ b/source/_integrations/zamg.markdown
@@ -17,6 +17,8 @@ The `zamg` platform uses meteorological details published by the Austrian weathe
 
 Only observations for capital cities are publicly available. You can check the list of stations in [CSV format](https://www.zamg.ac.at/ogd).
 
+{% include integrations/config_flow.md %}
+
 There is currently support for the following device types within Home Assistant:
 
 - **Weather** - It displays the current temperature, humidity, pressure and wind speed, but it doesn't have support for conditions which is a key feature of the `weather` platforms.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Changed documentation to met new config flow feature in zamg integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66469
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
