### PR TITLE
Document for greyscale filter when entity state is off in picture-elements

### DIFF
--- a/source/_dashboards/picture-elements.markdown
+++ b/source/_dashboards/picture-elements.markdown
@@ -353,7 +353,7 @@ state_image:
   type: map
 filter:
   required: false
-  description: Default CSS filter.
+  description: Default: `grayscale(100%)` when entity state is `off`. Set to `none` to remove this.
   type: string
 state_filter:
   required: false

--- a/source/_dashboards/picture-elements.markdown
+++ b/source/_dashboards/picture-elements.markdown
@@ -353,7 +353,7 @@ state_image:
   type: map
 filter:
   required: false
-  description: Default: `grayscale(100%)` when entity state is `off`. Set to `none` to remove this.
+  description: "Default: `grayscale(100%)` when entity state is `off`. Set to `none` to remove this."
   type: string
 state_filter:
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Clears up that image will be greyscaled when state of entity is `off`.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
