### PR TITLE
Improve advanced filtering documentation for the Plex Integration

### DIFF
--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -138,11 +138,16 @@ The integration must be configured with a token for playback commands to work. T
 
 ##### Examples:
 
+Play Hello from Adele's album 25 in the library Music
+
 ```yaml
 entity_id: media_player.plex_player
 media_content_type: MUSIC
 media_content_id: '{ "library_name": "Music", "artist_name": "Adele", "album_name": "25", "track_name": "Hello" }'
 ```
+
+Play a random track from Stevie Wonder in the library Music
+
 ```yaml
 entity_id: media_player.plex_player
 media_content_type: MUSIC
@@ -158,6 +163,9 @@ media_content_id: '{ "library_name": "Music", "artist_name": "Stevie Wonder", "s
 | `media_content_type`   | `PLAYLIST`                                                                                          |
 
 ##### Example:
+
+Plays the playlist The Best of Disco with shuffle enabled
+
 ```yaml
 entity_id: media_player.plex_player
 media_content_type: PLAYLIST
@@ -174,15 +182,28 @@ media_content_id: '{ "playlist_name": "The Best of Disco", "shuffle": "1" }'
 
 ##### Examples:
 
+Play Rick and Morty S2E5 from library Adult TV
+
 ```yaml
 entity_id: media_player.plex_player
 media_content_type: EPISODE
 media_content_id: '{ "library_name": "Adult TV", "show_name": "Rick and Morty", "season_number": 2, "episode_number": 5 }'
 ```
+
+Play a random episode of Sesame Street from the library Kids TV
+
 ```yaml
 entity_id: media_player.plex_player
 media_content_type: EPISODE
-media_content_id: '{ "library_name": "Kid TV", "show_name": "Sesame Street", "shuffle": "1" }'
+media_content_id: '{ "library_name": "Kids TV", "show_name": "Sesame Street", "shuffle": "1" }'
+```
+
+Play the next unfinished episode of 60 Minutes from the library News TV
+
+```yaml
+entity_id: media_player.plex_player
+media_content_type: EPISODE
+media_content_id: '{ "library_name": "News TV", "show_name": "60 Minutes", "episode.unwatched": true, "episode.inProgress": [true, false], "sort": "addedAt:asc", "maxresults": 1 }'
 ```
 
 #### Movie
@@ -194,6 +215,8 @@ media_content_id: '{ "library_name": "Kid TV", "show_name": "Sesame Street", "sh
 | `media_content_type`   | `movie`                                                                                                 |
 
 ##### Examples:
+
+Play Blade from the library Adult Movies
 
 ```yaml
 entity_id: media_player.plex_player
@@ -281,11 +304,16 @@ Call the `media_player.play_media` service with the `entity_id` of a Sonos integ
 
 ##### Examples:
 
+Play a track with advanced filtering on a Sonos Speaker
+
 ```yaml
 entity_id: media_player.sonos_speaker
 media_content_type: music
 media_content_id: 'plex://{ "library_name": "Music", "artist_name": "Adele", "album_name": "25", "track_name": "Hello" }'
 ```
+
+Play a playlist on a Sonos Speaker
+
 ```yaml
 entity_id: media_player.sonos_speaker
 media_content_type: playlist


### PR DESCRIPTION
Add descriptions for all examples

## Proposed change
When using `unwatched` or `inProgress` with episodes the flags did not seem to work. I switched this query to a `media_content_type: movie` it appears to work. I begin searching plex api when I run across the section about `libtype`. I suddenly realize what is going on, the `unwatched` and `inProgress` flags default to the TV Show series itself.

`libtype` _is_ mentioned in the current HA docs but it's ordering almost makes it seem like it only applies to the `movie` content type. (I realize I am not smart 😉)

I also think an extremely common use-case for this filtering is to play the next unfinished episode in a series and it requires a user to gather information from the entire article. Here I've simply added this use-case to the examples for an `EPISODE`. I think a lazy reader (like myself) may catch those `episode.` strings in the example and realize what is going on much faster.

I also added a description for all examples so that everything looked consistent.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
