### PR TITLE
Add config flow for Min/Max

### DIFF
--- a/source/_integrations/min_max.markdown
+++ b/source/_integrations/min_max.markdown
@@ -14,26 +14,29 @@ ha_platforms:
   - sensor
 ---
 
-The `min_max` sensor platform consumes the state from other sensors to determine the minimum, maximum, latest (last), mean and median of the collected states. The sensor will always show you the lowest/highest/latest value which was received from all monitored sensors. If you have spikes in your values, it's recommended to filter/equalize your values with a [statistics sensor](/integrations/statistics) first.
+The Min/Max integration consumes the state from other sensors to determine the minimum, maximum, latest (last), mean and median of the collected states.
 
-This sensor is an alternative to the [template sensor](/integrations/template)'s `value_template:` to get the average or the median of multiple sensors.
+The sensor provided by this integration will always show you the lowest/highest/latest value which was received from all monitored sensors. If you have spikes in your values, it's recommended to filter/equalize your values with a [statistics sensor](/integrations/statistics) first.
 
-{% raw %}
+If the source sensor provides an unknown state, it will be ignored in the calculation. If the unit of measurement of the sensors differs, the Min/Max sensor will go to an error state where the value is `UNKNOWN` and unit of measurement is `ERR`.
 
-```yaml
-{{ ((float(states('sensor.kitchen_temperature')) +
-     float(states('sensor.living_room_temperature')) +
-     float(states('sensor.office_temperature'))) / 3) | round(2)
-}}
-```
+{% include integrations/config_flow.md %}
+{% configuration_basic %}
+Name:
+  description: The name the sensor should have. You can change it again later.
+Input entities:
+  description: At least two entities to monitor. All entities must use the same unit of measurement.
+Type:
+  description: The type of the sensor, this can be either "last", "max", "mean", "mean", or "median".
+Precision:
+  description: Round the calculated mean or median value to at most N decimal places.
+{% endconfiguration_basic %}
 
-{% endraw %}
+## YAML Configuration
 
-Sensors with an unknown state will be ignored in the calculation. If the unit of measurement of the sensors differs, the `min_max` sensor will go to an error state where the value is `UNKNOWN` and unit of measurement is `ERR`.
-
-## Configuration
-
-To enable the `min_max` sensor, add the following lines to your `configuration.yaml`:
+Alternatlively, this integration can be configured and set up manually via YAML
+instead. To enable the Integration sensor in your installation, add the
+following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/min_max.markdown
+++ b/source/_integrations/min_max.markdown
@@ -10,6 +10,7 @@ ha_quality_scale: internal
 ha_codeowners:
   - '@fabaff'
 ha_domain: min_max
+ha_config_flow: true
 ha_platforms:
   - sensor
 ---


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds documentation for the config flow of the Min/Max integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/67807
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
