### PR TITLE
Add services documentation to Picnic docs

### DIFF
--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -53,18 +53,60 @@ The search result order is determined by Picnic, and can e.g. depend on what was
 | `device_id`            | yes      | The Picnic service to search against, defaults to the first registered service. |
 | `product_name`         | no       | The product name to search for.                                                 |
 
-Examples:
+Search result attributes:
 
-```yaml
-# Example automation action to search for a product.
-- service: picnic.search
-  data:
-    product_name: "Yoghurt"
-```
+| Search result attribute | Optional |
+|-------------------------|----------|
+| `id`                    | no       |
+| `name`                  | no       |
+| `price`                 | no       |
+| `quantity`              | no       |
+| `discount_price`        | yes      |
+| `discount_label`        | yes      |
+| `discount_validity`     | yes      |
+
+
+Example automation action to search for a product.
+  ```yaml 
+  - service: picnic.search
+    data:
+      product_name: "Yoghurt"
+  ```
 
 Example of the published event data:
 ```json
-
+{
+    "11474159": {
+        "id": "11474159",
+        "name": "Beyond Meat vegan burger",
+        "price": 3.99,
+        "quantity": "2 x 113 gram",
+        "discount_price": 3.19,
+        "discount_label": "20% korting",
+        "discount_validity": "2022-03-13"
+    },
+    "11474164": {
+        "id": "11474164",
+        "name": "Beyond Meat vegan worst",
+        "price": 3.99,
+        "quantity": "2 x 100 gram",
+        "discount_price": 3.19,
+        "discount_label": "20% korting",
+        "discount_validity": "2022-03-13"
+    },
+    "11474167": {
+        "id": "11474167",
+        "name": "Beyond Meat vegan balletjes",
+        "price": 3.99,
+        "quantity": "200 gram"
+    },
+    "11474170": {
+        "id": "11474170",
+        "name": "Beyond Meat vegan gehakt",
+        "price": 3.99,
+        "quantity": "300 gram"
+    }
+}
 ```
 
 ### Service `picnic.add_product`

--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -45,9 +45,9 @@ This integration provides the following sensors. Some sensors are disabled by de
 
 ### Service `picnic.add_product`
 
-Add a product to you cart using the `picnic.add_product` service, either using a product ID or a product name.
+Add a product to your cart using the `picnic.add_product` service, either using a product ID or a product name.
 A search will be done and the first result will be added to the cart when one adds a product using a product name.
-The service call will fail when no product could be found or when no `product_id` or `product_name` were specified. 
+The service call will fail when no product can be found, or when no `product_id` or `product_name` is specified. 
 
 | Service data attribute | Optional | Description                                                                      |
 |------------------------|----------|----------------------------------------------------------------------------------|

--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -51,7 +51,7 @@ The service call will fail when no product could be found or when no `product_id
 
 | Service data attribute | Optional | Description                                                                      |
 |------------------------|----------|----------------------------------------------------------------------------------|
-| `device_id`            | yes      | The Picnic service to search against, defaults to the first registered service.  |
+| `config_entry_id`      | No       | The Id of the Picnic service config entry.                                       |
 | `product_id`           | yes      | The Picnic product ID.                                                           |
 | `product_name`         | yes      | A product name to search for, the first search result will be added to the cart. |
 | `amount`               | yes      | The amount to add, defaults to 1.                                                |
@@ -60,5 +60,6 @@ The service call will fail when no product could be found or when no `product_id
 # Example automation action to add a product to the cart by name.
 - service: picnic.add_product
   data:
+    config_entry_id: 6b4be47a1fa7c3764f14cf756dc9899d
     product_name: "Picnic cola zero"
 ```

--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -40,3 +40,48 @@ This integration provides the following sensors. Some sensors are disabled by de
 | Next delivery ETA end          | End of the ETA window of the next delivery. |
 | Next delivery slot start       | Start of the next delivery's delivery slot. |
 | Next delivery slot end         | End of the next delivery's delivery slot. |
+
+## Services
+
+### Service `picnic.search`
+
+Search for a product using the `picnic.search` service. The first 5 results will be published using the `picnic_serach_result` event.
+The search result order is determined by Picnic, and can e.g. depend on what was bought previously using the account.
+
+| Service data attribute | Optional | Description                                                                     |
+|------------------------|----------|---------------------------------------------------------------------------------|
+| `device_id`            | yes      | The Picnic service to search against, defaults to the first registered service. |
+| `product_name`         | no       | The product name to search for.                                                 |
+
+Examples:
+
+```yaml
+# Example automation action to search for a product.
+- service: picnic.search
+  data:
+    product_name: "Yoghurt"
+```
+
+Example of the published event data:
+```json
+
+```
+
+### Service `picnic.add_product`
+
+Add a product to you cart using the `picnic.add_product` service, either using a product ID found with the `picnic.search` service or using a product name.
+A search will be done and the first result will be added to the cart when one adds a product using a product name.
+The service call will fail when no product could be found or when no `product_id` or `product_name` were specified. 
+
+| Service data attribute | Optional | Description                                                                      |
+|------------------------|----------|----------------------------------------------------------------------------------|
+| `device_id`            | yes      | The Picnic service to search against, defaults to the first registered service.  |
+| `product_id`           | yes      | The Picnic product ID.                                                           |
+| `product_name`         | yes      | A product name to search for, the first search result will be added to the cart. |
+
+```yaml
+# Example automation action to add a product to the cart by name.
+- service: picnic.add_product
+  data:
+    product_name: "Picnic cola zero"
+```

--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -43,75 +43,9 @@ This integration provides the following sensors. Some sensors are disabled by de
 
 ## Services
 
-### Service `picnic.search`
-
-Search for a product using the `picnic.search` service. The first 5 results will be published using the `picnic_serach_result` event.
-The search result order is determined by Picnic, and can e.g. depend on what was bought previously using the account.
-
-| Service data attribute | Optional | Description                                                                     |
-|------------------------|----------|---------------------------------------------------------------------------------|
-| `device_id`            | yes      | The Picnic service to search against, defaults to the first registered service. |
-| `product_name`         | no       | The product name to search for.                                                 |
-
-Search result attributes:
-
-| Search result attribute | Optional |
-|-------------------------|----------|
-| `id`                    | no       |
-| `name`                  | no       |
-| `price`                 | no       |
-| `quantity`              | no       |
-| `discount_price`        | yes      |
-| `discount_label`        | yes      |
-| `discount_validity`     | yes      |
-
-
-Example automation action to search for a product.
-  ```yaml 
-  - service: picnic.search
-    data:
-      product_name: "Yoghurt"
-  ```
-
-Example of the published event data:
-```json
-{
-    "11474159": {
-        "id": "11474159",
-        "name": "Beyond Meat vegan burger",
-        "price": 3.99,
-        "quantity": "2 x 113 gram",
-        "discount_price": 3.19,
-        "discount_label": "20% korting",
-        "discount_validity": "2022-03-13"
-    },
-    "11474164": {
-        "id": "11474164",
-        "name": "Beyond Meat vegan worst",
-        "price": 3.99,
-        "quantity": "2 x 100 gram",
-        "discount_price": 3.19,
-        "discount_label": "20% korting",
-        "discount_validity": "2022-03-13"
-    },
-    "11474167": {
-        "id": "11474167",
-        "name": "Beyond Meat vegan balletjes",
-        "price": 3.99,
-        "quantity": "200 gram"
-    },
-    "11474170": {
-        "id": "11474170",
-        "name": "Beyond Meat vegan gehakt",
-        "price": 3.99,
-        "quantity": "300 gram"
-    }
-}
-```
-
 ### Service `picnic.add_product`
 
-Add a product to you cart using the `picnic.add_product` service, either using a product ID found with the `picnic.search` service or using a product name.
+Add a product to you cart using the `picnic.add_product` service, either using a product ID or a product name.
 A search will be done and the first result will be added to the cart when one adds a product using a product name.
 The service call will fail when no product could be found or when no `product_id` or `product_name` were specified. 
 
@@ -120,6 +54,7 @@ The service call will fail when no product could be found or when no `product_id
 | `device_id`            | yes      | The Picnic service to search against, defaults to the first registered service.  |
 | `product_id`           | yes      | The Picnic product ID.                                                           |
 | `product_name`         | yes      | A product name to search for, the first search result will be added to the cart. |
+| `amount`               | yes      | The amount to add, defaults to 1.                                                |
 
 ```yaml
 # Example automation action to add a product to the cart by name.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the services being added by home-assistant/core#67877.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  home-assistant/core#67877
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
