### PR TITLE
Add lock information to wallbox.markdown

### DIFF
--- a/source/_integrations/wallbox.markdown
+++ b/source/_integrations/wallbox.markdown
@@ -9,6 +9,7 @@ ha_domain: wallbox
 ha_platforms:
   - number
   - sensor
+  - lock
 ha_config_flow: true
 ha_codeowners:
   - '@hesselonline'

--- a/source/_integrations/wallbox.markdown
+++ b/source/_integrations/wallbox.markdown
@@ -42,3 +42,7 @@ The integration adds the following number entity:
 - Max Charging Current
 
 The number entity is only loaded if the supplied username has sufficient rights to change the Max. Charging Current.
+
+## Lock
+
+The integration adds a lock entity, allowing you to lock the charger. Please note, this only works with a user with admin rights.


### PR DESCRIPTION
Information is added for the lock integration which is added in #68414 in core

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation added for wallbox lock component.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/68414
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
