### PR TITLE
Allow disabling specific triggers/actions/conditions

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -879,3 +879,23 @@ automation:
         - sensor.two
         - sensor.three
 ```
+
+## Disabling a trigger
+
+Every individual trigger in an automation can be disabled, without removing it.
+To do so, add `enabled: false` to the trigger. For example:
+
+```yaml
+# Example script with a disabled trigger
+automation:
+  trigger:
+    # This trigger will not trigger, as it is disabled.
+    # This automation does not run when the sun is set.
+    - enabled: false
+      platform: sun
+      event: sunset
+
+    # This trigger will fire, as it is not disabled.
+    - platform: time
+      at: "15:32:00"
+```

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -767,6 +767,31 @@ it encounters an error; it will continue to the next action.
 Please note that `continue_on_error` will not suppress/ignore misconfiguration
 or errors that Home Assistant does not handle.
 
+## Disabling an action
+
+Every individual action in a sequence can be disabled, without removing it.
+To do so, add `enabled: false` to the action. For example:
+
+```yaml
+# Example script with a disabled action
+script:
+  example_script:
+    sequence:
+      # This action will not run, as it is disabled.
+      # The message will not be sent.
+      - enabled: false
+        alias: "Notify that ceiling light is being turned on"
+        service: notify.notify
+        data:
+          message: "Turning on the ceiling light!"
+
+      # This action will run, as it is not disabled
+      - alias: "Turn on ceiling light"
+        service: light.turn_on
+        target:
+          entity_id: light.ceiling
+```
+
 [Script component]: /integrations/script/
 [automations]: /getting-started/automation-action/
 [Alexa/Amazon Echo]: /integrations/alexa/

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -630,3 +630,22 @@ condition:
 ```
 
 {% endraw %}
+
+## Disabling a condition
+
+Every individual condition can be disabled, without removing it.
+To do so, add `enabled: false` to the condition configuration.
+
+This can be useful if you want to temporarily disable a condition, for example,
+for testing. A disabled condition will always pass.
+
+For example:
+
+```yaml
+# This condition will always pass, as it is disabled.
+condition:
+  enabled: false
+  condition: state
+  entity_id: sun.sun
+  state: "above_horizon"
+```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This documents the new `enabled` option for all triggers, conditions and actions.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/70082
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
