### PR TITLE
Deprecate the updater integration

### DIFF
--- a/source/_integrations/default_config.markdown
+++ b/source/_integrations/default_config.markdown
@@ -39,7 +39,6 @@ This integration is a meta-component and configures a default set of integration
 - [System Health](/integrations/system_health/) (`system_health`)
 - [Tag](/integrations/tag/) (`tag`)
 - [Timer](/integrations/timer/) (`timer`)
-- [Updater](/integrations/updater/) (`updater`)
 - [USB](/integrations/usb/) (`usb`)
 - [Webhooks](/integrations/webhook) (`webhook`)
 - [Zero-configuration networking (zeroconf)](/integrations/zeroconf/) (`zeroconf`)

--- a/source/_integrations/updater.markdown
+++ b/source/_integrations/updater.markdown
@@ -13,6 +13,12 @@ ha_platforms:
   - binary_sensor
 ---
 
+<div class='note warning'>
+
+This integration is deprecated and will be removed in Home Assistant Core 2022.5.
+
+</div>
+
 The `updater` binary sensor will check daily for new releases of the Home
 Assistant Core. The state will be "on" when an update is available. Otherwise,
 the state will be "off". The newer version, as well as the link to the release

--- a/source/_integrations/updater.markdown
+++ b/source/_integrations/updater.markdown
@@ -26,9 +26,8 @@ notes, are attributes of the updater.
 
 ## Configuration
 
-This integration is by default enabled, unless you've disabled or removed the [`default_config:`](/integrations/default_config/) line from your configuration. If that is the case, the following example shows you how to enable this integration manually:
-
 ```yaml
+# Example configuration.yaml entry
 updater:
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/67038
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
