### PR TITLE
Update webostv.markdown

### DIFF
--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -32,7 +32,7 @@ To begin with enable *LG Connect Apps* feature in *Network* settings of the TV.
 
 ## Turn on action
 
-Home Assistant is able to turn on a LG webOS Smart TV if you specify an action, like HDMI-CEC or WakeOnLan.
+Home Assistant is able to turn on a LG webOS Smart TV if you specify an action, provided by an integration like [HDMI-CEC](https://www.home-assistant.io/integrations/hdmi_cec/) or [WakeOnLan](https://www.home-assistant.io/integrations/wake_on_lan/).
 
 Common for webOS 3.0 and higher would be to use WakeOnLan feature. To use this feature your TV should be connected to your network via Ethernet rather than Wireless and you should enable the *LG Connect Apps* feature in *Network* settings of the TV (or *Mobile App* in *General* settings for older models) (*may vary by version).
 

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -32,7 +32,7 @@ To begin with enable *LG Connect Apps* feature in *Network* settings of the TV.
 
 ## Turn on action
 
-Home Assistant is able to turn on a LG webOS Smart TV if you specify an action, provided by an integration like [HDMI-CEC](https://www.home-assistant.io/integrations/hdmi_cec/) or [WakeOnLan](https://www.home-assistant.io/integrations/wake_on_lan/).
+Home Assistant is able to turn on an LG webOS Smart TV if you specify an action, provided by an integration like [HDMI-CEC](/integrations/hdmi_cec/) or [WakeOnLan](/integrations/wake_on_lan/).
 
 Common for webOS 3.0 and higher would be to use WakeOnLan feature. To use this feature your TV should be connected to your network via Ethernet rather than Wireless and you should enable the *LG Connect Apps* feature in *Network* settings of the TV (or *Mobile App* in *General* settings for older models) (*may vary by version).
 


### PR DESCRIPTION
Turn on Action: clarify an additional integration which is not part of default_config: is required to enable either action. Helps new installs avoid needing to troubleshoot the automation to discover the integration is missing.

## Proposed change
Current docs don't meet HA Standards: "Integration and platform names should be a link to their respective documentation pages."

Makes following the documentation easier for less experienced HA users by allowing them to avoid troubleshooting an error that is obvious to more experienced users. 


## Type of change

- [] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
