### PR TITLE
Updated URL for weather forecast from yr.no

### DIFF
--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -95,9 +95,10 @@ In this section, you find some real-life examples of how to use this camera plat
 camera:
   - platform: generic
     name: Weather
-    still_image_url: https://www.yr.no/place/Norway/Oslo/Oslo/Oslo/meteogram.svg
+    still_image_url: https://www.yr.no/en/content/1-72837/meteogram.svg
     content_type: "image/svg+xml"
 ```
+Instructions on how to locate the SVG for your location is available at [developer.yr.no](https://developer.yr.no/doc/guides/deprecating-old-widgets/)
 
 ### Local image
 


### PR DESCRIPTION
## Proposed change
Updated documentation for generic camera. The old URL for SVG-based weather forecasts was currently showing a deprecation message. Added link to documentation of how to locate the SVG for your location, as the new URLs are not intuitive.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
