### PR TITLE
Detail the event data for folder_watcher

### DIFF
--- a/source/_integrations/folder_watcher.markdown
+++ b/source/_integrations/folder_watcher.markdown
@@ -55,6 +55,17 @@ folder_watcher:
 
 ## Automations
 
+The elements the events contain are:
+- `event_type`: matching the `event_type` of the filter (one of `created`, `moved`, `modified`, `deleted`, `closed`)
+- `path`: The full path to the file (e.g. "/hello/world.txt")
+- `file`: The name of the file (e.g. "world.txt")
+- `folder`: The folder path (e.g. "/hello")
+
+When the `event_type` is `moved`, the file details are for the source file and destination details are included:
+- `dest_path`: The full path to the moved file (e.g. "/hello/world.txt")
+- `dest_file`: The name of the moved file (e.g. "world.txt")
+- `dest_folder`: The folder moved path (e.g. "/hello")
+
 Automations can be triggered on filesystem event data using a template. The following automation will send a notification with the name and folder of new files added to that folder:
 
 {% raw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fully describe the event data of the folder_watcher component, especially the new destination details available for `moved` events.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#70252
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
