### PR TITLE
Update decora_wifi setup instructions

### DIFF
--- a/source/_integrations/decora_wifi.markdown
+++ b/source/_integrations/decora_wifi.markdown
@@ -3,11 +3,13 @@ title: Leviton Decora Wi-Fi
 description: Instructions on how to setup Leviton Decora Smart Wi-Fi switches/dimmers within Home Assistant.
 ha_category:
   - Light
+  - Fan
 ha_iot_class: Cloud Polling
 ha_release: 0.51
 ha_domain: decora_wifi
 ha_platforms:
   - light
+  - fan
 ---
 
 Support for [Leviton Decora Wi-Fi](https://www.leviton.com/en/products/lighting-controls/decora-smart-with-wifi) dimmers/switches via the MyLeviton API.
@@ -17,18 +19,11 @@ Supported devices (tested):
 - [DW6HD1-BZ](https://www.leviton.com/en/products/dw6hd-1bz) (Decora Smart Wi-Fi 600W Dimmer)
 - [DW15S-1BZ](https://www.leviton.com/en/products/dw15s-1bz) (Decora Smart Wi-Fi 15A Switch)
 - [DW15P-1BW](https://www.leviton.com/en/products/dw15p-1bw) (Decora Smart Wi-Fi Plug-in Outlet)
+- [DW4SF-1BW](https://www.leviton.com/en/products/dw4sf) (Decora Smart Wi-Fi Fan Speed Controller)
 
-To enable these lights, add the following lines to your `configuration.yaml` file:
+To enable the integration, configure it via the "Add Integration" workflow in the configuration section of the Home Assistant web UI.
 
-```yaml
-# Example configuration.yaml entry
-light:
-  - platform: decora_wifi
-    username: YOUR_USERNAME
-    password: YOUR_PASSWORD
-```
-
-{% configuration %}
+{% configuration_basic %}
 username:
   description: Your "My Leviton" app email address/user name.
   required: true


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR updates the decora_wifi integration to be configurable via the UI
and adds explicit support for Leviton Decora fan controllers.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/68070
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
