### PR TITLE
Create documentation for iAlarmXR device support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -235,6 +235,7 @@ source/_integrations/hvv_departures.markdown @vigonotion
 source/_integrations/hydrawise.markdown @ptcryan
 source/_integrations/hyperion.markdown @dermotduffy
 source/_integrations/ialarm.markdown @RyuzakiKK
+source/_integrations/ialarmxr.markdown @bigmoby
 source/_integrations/iammeter.markdown @lewei50
 source/_integrations/iaqualink.markdown @flz
 source/_integrations/icloud.markdown @Quentame @nzapponi

--- a/source/_integrations/ialarm.markdown
+++ b/source/_integrations/ialarm.markdown
@@ -14,7 +14,7 @@ ha_platforms:
 ---
 
 The iAlarm integration provides connectivity with the [Antifurto365](https://www.antifurtocasa365.it/) iAlarm alarm systems and has also been confirmed to work with the alarm system brands Meian and Emooluxr.
-Please note that the latest iAlarm-XR alarm system is not supported.
+Please install iAlarmXR integration for the latest iAlarm-XR alarm system.
 
 This platform supports the following services:
 

--- a/source/_integrations/ialarmxr.markdown
+++ b/source/_integrations/ialarmxr.markdown
@@ -1,0 +1,24 @@
+---
+title: Antifurto365 iAlarmXR
+description: Instructions on how to integrate iAlarmsXR alarms into Home Assistant.
+ha_category:
+  - Alarm
+ha_iot_class: Local Polling
+ha_config_flow: true
+ha_release: '2021.5'
+ha_domain: ialarmxr
+ha_codeowners:
+  - '@bigmoby'
+ha_platforms:
+  - alarm_control_panel
+---
+
+The iAlarmXR integration provides connectivity with the [Antifurto365](https://www.antifurtocasa365.it/) iAlarmXR alarm systems.
+
+This platform supports the following services:
+
+- `alarm_control_panel.alarm_arm_away`
+- `alarm_control_panel.alarm_arm_home`
+- `alarm_control_panel.alarm_disarm`
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
This PR extends Home Assistant component core support for iAlarmXR model. The current iAlarm Home Assistant component support is for GuardIP model. Unfortunately the two alarm system differs on authentication flow but the remaining API remains quite the same.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/67817
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
