### PR TITLE
Add example blueprint media selector

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -631,6 +631,35 @@ metadata:
         media-source://tts/cloud?message=TTS+Message&language=en-US&gender=female
 ```
 
+### Example media selector
+
+An example media seletor in a simple script blueprint.
+
+```yaml
+blueprint:
+  name: Media Player Script Blueprint test
+  domain: script
+  input:
+    media:
+      name: Media File to play
+      selector:
+        media: {}
+variables:
+  _media: !input media
+  eid: '{{ _media.entity_id }}'
+  mid: '{{ _media.media_content_id }}'
+  mct: '{{ _media.media_content_type }}'
+sequence:
+- alias: Media Player Blueprint Script
+  service: media_player.play_media
+  target:
+    entity_id: "{{ eid }}"
+  data:
+    media_content_id:  "{{ mid }}"
+    media_content_type:  "{{ mct }}"
+mode: queued
+```
+
 ## Number selector
 
 The number selector shows either a number input or a slider input, that allows


### PR DESCRIPTION
A tested functioning Media Selector in a simple Media Player script blueprint.
It shows the user how to generate the variables to make this work as Paulus suggested here.
https://github.com/home-assistant/core/issues/69506

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I had a difficult time figuring this out and want to improve the experience of others trying to use this media selector.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
Tested as functional on 2022.4.2

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #69506

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
