### PR TITLE
Update docs for select selector

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -752,9 +752,7 @@ select:
 {% configuration select %}
 options:
   description: > 
-    List of options that the user can choose from. Small lists (5 items or less),
-    are displayed as radio buttons. When more items are added, a dropdown list
-    is used.
+    List of options that the user can choose from. Small lists (5 items or less), are displayed as radio buttons. When more items are added, a dropdown list is used.
   type: list
   required: true
 multiple:
@@ -799,9 +797,7 @@ select:
 {% configuration select_map %}
 options:
   description: > 
-    List of options that the user can choose from. Small lists (5 items or less),
-    are displayed as radio buttons. When more items are added, a dropdown list
-    is used.
+    List of options that the user can choose from. Small lists (5 items or less), are displayed as radio buttons. When more items are added, a dropdown list is used.
   type: map
   required: true
   keys:

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -770,10 +770,11 @@ custom_value:
   required: false
   default: false
 mode:
-  description: This can be either `list` or `dropdown` mode.
+  description: >
+    This can be either `list` or `dropdown` mode. When not specified, the frontend
+    decides what input type to use.
   type: string
   required: false
-  default: The frontend decides.
 {% endconfiguration %}
 
 Alternatively, a mapping can be used for the options. When you want to return

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -809,11 +809,13 @@ options:
       type: string
 {% endconfiguration %}
 
-The output of this selector is the string of the selected option value.
-When selecting `Green` in the last example, it returns: `g`, in the first
-example it would return `Green`.
+When `multiple` is false, the output of this selector is the string of
+the selected option value. When selecting `Green` in the last example,
+it returns: `g`, in the first example it would return `Green`.
 
-There are additional optional 
+When `multiple` is true, the output of this selector is the list of selected
+option values. In this case, if `Green` was selected, in the first example it
+would return ["Green"] and in the last example it returns ["g"].
 
 ## Target selector
 

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -739,7 +739,7 @@ The select selector shows a list of available options from which the user can ch
 
 ![Screenshot of a select selector](/images/blueprints/selector-select.png)
 
-When `custom_value` (which adds support for users to enter custom values) is `false`, the selector requires a list of options that the user can choose from.
+The selector requires a list of options that the user can choose from.
 
 ```yaml
 select:
@@ -754,9 +754,9 @@ options:
   description: > 
     List of options that the user can choose from. Small lists (5 items or less),
     are displayed as radio buttons. When more items are added, a dropdown list
-    is used. Required when `custom_value` is `false`.
+    is used.
   type: list
-  required: false
+  required: true
 multiple:
   description: >
     Allows selecting multiple options. If set to `true`, the resulting value of
@@ -801,9 +801,9 @@ options:
   description: > 
     List of options that the user can choose from. Small lists (5 items or less),
     are displayed as radio buttons. When more items are added, a dropdown list
-    is used. Required when `custom_value` is `false`.
+    is used.
   type: map
-  required: false
+  required: true
   keys:
     label:
       description: The description to show in the UI for this item.

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -739,8 +739,7 @@ The select selector shows a list of available options from which the user can ch
 
 ![Screenshot of a select selector](/images/blueprints/selector-select.png)
 
-When `custom_value` (which adds support for users to enter custom values) is `false`,
-the selector requires a list of options that the user can choose from.
+When `custom_value` (which adds support for users to enter custom values) is `false`, the selector requires a list of options that the user can choose from.
 
 ```yaml
 select:
@@ -753,8 +752,9 @@ select:
 {% configuration select %}
 options:
   description: > 
-    List of options that the user can choose from. Small lists (5 items or less), are displayed as radio buttons. When more items are added, a dropdown list is used. Required when `custom_value`
-    is `false`.
+    List of options that the user can choose from. Small lists (5 items or less),
+    are displayed as radio buttons. When more items are added, a dropdown list
+    is used. Required when `custom_value` is `false`.
   type: list
   required: false
 multiple:
@@ -799,8 +799,9 @@ select:
 {% configuration select_map %}
 options:
   description: > 
-    List of options that the user can choose from. Small lists (5 items or less), are displayed as radio buttons. When more items are added, a dropdown list is used. Required when `custom_value`
-    is `false`.
+    List of options that the user can choose from. Small lists (5 items or less),
+    are displayed as radio buttons. When more items are added, a dropdown list
+    is used. Required when `custom_value` is `false`.
   type: map
   required: false
   keys:

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -739,7 +739,8 @@ The select selector shows a list of available options from which the user can ch
 
 ![Screenshot of a select selector](/images/blueprints/selector-select.png)
 
-The selector requires a list of options that the user can choose from.
+When `custom_value` (which adds support for users to enter custom values) is `false`,
+the selector requires a list of options that the user can choose from.
 
 ```yaml
 select:
@@ -752,9 +753,10 @@ select:
 {% configuration select %}
 options:
   description: > 
-    List of options that the user can choose from. Small lists (5 items or less), are displayed as radio buttons. When more items are added, a dropdown list is used.
+    List of options that the user can choose from. Small lists (5 items or less), are displayed as radio buttons. When more items are added, a dropdown list is used. Required when `custom_value`
+    is `false`.
   type: list
-  required: true
+  required: false
 multiple:
   description: >
     Allows selecting multiple options. If set to `true`, the resulting value of
@@ -765,15 +767,17 @@ multiple:
 custom_value:
   description: >
     Allows the user to enter and select a custom value (or multiple custom values
-    in addition to the listed options if `multiple` is set to true).
+    in addition to the listed options if `multiple` is set to `true`).
   type: boolean
   required: false
   default: false
 mode:
   description: >
-    This can be either `list` or `dropdown` mode. When not specified, the frontend
-    decides what input type to use. If `custom_value` is true, this setting will be
-    ignored and the frontend will use a `dropdown` input.
+    This can be either `list` (radio button) or `dropdown` (combobox) mode.
+    When not specified, small lists (5 items or less), are displayed as
+    radio buttons. When more items are added, a dropdown list is used. If
+    `custom_value` is `true`, this setting will be ignored and the frontend
+    will use a `dropdown` input.
   type: string
   required: false
 {% endconfiguration %}
@@ -795,9 +799,10 @@ select:
 {% configuration select_map %}
 options:
   description: > 
-    List of options that the user can choose from. Small lists (5 items or less), are displayed as radio buttons. When more items are added, a dropdown list is used.
+    List of options that the user can choose from. Small lists (5 items or less), are displayed as radio buttons. When more items are added, a dropdown list is used. Required when `custom_value`
+    is `false`.
   type: map
-  required: true
+  required: false
   keys:
     label:
       description: The description to show in the UI for this item.
@@ -809,11 +814,11 @@ options:
       type: string
 {% endconfiguration %}
 
-When `multiple` is false, the output of this selector is the string of
+When `multiple` is `false`, the output of this selector is the string of
 the selected option value. When selecting `Green` in the last example,
 it returns: `g`, in the first example it would return `Green`.
 
-When `multiple` is true, the output of this selector is the list of selected
+When `multiple` is `true`, the output of this selector is the list of selected
 option values. In this case, if `Green` was selected, in the first example it
 would return ["Green"] and in the last example it returns ["g"].
 

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -772,7 +772,8 @@ custom_value:
 mode:
   description: >
     This can be either `list` or `dropdown` mode. When not specified, the frontend
-    decides what input type to use.
+    decides what input type to use. If `custom_value` is true, this setting will be
+    ignored and the frontend will use a `dropdown` input.
   type: string
   required: false
 {% endconfiguration %}

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -755,6 +755,25 @@ options:
     List of options that the user can choose from. Small lists (5 items or less), are displayed as radio buttons. When more items are added, a dropdown list is used.
   type: list
   required: true
+multiple:
+  description: >
+    Allows selecting multiple options. If set to `true`, the resulting value of
+    this selector will be a list instead of a single string value.
+  type: boolean
+  required: false
+  default: false
+custom_value:
+  description: >
+    Allows the user to enter and select a custom value (or multiple custom values
+    in addition to the listed options if `multiple` is set to true).
+  type: boolean
+  required: false
+  default: false
+mode:
+  description: This can be either `list` or `dropdown` mode.
+  type: string
+  required: false
+  default: The frontend decides.
 {% endconfiguration %}
 
 Alternatively, a mapping can be used for the options. When you want to return
@@ -791,6 +810,8 @@ options:
 The output of this selector is the string of the selected option value.
 When selecting `Green` in the last example, it returns: `g`, in the first
 example it would return `Green`.
+
+There are additional optional 
 
 ## Target selector
 

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -773,7 +773,7 @@ custom_value:
   default: false
 mode:
   description: >
-    This can be either `list` (radio button) or `dropdown` (combobox) mode.
+    This can be either `list` (radio buttons) or `dropdown` (combobox) mode.
     When not specified, small lists (5 items or less), are displayed as
     radio buttons. When more items are added, a dropdown list is used. If
     `custom_value` is `true`, this setting will be ignored and the frontend


### PR DESCRIPTION
## Proposed change
Adocumenting the following new config options for the `select` selector from https://github.com/home-assistant/frontend/pull/12099 :
- `multiple`: Allows the user to select multiple items from the list
- `mode`: `list` forces a radio button list, `dropdown` forces a dropdown, nothing lets the frontend decide
- `custom_value`: Allows users to enter custom values into the selector



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/68952
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
