### PR TITLE
hassio: Add missing compressed attribute to backup

### DIFF
--- a/source/_integrations/hassio.markdown
+++ b/source/_integrations/hassio.markdown
@@ -109,6 +109,7 @@ Create a full backup.
 | ---------------------- | -------- | ----------- |
 | `name` | yes | Name of the backup file. Default is current date and time
 | `password` | yes | Optional password for backup
+| `compressed` | yes | `false` to create uncompressed backups
 
 ### Service hassio.backup_partial
 
@@ -120,6 +121,7 @@ Create a partial backup.
 | `folders` | yes | List of directories to backup
 | `name` | yes | Name of the backup file. Default is current date and time
 | `password` | yes | Optional password for backup
+| `compressed` | yes | `false` to create uncompressed backups
 
 ### Service hassio.restore_full
 


### PR DESCRIPTION
Backup archives can be uncompressed, but the hassio integration docs don't mention it.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/70819 -  https://github.com/home-assistant/supervisor/pull/3378 and 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
