### PR TITLE
Update url to Twitter developers dashboard

### DIFF
--- a/source/_integrations/twitter.markdown
+++ b/source/_integrations/twitter.markdown
@@ -14,7 +14,7 @@ The `twitter` notification platform uses [Twitter](https://twitter.com) to deliv
 
 ## Setup
 
-Make sure you have a developer account registered with Twitter, then go to [Twitter Apps](https://developer.twitter.com/en/portal/projects-and-apps) and create an application. If you don't have a developer account you need to apply for one, it can take some time to get approved.
+Make sure you have a developer account registered with Twitter, then go to [Twitter Apps](https://developer.twitter.com/en/portal/dashboard) and create an application. If you don't have a developer account you need to apply for one, it can take some time to get approved.
 
 ### App permissions
 

--- a/source/_integrations/twitter.markdown
+++ b/source/_integrations/twitter.markdown
@@ -14,7 +14,7 @@ The `twitter` notification platform uses [Twitter](https://twitter.com) to deliv
 
 ## Setup
 
-Make sure you have a developer account registered with Twitter, then go to [Twitter Apps](https://apps.twitter.com/app/new) and create an application. If you don't have a developer account you need to apply for one, it can take some time to get approved.
+Make sure you have a developer account registered with Twitter, then go to [Twitter Apps](https://developer.twitter.com/en/portal/projects-and-apps) and create an application. If you don't have a developer account you need to apply for one, it can take some time to get approved.
 
 ### App permissions
 


### PR DESCRIPTION
Url to apps changed - https://developer.twitter.com/en/portal/projects-and-apps

## Proposed change
    Url to twitter developer apps has changed.

## Type of change
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
 - [x] The documentation follows the Home Assistant documentation [standards][].
