### PR TITLE
update location of Entities list : Deleting Automations

### DIFF
--- a/source/_docs/automation/yaml.markdown
+++ b/source/_docs/automation/yaml.markdown
@@ -160,6 +160,6 @@ If you want to migrate your manual automations to use the editor, you'll have to
 
 When automations remain visible in the Home Assistant Dashboard, even after having deleted in the YAML file, you have to delete them in the UI.
 
-To delete them completely, go to UI **{% my entities title="Configuration -> Entities" %}** and find the automation in the search field or by scrolling down.
+To delete them completely, go to UI **{% my entities title="Configuration -> Devices & Services -> Entities" %}** and find the automation in the search field or by scrolling down.
 
 Check the square box aside of the automation you wish to delete and from the top-right of your screen, select 'REMOVE SELECTED'.


### PR DESCRIPTION
slight update to instructions to now reflect the current HA UI
Entities are listed after click Configuration, Devices & Services, then Entities.

- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).


- [X] This PR uses the correct branch, based on the following:
  - I made a change to the existing documentation and used the `current` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
