### PR TITLE
Update reference to BART in GTFS examples

### DIFF
--- a/source/_integrations/gtfs.markdown
+++ b/source/_integrations/gtfs.markdown
@@ -16,7 +16,7 @@ You need to find a valid GTFS data set, which you can usually find just by searc
 
 Here are some examples:
 
-- [Bay Area Rapid Transit (BART)](https://www.bart.gov/schedules/developers/gtfs) - The light rail system for the San Francisco Bay Area.
+- [Bay Area Rapid Transit (BART)](https://www.bart.gov/schedules/developers/gtfs) - The rapid transit system for the San Francisco Bay Area.
 - [Metropolitan Transit Authority of New York City (MTA)](http://web.mta.info/developers/) - Provides separate data feeds for subway, bus, LIRR and Metro-North of the greater New York City metropolitan region.
 - [Official Timetable Switzerland](https://opentransportdata.swiss/en/dataset/timetable-2019-gtfs) - The official timetable data for Switzerland in 2019.
 


### PR DESCRIPTION
## Proposed change
Update the examples in the GTFS documentation to refer to BART as a rapid transit system, rather than a light rail system.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
