### PR TITLE
Remove deprecated YAML config from bmw_connected_drive

### DIFF
--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -46,53 +46,20 @@ This integration provides the following platforms:
 
 ## Configuration
 
-The preferred way to enable the `bmw_connected_drive` integration is via **Configuration** > **Devices & Services**. After connecting to your account, you can set the following settings in the integration's options:
+Enable the `BMW Connected Drive` integration via **Configuration** > **Devices & Services**.
+
+<div class='note'>
+
+  For `china`, it is mandatory to prefix your username/phone number with `86`, i.e. `8612345678`.
+
+</div>
+
+After connecting to your account, you can set the following settings in the integration's options:
 
 | Setting | Description |
 |---------|-------------|
 | Read-only | No execution of services to the vehicle. Still possible to send messages and POIs via `notify` and to request a status update via `bmw_connected_drive.update_state`.
-
-The following settings in your `configuration.yaml` file are considered legacy. They will be imported into **Configuration** > **Devices & Services** and you can set the options from above. Changes to `configuration.yaml` after the first import will be ignored.
-
-### Legacy configuration
-
-```yaml
-# Example configuration.yaml entry
-bmw_connected_drive:
-  name:
-    username: USERNAME_BMW_CONNECTED_DRIVE
-    password: PASSWORD_BMW_CONNECTED_DRIVE
-    region: one of "north_america", "china", "rest_of_world"
-```
-
-{% configuration %}
-bmw_connected_drive:
-  description: configuration
-  required: true
-  type: map
-  keys:
-    name:
-      description: Name of your account in Home Assistant.
-      required: true
-      type: string
-    username:
-      description: Your BMW Connected Drive username.
-      required: true
-      type: string
-    password:
-      description: Your BMW Connected Drive password.
-      required: true
-      type: string
-    region:
-      description: "The region of your Connected Drive account. Please use one of these values: `north_america`, `china`, `rest_of_world`"
-      required: true
-      type: string
-    read_only:
-      description: In read only mode, all services including the lock of the vehicle are disabled.
-      required: false
-      type: boolean
-      default: false
-{% endconfiguration %}
+| Use Home Assistant location for car location polls | Older cars (non i3/i8 build before 7/2014) require the phone to be close to the car to get location updates. Enable this option to use the location of your Home Assistant instance for these queries, so updates are available when your car is in the surrounding of your home. |
 
 ## Notifications
 

--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -59,7 +59,6 @@ After connecting to your account, you can set the following settings in the inte
 | Setting | Description |
 |---------|-------------|
 | Read-only | No execution of services to the vehicle. Still possible to send messages and POIs via `notify` and to request a status update via `bmw_connected_drive.update_state`.
-| Use Home Assistant location for car location polls | Older cars (non i3/i8 build before 7/2014) require the phone to be close to the car to get location updates. Enable this option to use the location of your Home Assistant instance for these queries, so updates are available when your car is in the surrounding of your home. |
 
 ## Notifications
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
* Remove legacy YAML configuration (https://github.com/home-assistant/core/pull/66965)
* ~Remove "send location" option (https://github.com/home-assistant/core/pull/60938) - missed that one earlier~ (now in https://github.com/home-assistant/home-assistant.io/pull/21728)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66965
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
