### PR TITLE
Add Undecoded support for RTXtrx

### DIFF
--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -54,6 +54,8 @@ logger:
 
 Not all protocols as advertised are enabled on the initial setup of your transceiver. Enabling all protocols is not recommended either. Your 433.92 product not showing in the logs? Visit the RFXtrx website to [download RFXmgmr](http://www.rfxcom.com/epages/78165469.sf/en_GB/?ViewObjectPath=%2FShops%2F78165469%2FCategories%2FDownloads) and enable the required protocol.
 
+The `Undecoded` protocol is used for products where the RFXtrx device understands the protocol but does not how to decode the payload into a device, command, value, or similar. The `Undecoded` protocol cannot be persisted by RFXmgr and must be configured in Home Assistent, so that it can be enabled every time the RFXtrx device is connected.
+
 ## ser2net
 
 You can host your device on another computer by setting up ser2net and example configuration for ser2net looks like this and then using host/port in your Home Assistant configuration.


### PR DESCRIPTION
## Proposed change
An undecoded device is available for each protocol supported by rfxtrx
devices. Each device has a Payload entity which is a string
representation of the payload of the undecoded message.

This is useful for things like garage door openers and very basic home
security systems that use 433MHz sensors.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/67485
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
