### PR TITLE
Make it clear that friendly_name can be used here

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -164,6 +164,10 @@ binary_sensor:
           description: The attribute and corresponding template.
           required: true
           type: template
+      friendly_name: 
+        description: Name to use in the frontend.
+        required: false
+        type: string      
     device_class:
       description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below). It does not set the `unit_of_measurement`.
       required: false


### PR DESCRIPTION
This is based on reading https://community.home-assistant.io/t/add-bring-back-friendly-name-to-template-sensors/305717/29. 

I'm actually not sure how this should be documented – and also not whether it's a field that can be templated (like for the legacy sensors). Please make a suggestion if there's a better way.

## Proposed change
Show that `friendly_name` can be used under `attributes`. 

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
