### PR TITLE
Add "Auxiliary Heat Status" binary_sensor for dmaker.airfresh.a1/t2017 to xiaomi_miio

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -501,7 +501,7 @@ LED                     | Turn on/off the LED
 
 Binary sensor           | Description
 ----------------------- | -----------------
-Auxiliary Heat Status   | Indicates the heater actually is on or off
+Auxiliary Heat Status   | Indicates if the heater is actually on
 
 - Sensor entities
 
@@ -564,7 +564,7 @@ LED                     | Turn on/off `led`
 
 Binary sensor           | Description
 ----------------------- | -----------------
-Auxiliary Heat Status   | Indicates the heater actually is on or off
+Auxiliary Heat Status   | Indicates if the heater is actually on
 
 - Sensor entities
 

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -497,6 +497,12 @@ LED                     | Turn on/off the LED
 
 - Power (on, off)
 - Operation modes (Auto, Sleep, Favorite)
+- Binary sensor entities
+
+Binary sensor           | Description
+----------------------- | -----------------
+Auxiliary Heat Status   | Indicates the heater actually is on or off
+
 - Sensor entities
 
 Sensor                          | Description                                                    
@@ -554,6 +560,12 @@ LED                     | Turn on/off `led`
 
 - Power (on, off)
 - Operation modes (Auto, Sleep, Favorite)
+- Binary sensor entities
+
+Binary sensor           | Description
+----------------------- | -----------------
+Auxiliary Heat Status   | Indicates the heater actually is on or off
+
 - Sensor entities
 
 Sensor                           | Description                                                   


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I added Auxiliary Heat Status binary sensor. As i mention in connecting PR: It could be different from switch because dmaker.airfresh.a1/t2017 has additional rules inside that blocking turning heater on

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/67040
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
