### PR TITLE
Remove EVENT_TIME_CHANGED and EVENT_TIMER_OUT_OF_SYNC

### DIFF
--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -124,22 +124,6 @@ This event is fired when a state has changed. It contains the entity identifier 
 
 This event is fired after a theme has been set or reloaded. It contains no additional data.
 
-### `timer_out_of_sync`
-
-This event is fired after `time_changed` if there was more that one second delay.
-
-| Field     | Description           |
-| --------- | --------------------- |
-| `seconds` | The delay in seconds. |
-
-### `time_changed`
-
-This event is fired every second by the timer and contains the current time.
-
-| Field | Description                                                                                                                |
-| ----- | -------------------------------------------------------------------------------------------------------------------------- |
-| `now` | A [datetime object](https://docs.python.org/3/library/datetime.html#datetime.datetime) containing the current time in UTC. |
-
 ## `user_added`
 
 This event is fired when a user has been added.

--- a/source/_integrations/history.markdown
+++ b/source/_integrations/history.markdown
@@ -164,7 +164,7 @@ The following characters can be used in entity globs:
 The history is stored in a SQLite database `home-assistant_v2.db` within your
 configuration directory unless the `recorder` integration is set up differently.
 
-- events table is all events except `time_changed` that happened while recorder integration was running.
+- events table is all that happened while recorder integration was running.
 - states table contains all the `new_state` values of `state_changed` events.
 - Inside the states table you have:
   - `entity_id`: the entity_id of the entity


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The `time_changed` and `timer_out_of_sync` events are no longer fired, and have been phased out in favor of asyncio
event loop scheduling.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/69643
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
