### PR TITLE
Add new QNAP QSW integration

### DIFF
--- a/source/_integrations/qnap_qsw.markdown
+++ b/source/_integrations/qnap_qsw.markdown
@@ -20,9 +20,9 @@ This integration interacts with the local API of [QNAP QSW switches](https://www
 
 {% configuration_basic %}
 URL:
-  description: "Device URL" (usually "http://IP")
+  description: "Device URL (usually http://IP)"
 Username:
-  description: "Username" (usually "admin")
+  description: "Username (usually admin)"
 Password:
   description: "Password"
 {% endconfiguration_basic %}

--- a/source/_integrations/qnap_qsw.markdown
+++ b/source/_integrations/qnap_qsw.markdown
@@ -14,7 +14,7 @@ ha_codeowners:
 ha_integration_type: integration
 ---
 
-This integration interacts with the local API of [QNAP QSW switches](https://www.qnap.com/).
+This integration interacts with the local API of [QNAP QSW managed switches](https://www.qnap.com/en/product/series/qsw-managed-switches).
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/qnap_qsw.markdown
+++ b/source/_integrations/qnap_qsw.markdown
@@ -1,0 +1,39 @@
+---
+title: QNAP QSW
+description: Instructions on how to integrate QNAP QSW within Home Assistant.
+ha_release: 2022.5
+ha_category:
+  - Sensor
+ha_iot_class: Local Polling
+ha_config_flow: true
+ha_domain: qnap_qsw
+ha_platforms:
+  - sensor
+ha_codeowners:
+  - '@Noltari'
+ha_integration_type: integration
+---
+
+This integration interacts with the local API of [QNAP QSW switches](https://www.qnap.com/).
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+URL:
+  description: "Device URL" (usually "http://IP")
+Username:
+  description: "Username" (usually "admin")
+Password:
+  description: "Password"
+{% endconfiguration_basic %}
+
+## Sensors
+
+The following *sensors* are created:
+
+| Condition           | Description                        |
+| :------------------ | :--------------------------------- |
+| fan_1_speed         | Fan 1 Speed.                       |
+| fan_2_speed         | Fan 2 Speed.                       |
+| temperature         | Switch temperature.                |
+| uptime              | Uptime seconds.                    |


### PR DESCRIPTION
## Proposed change
Document new integration for monitoring [QNAP QSW managed switches](https://www.qnap.com/en/product/series/qsw-managed-switches).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
 - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands). https://github.com/home-assistant/brands/pull/2904
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/70151
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2904
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
