### PR TITLE
Add timer support to tolo integration

### DIFF
--- a/source/_integrations/tolo.markdown
+++ b/source/_integrations/tolo.markdown
@@ -17,6 +17,7 @@ ha_platforms:
   - climate
   - fan
   - light
+  - number
   - sensor
   - select
 ha_dhcp: true
@@ -30,6 +31,7 @@ The integration allows for:
 - Setting the target temperature and target humidity
 - Controlling the fan (used for drying and cooling down the sauna)
 - Controlling the sauna lights (on/off, mode selection)
+- Configuring timers for automatic power shutdown, automatic fan shutdown and salt spray activation interval
 - Checking diagnostic information (water level, tank temperature, water in/out valves)
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
TOLO Sauna devices allow to configure timers to e.g. automatically shut down the device, shut down the fan or for regularly activating a salt spray. This pull request changes the documentation accordingly to the added features in https://github.com/home-assistant/core/pull/66799 and https://github.com/home-assistant/core/pull/66938.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66799, https://github.com/home-assistant/core/pull/66938
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
