### PR TITLE
Add config flow for Sun

### DIFF
--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -12,7 +12,7 @@ ha_domain: sun
 ha_config_flow: true
 ---
 
-The sun integration will use the location your
+The sun integration will use the location as
 {% my general title="configured in your Home Assistant configuration" %} to
 track if the sun is above or below the horizon. The sun can be used within
 automation as

--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -15,8 +15,8 @@ ha_config_flow: true
 The sun integration will use the location as
 {% my general title="configured in your Home Assistant configuration" %} to
 track if the sun is above or below the horizon. The sun can be used within
-automation as
-[a trigger with an optional offset to simulate dawn/dusk][sun_trigger]or as
+automations as
+[a trigger with an optional offset to simulate dawn/dusk][sun_trigger] or as
 [a condition with an optional offset to test if the sun has already set or risen][sun_condition].
 
 [sun_trigger]: /docs/automation/trigger/#sun-trigger

--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -33,7 +33,7 @@ If that is the case, you can configure it as described in the next paragraphs.
 ## YAML Configuration
 
 Alternatlively, this integration can be configured and set up manually via YAML
-as well. To enable the sun integration in your installation, add the
+instead. To enable the sun integration in your installation, add the
 following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -9,6 +9,7 @@ ha_codeowners:
   - '@Swamp-Ig'
 ha_iot_class: Calculated
 ha_domain: sun
+ha_config_flow: true
 ---
 
 The sun integration will use your current location to track if the sun is above or
@@ -18,21 +19,27 @@ below the horizon. The sun can be used within automation as
 [sun_trigger]: /docs/automation/trigger/#sun-trigger
 [sun_condition]: /docs/scripts/conditions/#sun-condition
 
-## Configuration
+## Configured by default
 
-This integration is by default enabled, unless you've disabled or removed the [`default_config:`](/integrations/default_config/) line from your configuration. If that is the case, the following example shows you how to enable this integration manually:
+This integration is by default configured and installed, and you don't need
+to configure it yourself, unless you've disabled or removed the
+[`default_config:`](/integrations/default_config/) line from your
+YAML configuration.
+
+If that is the case, you can configure it as described in the next paragraphs.
+
+{% include integrations/config_flow.md %}
+
+## YAML Configuration
+
+Alternatlively, this integration can be configured and set up manually via YAML
+as well. To enable the sun integration in your installation, add the
+following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 sun:
 ```
-
-{% configuration %}
-elevation:
-  description: "The (physical) elevation of your location, in meters above sea level. Defaults to the `elevation` in `configuration.yaml`, which is retrieved from Google Maps if not set."
-  required: false
-  type: integer
-{% endconfiguration %}
 
 <p class='img'>
 <img src='/images/screenshots/more-info-dialog-sun.png' />

--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -12,9 +12,12 @@ ha_domain: sun
 ha_config_flow: true
 ---
 
-The sun integration will use your current location to track if the sun is above or
-below the horizon. The sun can be used within automation as
-[a trigger with an optional offset to simulate dawn/dusk][sun_trigger] or as [a condition with an optional offset to test if the sun has already set or risen][sun_condition].
+The sun integration will use the location your
+{% my general title="configured in your Home Assistant configuration" %} to
+track if the sun is above or below the horizon. The sun can be used within
+automation as
+[a trigger with an optional offset to simulate dawn/dusk][sun_trigger]or as
+[a condition with an optional offset to test if the sun has already set or risen][sun_condition].
 
 [sun_trigger]: /docs/automation/trigger/#sun-trigger
 [sun_condition]: /docs/scripts/conditions/#sun-condition


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adjust documentation for the configuration flow that has been added to Sun.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/68295
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
