### PR TITLE
Revert "Correct MQTT scene docs"

### DIFF
--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -59,9 +59,14 @@ availability_topic:
   required: false
   type: string
 command_topic:
-  description: The MQTT topic to publish `payload_on` to activate the scene.
+  description: The MQTT topic to publish commands to change the scene state.
   required: false
   type: string
+enabled_by_default:
+  description: Flag which defines if the entity should be enabled when first added.
+  required: false
+  type: boolean
+  default: true
 entity_category:
   description: The [category](https://developers.home-assistant.io/docs/core/entity#generic-properties) of the entity.
   required: false
@@ -91,7 +96,7 @@ payload_not_available:
   type: string
   default: offline
 payload_on:
-  description: The payload that will be sent to `command_topic` when activating the MQTT scene.
+  description: The payload that represents `on` state. If specified, will be used for both comparing to the value in the `state_topic` (see `value_template` and `state_on`  for details) and sending as `on` command to the `command_topic`.
   required: false
   type: string
   default: "ON"


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#22193

as per <https://github.com/home-assistant/home-assistant.io/pull/22193#pullrequestreview-925981260>