### PR TITLE
Device class for covers can't be set on the group

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -74,7 +74,7 @@ binary_sensor:
       - binary_sensor.door_right_contact
 ```
 
-Example YAML configuration of a cover group:
+Example YAML configuration of a cover group (the [`device_class`](https://www.home-assistant.io/integrations/cover/#device-class) must be set via the [customize section](https://www.home-assistant.io/docs/configuration/customizing-devices/) or UI):
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
## Proposed change
Missing information.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
