### PR TITLE
Revert "Add target_temp_step to generic_thermostat"

### DIFF
--- a/source/_integrations/generic_thermostat.markdown
+++ b/source/_integrations/generic_thermostat.markdown
@@ -106,11 +106,6 @@ precision:
   required: false
   type: float
   default: "`0.1` for Celsius and `1.0` for Fahrenheit."
-target_temp_step:
-  description: "The desired step size for setting the target temperature. Supported values are `0.1`, `0.5` and `1.0`."
-  required: false
-  type: float
-  default: "equal to `precision`."
 {% endconfiguration %}
 
 Time for `min_cycle_duration` and `keep_alive` must be set as "hh:mm:ss" or it must contain at least one of the following entries: `days:`, `hours:`, `minutes:`, `seconds:` or `milliseconds:`. Alternatively, it can be an integer that represents time in seconds.


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#20052

- https://github.com/home-assistant/core/pull/70299

Note: we can wait with this revert few days as we try to resolve and undo the core revert