### PR TITLE
Fix typo in release notes

### DIFF
--- a/source/_posts/2022-04-06-release-20224.markdown
+++ b/source/_posts/2022-04-06-release-20224.markdown
@@ -965,7 +965,7 @@ Your existing YAML configuration is automatically imported on upgrade to this
 release; and thus can be safely removed from your YAML configuration
 after upgrading.
 
-([@davet2001] - [#52360]) ([documentation](/integrations/huawei_lte))
+([@davet2001] - [#52360]) ([documentation](/integrations/generic))
 
 [@davet2001]: https://github.com/davet2001
 [#52360]: https://github.com/home-assistant/core/pull/52360

--- a/source/_posts/2022-04-06-release-20224.markdown
+++ b/source/_posts/2022-04-06-release-20224.markdown
@@ -493,7 +493,7 @@ noteworthy changes this release:
 [Samsung TV]: /integrations/samsungtv
 [Shelly]: /integrations/shelly
 [these beautiful new icons]: https://pictogrammers.github.io/@mdi/font/6.6.96/
-[Timers]: /integration/timer
+[Timers]: /integrations/timer
 [TP-Link Kasa Smart]: /integrations/tplink
 [UniFi Protect]: /integrations/unifiprotect
 [Yamaha MusicCast]: /integrations/yamaha_musiccast


### PR DESCRIPTION
## Proposed change
A user in the comments found this typo



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
