### PR TITLE
SleepIQ doc updates

### DIFF
--- a/source/_integrations/sleepiq.markdown
+++ b/source/_integrations/sleepiq.markdown
@@ -8,12 +8,27 @@ ha_category:
 ha_release: 0.29
 ha_iot_class: Cloud Polling
 ha_domain: sleepiq
+ha_config_flow: true
+ha_dhcp: true
+ha_codeowners:
+  - '@kbickar'
+  - '@mfugate1'
 ha_platforms:
   - binary_sensor
+  - button
   - sensor
+  - switch
 ---
 
-The SleepIQ integration lets you view sensor data from [SleepIQ by SleepNumber](https://www.sleepnumber.com/sleepiq-sleep-tracker). In particular, it lets you see the occupancy and current SleepNumber (ie current firmness) of each side of a SleepNumber bed.
+The SleepIQ integration lets you integrate your SleepNumber Bed via [SleepIQ by SleepNumber](https://www.sleepnumber.com/sleepiq-sleep-tracker).
+
+There is currently support for the following platforms within Home Assistant:
+
+- Binary Sensor - View occupancy of each side
+- Sensor - View Current SleepNumber (ie current firmness) of each side
+- Switch - Toggle Privacy mode
+- Button - Calibrate the bed
+- Button - Stop the pump
 
 You will need an account on [SleepIQ](https://sleepiq.sleepnumber.com/) to use this integration.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

There were quite a few changes to the SleepIQ integration including config flow, discovery, new switch and new buttons

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
https://github.com/home-assistant/core/pull/64850
https://github.com/home-assistant/core/pull/66336
https://github.com/home-assistant/core/pull/66833
https://github.com/home-assistant/core/pull/66849
https://github.com/home-assistant/core/pull/66966

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
