### PR TITLE
Update the RFXTRX integration documentation for newer ser2net versions

### DIFF
--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -58,8 +58,25 @@ Not all protocols as advertised are enabled on the initial setup of your transce
 
 You can host your device on another computer by setting up ser2net and example configuration for ser2net looks like this and then using host/port in your Home Assistant configuration.
 
+Configuration example for ser2net older than 4.x.x (check with command `ser2net -v`):
+
 ```text
 50000:raw:0:/dev/ttyUSB0:38400 8DATABITS NONE 1STOPBIT
+```
+
+Configuration example for ser2net 4.x.x:
+
+```yaml
+# Example /etc/ser2net.yaml for proxying USB/serial connections
+connection: &rfxtrx
+    accepter: tcp,5000
+    enable: on
+    options:
+      kickolduser: true
+      telnet-brk-on-sync: true
+    connector: serialdev,
+              /dev/ttyUSB0,
+              38400n81,local
 ```
 
 ## Settings options


### PR DESCRIPTION
## Proposed change
With version 4 of ser2net the configuration file was changed into a yaml format, and there was no sample configuration in the RFXTRX integration documentation.


## Type of change
I've updated the documentation, added a new configuration format example.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
I've based the format on an older, similar PR (#19454) in case it matters.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
