### PR TITLE
Adds Tadiran to supported models list

### DIFF
--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -35,6 +35,7 @@ Any Gree Smart device working with the Gree+ app should be supported, including 
 - Innova
 - Cooper & Hunter
 - Proklima
+- Tadiran
 
 ## Climate
 


### PR DESCRIPTION
## Proposed change
Adds 'Tadiran' brand to supported brand list of devices in Official HA Core Gree integration


## Type of change
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information
Tadiran Supreme Inverter HVAC AC Series are confirmed to be supported by this integration, although the series doesn't use the 'Gree+' app, it uses 'EWPE Smart' which is also made by Gree, and detects and communicates flewlessly with the devices

More info about devices is available at (google translated to english):
https://www-tadiran--group-co-il.translate.goog/product/supreme-inv-140-%D7%91%D7%98%D7%9B%D7%A0%D7%95%D7%9C%D7%95%D7%92%D7%99%D7%99%D7%AA-uvc-aircare/?_x_tr_sl=iw&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
