### PR TITLE
Document known issues with reporting battery charge percentage with august locks

### DIFF
--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -56,9 +56,9 @@ Most devices will need either August Connect Bridge or Doorbell to connect to Ho
 
 ## Known Issues with battery reporting 
 
-The August Wi-Fi Smart Lock (Gen 4) uses different battery technology (lithium-ion) than the other locks. The battery charge percentage value reported by the lock detail API is frequently incorrect for these models.
+The August Wi-Fi Smart Lock (Gen 4) uses different battery technology (lithium-ion) than the other locks. The battery charge value reported by the lock detail API has frequently been reported as incorrect for these models.
 		
-Other august locks expect to be powered by AA alkaline (non-rechargeable) batteries. Rechargeable batteries in these locks will result in incorrect reporting of battery charge percentage.
+Other august locks expect to be powered by AA alkaline (non-rechargeable) batteries. Rechargeable batteries in these locks will result in incorrect reporting of battery charge.
 
 ## Known Unsupported Devices
 

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -56,9 +56,9 @@ Most devices will need either August Connect Bridge or Doorbell to connect to Ho
 
 ## Known Issues with battery reporting 
 
-August Wi-Fi Smart Lock (Gen 4) uses different battery technology than the other locks (lithium ion). It has been reported that the battery charge percentage value reported by the lock detail api is incorrect for these models.
-
-Other august locks expect to be powered by AA alkaline (non-rechargeable) batteries, using rechargable batteries in these locks will result in incorrect reporting of attery charge percentage.
+The August Wi-Fi Smart Lock (Gen 4) uses different battery technology (lithium-ion) than the other locks. The battery charge percentage value reported by the lock detail API is frequently incorrect for these models.
+		
+Other august locks expect to be powered by AA alkaline (non-rechargeable) batteries. Rechargeable batteries in these locks will result in incorrect reporting of battery charge percentage.
 
 ## Known Unsupported Devices
 

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -54,6 +54,12 @@ There is currently support for the following device types within Home Assistant:
 Most devices will need either August Connect Bridge or Doorbell to connect to Home Assistant.
 </div>
 
+## Known Issues with battery reporting 
+
+August Wi-Fi Smart Lock (Gen 4) uses different battery technology than the other locks (lithium ion). It has been reported that the battery charge percentage value reported by the lock detail api is incorrect for these models.
+
+Other august locks expect to be powered by AA alkaline (non-rechargeable) batteries, using rechargable batteries in these locks will result in incorrect reporting of attery charge percentage.
+
 ## Known Unsupported Devices
 
 - The Yale Doorman L3

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -58,7 +58,7 @@ Most devices will need either August Connect Bridge or Doorbell to connect to Ho
 
 The August Wi-Fi Smart Lock (Gen 4) uses different battery technology (lithium-ion) than the other locks. The battery charge value reported by the lock detail API has frequently been reported as incorrect for these models.
 		
-Other august locks expect to be powered by AA alkaline (non-rechargeable) batteries. Rechargeable batteries in these locks will result in incorrect reporting of battery charge.
+Other August locks expect to be powered by AA alkaline (non-rechargeable) batteries. Rechargeable batteries in these locks will result in incorrect reporting of battery charge.
 
 ## Known Unsupported Devices
 


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document known issues with reporting battery charge percentage with august locks


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
