### PR TITLE
Fix ha-icon example in Markdown card documentation

### DIFF
--- a/source/_dashboards/markdown.markdown
+++ b/source/_dashboards/markdown.markdown
@@ -112,7 +112,7 @@ For example:
 ```yaml
 type: markdown
 content: |
-  <ha-icon icon="mdi:home-assistant" />
+  <ha-icon icon="mdi:home-assistant"></ha-icon>
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

In the Markdown Card documentation, it references using icons via the `ha-icon` tag. However, it tries to use the inline HTML tag closer, `/>` , which does not work with this tag. Using the full `</ha-icon>` instead works just fine. I am unsure if this is a bug, but having proper documentation for whats currently available seems important. 

![image](https://user-images.githubusercontent.com/20761757/160279318-3af21560-2afa-4445-87df-886aacc0c8ae.png)
![image](https://user-images.githubusercontent.com/20761757/160279323-8cadf9d4-600d-459d-a38d-37639389e55d.png)
![image](https://user-images.githubusercontent.com/20761757/160279326-cf07330f-a23d-493e-8fea-86ec0607b321.png)
![image](https://user-images.githubusercontent.com/20761757/160279330-ab01a8a2-d8f8-4112-b8bb-a35904182101.png)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- HA Community Post which is the origin of this section of the documentation, and even shows use of `</ha-icon>` instead, which is how I figured out this issue.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
