### PR TITLE
Media Player and Spotify documentation improvements

### DIFF
--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -189,7 +189,7 @@ The example script below combines a number of media player commands to set the o
 This demonstrates how steps a user would go through manually can be combined into a script that can then be called by a single button press or automation.
 
 ```yaml
-# configuration.yaml
+# Example configuration.yaml entry
 script:
   demo_spotify:
     # Script demonstrating media player functionality

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -181,3 +181,64 @@ The way media players are displayed in the frontend can be modified in the [cust
 - `tv`: Device is a television type device.
 - `speaker`: Device is speaker or stereo type device.
 - `receiver`: Device is audio video receiver type device taking audio and outputting to speakers and video to some display.
+
+## Example script
+
+The example script below combines a number of media player commands to set the output speaker for [Spotify](https://www.home-assistant.io/integrations/spotify) to 30% volume and plays a randomly shuffled track from the playlist Calming Classical.
+
+This demonstrates how steps a user would go through manually can be combined into a script that can then be called by a single button press or automation.
+
+```yaml
+# configuration.yaml
+script:
+  demo_spotify:
+    # Script demonstrating media player functionality
+    # To use this script you must update both media_player entity ids and Spotify's name for the source to match your Spotify integration and smart speaker device
+    alias: Demo Spotify
+    icon: mdi:music-box
+    mode: single
+    sequence:
+      # In this demo we first prepare a receiver that supports Spotify
+      - service: scene.apply
+        data:
+          entities:
+            media_player.denon_avr_x2000:
+              state: 'on'
+              sound_mode: STEREO # Only supported by select devices
+              volume_level: 0.3
+      # Set the output. See the documentation about how the concept of source differs for Spotify than for other media players
+      - service: media_player.select_source
+        entity_id: media_player.spotify
+        data:
+          source: "Denon AVR-X2000"
+
+      # If the script was too fast we may get a "No active playback device" error
+      - alias: Allow time for service to wake from idle
+        wait_template: "{{ not is_state('media_player.spotify', 'idle') }}"
+        timeout: '00:00:30'
+
+      # Start a playlist then set it to repeat, shuffle and skip to a random track
+      - service: media_player.play_media
+        data:
+          entity_id: media_player.spotify
+          media_content_id: "spotify:playlist:37i9dQZF1DWVFeEut75IAL"
+          media_content_type: playlist
+
+      - service: media_player.repeat_set
+        data:
+          entity_id: media_player.spotify
+          repeat: all
+      - service: media_player.shuffle_set
+        data:
+          entity_id: media_player.spotify
+          shuffle: true
+      - service: media_player.media_next_track
+        data:
+          entity_id: media_player.spotify
+```
+
+Documentation:
+
+- [Scripts](https://www.home-assistant.io/integrations/script) configuration details
+- [Scripts Editor](https://www.home-assistant.io/docs/scripts/editor/) for a UI that reads and writes `scripts.yaml`
+- [Spotify](https://www.home-assistant.io/integrations/spotify) integration details

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -184,7 +184,7 @@ The way media players are displayed in the frontend can be modified in the [cust
 
 ## Example script
 
-The example script below combines a number of media player commands to set the output speaker for [Spotify](https://www.home-assistant.io/integrations/spotify) to 30% volume and plays a randomly shuffled track from the playlist Calming Classical.
+The example script below combines a number of media player commands to set the output speaker for [Spotify](/integrations/spotify) to 30% volume and plays a randomly shuffled track from the playlist Calming Classical.
 
 This demonstrates how steps a user would go through manually can be combined into a script that can then be called by a single button press or automation.
 
@@ -239,6 +239,6 @@ script:
 
 Documentation:
 
-- [Scripts](https://www.home-assistant.io/integrations/script) configuration details
-- [Scripts Editor](https://www.home-assistant.io/docs/scripts/editor/) for a UI that reads and writes `scripts.yaml`
-- [Spotify](https://www.home-assistant.io/integrations/spotify) integration details
+- [Scripts](/integrations/script) configuration details
+- [Scripts Editor](/docs/scripts/editor/) for a UI that reads and writes `scripts.yaml`
+- [Spotify](/integrations/spotify) integration details

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -16,9 +16,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The Spotify media player integration allows you to control [Spotify](https://www.spotify.com/) playback from Home Assistant.
-
-Once an output [source]](#selecting-output-source) is selected you will be able to play content from Spotify using the standard Media Browser UI or `media_player` service.
+The Spotify media player integration allows you to control [Spotify](https://www.spotify.com/) playback from Home Assistant. For playback see your {% my media_browser title="Media Browser" %} or the [Media Player](/integrations/media_player) service.
 
 ## Prerequisites
 

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -120,7 +120,7 @@ The `media_content_id` can be a URL (e.g. `https://open.spotify.com/playlist/37i
 
 ## Selecting output source
 
-To play media Spotify needs a device selected for audio output known as the `source`. Currently, this integration cannot initiate playback to a device not already available from the Spotify API. You need to first use Spotify on your smart speaker or phone to populate the source list.
+To play media Spotify needs a device selected for audio output known as the `source`. The Spotify API cannot initiate playback to a device not already known to the Spotify.
 
 ```yaml
 # Example code to select an AV receiver as the output device
@@ -130,12 +130,10 @@ data:
   source: "Denon AVR-X2000"
 ```
 
-The device name must be known to Spotify and therefore is often different from names given to entities in Home Assistant.
-
-The source list of available devices can be found in the Details section of the Spotify Media Player Control and the `source_list` attribute in the {% my developer_states title="Developer Tools States" %}.
+The source name must match the name in Spotify. The source list of available devices can be found in the Details section of the Spotify Media Player Control and the `source_list` attribute in the {% my developer_states title="Developer Tools States" %}.
 
 <div class='note'>
-  A known limitation with Spotify is that devices disappear from the source list over time. Many Spotify Connect devices tend to persist, other devices such as Amazon Alexa speakers may only be remembered for a while, and phones and Google Cast devices disappear as soon as playback stops.
+  Spotify devices are only visible in the list of media sources when they are actively used with the connected Spotify account. A known limitation with Spotify is that only certain Spotify Connect devices persist after playback stops allowing this integration to later initiate playback.
 </div>
 
 ## Unsupported Devices

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -114,6 +114,30 @@ script:
 
 The `media_content_id` value can be obtained from the Spotify desktop app by clicking on the more options ("...") next to the album art picture, selecting "Share" and then "Copy Spotify URI" or "Copy Playlist Link" (also available in the Spotify phone and web app).
 
+## Selecting output source
+
+To play media Spotify needs a device selected for audio output known as the `source`. Currently, this integration cannot initiate playback to a device not already available from the Spotify API. You need to first use Spotify on your smart speaker or phone to populate the source list.
+
+```yaml
+# Example code to select an AV receiver as the output device
+service: media_player.select_source
+entity_id: media_player.spotify
+data:
+  source: "Denon AVR-X2000"
+```
+
+The device name must be known to Spotify and therefore is often different from names given to entities in Home Assistant.
+
+The source list of available devices can be found in the Details section of the Spotify Media Player Control and the `source_list` attribute in the Developer tools States or templates using:
+
+```jinja
+{{ state_attr('media_player.spotify', 'source_list') }}
+```
+
+<div class='note'>
+  A known limitation with Spotify is that devices disappear from the source list over time. Many Spotify Connect devices tend to persist, other devices such as Amazon Alexa speakers may only be remembered for a while, and phones and Google Cast devices disappear as soon as playback stops.
+</div>
+
 ## Unsupported Devices
 
 - **Sonos**: Although Sonos is a Spotify Connect device, it is not supported by the official Spotify API.

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -116,7 +116,7 @@ script:
 
 The `media_content_id` value can be obtained from the Spotify desktop app by clicking on the more options ("...") next to the album art picture, selecting "Share" and then "Copy Spotify URI" or "Copy Playlist Link" (also available in the Spotify phone and web app).
 
-The `media_content_id` can be a URL (e.g. `https://open.spotify.com/playlist/37i9dQZF1DWVFeEut75IAL`) or the Spotify URI string (e.g. `spotify:playlist:37i9dQZF1DWVFeEut75IAL`). (play_media)[https://www.home-assistant.io/integrations/media_player/#service-media_playerplay_media] requires the correct corresponding `media_content_type`.
+The `media_content_id` can be a URL (e.g. `https://open.spotify.com/playlist/37i9dQZF1DWVFeEut75IAL`) or the Spotify URI string (e.g. `spotify:playlist:37i9dQZF1DWVFeEut75IAL`). (play_media)[/integrations/media_player/#service-media_playerplay_media] requires the correct corresponding `media_content_type`.
 
 ## Selecting output source
 

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -132,11 +132,7 @@ data:
 
 The device name must be known to Spotify and therefore is often different from names given to entities in Home Assistant.
 
-The source list of available devices can be found in the Details section of the Spotify Media Player Control and the `source_list` attribute in the Developer tools States or templates using:
-
-```jinja
-{{ state_attr('media_player.spotify', 'source_list') }}
-```
+The source list of available devices can be found in the Details section of the Spotify Media Player Control and the `source_list` attribute in the {% my developer_states title="Developer Tools States" %}.
 
 <div class='note'>
   A known limitation with Spotify is that devices disappear from the source list over time. Many Spotify Connect devices tend to persist, other devices such as Amazon Alexa speakers may only be remembered for a while, and phones and Google Cast devices disappear as soon as playback stops.

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -18,6 +18,8 @@ ha_integration_type: integration
 
 The Spotify media player integration allows you to control [Spotify](https://www.spotify.com/) playback from Home Assistant.
 
+Once an output [source]](#selecting-output-source) is selected you will be able to play content from Spotify using the standard Media Browser UI or `media_player` service.
+
 ## Prerequisites
 
 - Spotify account
@@ -92,7 +94,7 @@ modification to the `configuration.yaml` file is needed. Multiple Spotify
 accounts can be linked to a _single_ Spotify application. You will have to add those accounts into the **Users and Access** section of your application in the Spotify Developer Portal.
 
 To add an additional Spotify account to Home Assistant, go to the Spotify website and log out, then repeat _only_ the steps
-in the [Configuration](#configuration) section. 
+in the [Configuration](#configuration) section.
 
 ## Playing Spotify playlists
 
@@ -113,6 +115,8 @@ script:
 ```
 
 The `media_content_id` value can be obtained from the Spotify desktop app by clicking on the more options ("...") next to the album art picture, selecting "Share" and then "Copy Spotify URI" or "Copy Playlist Link" (also available in the Spotify phone and web app).
+
+The `media_content_id` can be a URL (e.g. `https://open.spotify.com/playlist/37i9dQZF1DWVFeEut75IAL`) or the Spotify URI string (e.g. `spotify:playlist:37i9dQZF1DWVFeEut75IAL`). (play_media)[https://www.home-assistant.io/integrations/media_player/#service-media_playerplay_media] requires the correct corresponding `media_content_type`.
 
 ## Selecting output source
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation of existing functionality for `media_player` and `spotify` integrations. 

Describe the quirks of `source` from the Spotify API (name and forgetfulness) that can confuse users. Provider full example of various commands. Cross link relevant documentation (Spotify, Media Player, Scripts) to further help find relevant details.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link forum post: https://community.home-assistant.io/t/minor-improvements-to-the-spotify-integration-documentation/396168

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
