### PR TITLE
Added note to distinguish Statistics integration v.s. Long-term statistics

### DIFF
--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -23,6 +23,12 @@ Both `sensor` and `binary_sensor` are supported as source sensor. A number of ch
 
 Assuming the [`recorder`](/integrations/recorder/) integration is running, historical sensor data is read from the database on startup and is available immediately after a restart of the platform. If the [`recorder`](/integrations/recorder/) integration is *not* running, it can take some time for the sensor to start reporting data because some characteristics calculations require more than one source sensor value.
 
+<div class='note tip'>
+
+The `statistics` integration is different to a [Long-term Statistics](https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics). More details on the differences can be found in the [2021.8.0 release notes](https://www.home-assistant.io/blog/2021/08/04/release-20218/#long-term-statistics).
+
+</div>
+
 ## Characteristics
 
 The following statistical characteristics are available. Pay close attention to the right configuration of `sampling_size` and `max_age`, as most characteristics are directly related to the count of samples or the age of processed samples.

--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -25,7 +25,7 @@ Assuming the [`recorder`](/integrations/recorder/) integration is running, histo
 
 <div class='note tip'>
 
-The `statistics` integration is different to a [Long-term Statistics](https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics). More details on the differences can be found in the [2021.8.0 release notes](https://www.home-assistant.io/blog/2021/08/04/release-20218/#long-term-statistics).
+The `statistics` integration is different to a [Long-term Statistics](https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics). More details on the differences can be found in the [2021.8.0 release notes](/blog/2021/08/04/release-20218/#long-term-statistics).
 
 </div>
 


### PR DESCRIPTION
## Proposed change
Added note section to make it very clear there is a difference between the Statistics integration and Long-term Statistics. I have referenced the 2021.8.0 release notes because it describes the differences very well.



## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #22161

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
