### PR TITLE
Added blurb to point users time templating

### DIFF
--- a/source/_integrations/time_date.markdown
+++ b/source/_integrations/time_date.markdown
@@ -71,6 +71,6 @@ template:
 
 {% endraw %}
 
-## More time related resources ##
+## More time-related resources
 
-For more information about using time related variables and sensors in templates (such as `today_at()`, `now()` or `as_timestamp()`) visit this [time section](https://www.home-assistant.io/docs/configuration/templating/#time) on the templating page.
+For more information about using time related variables and sensors in templates (such as `today_at()`, `now()` or `as_timestamp()`) visit this [time section](/docs/configuration/templating/#time) on the templating page.

--- a/source/_integrations/time_date.markdown
+++ b/source/_integrations/time_date.markdown
@@ -70,3 +70,7 @@ template:
 ```
 
 {% endraw %}
+
+## More time related resources ##
+
+For more information about using time related variables and sensors in templates (such as `today_at()`, `now()` or `as_timestamp()`) visit this [time section](https://www.home-assistant.io/docs/configuration/templating/#time) on the templating page.


### PR DESCRIPTION
## Proposed change

I had a hard time finding/remembering the `today_at()` variable and was searching here and there with little luck. After finding it where it was not located, I figured adding this blurb for more info at the bottom of the Time and Date might help others find (or discover) that it exists.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
