### PR TITLE
Update docs for support for custom baud speed

### DIFF
--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -32,6 +32,7 @@ You can also enable `SMS` via your `configuration.yaml` file:
 # Example configuration.yaml entry
 sms:
   device: /dev/ttyUSB2
+  baud_speed: 19200 # Optional
 ```
 
 To configure the notification service, edit your `configuration.yaml` file:
@@ -51,6 +52,10 @@ device:
   description: The gsm modem device.
   required: true
   type: string
+baud_speed:
+  description: Baud speed of the modem device. Only needed for modems that cannot auto configure this setting.
+  required: False
+  type: integer
 {% endconfiguration %}
 
 ## Notifications

--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -21,7 +21,23 @@ This integration provides the following platforms:
 
 - Notify
 
-## Configuration
+## Configuration - UI
+
+Connect your modem and restart Home Assistant.
+
+From the Home Assistant front page go to **Configuration** and then select **Integrations** from the list.
+
+Use the plus button in the bottom right to add a new integration called **SMS**.
+
+In the popup:
+
+- Serial Device Path - [See here for more info](./sms#huawei-modems-on-raspberry-pi-and-similar-devices)
+- Buad Speed - By default speed is 0 which means that the modem automatically detect what speed to use.
+- Submit
+
+Press `Submit` and the integration will try to connect to the modem automatically. 
+
+## Configuration - YAML (Deprecated)
 
 Activate `SMS` via the integrations menu and search for `SMS`.
 While activating the integration, it will ask for your serial device. Make sure the device is connected and have a valid SIM activated.
@@ -32,8 +48,16 @@ You can also enable `SMS` via your `configuration.yaml` file:
 # Example configuration.yaml entry
 sms:
   device: /dev/ttyUSB2
-  baud_speed: 19200 # Optional
 ```
+
+{% configuration %}
+device:
+  description: The gsm modem device.
+  required: true
+  type: string
+{% endconfiguration %}
+
+## Notifications
 
 To configure the notification service, edit your `configuration.yaml` file:
 
@@ -46,15 +70,6 @@ notify:
     name: sms_person2
     recipient: PHONE_NUMBER
 ```
-
-{% configuration %}
-device:
-  description: The gsm modem device.
-  required: true
-  type: string
-{% endconfiguration %}
-
-## Notifications
 
 You can also receive SMS messages that are sent to the SIM card number in your device.
 Every time there is a message received, `event: sms.incoming_sms` is fired with date, phone number and text message.

--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -52,10 +52,6 @@ device:
   description: The gsm modem device.
   required: true
   type: string
-baud_speed:
-  description: Baud speed of the modem device. Only needed for modems that cannot auto configure this setting.
-  required: False
-  type: integer
 {% endconfiguration %}
 
 ## Notifications

--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -31,16 +31,13 @@ Use the plus button in the bottom right to add a new integration called **SMS**.
 
 In the popup:
 
-- Serial Device Path - [See here for more info](./sms#huawei-modems-on-raspberry-pi-and-similar-devices)
+- Serial Device Path - [See here for more info](./sms.markdown#huawei-modems-on-raspberry-pi-and-similar-devices)
 - Buad Speed - By default speed is 0 which means that the modem automatically detect what speed to use.
 - Submit
 
 Press `Submit` and the integration will try to connect to the modem automatically. 
 
 ## Configuration - YAML (Deprecated)
-
-Activate `SMS` via the integrations menu and search for `SMS`.
-While activating the integration, it will ask for your serial device. Make sure the device is connected and have a valid SIM activated.
 
 You can also enable `SMS` via your `configuration.yaml` file:
 

--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -21,8 +21,6 @@ This integration provides the following platforms:
 
 - Notify
 
-## Configuration
-
 {% include integrations/config_flow.md %}
 
 ## Notifications

--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -21,38 +21,9 @@ This integration provides the following platforms:
 
 - Notify
 
-## Configuration - UI
+## Configuration
 
-Connect your modem and restart Home Assistant.
-
-From the Home Assistant front page go to **Configuration** and then select **Integrations** from the list.
-
-Use the plus button in the bottom right to add a new integration called **SMS**.
-
-In the popup:
-
-- Serial Device Path - [See here for more info](./sms.markdown#huawei-modems-on-raspberry-pi-and-similar-devices)
-- Buad Speed - By default speed is 0 which means that the modem automatically detect what speed to use.
-- Submit
-
-Press `Submit` and the integration will try to connect to the modem automatically. 
-
-## Configuration - YAML (Deprecated)
-
-You can also enable `SMS` via your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-sms:
-  device: /dev/ttyUSB2
-```
-
-{% configuration %}
-device:
-  description: The gsm modem device.
-  required: true
-  type: string
-{% endconfiguration %}
+{% include integrations/config_flow.md %}
 
 ## Notifications
 

--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -81,12 +81,13 @@ Note: When running Home Assistant, you need to install the SSH add-on.
 You will need a USB GSM stick modem or device like SIM800L v2 connected via USB UART.
 
 ### List of modems known to work
-
+- [SIM800C HAT form factor](https://www.amazon.com/gp/product/B07PQLRCNR/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&psc=1) Make sure to `enable_uart=1` on your `config.txt` boot file.
+- [SIM800C](https://www.amazon.com/gp/product/B087Z6F953/ref=ppx_yo_dt_b_asin_title_o00_s00?ie=UTF8&psc=1)
 - [Huawei E3372-510](https://www.amazon.com/gp/product/B01N6P3HI2/ref=ppx_yo_dt_b_asin_title_o00_s00?ie=UTF8&psc=1)(
 Need to unlock it using [this guide](http://blog.asiantuntijakaveri.fi/2015/07/convert-huawei-e3372h-153-from.html))
 - [Huawei E3531](https://www.amazon.com/Modem-Huawei-Unlocked-Caribbean-Desbloqueado/dp/B011YZZ6Q2/ref=sr_1_1?keywords=Huawei+E3531&qid=1581447800&sr=8-1)
 - [Huawei E3272](https://www.amazon.com/Huawei-E3272s-506-Unlocked-Americas-Europe/dp/B00HBL51OQ)
-- [SIM800C](https://www.amazon.com/gp/product/B087Z6F953/ref=ppx_yo_dt_b_asin_title_o00_s00?ie=UTF8&psc=1)
+
 
 ### List of modems known to NOT work
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Corresponding documentation change for [supporting custom baud speeds](https://github.com/home-assistant/core/pull/68320)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/68320
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
