### PR TITLE
Add documention for Mazda switch platform

### DIFF
--- a/source/_integrations/mazda.markdown
+++ b/source/_integrations/mazda.markdown
@@ -9,6 +9,7 @@ ha_category:
   - Lock
   - Presence Detection
   - Sensor
+  - Switch
 ha_iot_class: Cloud Polling
 ha_quality_scale: platinum
 ha_config_flow: true
@@ -22,6 +23,7 @@ ha_platforms:
   - device_tracker
   - lock
   - sensor
+  - switch
 ---
 
 The Mazda Connected Services integration allows you to retrieve data from a Mazda vehicle. In order to use this integration, you must first register your vehicle using the MyMazda app ([iOS](https://apps.apple.com/us/app/mymazda/id451886367)/[Android](https://play.google.com/store/apps/details?id=com.interrait.mymazda)).
@@ -85,25 +87,13 @@ Displays the current door lock status of the vehicle, and locks/unlocks the door
     The "Automatic Re-Lock" feature will automatically re-lock the doors if they are not opened shortly after being unlocked. This applies regardless of whether you are using the key, or unlocking the doors remotely using Home Assistant or the MyMazda app.
 </div>
 
+### Switch
+
+For electric vehicles, a "charging" switch entity will be created. This allows viewing and controlling the charging state of the vehicle battery.
+
 ## Services
 
-This integration provides the following services:
-
-### Service `mazda.start_charging`
-
-Starts charging the vehicle battery. This only works with electric vehicles.
-
-| Service Data Attribute | Required | Description |
-| ---------------------- | -------- | ----------- |
-| `device_id` | yes | The device ID of the vehicle to start charging |
-
-### Service `mazda.stop_charging`
-
-Stops charging the vehicle battery. This only works with electric vehicles.
-
-| Service Data Attribute | Required | Description |
-| ---------------------- | -------- | ----------- |
-| `device_id` | yes | The device ID of the vehicle to stop charging |
+This integration provides a single service:
 
 ### Service `mazda.send_poi`
 

--- a/source/_integrations/mazda.markdown
+++ b/source/_integrations/mazda.markdown
@@ -89,7 +89,7 @@ Displays the current door lock status of the vehicle, and locks/unlocks the door
 
 ### Switch
 
-For electric vehicles, a "charging" switch entity will be created. This allows viewing and controlling the charging state of the vehicle battery.
+For electric vehicles, a "charging" switch entity will be created, which allows viewing and controlling the charging state of the vehicle battery.
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the Mazda charging switch entity. Also remove documentation for the now-deprecated `start_charging` and `stop_charging` services.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/68025
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
