### PR TITLE
 Improve glossary entries of domain, integration, platform

### DIFF
--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -53,7 +53,7 @@
 - topic: Packages
   description: "[Packages](/docs/configuration/packages/) allow you to bundle different component configurations together."
 - topic: Platform
-  description: "[Platforms](/docs/configuration/platform_options/) are building blocks provided by some integrations to be used by other integrations. For example, the `light` integration provides the `light platform` that is utilized by all integrations providing `light` entities such as e.g. `hue`."
+  description: "[Platforms](/docs/configuration/platform_options/) are building blocks provided by some integrations to be used by other integrations. For example, the [Light](/integrations/light) integration provides the `light platform` that is utilized by all integrations providing `light` entities such as e.g. [Hue](/integrations/hue)."
 - topic: Scene
   description: "[Scenes](/integrations/scene/) capture the states you want certain entities to be. For example, a scene can specify that light A should be turned on and light B should be bright red."
 - topic: Script

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -21,7 +21,7 @@
 - topic: Discovery
   description: "[Discovery](/integrations/discovery/) is the automatic setup of zeroconf/mDNS and uPnP devices after they are discovered."
 - topic: Domain
-  description: "Entities and services belong to a domain, which is the first part of the entity or service, before the `.`. For example `light.kitchen` is an entity in the `light` domain, while `homeassistant.turn_on` is the `turn_on` service for the `homeassistant` domain."
+  description: "Domains provide generic interfaces for high-level concepts such as `light`, `switch` or `sensor`. These are then implemented by `integrations`. Entities and services belong to a domain, which is the first part of the entity or service, before the `.`. For example `light.kitchen` is an entity in the `light` domain, while `homeassistant.turn_on` is the `turn_on` service for the `homeassistant` domain."
 - topic: Entity
   description: "An [entity](/docs/configuration/platform_options/) is the representation of a function of a single device, unit, or web service. There may be multiple entities for a single device, unit, or web service, or there may be only one."
 - topic: Event
@@ -43,7 +43,7 @@
 - topic: Home Assistant Operating System
   description: "Home Assistant OS, the Home Assistant Operating System, is an embedded, minimalistic, operating system designed to run the Home Assistant ecosystem on single board computers (like the Raspberry Pi) or Virtual Machines. The Home Assistant Supervisor can keep it up to date, removing the need for you to manage an operating system."
 - topic: Integration
-  description: "[Integrations](/integrations/) provide the core logic for the functionality in Home Assistant. Like `notify` provides sending notifications."
+  description: "[Integrations](/integrations/) are the abstraction layer that connects devices, web services and more to Home Assistant by mapping their functionality to existing Home Assistant domains. They contain all the logic that takes care of vendor- and device-specific stuff such as authentication or special protocols.
 - topic: Lovelace
   description: "[Lovelace](/lovelace/) is the name of the current frontend."
 - topic: Light
@@ -53,7 +53,7 @@
 - topic: Packages
   description: "[Packages](/docs/configuration/packages/) allow you to bundle different component configurations together."
 - topic: Platform
-  description: "[Platforms](/docs/configuration/platform_options/) make the connection to a specific software or hardware platform. For example, the `pushbullet` platform works with the service pushbullet.com to send notifications."
+  description: "[Platforms](/docs/configuration/platform_options/) is just a different name for integrations that isn't used that often anymore."
 - topic: Scene
   description: "[Scenes](/integrations/scene/) capture the states you want certain entities to be. For example, a scene can specify that light A should be turned on and light B should be bright red."
 - topic: Script

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -21,7 +21,7 @@
 - topic: Discovery
   description: "[Discovery](/integrations/discovery/) is the automatic setup of zeroconf/mDNS and uPnP devices after they are discovered."
 - topic: Domain
-  description: "Domains provide generic interfaces for high-level concepts such as `light`, `switch` or `sensor`. These are then implemented by `integrations`. Entities and services belong to a domain, which is the first part of the entity or service, before the `.`. For example `light.kitchen` is an entity in the `light` domain, while `homeassistant.turn_on` is the `turn_on` service for the `homeassistant` domain."
+  description: "Entities and services belong to a domain, which is the first part of the entity or service, before the `.`. For example `light.kitchen` is an entity in the `light` domain, while `homeassistant.turn_on` is the `turn_on` service for the `homeassistant` domain."
 - topic: Entity
   description: "An [entity](/docs/configuration/platform_options/) is the representation of a function of a single device, unit, or web service. There may be multiple entities for a single device, unit, or web service, or there may be only one."
 - topic: Event
@@ -53,7 +53,7 @@
 - topic: Packages
   description: "[Packages](/docs/configuration/packages/) allow you to bundle different component configurations together."
 - topic: Platform
-  description: "[Platforms](/docs/configuration/platform_options/) is just a different name for integrations that isn't used that often anymore."
+  description: "[Platforms](/docs/configuration/platform_options/) are building blocks provided by some integrations to be used by other integrations. For example, the `light` integration provides the `light platform` that is utilized by all integrations providing `light` entities such as e.g. `hue`."
 - topic: Scene
   description: "[Scenes](/integrations/scene/) capture the states you want certain entities to be. For example, a scene can specify that light A should be turned on and light B should be bright red."
 - topic: Script

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -43,7 +43,7 @@
 - topic: Home Assistant Operating System
   description: "Home Assistant OS, the Home Assistant Operating System, is an embedded, minimalistic, operating system designed to run the Home Assistant ecosystem on single board computers (like the Raspberry Pi) or Virtual Machines. The Home Assistant Supervisor can keep it up to date, removing the need for you to manage an operating system."
 - topic: Integration
-  description: "[Integrations](/integrations/) connect and integration Home Assistant with devices, services, and more. Such an integration contains all the logic that takes care of vendor- and device-specific implementations such as authentication or special protocols and brings those into Home Assistant in a standardized way. For example, the [Hue](/integrations/hue) integration integrates the Philips Hue bridge and its connected bulbs into Home Assistant, making them available as Home Assistant light entities you can control.
+  description: "[Integrations](/integrations/) connect and integrates Home Assistant with devices, services, and more. Such an integration contains all the logic that takes care of vendor- and device-specific implementations such as authentication or special protocols and brings those into Home Assistant in a standardized way. For example, the [Hue](/integrations/hue) integration integrates the Philips Hue bridge and its connected bulbs into Home Assistant, making them available as Home Assistant light entities you can control.
 - topic: Lovelace
   description: "[Lovelace](/lovelace/) is the name of the current frontend."
 - topic: Light

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -21,7 +21,7 @@
 - topic: Discovery
   description: "[Discovery](/integrations/discovery/) is the automatic setup of zeroconf/mDNS and uPnP devices after they are discovered."
 - topic: Domain
-  description: "Entities and services belong to a domain, which is the first part of the entity or service, before the `.`. For example `light.kitchen` is an entity in the `light` domain, while `homeassistant.turn_on` is the `turn_on` service for the `homeassistant` domain."
+  description: "Each integration in Home Assitant has a unique identifier: a domain. All of the entities and services available in Home Assistant are provided by integrations and thus belong to such a domain. The first part of the entity or service, before the `.` shows the domain they belong to. For example `light.kitchen` is an entity in the `light` domain from the [light integration](/integrations/light), while `hue.activate_scene` is the `activate_scene` service for the `hue` domain which belongs to the [Hue integration](/integrations/hue)."
 - topic: Entity
   description: "An [entity](/docs/configuration/platform_options/) is the representation of a function of a single device, unit, or web service. There may be multiple entities for a single device, unit, or web service, or there may be only one."
 - topic: Event
@@ -43,7 +43,7 @@
 - topic: Home Assistant Operating System
   description: "Home Assistant OS, the Home Assistant Operating System, is an embedded, minimalistic, operating system designed to run the Home Assistant ecosystem on single board computers (like the Raspberry Pi) or Virtual Machines. The Home Assistant Supervisor can keep it up to date, removing the need for you to manage an operating system."
 - topic: Integration
-  description: "[Integrations](/integrations/) connect and integrates Home Assistant with devices, services, and more. Such an integration contains all the logic that takes care of vendor- and device-specific implementations such as authentication or special protocols and brings those into Home Assistant in a standardized way. For example, the [Hue](/integrations/hue) integration integrates the Philips Hue bridge and its connected bulbs into Home Assistant, making them available as Home Assistant light entities you can control.
+  description: "[Integrations](/integrations/) connect and integrates Home Assistant with devices, services, and more. Such an integration contains all the logic that takes care of vendor- and device-specific implementations such as authentication or special protocols and brings those into Home Assistant in a standardized way. For example, the [Hue](/integrations/hue) integration integrates the Philips Hue bridge and its connected bulbs into Home Assistant, making them available as Home Assistant light entities you can control."
 - topic: Lovelace
   description: "[Lovelace](/lovelace/) is the name of the current frontend."
 - topic: Light

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -43,7 +43,7 @@
 - topic: Home Assistant Operating System
   description: "Home Assistant OS, the Home Assistant Operating System, is an embedded, minimalistic, operating system designed to run the Home Assistant ecosystem on single board computers (like the Raspberry Pi) or Virtual Machines. The Home Assistant Supervisor can keep it up to date, removing the need for you to manage an operating system."
 - topic: Integration
-  description: "[Integrations](/integrations/) are the abstraction layer that connects devices, web services and more to Home Assistant by mapping their functionality to existing Home Assistant domains. They contain all the logic that takes care of vendor- and device-specific stuff such as authentication or special protocols.
+  description: "[Integrations](/integrations/) connect and integration Home Assistant with devices, services, and more. Such an integration contains all the logic that takes care of vendor- and device-specific implementations such as authentication or special protocols and brings those into Home Assistant in a standardized way. For example, the [Hue](/integrations/hue) integration integrates the Philips Hue bridge and its connected bulbs into Home Assistant, making them available as Home Assistant light entities you can control.
 - topic: Lovelace
   description: "[Lovelace](/lovelace/) is the name of the current frontend."
 - topic: Light


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR attempts to improve the glossary entries of domain, integration and platform, however I'm only ~80% sure that I got that correct.

Please let me know if I got something wrong there.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
