### PR TITLE
Docs: Add Rust as dependency for source installation

### DIFF
--- a/source/_includes/installation/core.md
+++ b/source/_includes/installation/core.md
@@ -33,7 +33,7 @@ sudo apt-get upgrade -y
 Install the dependencies:
 
 ```bash
-sudo apt-get install -y python3 python3-dev python3-venv python3-pip libffi-dev libssl-dev libjpeg-dev zlib1g-dev autoconf build-essential libopenjp2-7 libtiff5 libturbojpeg0-dev tzdata rustc
+sudo apt-get install -y python3 python3-dev python3-venv python3-pip libffi-dev libssl-dev libjpeg-dev zlib1g-dev autoconf build-essential libopenjp2-7 libtiff5 libturbojpeg0-dev tzdata rustc cargo
 ```
 
 The above-listed dependencies might differ or missing, depending on your system or personal use of Home Assistant.

--- a/source/_includes/installation/core.md
+++ b/source/_includes/installation/core.md
@@ -33,7 +33,7 @@ sudo apt-get upgrade -y
 Install the dependencies:
 
 ```bash
-sudo apt-get install -y python3 python3-dev python3-venv python3-pip libffi-dev libssl-dev libjpeg-dev zlib1g-dev autoconf build-essential libopenjp2-7 libtiff5 libturbojpeg0-dev tzdata
+sudo apt-get install -y python3 python3-dev python3-venv python3-pip libffi-dev libssl-dev libjpeg-dev zlib1g-dev autoconf build-essential libopenjp2-7 libtiff5 libturbojpeg0-dev tzdata rustc
 ```
 
 The above-listed dependencies might differ or missing, depending on your system or personal use of Home Assistant.


### PR DESCRIPTION
## Proposed change

When building Home Assistant and its required dependencies from source (e.g. on a platform without pre-built wheels),
a recent version of the Rust compiler is required to build the Python "cryptography" module.

Otherwise, the following error occurs:

```
  Building wheel for cryptography (PEP 517) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/homeassistant/venv/bin/python3 /tmp/tmp3dbesfux_in_process.py build_wheel /tmp/tmp_c7dj4fc
       cwd: /tmp/pip-install-0oiog5r2/cryptography_93a1421695c246a39bcfa7a09b4e9f2e
  Complete output (168 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-armv7l-cpython-39
  creating build/lib.linux-armv7l-cpython-39/cryptography
  copying src/cryptography/utils.py -> build/lib.linux-armv7l-cpython-39/cryptography
  copying src/cryptography/fernet.py -> build/lib.linux-armv7l-cpython-39/cryptography
  copying src/cryptography/exceptions.py -> build/lib.linux-armv7l-cpython-39/cryptography
  copying src/cryptography/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography
  copying src/cryptography/__about__.py -> build/lib.linux-armv7l-cpython-39/cryptography
  creating build/lib.linux-armv7l-cpython-39/cryptography/x509
  copying src/cryptography/x509/oid.py -> build/lib.linux-armv7l-cpython-39/cryptography/x509
  copying src/cryptography/x509/ocsp.py -> build/lib.linux-armv7l-cpython-39/cryptography/x509
  copying src/cryptography/x509/name.py -> build/lib.linux-armv7l-cpython-39/cryptography/x509
  copying src/cryptography/x509/general_name.py -> build/lib.linux-armv7l-cpython-39/cryptography/x509
  copying src/cryptography/x509/extensions.py -> build/lib.linux-armv7l-cpython-39/cryptography/x509
  copying src/cryptography/x509/certificate_transparency.py -> build/lib.linux-armv7l-cpython-39/cryptography/x509
  copying src/cryptography/x509/base.py -> build/lib.linux-armv7l-cpython-39/cryptography/x509
  copying src/cryptography/x509/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/x509
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat
  copying src/cryptography/hazmat/_oid.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat
  copying src/cryptography/hazmat/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/poly1305.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/padding.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/keywrap.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/hmac.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/hashes.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/constant_time.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/cmac.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_serialization.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_cipheralgorithm.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_asymmetric.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings
  copying src/cryptography/hazmat/bindings/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends
  copying src/cryptography/hazmat/backends/interfaces.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends
  copying src/cryptography/hazmat/backends/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/totp.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/hotp.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/twofactor
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/ssh.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/pkcs7.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/pkcs12.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/base.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/serialization
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/x963kdf.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/scrypt.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/pbkdf2.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/kbkdf.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/hkdf.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/concatkdf.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/kdf
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/modes.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/base.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/algorithms.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/aead.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/ciphers
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/x448.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/x25519.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/utils.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/types.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/rsa.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/padding.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ed448.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ed25519.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ec.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/dsa.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/dh.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/primitives/asymmetric
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/binding.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/_conditional.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings/openssl
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x509.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x448.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x25519.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/utils.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/rsa.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/poly1305.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/hmac.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/hashes.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/encode_asn1.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ed448.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ed25519.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ec.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/dsa.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/dh.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/decode_asn1.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/cmac.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ciphers.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/backend.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/aead.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/__init__.py -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/backends/openssl
  running egg_info
  writing src/cryptography.egg-info/PKG-INFO
  writing dependency_links to src/cryptography.egg-info/dependency_links.txt
  writing requirements to src/cryptography.egg-info/requires.txt
  writing top-level names to src/cryptography.egg-info/top_level.txt
  reading manifest file 'src/cryptography.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  no previously-included directories found matching 'docs/_build'
  warning: no previously-included files found matching 'vectors'
  warning: no previously-included files matching '*' found under directory 'vectors'
  warning: no previously-included files matching '*' found under directory '.github'
  warning: no previously-included files found matching 'release.py'
  warning: no previously-included files found matching '.coveragerc'
  warning: no previously-included files found matching 'codecov.yml'
  warning: no previously-included files found matching '.readthedocs.yml'
  warning: no previously-included files found matching 'dev-requirements.txt'
  warning: no previously-included files found matching 'tox.ini'
  warning: no previously-included files found matching 'mypy.ini'
  warning: no previously-included files matching '*' found under directory '.zuul.d'
  warning: no previously-included files matching '*' found under directory '.zuul.playbooks'
  adding license file 'LICENSE'
  adding license file 'LICENSE.APACHE'
  adding license file 'LICENSE.BSD'
  adding license file 'LICENSE.PSF'
  writing manifest file 'src/cryptography.egg-info/SOURCES.txt'
  copying src/cryptography/py.typed -> build/lib.linux-armv7l-cpython-39/cryptography
  creating build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/__init__.pyi -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/asn1.pyi -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/ocsp.pyi -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/x509.pyi -> build/lib.linux-armv7l-cpython-39/cryptography/hazmat/bindings/_rust
  running build_ext
  running build_rust
  
      =============================DEBUG ASSISTANCE=============================
      If you are seeing a compilation error please try the following steps to
      successfully install cryptography:
      1) Upgrade to the latest pip and try again. This will fix errors for most
         users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
      2) Read https://cryptography.io/en/latest/installation/ for specific
         instructions for your platform.
      3) Check our frequently asked questions for more information:
         https://cryptography.io/en/latest/faq/
      4) Ensure you have a recent Rust toolchain installed:
         https://cryptography.io/en/latest/installation/#rust
  
      Python: 3.9.2
      platform: Linux-5.15.25-sunxi-armv7l-with-glibc2.31
      pip: n/a
      setuptools: 62.1.0
      setuptools_rust: 1.2.0
      =============================DEBUG ASSISTANCE=============================
  
  error: can't find Rust compiler
  
  If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.
  
  To update pip, run:
  
      pip install --upgrade pip
  
  and then retry package installation.
  
  If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.
  
  This package requires Rust >=1.41.0.
  ----------------------------------------
  ERROR: Failed building wheel for cryptography
```

This patch adds the required dependency to the documentation.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
