### PR TITLE
Document that variables can be templated

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -84,7 +84,7 @@ Variables can be templated.
   variables:
     blind_state_message: "The blind is {{ states('cover.blind') }}."
 - alias: "Notify about the state of the blind"
-  service: notify.mobile_app_<your_device>
+  service: notify.mobile_app_iphone
   data:
     message: "{{ blind_state_message }}"
 ```

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -75,6 +75,22 @@ The variables action allows you to set/override variables that will be accessibl
 
 {% endraw %}
 
+Variables can be templated.
+
+{% raw %}
+
+```yaml
+- alias: "Set a templated variable"
+  variables:
+    blind_state_message: "The blind is {{ states('cover.blind') }}."
+- alias: "Notify about the state of the blind"
+  service: notify.mobile_app_<your_device>
+  data:
+    message: "{{ blind_state_message }}"
+```
+
+{% endraw %}
+
 ### Scope of Variables
 
 Variables have local scope. This means that if a variable is changed in a nested sequence block, that change will not be visible in an outer sequence block.


### PR DESCRIPTION
I didn't know until I (re)read https://companion.home-assistant.io/docs/notifications/actionable-notifications#building-notification-action-scripts.

## Proposed change
A simplistic example that shows templates are allowed. 

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
