### PR TITLE
Describe Plex "scan_clients" button

### DIFF
--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -114,8 +114,12 @@ play_plex_on_tv:
         entity_id: media_player.smart_tv
       data:
         source: "Plex"
-    - wait_template: "{{ is_state('media_player.smart_tv', 'On') }}"
-      timeout: "00:00:10"
+    - wait_for_trigger:
+        - platform: state
+          entity_id: media_player.smart_tv
+          to: "on"
+      timeout:
+        seconds: 10
     - service: button.press
       target:
         entity_id: button.scan_clients_plex

--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -26,6 +26,7 @@ Support for playing music directly on linked [Sonos](/integrations/sonos/) speak
 There is currently support for the following device types within Home Assistant:
 
 - [Sensor](#sensor)
+- [Button](#button)
 - [Media Player](#media-player)
 
 If a Plex server has been claimed by a Plex account via the [claim interface](https://plex.tv/claim), Home Assistant will require authentication to connect.
@@ -97,6 +98,39 @@ The library sensors are disabled by default, but can be enabled via the Plex int
   
 </div>
 
+## Button
+
+A `button.scan_clients` entity is available to discover new controllable Plex clients. This may be necessary in scripts or automations which control a Plex client app, but where the underlying device must be turned on first. This button is preferred over the legacy `plex.scan_for_clients` service.
+
+Example script:
+
+{% raw %}
+
+```yaml
+play_plex_on_tv:
+  sequence:
+    - service: media_player.select_source
+      target:
+        entity_id: media_player.smart_tv
+      data:
+        source: "Plex"
+    - wait_template: "{{ is_state('media_player.smart_tv', 'On') }}"
+      timeout: "00:00:10"
+    - service: button.press
+      target:
+        entity_id: button.scan_clients_plex
+    - wait_template: "{{ not is_state('media_player.plex_smart_tv', 'unavailable') }}"
+      timeout: "00:00:10"
+      continue_on_timeout: false
+    - service: media_player.play_media
+      target:
+        entity_id: media_player.plex_smart_tv
+      data:
+        media_content_id: "{"library_name": "Movies", "title": "Zoolander"}"
+        media_content_type: movie
+```
+
+{% endraw %}
 
 ## Media Player
 
@@ -333,37 +367,6 @@ Refresh a Plex library to scan for new and updated media.
 | `server_name` | No | Name of Plex server to use if multiple servers configured. | "My Plex Server" |
 | `library_name` | Yes | Name of Plex library to update. | "TV Shows" |
 
-### Service `plex.scan_for_clients`
-
-Scan for new controllable Plex clients. This may be necessary in scripts or automations which control a Plex `media_player` entity, but where the underlying device must be turned on first.
-
-Example script:
-
-{% raw %}
-
-```yaml
-play_plex_on_tv:
-  sequence:
-    - service: media_player.select_source
-      target:
-        entity_id: media_player.smart_tv
-      data:
-        source: "Plex"
-    - wait_template: "{{ is_state('media_player.smart_tv', 'On') }}"
-      timeout: "00:00:10"
-    - service: plex.scan_for_clients
-    - wait_template: "{{ not is_state('media_player.plex_smart_tv', 'unavailable') }}"
-      timeout: "00:00:10"
-      continue_on_timeout: false
-    - service: media_player.play_media
-      target:
-        entity_id: media_player.plex_smart_tv
-      data:
-        media_content_id: "{"library_name": "Movies", "title": "Zoolander"}"
-        media_content_type: movie
-```
-
-{% endraw %}
 
 ## Notes
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds a description of the "scan clients" `button` entity added to Plex.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/67055
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
