### PR TITLE
Fix link to ContentDirectory spec

### DIFF
--- a/source/_integrations/dlna_dms.markdown
+++ b/source/_integrations/dlna_dms.markdown
@@ -31,7 +31,7 @@ The `<media_identifier>` can have one of three forms:
 
 - `path/to/file` or `/path/to/file`: Slash-separated path through the Content Directory. This must refer to a unique media item.
 - `:ObjectID`: Colon followed by a server-assigned ID for an object.
-- `?query`: Question mark followed by a query string to search for, see [DLNA ContentDirectory SearchCriteria](http://www.upnp.org/specs/av/UPnP-av-ContentDirectory-v1-Service.pdf) for the syntax. The first result found will be used.
+- `?query`: Question mark followed by a query string to search for, see [DLNA ContentDirectory SearchCriteria](https://openconnectivity.org/wp-content/uploads/2015/11/UPnP-av-ContentDirectory-v4-Service.pdf) (part 5.3.16 "A_ARG_TYPE_SearchCriteria" on page 65 and part D.5 "Searching" on page 269) for the syntax. The first result found will be used.
 
 URIs generated while browsing will look like the Object ID form above. However, all three forms will work with the [media_player.play_media](/integrations/media_player/#service-media_playerplay_media) service.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fix a broken link in the documentation, and add some specific section and page references.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #21889

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
