### PR TITLE
Extend Nanoleaf documention on support for touch events

### DIFF
--- a/source/_integrations/nanoleaf.markdown
+++ b/source/_integrations/nanoleaf.markdown
@@ -25,6 +25,19 @@ This integration does not support the Nanoleaf Remote and Essentials lights.
 
 {% include integrations/config_flow.md %}
 
-# Transition and brightness
+## Transition and brightness
 
 When using a transition in service calls (such as `light.turn_on`), the transition is only applied to brightness and does not apply to color. When a service call has a transition set but no brightness is included, the light will automatically transition to 100% brightness.
+
+## Touch events (Gestures)
+
+Nanoleaf Canvas, Shapes and Elements panels support touch events. These events are exposed to Home Assistant as `nanoleaf_event` with a payload of `device_id` and `type`, where `device_id` is a unique device identifier and `type` contains the captured gesture.
+
+| Gesture    | type |
+|------------|------------|
+| Swipe up   | swipe_up   |
+| Swipe down | swipe_down |
+| Swipe left | swipe_left |
+| Swipe right| swipe_right|
+
+Touch events need to be enabled for the device through the Nanoleaf app. Note that gestures are only detected when swiping across multiple panels.


### PR DESCRIPTION
added documentation on capturing touch events, as supported per 2022.3

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
