### PR TITLE
Add documentation for PubliBike integration

### DIFF
--- a/source/_integrations/publibike.markdown
+++ b/source/_integrations/publibike.markdown
@@ -13,7 +13,7 @@ ha_config_flow: true
 This `publibike` sensor platform allows you to connect the [PubliBike API](https://api.publibike.ch/v1/static/api.html) to Home Assistant to access real time data on availability of [PubliBike](https://www.publibike.ch/)s in some Swiss cities. 
 It reports counts of available bikes and e-bikes given station geo-coordinates. Displayed count of available e-bikes can be adjusted to take into account their battery level, i.e. only show bikes with battery level higher than the provided threshold.
 
-Coordinates can be entered manually during configuration or picked up from Home Assistant's configuration - the sensor will find the nearest available PubliBike station. 
+Coordinates are picked up from Home Assistant's configuration (and can be adjusted manually using the integration's configuration panel) - the sensor will find the nearest available PubliBike station. 
 Alternatively, you can provide an ID of the station you want to get bikes for. See [here](https://github.com/misialq/publibike-stations) for the list of available stations (updated weekly).
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/publibike.markdown
+++ b/source/_integrations/publibike.markdown
@@ -1,0 +1,19 @@
+---
+title: PubliBike
+description: Instructions on how to integrate PubliBike API with Home Assistant
+ha_category: Transport
+ha_release: "2022.4"
+ha_iot_class: "Cloud Polling"
+ha_domain: publibike
+ha_codeowners:
+  - '@misialq'
+ha_config_flow: true
+---
+
+This `publibike` sensor platform allows you to connect the [PubliBike API](https://api.publibike.ch/v1/static/api.html) to Home Assistant to access real time data on availability of [PubliBike](https://www.publibike.ch/)s in some Swiss cities. 
+It reports counts of available bikes and e-bikes given station geo-coordinates. Displayed count of available e-bikes can be adjusted to take into account their battery level, i.e. only show bikes with battery level higher than the provided threshold.
+
+Coordinates can be entered manually during configuration or picked up from Home Assistant's configuration - the sensor will find the nearest available PubliBike station. 
+Alternatively, you can provide an ID of the station you want to get bikes for. See [here](https://github.com/misialq/publibike-stations) for the list of available stations (updated weekly).
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds documentation for the PubliBike integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/68526
- Link to parent pull request in the Brands repository: 
- ~This PR fixes or closes issue: fixes #~

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
