### PR TITLE
Document new Airzone thermostat low battery warning

### DIFF
--- a/source/_integrations/airzone.markdown
+++ b/source/_integrations/airzone.markdown
@@ -42,6 +42,7 @@ For each Airzone zone (Thermostat), the following *binary sensors* are created:
 | Condition           | Description                        |
 | :------------------ | :--------------------------------- |
 | air_demand          | HVAC is running.                   |
+| battery_low         | Thermostat battery warning.        |
 | floor_demand        | Radiating floor is running.        |
 | problems            | Zone has errors or warnings.       |
 


### PR DESCRIPTION
## Proposed change
Document new Airzone thermostat low battery warning.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/69022
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
