### PR TITLE
Add clear_skipped service to update entity

### DIFF
--- a/source/_integrations/update.markdown
+++ b/source/_integrations/update.markdown
@@ -114,6 +114,29 @@ Even if an update is skipped and shows as `off` (meaning no update), if there
 is a newer version available, calling the `update.install` service on the entity
 will still install the latest version.
 
+### Service {% my developer_call_service service="update.clear_skipped" %}
+
+The {% my developer_call_service service="update.clear_skipped" %} service can
+be used to remove skipped version marker of a previously skipped an offered
+update to the device or service.
+
+After skipping an offered update, the entity will return to the `off` state,
+but will not return to it until a newer version becomes available again.
+
+Using the `update.clear_skipped` service, the skipped version marker can be
+removed and thus the entity will return to the `on` state and the update
+notification will return.
+
+```yaml
+service: update.clear_skipped
+target:
+  entity_id:
+    - update.my_light_bulb
+```
+
+This can be helpful to, for example, in an automation that weekly unskips
+all updates you have previously marked as skipped; as a reminder to update.
+
 ## Example: Sending update available notifications
 
 A common use case for using update entities is to notify you if an update


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for the `update.clear_skipped` service.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/70116
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
