### PR TITLE
Wordsmithing for Kaleidescape integration

### DIFF
--- a/source/_integrations/kaleidescape.markdown
+++ b/source/_integrations/kaleidescape.markdown
@@ -35,25 +35,25 @@ This integration is intended for the automation of Kaleidescape players with a m
 
 ## Media Player
 
-The Kaleidescape media player platform will create a Media Player entity for the device. This entity will display the currently playing media and playback controls.
+The Kaleidescape media player platform will create a [Media Player](/integrations/media_player/) entity for the device. This entity will display the currently playing media and playback controls.
 
 ## Remote
 
-The Kaleidescape remote platform will create a Remote entity for the device. This entity allows you to send the following commands via the `remote.send_command` service.
+The Kaleidescape remote platform will create a [Remote](/integrations/remote/) entity for the device. This entity allows you to send the following commands via the [remote.send_command](/integrations/remote/) service.
 
-- select
-- up
-- down
-- left
-- right
-- cancel
-- replay
-- scan_forward
-- scan_reverse
-- go_movie_covers
-- menu_toggle
+- `select`
+- `up`
+- `down`
+- `left`
+- `right`
+- `cancel`
+- `replay`
+- `scan_forward`
+- `scan_reverse`
+- `go_movie_covers`
+- `menu_toggle`
 
-A typical service call might look like the example below, which sends a command to the device to `select` the currently highlighted item.
+A typical service call might look like the example below, which sends a command to the device to _select_ the currently highlighted item.
 
 ```yaml
 service: remote.send_command
@@ -66,7 +66,7 @@ data:
 
 ## Sensor
 
-The Kaleidescape sensor platform will create multiple Sensor entities for the device. The follow sensors are provided:
+The Kaleidescape sensor platform will create multiple [Sensor](/integrations/sensor/) entities for the device. The follow sensors are provided:
 
 ### Media Location
 
@@ -224,7 +224,7 @@ The Cinemascape mode of the current movie.
 
 Additional details about the values provided by the sensors can be found in Kaleidescape's [Control Protocol Reference Manual](https://www.kaleidescape.com/wp-content/uploads/Kaleidescape-System-Control-Protocol-Reference-Manual.pdf).
 
-A typical automation might look like the example below. This turns up the lights when the `media_location` sensor leaves the `content` state.
+A typical automation might look like the example below, which turns up the lights when the _media_location_ sensor leaves the _content_ state.
 
 ```yaml
 - alias: kaleidescape_theater_lights_up


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Fixes grammar, links, and highlighting for Kaleidescape integration based on feedback in https://github.com/home-assistant/home-assistant.io/pull/21995.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
