### PR TITLE
Prepend the generated speech stream with a configurable amount of silence

### DIFF
--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -29,10 +29,18 @@ language:
   required: false
   type: string
   default: "`en`"
+
+delay:
+  description: "Prepend the generated speech with this amount of silence (miliseconds)."
+  required: false
+  type: int
+  default: 0
 {% endconfiguration %}
 
 Check the [complete list of supported languages](https://translate.google.com/intl/en_ALL/about/languages/) (languages where "Talk" feature is enabled in Google Translate) for allowed values.
 Use the 2 digit language code which you can find at the end of URL when you click on Language name.
+
+With the `delay` option you can add some silence to the beginning of the rendered speech, to cope with audio systems which need time to wake up their speakers when starting a network stream. Value is in miliseconds, maximum is 15000 (15s).
 
 For more information about using text-to-speech with Home Assistant and more details on all the options it provides, see the [TTS documentation](/integrations/tts/).
 
@@ -45,4 +53,5 @@ A full configuration sample including optional variables:
 tts:
   - platform: google_translate
     language: "de"
+    delay: 1000
 ```

--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -33,7 +33,7 @@ language:
 delay:
   description: "Prepend the generated speech with this amount of silence (miliseconds)."
   required: false
-  type: int
+  type: integer
   default: 0
 {% endconfiguration %}
 

--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -40,7 +40,7 @@ delay:
 Check the [complete list of supported languages](https://translate.google.com/intl/en_ALL/about/languages/) (languages where "Talk" feature is enabled in Google Translate) for allowed values.
 Use the 2 digit language code which you can find at the end of URL when you click on Language name.
 
-With the `delay` option you can add some silence to the beginning of the rendered speech, to cope with audio systems which need time to wake up their speakers when starting a network stream. Value is in miliseconds, maximum is 15000 (15s).
+With the `delay` option you can add some silence to the beginning of the rendered speech, to cope with audio systems which need time to wake up their speakers when starting a network stream. Value is in milliseconds, maximum is 15000 (15s).
 
 For more information about using text-to-speech with Home Assistant and more details on all the options it provides, see the [TTS documentation](/integrations/tts/).
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/70440
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
