### PR TITLE
Add new characteristics to statistics integration

### DIFF
--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -48,8 +48,8 @@ The following characteristics are supported for `sensor` source sensors:
 | `count` | The number of stored source sensor readings. This number is limited by `sampling_size` and can be low within the bounds of `max_age`.
 | `datetime_newest` | The timestamp of the newest measurement.
 | `datetime_oldest` | The timestamp of the oldest measurement.
-| `datetime_value_max` | The timestamp of the biggest value among the number of measurements.
-| `datetime_value_min` | The timestamp of the smallest value among the number of measurements.
+| `datetime_value_max` | The timestamp of the numerically biggest measurement.
+| `datetime_value_min` | The timestamp of the numerically smallest measurement.
 | `distance_95_percent_of_values` | A statistical indicator derived from the standard deviation of an assumed normal distribution. 95% of all stored values fall into a range of returned size.
 | `distance_99_percent_of_values` | A statistical indicator derived from the standard deviation of an assumed normal distribution. 99% of all stored values fall into a range of returned size.
 | `distance_absolute` | The difference between the extreme values of measurements. Equals `value_max` minus `value_min`.

--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -71,9 +71,9 @@ The following characteristic are supported for `binary_sensor` source sensors:
 | -------------------- | ----------- |
 | `average_step` | A percentage of time across all stored measurements, in which the binary source sensor was "On". If over the course of one hour, movement was detected for 6 minutes, the `average_step` is 10%.
 | `average_timeless` | The percentage of stored measurements, for which the binary source sensor was "On". Time in on/off states is ignored. If over the course of one hour, a single movement was detected, the `average_timeless` is 33.3% (assuming the stored measurements "Off", "On", "Off"). Equal to `mean`.
-| `count` | The number of stored source sensor readings. Be aware that only value changes are registered by default, except if the source sensor has the property `force_update`.
+| `count` | The number of stored source sensor readings.
 | `count_on` | The number of stored source sensor readings with the value "On". Be aware that only value changes are registered by default, except if the source sensor has the property `force_update`.
-| `count_off` | The number of stored source sensor readings with the value "Off".
+| `count_off` | The number of stored source sensor readings with the value "Off". Be aware that only value changes are registered by default, except if the source sensor has the property `force_update`.
 | `datetime_newest` | The timestamp of the newest measurement.
 | `datetime_oldest` | The timestamp of the oldest measurement.
 | `mean` | The percentage of stored measurements, for which the binary source sensor was "On". Time in on/off states is ignored. If over the course of one hour, a single movement was detected, the `average_timeless` is 33.3% (assuming the stored measurements "Off", "On", "Off").

--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -44,10 +44,12 @@ The following characteristics are supported for `sensor` source sensors:
 | `average_timeless` | The average value of stored measurements. This method assumes that all measurements are equally spaced and, therefore, time is ignored and a simple average of values is computed. Equal to `mean`.
 | `change_sample` | The average change per sample. The difference between the oldest and newest measurement is divided by the number of in-between measurements (n-1).
 | `change_second` | The average change per second. The difference between the oldest and newest measurement is divided by seconds between them.
-| `change` | The difference between the oldest and newest measurement stored.
+| `change` | The difference between the oldest and newest measurement.
 | `count` | The number of stored source sensor readings. This number is limited by `sampling_size` and can be low within the bounds of `max_age`.
-| `datetime_newest` | The timestamp of the newest measurement stored.
-| `datetime_oldest` | The timestamp of the oldest measurement stored.
+| `datetime_newest` | The timestamp of the newest measurement.
+| `datetime_oldest` | The timestamp of the oldest measurement.
+| `datetime_value_max` | The timestamp of the biggest value among the number of measurements.
+| `datetime_value_min` | The timestamp of the smallest value among the number of measurements.
 | `distance_95_percent_of_values` | A statistical indicator derived from the standard deviation of an assumed normal distribution. 95% of all stored values fall into a range of returned size.
 | `distance_99_percent_of_values` | A statistical indicator derived from the standard deviation of an assumed normal distribution. 99% of all stored values fall into a range of returned size.
 | `distance_absolute` | The difference between the extreme values of measurements. Equals `value_max` minus `value_min`.
@@ -69,7 +71,11 @@ The following characteristic are supported for `binary_sensor` source sensors:
 | -------------------- | ----------- |
 | `average_step` | A percentage of time across all stored measurements, in which the binary source sensor was "On". If over the course of one hour, movement was detected for 6 minutes, the `average_step` is 10%.
 | `average_timeless` | The percentage of stored measurements, for which the binary source sensor was "On". Time in on/off states is ignored. If over the course of one hour, a single movement was detected, the `average_timeless` is 33.3% (assuming the stored measurements "Off", "On", "Off"). Equal to `mean`.
-| `count` | The number of stored source sensor readings. This number is limited by `sampling_size` and can be low within the bounds of `max_age`.
+| `count` | The number of stored source sensor readings. Be aware that only value changes are registered by default, except if the source sensor has the property `force_update`.
+| `count_on` | The number of stored source sensor readings with the value "On". Be aware that only value changes are registered by default, except if the source sensor has the property `force_update`.
+| `count_off` | The number of stored source sensor readings with the value "Off".
+| `datetime_newest` | The timestamp of the newest measurement.
+| `datetime_oldest` | The timestamp of the oldest measurement.
 | `mean` | The percentage of stored measurements, for which the binary source sensor was "On". Time in on/off states is ignored. If over the course of one hour, a single movement was detected, the `average_timeless` is 33.3% (assuming the stored measurements "Off", "On", "Off").
 
 ## Attributes


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document new statistics characteristics from https://github.com/home-assistant/core/pull/62631


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/62631
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
