### PR TITLE
Add hint to using MQTT Discovery as alternative to ebusd integration

### DIFF
--- a/source/_integrations/ebusd.markdown
+++ b/source/_integrations/ebusd.markdown
@@ -13,6 +13,8 @@ ha_integration_type: integration
 
 Integration between [ebusd](https://github.com/john30/ebusd/) daemon for communication with eBUS heating systems, and Home Assistant using sensor component.
 
+Note: [ebusd](https://github.com/john30/ebusd/) also supports a more generic approach using the [MQTT discovery feature](https://www.home-assistant.io/docs/mqtt/discovery/), which allows to make almost everything available as entities in home assistant automatically, see [documentation and setup instructions here](https://github.com/john30/ebusd/wiki/MQTT-integration).
+
 ## Configuration
 
 Enable the sensor by adding the following to your `configuration.yaml` file:


### PR DESCRIPTION
## Proposed change
Extend the documentation of ebusd integration with a hint to the more generic MQTT discovery approach with [ebusd](https://github.com/john30/ebusd).

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue:

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
