### PR TITLE
Drop support for Tradfri groups

### DIFF
--- a/source/_integrations/tradfri.markdown
+++ b/source/_integrations/tradfri.markdown
@@ -56,4 +56,4 @@ Please make sure you have `autoconf` installed (`$ sudo apt-get install autoconf
 ## Known limitations
 
 - The TRÅDFRI Shortcut button, Remotes and motion sensor only send information about their battery status, no events, to Home Assistant and thus can't be used to automate with. If you want to automate with these devices, you need to use something like [ZHA](/integrations/zha/).
-- The groups you find in the app are not imported into Home Assistant, as they are known to cause stability issues. We recommend that you use the native [light groups](/integrations/light.group/) instead.
+- The groups you find in the app are not imported into Home Assistant as they are known to cause stability issues. We recommend that you use the native [light groups](/integrations/light.group/) instead.

--- a/source/_integrations/tradfri.markdown
+++ b/source/_integrations/tradfri.markdown
@@ -56,4 +56,4 @@ Please make sure you have `autoconf` installed (`$ sudo apt-get install autoconf
 ## Known limitations
 
 - The TRÅDFRI Shortcut button, Remotes and motion sensor only send information about their battery status, no events, to Home Assistant and thus can't be used to automate with. If you want to automate with these devices, you need to use something like [ZHA](/integrations/zha/).
-- The groups you find in the app are not imported into Home Assistant as they are known to cause stability issues. We recommend that you use the native [light group](/integrations/light.group/) instead.
+- The groups you find in the app are not imported into Home Assistant as they are known to cause stability issues. We recommend that you use the native [light groups](/integrations/light.group/) instead.

--- a/source/_integrations/tradfri.markdown
+++ b/source/_integrations/tradfri.markdown
@@ -56,4 +56,4 @@ Please make sure you have `autoconf` installed (`$ sudo apt-get install autoconf
 ## Known limitations
 
 - The TRÅDFRI Shortcut button, Remotes and motion sensor only send information about their battery status, no events, to Home Assistant and thus can't be used to automate with. If you want to automate with these devices, you need to use something like [ZHA](/integrations/zha/).
-- The groups you find in the app are not imported into Home Assistant as they are known to cause stability issues. We recommend that you use the native [light groups](/integrations/light.group/) instead.
+- The groups you find in the app are not imported into Home Assistant as they are known to cause stability issues. We recommend that you use the native [light group](/integrations/light.group/) instead.

--- a/source/_integrations/tradfri.markdown
+++ b/source/_integrations/tradfri.markdown
@@ -56,3 +56,4 @@ Please make sure you have `autoconf` installed (`$ sudo apt-get install autoconf
 ## Known limitations
 
 - The TRÅDFRI Shortcut button, Remotes and motion sensor only send information about their battery status, no events, to Home Assistant and thus can't be used to automate with. If you want to automate with these devices, you need to use something like [ZHA](/integrations/zha/).
+- The groups you find in the app are not imported into Home Assistant, as they are known to cause stability issues. We recommend that you use the native [light groups](/integrations/light.group/) instead.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

We dropped support for YAML-configuration in 2022.3 and updated this documentation accordingly. This PR suggests a clarification to let the user know why they cannot find their groups imported into Home Assistant.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/68033
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
