### PR TITLE
Add note that UDP port 20002 needs to be open

### DIFF
--- a/source/_integrations/switcher_kis.markdown
+++ b/source/_integrations/switcher_kis.markdown
@@ -23,7 +23,7 @@ Supported devices:
 - Switcher Power Plug
 - Switcher Touch (from firmware 1.51)
 - Switcher V2 (Espressif chipset - from firmware 3.21)
-- Switcher V2 (Qualcomm chipset - from firmware 72.32)
+- Switcher V2 (Qualcomm chipset - from firmware 72.32) Note: make sure port 20002 with udp is open.
 - Switcher V4
 
 If you completed the integration setup but are still unable to control the device, please make sure your device's firmware is up-to-date.


### PR DESCRIPTION

Had to run for UFW:
```
sudo ufw allow 20002/udp
```

You can see its being used here in the lib this integration imports:
https://github.com/TomerFi/aioswitcher/blob/dev/src/aioswitcher/bridge.py#L112

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I could not understand why my switcher is not detected. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
