### PR TITLE
Fixed spelling mistake in template example in 2022.2 release note

### DIFF
--- a/source/_posts/2022-02-02-release-20222.markdown
+++ b/source/_posts/2022-02-02-release-20222.markdown
@@ -322,7 +322,7 @@ a "Yes" or "No" (or similar) value in templates. Some examples:
 ```yaml
 {{ iif(is_state('light.kitchen', 'on'), 'Yes', 'No') }}
 {{ is_state('light.kitchen', 'on') | iif('Yes', 'No') }}
-{{ (state('light.kitchen') == 'on') | iif('Yes', 'No') }}
+{{ (states('light.kitchen') == 'on') | iif('Yes', 'No') }}
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
`iif()` example was missing a "s" in the template example so corrected the release notes so it won't error if anyone copied the example.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #21497

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
