### PR TITLE
Reflect new nomenclature in base lib python-holidays

### DIFF
--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -43,7 +43,7 @@ country:
   required: true
   type: string
 province:
-  description: Province/State code according to [holidays](https://pypi.org/project/holidays/) notation.
+  description: Subdivision code according to [holidays](https://pypi.org/project/holidays/) notation.
   required: false
   type: string
 workdays:


### PR DESCRIPTION
When python-holidays went from 0.12 to 0.13 the heading on the table on the documentation regarding the countries' subdivisions changed from "Provinces/States Available" to "Subdivisions Available". This change aims to bring this doc in line with that change.

## Proposed change

Change the word used to refer to a country's subdivision to be in line with the documentation of the base lib. Being out of synch may cause confusion as exemplified by https://github.com/home-assistant/core/issues/67621


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #67621

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
