### PR TITLE
Migrate openhome to config_flow

### DIFF
--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -15,7 +15,6 @@ Home Assistant can discover and automatically configure [zeroconf](https://en.wi
  * [Enigma2 media player](/integrations/enigma2)
  * [Frontier Silicon internet radios](/integrations/frontier_silicon)
  * [LG Soundbars](/integrations/lg_soundbar)
- * [Linn / Openhome](/integrations/openhome)
  * [Logitech Media Server (Squeezebox)](/integrations/squeezebox)
  * [NETGEAR routers](/integrations/netgear)
  * [SABnzbd downloader](/integrations/sabnzbd)

--- a/source/_integrations/openhome.markdown
+++ b/source/_integrations/openhome.markdown
@@ -10,17 +10,12 @@ ha_codeowners:
   - '@bazwilliams'
 ha_platforms:
   - media_player
+ha_ssdp: true
 ---
 
 The `openhome` platform allows you to connect an [Openhome Compliant Renderer](http://openhome.org/) to Home Assistant such as a [Linn Products Ltd](https://www.linn.co.uk) HiFi streamer. It will allow you to control media playback, volume, source and see the current playing item. Openhome devices should be discovered by using [the discovery component](/integrations/discovery/), their device names are taken from the name of the room configured on the device.
 
-### Example `configuration.yaml` entry
-
-```yaml
-discovery:
-media_player:
-  - platform: openhome
-```
+{% include integrations/config_flow.md %}
 
 ### Example local audio playback action
 

--- a/source/_integrations/openhome.markdown
+++ b/source/_integrations/openhome.markdown
@@ -11,9 +11,10 @@ ha_codeowners:
 ha_platforms:
   - media_player
 ha_ssdp: true
+ha_config_flow: true
 ---
 
-The `openhome` platform allows you to connect an [Openhome Compliant Renderer](http://openhome.org/) to Home Assistant such as a [Linn Products Ltd](https://www.linn.co.uk) HiFi streamer. It will allow you to control media playback, volume, source and see the current playing item. Openhome devices should be discovered by using [the discovery component](/integrations/discovery/), their device names are taken from the name of the room configured on the device.
+The Linn / OpenHome integration allows you to connect an [Openhome Compliant Renderer](http://openhome.org/) to Home Assistant such as a [Linn Products Ltd](https://www.linn.co.uk) HiFi streamer. It will allow you to control media playback, volume, source and see the current playing item. Their device names are taken from the name of the room configured on the device.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change

Migrate the openhome component away from yaml configuration and to config_flow.

Updated the discovery component documentation removing `openhome` form the list of supported integrations; but I've left the documentation to skip discovery of `openhome` devices since that still applies. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66850
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
