### PR TITLE
Add Matrix HTML format message documentation

### DIFF
--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -182,6 +182,24 @@ The target room has to be precreated, the room id can be obtained from the rooms
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
 
+
+### Message formats
+
+Matrix supports sending messages as HTML; as markdown can be rendered to HTML, it is supported as well. To specify the message format, add it in the notification `data`.
+
+Supported formats are: `text` (default), `html`, and `markdown`.
+
+```yaml
+# Example of notification as HTML
+action:
+  service: notify.matrix_notify
+  data:
+    message: >-
+      <h1>Hello, world!</h1>
+    data:
+      format: html
+```
+
 ### Images in notification
 
 It is possible to send images with notifications. To do so, add a list of paths in the notification `data`.

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -197,7 +197,7 @@ action:
     message: >-
       <h1>Hello, world!</h1>
     data:
-      format: html
+      format: "html"
 ```
 
 ### Images in notification

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -185,9 +185,9 @@ To use notifications, please see the [getting started with automation page](/get
 
 ### Message formats
 
-Matrix supports sending messages using a [limited HTML subset](https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes); Markdown is also supported as it can be rendered to HTML. To specify the message format, add it in the notification `data`.
+Matrix supports sending messages using a [limited HTML subset](https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes). To specify the message format, add it in the notification `data`.
 
-Supported formats are: `text` (default), `html`, and `markdown`.
+Supported formats are: `text` (default), and `html`.
 
 ```yaml
 # Example of notification as HTML

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -185,7 +185,7 @@ To use notifications, please see the [getting started with automation page](/get
 
 ### Message formats
 
-Matrix supports sending messages as HTML; as markdown can be rendered to HTML, it is supported as well. To specify the message format, add it in the notification `data`.
+Matrix supports sending messages using a [limited HTML subset](https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes); Markdown is also supported as it can be rendered to HTML. To specify the message format, add it in the notification `data`.
 
 Supported formats are: `text` (default), `html`, and `markdown`.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds documentation for sending Matrix message notifications as HTML or Markdown.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/69951

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
