### PR TITLE
Documentation to address late review of nina

### DIFF
--- a/source/_integrations/nina.markdown
+++ b/source/_integrations/nina.markdown
@@ -23,11 +23,11 @@ For each county/city it creates warning slots that change to Unsafe when warning
 
 | Attribute    | Description                            |
 | ------------ | -------------------------------------- |
-| `Headline` | *(str)* Official headline of the warning. |
-| `Description` | *(str)* Official description of the warning. |
-| `Sender` | *(str)* Sender of the warning. Can be empty. |
-| `Severity` | *(str)* Severity of the warning. <br>Extreme - Extraordinary threat to life or property <br>Severe - Significant threat to life or property <br>Moderate - Possible threat to life or property <br>Minor – Minimal to no known threat to life or property <br>Unknown - Severity unknown |
-| `ID` | *(str)* Individual ID for each warning. |
-| `Sent` | *(time)* Transmission time and date (UTC) of the issued warning. |
-| `Start` | *(time)* Starting time and date (UTC) of the issued warning. Can be empty. |
-| `Expires` | *(time)* Expiration time and date (UTC) of the issued warning. Can be empty. |
+| `headline` | *(str)* Official headline of the warning. |
+| `description` | *(str)* Official description of the warning. |
+| `sender` | *(str)* Sender of the warning. Can be empty. |
+| `severity` | *(str)* Severity of the warning. <br>Extreme - Extraordinary threat to life or property <br>Severe - Significant threat to life or property <br>Moderate - Possible threat to life or property <br>Minor – Minimal to no known threat to life or property <br>Unknown - Severity unknown |
+| `id` | *(str)* Individual ID for each warning. |
+| `sent` | *(time)* Transmission time and date (UTC) of the issued warning. |
+| `start` | *(time)* Starting time and date (UTC) of the issued warning. Can be empty. |
+| `expires` | *(time)* Expiration time and date (UTC) of the issued warning. Can be empty. |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This pull request implements the changes made by improvements requested by @MartinHjelmare in https://github.com/home-assistant/core/pull/67135 (review).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
