### PR TITLE
Add Mazda breaking changes to 2022.4 release notes

### DIFF
--- a/source/_posts/2022-04-06-release-20224.markdown
+++ b/source/_posts/2022-04-06-release-20224.markdown
@@ -1026,7 +1026,7 @@ removed from your YAML configuration files.
 {% details "Mazda" %}
 
 The Mazda services `start_engine`, `stop_engine`, `turn_on_hazard_lights`,
-and turn_off_hazard_lights are deprecated and have been replaced by button
+and `turn_off_hazard_lights` are deprecated and have been replaced by button
 entities. Please use the button entities instead.
 
 ([@bdr99] - [#67597]) ([documentation](/integrations/mazda))

--- a/source/_posts/2022-04-06-release-20224.markdown
+++ b/source/_posts/2022-04-06-release-20224.markdown
@@ -1023,6 +1023,29 @@ removed from your YAML configuration files.
 
 {% enddetails %}
 
+{% details "Mazda" %}
+
+The Mazda services `start_engine`, `stop_engine`, `turn_on_hazard_lights`,
+and turn_off_hazard_lights are deprecated and have been replaced by button
+entities. Please use the button entities instead.
+
+([@bdr99] - [#67597]) ([documentation](/integrations/mazda))
+
+[@bdr99]: https://github.com/bdr99
+[#67597]: https://github.com/home-assistant/core/pull/67597
+
+---
+
+The Mazda services `start_charging` and `stop_charging` are deprecated and
+replaced by a charging switch entity. Please use the switch entity instead.
+
+([@bdr99] - [#68025]) ([documentation](/integrations/mazda))
+
+[@bdr99]: https://github.com/bdr99
+[#68025]: https://github.com/home-assistant/core/pull/68025
+
+{% enddetails %}
+
 {% details "Met.no" %}
 
 The previously deprecated YAML configuration of the Met.no


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
It looks like the breaking changes to the Mazda integration from https://github.com/home-assistant/core/pull/67597 and https://github.com/home-assistant/core/pull/68025 were missed in the 2022.4 release notes. This PR adds them so that users will be informed of the deprecated services.

Hope it's OK to open a PR targeted at the `rc` branch. I waited a few days to see if this would be fixed, but now we are 1 day from release and it doesn't look like it will be fixed.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
