### PR TITLE
Allow any entity to match state condition

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -136,7 +136,7 @@ condition:
 {% endraw %}
 
 It is also possible to test the condition against multiple entities at once.
-The condition will pass if all entities match the thresholds.
+The condition will pass if **all** entities match the thresholds.
 
 ```yaml
 condition:
@@ -190,7 +190,7 @@ condition:
 ```
 
 It is also possible to test the condition against multiple entities at once.
-The condition will pass if all entities match the state.
+The condition will pass if **all** entities match the state.
 
 ```yaml
 condition:
@@ -198,6 +198,19 @@ condition:
   entity_id:
     - light.kitchen
     - light.living_room
+  state: "on"
+```
+
+Instead of matching all, it is also possible if one of the entities matches.
+In the following example the condition will pass if **any** entities match the state.
+
+```yaml
+condition:
+  condition: state
+  entity_id:
+    - binary_sensor.motion_sensor_left
+    - binary_sensor.motion_sensor_right
+  match: any
   state: "on"
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds support for conditions, using multiple entities, to pass when any entity matches (instead of all entities).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/69763
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
