### PR TITLE
Merge stop & error script actions

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -712,10 +712,9 @@ automation:
 
 ## Stopping a script sequence
 
-It is possible to halt a script sequence at any point. Using the `stop` or
-`error` action.
+It is possible to halt a script sequence at any point. Using the `stop` action.
 
-Both actions take a text as input explaining the reason for halting the
+The `stop` action takes a text as input explaining the reason for halting the
 sequence. This text will be logged and shows up in the automations and
 script traces.
 
@@ -726,11 +725,13 @@ for example, a condition is not met.
 - stop: "Stop running the rest of the sequence"
 ```
 
-The `error` action stops a script as well, but marks the automation
+There is also an `error` option, to indicate we are stopping because of
+an unexpected error. It stops the sequence as well, but marks the automation
 or script as failed to run.
 
 ```yaml
-- error: "Well, that was unexpected!"
+- stop: "Well, that was unexpected!"
+  error: true
 ```
 
 ## Continuing on error


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adjust the scripts documentation for the merger of the `stop` and `error` action.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/70109
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
