### PR TITLE
Update filter.markdown

### DIFF
--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -31,6 +31,7 @@ To enable Filter Sensors in your installation, add the following to your `config
 sensor:
   - platform: filter
     name: "filtered realistic humidity"
+    unique_id: sensor.realistic_humidity_filtered
     entity_id: sensor.realistic_humidity
     filters:
       - filter: outlier
@@ -65,7 +66,7 @@ name:
   required: false
   type: string
 unique_id:
-  description: An ID that uniquely identifies the filter sensor. Set this to a unique value to allow customization through the UI.
+  description: An ID that uniquely identifies the filter sensor. Set this to a unique value to allow customization through the UI. If you do not define it, it will be automatically derived from the ´name´ by HA
   required: false
   type: string
 filters:


### PR DESCRIPTION
I improved on the definition of the unique_id and included the tag into the example.
This seems to make sense because I needed more then one day to find out that without this field there was an autocreated id, that was not visible to me

## Proposed change
Extend description as proposed

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Improved explanation of handling. Asking around among other users of HA showed they did not know this feature either. And I only located it by finding an older error message and improvement request. The problem here is, that the term 'unique_id' is used for the object resulting from the filtering, usually this would be 'entity_id' but that has historically already been used of the object of the filter-operation.

From reading this documentation I was not able to conclude that I have to define this 'unique_id' since I was looking for some expression containing 'entity'.

I hope the new phrasing makes it easier for the next guy or girl



## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
