### PR TITLE
Document new timer configuration options

### DIFF
--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -54,6 +54,13 @@ timer:
       description: Set a custom icon for the state card.
       required: false
       type: icon
+    restore:
+      description: When true, active timer and paused timers will be restored on startup. If an active timer was supposed to end while Home Assistant is stopped, the `restore_grace_period` property controls which event fires.
+      required: false
+      type: bool
+      default: false
+    restore_grace_period:
+      description: If `restore` is true and the timer ends when Home Assistant is stopped, this property controls which event fires. If the difference in time between when Home Assistant started and when timer ended is **less** than the grace period time, the `timer.finished` event will fire. If the difference in time between when Home Assistant started and when timer ended is **greater** than the grace period time, the `timer.finished_while_homeassistant_stopped` event will fire.
 {% endconfiguration %}
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your timer and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.
@@ -70,9 +77,10 @@ Pick an icon that you can find on [materialdesignicons.com](https://materialdesi
 
 |           Event | Description |
 | --------------- | ----------- |
-| `timer.cancelled` | Fired when a timer has been canceled |
-| `timer.finished` | Fired when a timer has completed |
-| `timer.started` | Fired when a timer has been started|
+| `timer.cancelled` | Fired when a timer has been cancelled |
+| `timer.finished` | Fired when a timer has completed and includes `finished_at` date/time in event data |
+| `timer.finished_while_homeassistant_stopped` | Fired when a timer completed while Home Assistant is stopped (see `restore` and `restore_grace_period` configuration options for more information) and includes `finished_at` date/time in event data |
+| `timer.started` | Fired when a timer has been started |
 | `timer.restarted` | Fired when a timer has been restarted |
 | `timer.paused` | Fired when a timer has been paused |
 

--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -61,6 +61,8 @@ timer:
       default: false
     restore_grace_period:
       description: If `restore` is true and the timer ends when Home Assistant is stopped, this property controls which event fires. If the difference in time between when Home Assistant started and when timer ended is **less** than the grace period time, the `timer.finished` event will fire. If the difference in time between when Home Assistant started and when timer ended is **greater** than the grace period time, the `timer.finished_while_homeassistant_stopped` event will fire.
+      required: false
+      type: [integer, time]
 {% endconfiguration %}
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your timer and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.

--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -57,7 +57,7 @@ timer:
     restore:
       description: When true, active timer and paused timers will be restored on startup. If an active timer was supposed to end while Home Assistant is stopped, the `restore_grace_period` property controls which event fires.
       required: false
-      type: bool
+      type: boolean
       default: false
     restore_grace_period:
       description: If `restore` is true and the timer ends when Home Assistant is stopped, this property controls which event fires. If the difference in time between when Home Assistant started and when timer ended is **less** than the grace period time, the `timer.finished` event will fire. If the difference in time between when Home Assistant started and when timer ended is **greater** than the grace period time, the `timer.finished_while_homeassistant_stopped` event will fire.

--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -77,7 +77,7 @@ Pick an icon that you can find on [materialdesignicons.com](https://materialdesi
 
 |           Event | Description |
 | --------------- | ----------- |
-| `timer.cancelled` | Fired when a timer has been cancelled |
+| `timer.cancelled` | Fired when a timer has been canceled |
 | `timer.finished` | Fired when a timer has completed and includes `finished_at` date/time in event data |
 | `timer.finished_while_homeassistant_stopped` | Fired when a timer completed while Home Assistant is stopped (see `restore` and `restore_grace_period` configuration options for more information) and includes `finished_at` date/time in event data |
 | `timer.started` | Fired when a timer has been started |

--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -55,14 +55,10 @@ timer:
       required: false
       type: icon
     restore:
-      description: When true, active timer and paused timers will be restored on startup. If an active timer was supposed to end while Home Assistant is stopped, the `restore_grace_period` property controls which event fires.
+      description: When true, active and paused timers will be restored to the right state on startup. If an active timer was supposed to end while Home Assistant is stopped, the `time.finished` event will fire on startup for that timer. The `finished_at` property in the event data will provide you with the time that the timer was actually supposed to fire which you can use in automation conditions to decide whether or not to act on it.
       required: false
       type: boolean
       default: false
-    restore_grace_period:
-      description: If `restore` is true and the timer ends when Home Assistant is stopped, this property controls which event fires. If the difference in time between when Home Assistant started and when timer ended is **less** than the grace period time, the `timer.finished` event will fire. If the difference in time between when Home Assistant started and when timer ended is **greater** than the grace period time, the `timer.finished_while_homeassistant_stopped` event will fire.
-      required: false
-      type: [integer, time]
 {% endconfiguration %}
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your timer and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.
@@ -80,8 +76,7 @@ Pick an icon that you can find on [materialdesignicons.com](https://materialdesi
 |           Event | Description |
 | --------------- | ----------- |
 | `timer.cancelled` | Fired when a timer has been canceled |
-| `timer.finished` | Fired when a timer has completed and includes `finished_at` date/time in event data |
-| `timer.finished_while_homeassistant_stopped` | Fired when a timer completed while Home Assistant is stopped (see `restore` and `restore_grace_period` configuration options for more information) and includes `finished_at` date/time in event data |
+| `timer.finished` | Fired when a timer has completed and includes `finished_at` date/time in event data. `finished_at` should usually be now, or within the last several seconds, but if the `restore` property is true, `finished_at` may be further in the past since this event will fire on startup for any timers that would have ended while Home Assistant was stopped. |
 | `timer.started` | Fired when a timer has been started |
 | `timer.restarted` | Fired when a timer has been restarted |
 | `timer.paused` | Fired when a timer has been paused |


### PR DESCRIPTION
## Proposed change
In the upstream PR we added support for two new configuration properties, `restore` and `restore_grace_period` which allow active and paused timers to persist between restarts. As part of this we also added a new event



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/67658

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
