### PR TITLE
Rename manual alarm docs

### DIFF
--- a/source/_integrations/alarm_control_panel.manual.markdown
+++ b/source/_integrations/alarm_control_panel.manual.markdown
@@ -1,5 +1,5 @@
 ---
-title: Manual
+title: Manual Alarm
 description: Instructions on how to integrate manual alarms into Home Assistant.
 ha_category:
   - Alarm

--- a/source/_integrations/alarm_control_panel.manual.markdown
+++ b/source/_integrations/alarm_control_panel.manual.markdown
@@ -1,5 +1,5 @@
 ---
-title: Manual Alarm
+title: Manual Alarm Control Panel
 description: Instructions on how to integrate manual alarms into Home Assistant.
 ha_category:
   - Alarm

--- a/source/_integrations/alarm_control_panel.manual_mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.manual_mqtt.markdown
@@ -1,5 +1,5 @@
 ---
-title: Manual MQTT Alarm
+title: Manual MQTT Alarm Control Panel
 description: Instructions on how to integrate manual alarms into Home Assistant with MQTT support.
 ha_category:
   - Alarm

--- a/source/_integrations/alarm_control_panel.manual_mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.manual_mqtt.markdown
@@ -1,5 +1,5 @@
 ---
-title: Manual MQTT
+title: Manual MQTT Alarm
 description: Instructions on how to integrate manual alarms into Home Assistant with MQTT support.
 ha_category:
   - Alarm
@@ -10,7 +10,7 @@ ha_platforms:
   - alarm_control_panel
 ---
 
-The `mqtt` platform extends the [manual alarm](/integrations/manual) by adding support for MQTT control of the alarm by a remote device. It can be used to create external keypads which simply change the state of the manual alarm in Home Assistant.
+The `mqtt` platform extends the [manual alarm](/integrations/alarm_control_panel.manual) by adding support for MQTT control of the alarm by a remote device. It can be used to create external keypads which simply change the state of the manual alarm in Home Assistant.
 
 It's essentially the opposite of the [MQTT Alarm Panel](/integrations/alarm_control_panel.mqtt/) which allows Home Assistant to observe an existing, fully-featured alarm where all of the alarm logic is embedded in that physical device.
 
@@ -111,7 +111,7 @@ armed_home/armed_away/armed_night/armed_vacation/disarmed/triggered:
       type: integer
 {% endconfiguration %}
 
-See the documentation for the [manual alarm platform](/integrations/manual) for a description.
+See the documentation for the [manual alarm platform](/integrations/alarm_control_panel.manual) for a description.
 
 Additionally, the following MQTT configuration variables are also available.
 
@@ -183,7 +183,7 @@ alarm_control_panel:
       pending_time: 0
 ```
 
-Refer to the [Manual Alarm Control page](/integrations/manual#examples) for more real-life examples on how to use this panel.
+Refer to the [Manual Alarm Control page](/integrations/alarm_control_panel.manual#examples) for more real-life examples on how to use this panel.
 
 ## MQTT Control
 
@@ -191,18 +191,18 @@ The state of this alarm can be controlled using [MQTT](/integrations/mqtt/). Ens
 
 To change the state of the alarm, publish one of the following messages to the `command_topic`:
 
- - `DISARM`
- - `ARM_HOME`
- - `ARM_AWAY`
- - `ARM_NIGHT`
- - `ARM_VACATION`
+- `DISARM`
+- `ARM_HOME`
+- `ARM_AWAY`
+- `ARM_NIGHT`
+- `ARM_VACATION`
 
 To receive state updates from HA, subscribe to the `state_topic`. Home Assistant will publish a new message whenever the state changes:
 
- - `disarmed`
- - `armed_home`
- - `armed_away`
- - `armed_night`
- - `armed_vacation`
- - `pending`
- - `triggered`
+- `disarmed`
+- `armed_home`
+- `armed_away`
+- `armed_night`
+- `armed_vacation`
+- `pending`
+- `triggered`

--- a/source/_integrations/alarm_control_panel.markdown
+++ b/source/_integrations/alarm_control_panel.markdown
@@ -9,4 +9,4 @@ ha_domain: alarm_control_panel
 ---
 
 Home Assistant can give you an interface which is similar to a classic alarm system.
-Please see [manual alarm](/integrations/manual) for alarm configuration.
+Please see [manual alarm](/integrations/alarm_control_panel.manual) for alarm configuration.

--- a/source/_integrations/arlo.markdown
+++ b/source/_integrations/arlo.markdown
@@ -135,7 +135,7 @@ Setting Arlo to a custom mode (mapped to `home_mode_name` in `configuration.yaml
 
 You can also completely disarm the Arlo base station by calling the `alarm_control_panel.alarm_disarm` service, and trigger the alarm by calling the `alarm_control_panel.alarm_trigger` service.
 
-More examples and configuration options can be found on the [Manual Alarm Control page](/integrations/manual#examples).
+More examples and configuration options can be found on the [Manual Alarm Control page](/integrations/alarm_control_panel.manual#examples).
 
 ## Camera
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Currently these integrations are called "Manual" and "Manual MQTT" which doesn't really tell what they are about and also isn't searchable. Adding "Alarm" to their names to make it clearer. Also, moving docs to /integrations/alarm_control_panel.manual similar to mqtt and template versions.

Next branch because it needs to be in sync with updated documentation links in core repo - see parent PR.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/66979
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
