### PR TITLE
Updates Fronius docs adding consumption path

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -141,13 +141,13 @@ sensor:
 
 Now, you only need to configure Energy dashboard's params using the UI (first to values use the newly created entities, other ones are just the same as in the _"feed in path"_ config):
 
-- For `Grid consumption` use the meters `energy_bough` entity.
-- For `Return to grid` use the meters `energy_sold` entity.using `energy_bough`.
-- For `Solar production`: 
-  - If no battery is connected to an inverter: Add each inverters `Energy total` entity.
-  - If a battery is connected to an inverter: Use [Riemann sum](/integrations/integration/) over `Power photovoltaics` entity (from power_flow endpoint found in your `SolarNet` device)
-- `Battery systems` aren't supported directly. Use [Template](/integrations/template) to split and invert negative values of `Power battery` entity (from power_flow) for charging power (W) and positive values for discharging power (W). Then use [Riemann sum](/integrations/integration/) to integrate each into energy values (kWh).
-- For `Devices` use the Ohmpilots `Energy consumed` entity.
+- For **Grid consumption** use the meters `energy_bough` entity.
+- For **Return to grid** use the meters `energy_sold` entity.using `energy_bough`.
+- For **Solar production**: 
+  - If no battery is connected to an inverter: Add each inverters **Energy total** entity.
+  - If a battery is connected to an inverter: Use [Riemann sum](/integrations/integration/) over **Power photovoltaics** entity (from power_flow endpoint found in your **SolarNet** device)
+- **Battery systems** aren't supported directly. Use [Template](/integrations/template) to split and invert negative values of **Power battery** entity (from power_flow) for charging power (W) and positive values for discharging power (W). Then use [Riemann sum](/integrations/integration/) to integrate each into energy values (kWh).
+- For **Devices** use the Ohmpilots **Energy consumed** entity.
 
 
 ## Note

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -78,77 +78,28 @@ When a device is not responding correctly the update interval will increase to 1
 
 ## Energy dashboard
 
-Home Assistant's Energy Dashboard expects some sources of data to be configured for it to work properly. They mainly are the energy you get from the grid, the energy you send to the grid, the energy produced by your solar panels and others relative to batteries and devices you can see below.
-
-The meter integrated with de Fronius can be installed (and configured) in two different positions: _"feed in path"_ (`meter_location` = 0) or _"in consumption path"_ (`meter_location` = 1). In the first case, the meter provides all data you need but, in the second case, it doesn't so you need to calculate some of them by using helpers.
-
-How to know which is your case? Just go to your entities list and search `meter_location` to see the value it has.
-
-Below you can find instructions for configuring both cases.
-
-### Feed in path
-
-Recommended energy dashboard configuration for meter location in feed in path (`Meter location: 0`):
-
-- For `Grid consumption` use the meters `Energy real consumed` entity.
-- For `Return to grid` use the meters `Energy real produced` entity.
 - For `Solar production`: 
   - If no battery is connected to an inverter: Add each inverters `Energy total` entity.
   - If a battery is connected to an inverter: Use [Riemann sum](/integrations/integration/) over `Power photovoltaics` entity (from power_flow endpoint found in your `SolarNet` device)
 - `Battery systems` aren't supported directly. Use [Template](/integrations/template) to split and invert negative values of `Power battery` entity (from power_flow) for charging power (W) and positive values for discharging power (W). Then use [Riemann sum](/integrations/integration/) to integrate each into energy values (kWh).
 - For `Devices` use the Ohmpilots `Energy consumed` entity.
 
-### Consumption path
+The energy meter integrated with Fronius devices can be installed (and configured) in two different installation positions: _"feed in path"_ (`meter_location` = 0) or _"consumption path"_ (`meter_location` = 1). In the first case, the meter provides all data you need but, in the second case, it doesn't so you need to calculate some of them by using helpers.
 
-Recommended energy dashboard configuration for meter location in consumption path (`Meter location: 1`):
+### Feed in path meter
 
-This configuration has been possible thanks to [@GianlucaCollot work](https://github.com/GianlucaCollot), honors and credit go to him as I have just reproduced his work and documented it here :)
+Recommended energy dashboard configuration for meter location in feed in path:
 
-First you need to create the power entities in your `configuration.yaml`. Make sure to replace the name of the sensor, you may only need to update the IP on the end if it was auto-detected:
+- For `Grid consumption` use the meters `Energy real consumed` entity.
+- For `Return to grid` use the meters `Energy real produced` entity.
 
-```yaml
-template:
-  - sensor:
-    # Positive values are from grid
-    - name: "power_bought"
-      unit_of_measurement: W
-      state: >-
-        {{ max(states('sensor.power_grid_fronius_power_flow_0_XXX_XXX_XXX_XXX') | float, 0) }}
-      device_class: power
+### Consumption path meter
 
-    # Negative values are to grid
-    - name: "power_sold"
-      unit_of_measurement: W
-      state: >-
-        {{ max((0 - states('sensor.power_grid_fronius_power_flow_0_XXX_XXX_XXX_XXX') | float), 0) }}
-      device_class: power
-```
+Recommended energy dashboard configuration for meter location in consumption path:
 
-then, you need to create the energy entities that get data from the power ones (also in your `configuration.yaml` file):
-
-```yaml
-sensor:
-  - platform: integration
-    source: sensor.power_sold
-    name: energy_sold
-    round: 2
-    
-  - platform: integration
-    source: sensor.power_bought
-    name: energy_bought
-    round: 2
-```
-
-Now, you only need to configure Energy dashboard's params using the UI (first to values use the newly created entities, other ones are just the same as in the _"feed in path"_ config):
-
-- For **Grid consumption** use the meters `energy_bough` entity.
-- For **Return to grid** use the meters `energy_sold` entity.using `energy_bough`.
-- For **Solar production**: 
-  - If no battery is connected to an inverter: Add each inverters **Energy total** entity.
-  - If a battery is connected to an inverter: Use [Riemann sum](/integrations/integration/) over **Power photovoltaics** entity (from power_flow endpoint found in your **SolarNet** device)
-- **Battery systems** aren't supported directly. Use [Template](/integrations/template) to split and invert negative values of **Power battery** entity (from power_flow) for charging power (W) and positive values for discharging power (W). Then use [Riemann sum](/integrations/integration/) to integrate each into energy values (kWh).
-- For **Devices** use the Ohmpilots **Energy consumed** entity.
-
+- The "Power Grid" entity provided by the Fronius API is positive on import and negative on export. Split it up into import- and export-power entities by using helpers with templates `max(states(sensor.power_grid) | float, 0)` and `max(0 - states(sensor.power_grid) | float, 0)`.
+- Then use [Riemann sum](/integrations/integration/) to integrate these import-/export-power entities into energy values (kWh).
+- Use these energy entities for `Grid consumption` and `Return to grid` in the energy dashboard configuration.
 
 ## Note
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -80,7 +80,7 @@ When a device is not responding correctly the update interval will increase to 1
 
 Home Assistant's Energy Dashboard expects some sources of data to be configured for it to work properly. They mainly are the energy you get from the grid, the energy you send to the grid, the energy produced by your solar panels and others relative to batteries and devices you can see below.
 
-The meter integrated with de Fronius can be installed (and configured) in two different positions: _"feed in path"_ (`meter_location` = 0) or _"in consumption path"_ (`meter_location` = 1). In the first case, the meter provides all data you need but, in the second case, it doesn't so you need to calculate some of them by creating some entities in your configuration file.
+The meter integrated with de Fronius can be installed (and configured) in two different positions: _"feed in path"_ (`meter_location` = 0) or _"in consumption path"_ (`meter_location` = 1). In the first case, the meter provides all data you need but, in the second case, it doesn't so you need to calculate some of them by using helpers.
 
 How to know which is your case? Just go to your entities list and search `meter_location` to see the value it has.
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -104,26 +104,24 @@ Recommended energy dashboard configuration for meter location in consumption pat
 
 This configuration has been possible thanks to [@GianlucaCollot work](https://github.com/GianlucaCollot), honors and credit go to him as I have just reproduced his work and documented it here :)
 
-First you need to create the power entities in your `configuration.yaml`:
+First you need to create the power entities in your `configuration.yaml`. Make sure to replace the name of the sensor, you may only need to update the IP on the end if it was auto-detected:
 
 ```yaml
 template:
   - sensor:
-      # positive values are from grid
-      - name: "power_bought"
-        # friendly_name: 'Solar power production'
-        unit_of_measurement: W
-        state: >-
-          {{ max(states('sensor.power_grid_fronius_power_flow_0_XXX_XXX_XXX_XXX') | float, 0) }}
-        device_class: power
+    # Positive values are from grid
+    - name: "power_bought"
+      unit_of_measurement: W
+      state: >-
+        {{ max(states('sensor.power_grid_fronius_power_flow_0_XXX_XXX_XXX_XXX') | float, 0) }}
+      device_class: power
 
-      # negative values are to grid
-      - name: "power_sold"
-        # friendly_name: 'Solar power production'
-        unit_of_measurement: W
-        state: >-
-          {{ max((0 - states('sensor.power_grid_fronius_power_flow_0_XXX_XXX_XXX_XXX') | float), 0) }}
-        device_class: power
+    # Negative values are to grid
+    - name: "power_sold"
+      unit_of_measurement: W
+      state: >-
+        {{ max((0 - states('sensor.power_grid_fronius_power_flow_0_XXX_XXX_XXX_XXX') | float), 0) }}
+      device_class: power
 ```
 
 then, you need to create the energy entities that get data from the power ones (also in your `configuration.yaml` file):
@@ -134,13 +132,11 @@ sensor:
     source: sensor.power_sold
     name: energy_sold
     round: 2
-    #device_class: energy
     
   - platform: integration
     source: sensor.power_bought
     name: energy_bought
     round: 2
-    #device_class: energy
 ```
 
 Now, you only need to configure Energy dashboard's params using the UI (first to values use the newly created entities, other ones are just the same as in the _"feed in path"_ config):


### PR DESCRIPTION
## Proposed change
Documentation improvement.

Adds config steps for Froinus meter installed in consumption path. I've reproduced and tested myself this configuration from 
https://github.com/home-assistant/home-assistant.io/issues/21804

Documentation gives credit to real author (not me).


## Type of change

Documentation

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

Doesn't edit previous content.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: documents solution in closed issue #21804 

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
