### PR TITLE
Update waze_travel_time.markdown

### DIFF
--- a/source/_integrations/waze_travel_time.markdown
+++ b/source/_integrations/waze_travel_time.markdown
@@ -20,7 +20,7 @@ The `waze_travel_time` sensor provides travel time from the [Waze](https://www.w
 Notes:
 
 - If a unit system is not specified, the integration will use the unit system configured on your Home Assistant instance.
-- Origin and Destination can be the address or the GPS coordinates of the location (GPS coordinates has to be separated by a comma). You can also enter an entity id which provides this information in its state, an entity id with latitude and longitude attributes, or zone friendly name (case sensitive).
+- Origin and Destination can be the address or the GPS coordinates of the location (GPS coordinates have to be separated by a comma). You can also enter an entity id which provides this information in its state, an entity id with latitude and longitude attributes, or zone friendly name (case sensitive).
 - The string inputs for `Substring *` allow you to force the integration to use a particular route or avoid a particular route in its time travel calculation. These inputs are case insensitive matched against the description of the route.
 - When using the `Avoid Toll Roads?`, `Avoid Subscription Roads?` and `Avoid Ferries?` options be aware that Waze will sometimes still route you over toll roads or ferries if a valid vignette/subscription is assumed. Default behavior is that Waze will route you over roads having subscription options, so best is to set both `Avoid Toll Roads?` and `Avoid Subscription Roads?` or `Avoid Ferries?` if needed and experiment to ensure the desired outcome.
 
@@ -69,36 +69,37 @@ template:
 
 In this example we use a device_tracker entity ID as the origin and the sensor created above as the destination.
 
-Name: "Me to destination"
-Origin: device_tracker.myphone
-Destination: sensor.dest_address
-Region: "US"
+  - Name: "Me to some destination"
+  - Origin: `device_tracker.myphone`
+  - Destination: `sensor.dest_address`
+  - Region: `US`
 
 #### Tracking entity to zone friendly name
 
 In this example we are using the entity ID of a zone as the origin and the friendly name of a zone as the destination.
 
-Name: "Home To Eddie's House"
-Origin: zone.home
-Destination: "Eddies House"
-Region: "US"
+  - Name: "Home to Eddie's house"
+  - Origin: `zone.home`
+  - Destination: `Eddies House`
+  - Region: `US`
 
 #### Tracking entity in Imperial Units
 
-Origin: person.paulus
-Destination: "725 5th Ave, New York, NY 10022, USA"
-Region: "US"
-Units: imperial
-Vehicle Type: motorcycle
+  - Name: "Somewhere in New York"
+  - Origin: `person.paulus`
+  - Destination: `725 5th Ave, New York, NY 10022, USA`
+  - Region: `US`
+  - Units: `imperial`
+  - Vehicle Type: `motorcycle`
 
 #### Avoiding toll, subscription
 
-Name: "Westerscheldetunnel"
-Origin: 51.330436, 3.802043
-Destination: 51.445677, 3.749929
-Region: "EU"
-Avoid Toll Roads?: True
-Avoid Subscription Roads?: True  
+  - Name: "Westerscheldetunnel"
+  - Origin: `51.330436, 3.802043`
+  - Destination: `51.445677, 3.749929`
+  - Region: `EU`
+  - Avoid Toll Roads: `True`
+  - Avoid Subscription Roads: `True`
 
 ## Using the live map in an iFrame
 

--- a/source/_integrations/waze_travel_time.markdown
+++ b/source/_integrations/waze_travel_time.markdown
@@ -72,7 +72,7 @@ In this example we use a device_tracker entity ID as the origin and the sensor c
   - Name: "Me to some destination"
   - Origin: `device_tracker.myphone`
   - Destination: `sensor.dest_address`
-  - Region: `US`
+  - Region: "US"
 
 #### Tracking entity to zone friendly name
 
@@ -80,24 +80,24 @@ In this example we are using the entity ID of a zone as the origin and the frien
 
   - Name: "Home to Eddie's house"
   - Origin: `zone.home`
-  - Destination: `Eddies House`
-  - Region: `US`
+  - Destination: "Eddies House"
+  - Region: "US"
 
 #### Tracking entity in Imperial Units
 
   - Name: "Somewhere in New York"
   - Origin: `person.paulus`
-  - Destination: `725 5th Ave, New York, NY 10022, USA`
-  - Region: `US`
-  - Units: `imperial`
-  - Vehicle Type: `motorcycle`
+  - Destination: "725 5th Ave, New York, NY 10022, USA"
+  - Region: "US"
+  - Units: "imperial"
+  - Vehicle Type: "motorcycle"
 
 #### Avoiding toll, subscription
 
   - Name: "Westerscheldetunnel"
-  - Origin: `51.330436, 3.802043`
-  - Destination: `51.445677, 3.749929`
-  - Region: `EU`
+  - Origin: "51.330436, 3.802043"
+  - Destination: "51.445677, 3.749929"
+  - Region: "EU"
   - Avoid Toll Roads: `True`
   - Avoid Subscription Roads: `True`
 


### PR DESCRIPTION
Text describing examples was cluttered to one line so I fixed that. Fixed one grammar error as well while I was at it.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
