### PR TITLE
Add parallel automation/script actions

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -710,6 +710,76 @@ automation:
 
 {% endraw %}
 
+## Parallelizing actions
+
+By default, all sequences of actions in Home Assistant run sequentially. This
+means the next action is started after the current action has been completed.
+
+This is not always needed, for example, if the sequence of actions doesn't rely
+on each other and order doesn't matter. For those cases, the `parallel` action
+can be used to run the actions in the sequence in parallel, meaning all
+the actions are started at the same time.
+
+The following example shows sending messages out at the time (in parallel):
+
+```yaml
+automation:
+  - trigger:
+      - platform: state
+        entity_id: binary_sensor.motion
+        to: "on"
+    action:
+      - parallel:
+          - service: notify.person1
+            data:
+              message: "These messages are sent at the same time!"
+          - service: notify.person2
+            data:
+              message: "These messages are sent at the same time!"
+```
+
+It is also possible to run a group of actions sequantially inside the parallel
+actions. The example below demonstrates that:
+
+```yaml
+script:
+  example_script:
+    sequence:
+      - parallel:
+          - sequence:
+              - wait_for_trigger:
+                  - platform: state
+                    entity_id: binary_sensor.motion
+                    to: "on"
+              - service: notify.person1
+                data:
+                  message: "This message awaited the motion trigger"
+          - service: notify.person2
+            data:
+              message: "I am sent immediately and do not await the above action!"
+```
+
+<div class='note'>
+
+Running actions in parallel can be helpful in many cases, but use it with
+caution and only if you need it.
+
+There are some caveats (see below) when using parallel actions.
+
+While it sounds attractive to parallelize, most of the time, just the regular
+sequential actions will work just fine.
+
+</div>
+
+Some of the caveats of running actions in parallel:
+
+- There is no order guarantee. The actions will be started in parallel, but
+  there is no guarantee that they will be completed in the same order.
+- If one action fails or errors, the other actions will keep running until
+  they too have finished or errored.
+- Variables created/modified in one parallelized action are not available
+  in another parallelized action. Each step in a parallelized has its own scope.
+
 ## Stopping a script sequence
 
 It is possible to halt a script sequence at any point. Using the `stop` or


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds the possibility to run script sequences/automation actions (or groups of those) in parallel.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/69903
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
