### PR TITLE
Add ability to continue scripts/automations on error

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -733,6 +733,40 @@ or script as failed to run.
 - error: "Well, that was unexpected!"
 ```
 
+## Continuing on error
+
+By default, a sequence of actions will be halted when one of the actions in
+that sequence encounters an error. The automation or script will be halted,
+an error is logged, and the automation or script run is marked as errored.
+
+Sometimes these errors are expected, for example, because you know the service
+you call can be problematic at times, and it doesn't matter if it fails.
+You can set `continue_on_error` for those cases on such an action.
+
+The `continue_on_error` is available on all actions and is set to
+`false`. You can set it to `true` if you'd like to continue the action
+sequence, regardless of whether that action encounters an error.
+
+The example below shows the `continue_on_error` set on the first action. If
+it encounters an error; it will continue to the next action.
+
+```yaml
+- alias: "If this one fails..."
+  continue_on_error: true
+  service: notify.super_unreliable_service_provider
+  data:
+    message: "I'm going to error out..."
+
+- alias: "This one will still run!"
+  service: persistent_notification.create
+  data:
+    title: "Hi there!"
+    message: "I'm fine..."
+```
+
+Please note that `continue_on_error` will not suppress/ignore misconfiguration
+or errors that Home Assistant does not handle.
+
 [Script component]: /integrations/script/
 [automations]: /getting-started/automation-action/
 [Alexa/Amazon Echo]: /integrations/alexa/


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new `continue_on_error` flag for actions.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/70004
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
