### PR TITLE
Add note for H and J models

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -96,3 +96,7 @@ It's possible to switch between the 2 sources `TV` and `HDMI`.
 
 Samsung SmartTV does not allow WebSocket connections across different subnets or VLANs. If your TV is not on the same subnet as Home Assistant this will fail.
 It may be possible to bypass this issue by using IP masquerading or a proxy.
+
+#### H and J models
+
+Some televisions from H and J series use an encrypted protocol and require manual pairing with the TV. This should be detected automatically when attempting to send commands using the websocket connection, and trigger the corresponding authentication flow.

--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -99,4 +99,4 @@ It may be possible to bypass this issue by using IP masquerading or a proxy.
 
 #### H and J models
 
-Some televisions from H and J series use an encrypted protocol and require manual pairing with the TV. This should be detected automatically when attempting to send commands using the websocket connection, and trigger the corresponding authentication flow. Sending commands to these televisions is not yet supported.
+Some televisions from the H and J series use an encrypted protocol and require manual pairing with the TV. This should be detected automatically when attempting to send commands using the WebSocket connection, and trigger the corresponding authentication flow. Sending commands to these televisions is not yet supported.

--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -99,4 +99,4 @@ It may be possible to bypass this issue by using IP masquerading or a proxy.
 
 #### H and J models
 
-Some televisions from H and J series use an encrypted protocol and require manual pairing with the TV. This should be detected automatically when attempting to send commands using the websocket connection, and trigger the corresponding authentication flow.
+Some televisions from H and J series use an encrypted protocol and require manual pairing with the TV. This should be detected automatically when attempting to send commands using the websocket connection, and trigger the corresponding authentication flow. Sending commands to these televisions is not yet supported.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Some televisions from H and J series use an encrypted protocol and require manual pairing with the TV. This should be detected automatically when attempting to send commands using the websocket connection, and trigger the corresponding authentication flow.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/68500
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
