### PR TITLE
Add unsupported help for `systemd-resolved`

### DIFF
--- a/source/more-info/unsupported/systemd_resolved.markdown
+++ b/source/more-info/unsupported/systemd_resolved.markdown
@@ -5,12 +5,12 @@ description: "More information on why systemd-resolved marks the installation as
 
 ## The issue
 
-Systemd-resolved is used over DBus to resolve DNS queries made by Home Assistant, Supervisor,
-and Add-Ons. Without it, DNS will not work correctly in your installation.
+systemd-resolved is used over D-Bus to resolve DNS queries made by Home Assistant, Supervisor,
+and add-ons. Without it, DNS will not work correctly in your installation.
 
 ## The solution
 
-If you see a message about an issue with DBus, [fix that first](https://www.home-assistant.io/more-info/unsupported/dbus#the-solution).
+If you see a message about an issue with D-Bus, [resolve that first](/more-info/unsupported/dbus#the-solution).
 
 If the systemd-resolved service is not running or disabled, enable and start it.
 

--- a/source/more-info/unsupported/systemd_resolved.markdown
+++ b/source/more-info/unsupported/systemd_resolved.markdown
@@ -1,0 +1,20 @@
+---
+title: "Systemd-Resolved"
+description: "More information on why systemd-resolved marks the installation as unsupported."
+---
+
+## The issue
+
+Systemd-resolved is used over DBus to resolve DNS queries made by Home Assistant, Supervisor,
+and Add-Ons. Without it, DNS will not work correctly in your installation.
+
+## The solution
+
+If you see a message about an issue with DBus, [fix that first](https://www.home-assistant.io/more-info/unsupported/dbus#the-solution).
+
+If the systemd-resolved service is not running or disabled, enable and start it.
+
+If that does not help, reboot your operating system.
+
+As a last resort, you need to reinstall the host running the Supervisor
+with one of the supported operating systems, [see instructions here](/more-info/unsupported/os).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
New unsupported OS reason added to supervisor, adding the corresponding help page for users with this issue.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/supervisor/pull/3487
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
