### PR TITLE
Show a way how ink levels in IPP can be "saved"

### DIFF
--- a/source/_integrations/ipp.md
+++ b/source/_integrations/ipp.md
@@ -17,3 +17,5 @@ The `Internet Printing Protocol (IPP)` integration allows you to read current da
 It provides information about the printer's state and remaining ink levels.
 
 {% include integrations/config_flow.md %}
+
+Currently, this integration shows ink levels as unavailable when a printer is offline. To save the levels an automation can be used to save them into an input_number helper when the printer comes online or the level is updated. Then a template sensor can be used to display them as sensors even when the printer is offline.

--- a/source/_integrations/ipp.md
+++ b/source/_integrations/ipp.md
@@ -18,4 +18,71 @@ It provides information about the printer's state and remaining ink levels.
 
 {% include integrations/config_flow.md %}
 
-Ink levels are shown as unavailable when a printer is offline. To save the levels for displaying during an unavailability, automation can be used to save them into an [Input Number](/integrations/input_number) helper.
+Ink levels are shown as unavailable or unknown (depending on printer type) when a printer is offline. To save the levels for displaying during an unavailability, either an automation can be used to save them into an [Input Number](/integrations/input_number) helper and displayed via template sensor or they can be updated via trigger-based template sensor. In the later case the sensor does not retain its state during a reboot of Home Assistant.
+
+## Example for input_number-based solution
+
+This examples creates the sensor "Canon Printer Cyan", updates its value based on the cyan ink level of a Canon TR8500 via an automation and retains its while the printer is offline and while Home Assistant is offline.
+
+An [Input Number](/integrations/input_number) helper named input_number.canon_tr8500_cyan is needed and must created in the Configuration->Helpers menu.
+
+An automation to update the value of the input_number.canon_tr8500_cyan is needed:
+
+{% raw %}
+```yaml
+alias: 'background: save printer values'
+description: ''
+trigger:
+  - platform: numeric_state
+    entity_id: sensor.canon_tr8500_series_cyan
+    above: -1
+condition: []
+action:  
+  - service: input_number.set_value
+    target:
+      entity_id: input_number.canon_tr8500_cyan
+    data:
+      value: '{{ states(''sensor.canon_tr8500_series_cyan'') }}'  
+mode: single
+```
+{% endraw %}
+
+A template sensor to display the [Input Number](/integrations/input_number) as a sensor is needed:
+
+{% raw %}
+```yaml
+template:
+  - sensor:
+    - name: "Canon Printer Cyan"      
+      state: >   
+        {{ states('input_number.canon_tr8500_cyan') | float}}    
+      unique_id: "template_canon_printer_cyan"  
+      icon: mdi:water
+      unit_of_measurement: "%"
+```
+{% endraw %}
+
+
+
+## Example for trigger-based template sensor solution
+
+This examples creates the sensor "Canon Printer Cyan", updates its value based on the cyan ink level of a Canon TR8500 via a trigger and retains its value while the printer is offline.
+
+{% raw %}
+
+```yaml
+template:
+  - trigger:
+      - platform: numeric_state
+        entity_id: sensor.canon_tr8500_series_cyan
+        above: -1
+    sensor:
+      - name: Canon Printer Cyan      
+        unique_id: "template_canon_printer_cyan"  
+        icon: mdi:water                  
+        unit_of_measurement: "%"
+        state: >
+          {{ states("sensor.canon_tr8500_series_cyan") }}
+```
+
+{% endraw %}

--- a/source/_integrations/ipp.md
+++ b/source/_integrations/ipp.md
@@ -18,4 +18,4 @@ It provides information about the printer's state and remaining ink levels.
 
 {% include integrations/config_flow.md %}
 
-Currently, this integration shows ink levels as unavailable when a printer is offline. To save the levels an automation can be used to save them into an input_number helper when the printer comes online or the level is updated. Then a template sensor can be used to display them as sensors even when the printer is offline.
+Ink levels are shown as unavailable when a printer is offline. To save the levels for displaying during an unavailability, automation can be used to save them into an [Input Number](/integrations/input_number) helper.


### PR DESCRIPTION
The IPP integration does not show the ink levels when the printer is offline, which will be most of the time in home scenarios. This commit describes a workaround for this problem.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
