### PR TITLE
Add Wikipedia link to derivative

### DIFF
--- a/source/_integrations/derivative.markdown
+++ b/source/_integrations/derivative.markdown
@@ -18,7 +18,7 @@ ha_platforms:
 ha_integration_type: helper
 ---
 
-The derivative integration creates a sensor that estimates the derivative of the
+The derivative ([Wikipedia](https://en.wikipedia.org/wiki/Derivative)) integration creates a sensor that estimates the derivative of the
 values provided by another sensor (the **source sensor**). Derivative sensors are updated upon changes of the **source sensor**.
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
Fixes https://github.com/home-assistant/home-assistant.io/issues/22395

Added a Wikipedia link that explains derivatives. 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
