### PR TITLE
workday sensor example added to documentation

### DIFF
--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -146,6 +146,20 @@ binary_sensor:
       - 'Christmas Day'
 ```
 
+This example has two workday sensors. The default mon-fri workday and a 2nd `schoolday-name` sensor for tue-thu.
+
+```yaml
+# Example 5 configuration.yaml entry
+binary_sensor:
+  - platform: workday
+    name: workday-default
+    country: US
+  - platform: workday
+    name: schoolday-name
+    country: US
+    workdays: [tue, wed, thu]
+```
+
 ## Automation example
 
 Example usage for automation:


### PR DESCRIPTION
## Proposed change
Add example with 2 workday sensors

## Type of change
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information
People in this thread thought they were limited to 1 workday sensor.
https://community.home-assistant.io/t/create-2-different-calendars-for-different-automations-to-work-or-not/283634/13

