### PR TITLE
Update LIFX documentation

### DIFF
--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -12,9 +12,7 @@ ha_platforms:
   - light
 ---
 
-The `lifx` integration allows you to integrate your [LIFX](https://www.lifx.com) into Home Assistant.
-
-_Please note, the `lifx` integration does not support Windows. The `lifx_legacy` light platform (supporting basic functionality) can be used instead._
+The `lifx` integration allows you to integrate your [LIFX](https://www.lifx.com) bulbs into Home Assistant.
 
 {% include integrations/config_flow.md %}
 
@@ -136,3 +134,19 @@ broadcast:
   required: false
   type: string
 {% endconfiguration %}
+
+## LIFX Switch
+
+The `lifx` integration does not support the LIFX Switch. However, the `homekit_controller` integration can be used instead for
+[LIFX Switch running firmware 3.90](https://support.lifx.com/en_us/switch-3-90-update-rk4zYiXVq) or higher. Follow the LIFX
+documentation to obtain a HomeKit code prior to integrating the Switch with Home Assistant as it will be needed during the process.
+
+When using the `homekit_controller` integration, each button on the LIFX Switch is discovered as a
+[stateless switch](/integrations/homekit_controller#stateless-switches-and-sensors) and will not appear as an entity in Home Assistant.
+Relays that are configured as wired to non-LIFX devices will appear as normal switches in Home Assistant.
+
+### Troubleshooting discovery
+
+If your switch is not automatically discovered or you get a "_Cannot add pairing as device can no longer be found_" error
+during the config process, [reboot your LIFX Switch](https://support.lifx.com/troubleshooting-switch-Hk6RWujLd) as they
+only broadcast HomeKit compatibility for 15 minutes.


### PR DESCRIPTION
## Proposed change

This removes the reference to `lifx_legacy` which no longer exists
and adds a section for the LIFX Switch which can only be integrated
using the homekit_controller component.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [X] Removed stale or deprecated documentation.

## Additional information

- Link to initial pull request in the codebase: ~https://github.com/home-assistant/core/pull/70027~
- Initial commit superceded by https://github.com/home-assistant/core/pull/70125 which has been merged.
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

Signed-off-by: Avi Miller <me@dje.li>