### PR TITLE
Add Yamaha MusicCast Switch entities

### DIFF
--- a/source/_integrations/yamaha_musiccast.markdown
+++ b/source/_integrations/yamaha_musiccast.markdown
@@ -96,6 +96,25 @@ The following entities will be added, if they are supported by the MusicCast dev
 - Link Audio Quality (configuration, zone level)
   - Set the audio quality for grouped speakers
 
+### Switch Entities
+The following entities will be added, if they are supported by the MusicCast device:
+- Speaker A (configuration, device level)
+  - A switch to turn on the speaker set A
+- Speaker B (configuration, device level)
+  - A switch to turn on the speaker set B
+- Party Mode (configuration, device level)
+  - Lets all zones play the same content like the main zone
+- Bass Extension (configuration, zone level)
+  - Extend the bass to more speakers (especially useful in configurations without a subwoofer)
+- Extra Bass (configuration, zone level)
+  - Seems to be the same as bass extension, but on other devices
+- Enhancer (configuration, zone level)
+  - Enhances compressed audio formats
+- Pure Direct (configuration, zone level)
+  - Lets the device play the audio directly without any additional processing
+- Adaptive DRC (configuration, zone level)
+  - Adjusts the volume of high and low frequency levels for better sound at low volume
+
 ## Troubleshooting
 
 In this section known problems and their resolution are documented.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
After adding select and number entities for configuration purposes, we will now also add the switch entities described in the changes.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66925
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
