### PR TITLE
Update documentation to use the generic python3 version of venv

### DIFF
--- a/source/_includes/installation/core.md
+++ b/source/_includes/installation/core.md
@@ -71,7 +71,7 @@ Next up is to create and change to a virtual environment for Home Assistant Core
 ```bash
 sudo -u homeassistant -H -s
 cd /srv/homeassistant
-python{{site.installation.versions.python}} -m venv .
+python3 -m venv .
 source bin/activate
 ```
 


### PR DESCRIPTION


## Proposed change
We use generic python3 for installing packages in later steps, so there's no need to specify a specific version of venv in the documentation, as most any modern version of python3 should work properly.

## Type of change
Documentation change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- X ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
