### PR TITLE
Use context data when debugging templates

### DIFF
--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -40,6 +40,6 @@ It is also useful to go to **{% my server_controls title="Configuration -> Serve
 If your automation uses templates in any part, you can do the following to make sure it works as expected:
 
 1. Go to **{% my developer_template title="Developer tools -> Template" %}** tab.
-1. In your trace go through the steps preceeding the one with your template and copy what you need from the `changed variables` tabs into `Context data for template` in the Template tab. *Tip: `trigger` and `this` are set in the very first step*
+1. In your trace go through the steps preceding the one with your template and copy what you need from the `changed variables` tabs into `Context data for template` in the Template tab. *Tip: `trigger` and `this` are set in the very first step*
 1. Copy your template code and paste it in Template editor straight after your variables.
 1. Change the template and (if necessary) sources' value until the template works as expected without errors.

--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -40,6 +40,6 @@ It is also useful to go to **{% my server_controls title="Configuration -> Serve
 If your automation uses templates in any part, you can do the following to make sure it works as expected:
 
 1. Go to **{% my developer_template title="Developer tools -> Template" %}** tab.
-2. Create all variables (sources) required for your template as described at the end of [this](https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data) paragraph.
-3. Copy your template code and paste it in Template editor straight after your variables.
-4. If necessary, change your sources' value and check if the template works as you want and does not generate any errors.
+1. In your trace go through the steps preceeding the one with your template and copy what you need from the `changed variables` tabs into `Context data for template` in the Template tab. *Tip: `trigger` and `this` are set in the very first step*
+1. Copy your template code and paste it in Template editor straight after your variables.
+1. Change the template and (if necessary) sources' value until the template works as expected without errors.

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -775,19 +775,41 @@ The following overview contains a couple of options to get the needed values:
 
 {% endraw %}
 
-To evaluate a response, go to **{% my developer_template title="Developer Tools -> Template" %}**, create your output in "Template editor", and check the result.
+To evaluate a response, go to **{% my developer_template title="Developer Tools -> Template" %}**, create your output in "Template editor", and check the result. You can use the `Context data for template` field to set the value of `value_json` before your template runs like what would normally happen at runtime. For example you could put this in context data:
 
 {% raw %}
 
 ```yaml
-{% set value_json=
-    {"name":"Outside",
+value_json:
+  name: Outside
+  device: weather-ha
+  data:
+    temp: 24C
+    hum: 35%
+```
+
+{% endraw %}
+
+Or this if you have an existing JSON sample you want to use:
+
+{% raw %}
+
+```yaml
+value_json: {"name":"Outside",
      "device":"weather-ha",
      "data":
         {"temp":"24C",
          "hum":"35%"
-         } }%}
+         } }
+```
 
+{% endraw %}
+
+And then you can put in your template and see the result:
+
+{% raw %}
+
+```text
 {{value_json.data.hum[:-1]}}
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update automation troubleshooting and template testing documentation to mention the new "Context data for template" option as an easier way to set variables your template is expecting to exist already.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/11748
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
