### PR TITLE
Add remote platform docs for Kaliedescape integration

### DIFF
--- a/source/_integrations/kaleidescape.markdown
+++ b/source/_integrations/kaleidescape.markdown
@@ -39,7 +39,7 @@ The Kaleidescape media player platform will create a Media Player entity for the
 
 ## Remote
 
-The Kaleidescape remote platform will create a Remote entity for the device. This entity allows you to send the following commands via the `remote/send_command` service.
+The Kaleidescape remote platform will create a Remote entity for the device. This entity allows you to send the following commands via the `remote.send_command` service.
 
 - select
 - up

--- a/source/_integrations/kaleidescape.markdown
+++ b/source/_integrations/kaleidescape.markdown
@@ -3,6 +3,7 @@ title: Kaleidescape
 description: Instructions on how to integrate Kaleidescape into Home Assistant.
 ha_category:
   - Media Player
+  - Remote
   - Sensor
 ha_release: '2022.4'
 ha_iot_class: Local Push
@@ -13,10 +14,11 @@ ha_codeowners:
 ha_domain: kaleidescape
 ha_platforms:
   - media_player
+  - remote
   - sensor
 ---
 
-The Kaleidescape integration allows for the automation of Kaleidescape movie players.
+The Kaleidescape integration allows for the automation of [Kaleidescape](https://www.kaleidescape.com/) movie players.
 
 Ideas for automation include:
 
@@ -34,6 +36,33 @@ This integration is intended for the automation of Kaleidescape players with a m
 ## Media Player
 
 The Kaleidescape media player platform will create a Media Player entity for the device. This entity will display the currently playing media and playback controls.
+
+## Remote
+
+The Kaleidescape remote platform will create a Remote entity for the device. This entity allows you to send the following commands via the `remote/send_command` service.
+
+- select
+- up
+- down
+- left
+- right
+- cancel
+- replay
+- scan_forward
+- scan_reverse
+- go_movie_covers
+- menu_toggle
+
+A typical service call might look like the example below. This sends a command to the device to `select` the currently highlighted item.
+
+```yaml
+service: remote.send_command
+target:
+  entity_id: remote.kaleidescape_theater
+data:
+  command:
+    - select
+```
 
 ## Sensor
 

--- a/source/_integrations/kaleidescape.markdown
+++ b/source/_integrations/kaleidescape.markdown
@@ -53,7 +53,7 @@ The Kaleidescape remote platform will create a Remote entity for the device. Thi
 - go_movie_covers
 - menu_toggle
 
-A typical service call might look like the example below. This sends a command to the device to `select` the currently highlighted item.
+A typical service call might look like the example below, which sends a command to the device to `select` the currently highlighted item.
 
 ```yaml
 service: remote.send_command


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add remote platform documentation for new Kaleidescape integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/67959
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
