### PR TITLE
BMW: Revert #22452, remove refresh button documentation 

### DIFF
--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -129,18 +129,9 @@ The `button.<your_vehicle>_find_vehicle` button requests the vehicle to update t
 
 </div>
 
-## Update the state / refresh from API
+### Update the state / refresh from API
 
-To force a refresh from the BMW servers to Home Assistant, execute the `homeassistant.update_entity` service on an arbitrary entity such as the lock or any sensor.
-
-```yaml
-...
-service: homeassistant.update_entity
-target:
-  entity_id: binary_sensor.<your_vehicle>_windows
-```
-
-This does *not* trigger an update from the vehicle; it gets the data from the BMW servers, so this service does *not* interact with your vehicles.
+The `button.<vehicle_model>_refresh_from_api` button fetches the last state of the vehicles of all your accounts from the BMW server. This does *not* trigger an update from the vehicle; it gets the data from the BMW servers. So this service does *not* interact with your vehicles.
 
 ## Disclaimer
 

--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -129,16 +129,6 @@ The `button.<your_vehicle>_find_vehicle` button requests the vehicle to update t
 
 </div>
 
-### Update the state / refresh from API
-
-<div class="note">
-
-  This button is deprecated and will be removed in a future version.
-
-</div>
-
-The `button.<vehicle_model>_refresh_from_api` button fetches the last state of the vehicles of all your accounts from the BMW server. This does *not* trigger an update from the vehicle; it gets the data from the BMW servers. So this service does *not* interact with your vehicles.
-
 ## Disclaimer
 
 This software is not affiliated with or endorsed by BMW Group.

--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -131,6 +131,12 @@ The `button.<your_vehicle>_find_vehicle` button requests the vehicle to update t
 
 ### Update the state / refresh from API
 
+<div class="note">
+
+  This button is deprecated and will be removed in a future version.
+
+</div>
+
 The `button.<vehicle_model>_refresh_from_api` button fetches the last state of the vehicles of all your accounts from the BMW server. This does *not* trigger an update from the vehicle; it gets the data from the BMW servers. So this service does *not* interact with your vehicles.
 
 ## Disclaimer


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Reverts #22452 (see https://github.com/home-assistant/home-assistant.io/pull/22452#discussion_r858422662) and adds a deprecation notice.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
