### PR TITLE
Install psycopg2 to the correct python virtual environment

### DIFF
--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -403,11 +403,9 @@ pip3 install psycopg2
 If Home Assistant is installed in a virtual environment, the additional libraries should be installed in the same virtual environment. If you installed Home Assistant Core to a Raspberry Pi following the [standard installation instructions](/installation/raspberrypi) the venv can be activated like this prior to installing `psycopg2`:
 
 ```bash
-pip3 uninstall psycopg2
-sudo systemctl stop home-assistant@homeassistant.service
-sudo -u homeassistant -H -s
 source /srv/homeassistant/bin/activate
 pip3 install psycopg2
+deactivate
 ```
 
 Then hit Control-D to exit the virtual environment.

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -392,6 +392,18 @@ sudo apt-get install postgresql-server-dev-X.Y
 pip3 install psycopg2
 ```
 
+If this doesn't work you may have to install the psycopg2 package as part of the same virtual environment that runs Home Assistant
+```
+pip3 uninstall psycopg2
+sudo systemctl stop home-assistant@homeassistant.service
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+pip3 install psycopg2
+```
+
+Then hit Control-D to exit the virtual environment.
+
+
 For using Unix Sockets, first create your user from the `postgres` user account;
 ```bash
 createuser USER_NAME

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -400,7 +400,7 @@ sudo apt-get install postgresql-server-dev-X.Y
 pip3 install psycopg2
 ```
 
-If Home Assistant is installed in a virtual environment, the additional libraries should be installed in the same virtual environment. If you installed Home Assistant Core to a Raspberry Pi following the [standard installation instructions](https://www.home-assistant.io/installation/raspberrypi) the following process should work.
+If Home Assistant is installed in a virtual environment, the additional libraries should be installed in the same virtual environment. If you installed Home Assistant Core to a Raspberry Pi following the [standard installation instructions](/installation/raspberrypi) the venv can be activated like this prior to installing `psycopg2`:
 
 ```bash
 pip3 uninstall psycopg2

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -371,6 +371,16 @@ sudo apt-get install default-libmysqlclient-dev libssl-dev
 pip3 install mysqlclient
 ```
 
+If Home Assistant is installed in a virtual environment, the additional libraries should be installed in the same virtual environment. If you installed Home Assistant Core to a Raspberry Pi following the [standard installation instructions](https://www.home-assistant.io/installation/raspberrypi) the following process should work.
+
+```bash
+pip3 uninstall psycopg2
+sudo systemctl stop home-assistant@homeassistant.service
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+pip3 install mysqlclient
+```
+
 After installing the dependencies, it is required to create the database manually. During the startup, Home Assistant will look for the database specified in the `db_url`. If the database doesn't exist, it will not automatically create it for you.
 
 Once Home Assistant finds the database, with the right level of permissions, all the required tables will then be automatically created and the data will be populated accordingly.
@@ -392,7 +402,8 @@ sudo apt-get install postgresql-server-dev-X.Y
 pip3 install psycopg2
 ```
 
-If this doesn't work you may have to install the psycopg2 package as part of the same virtual environment that runs Home Assistant
+If Home Assistant is installed in a virtual environment, the additional libraries should be installed in the same virtual environment. If you installed Home Assistant Core to a Raspberry Pi following the [standard installation instructions](https://www.home-assistant.io/installation/raspberrypi) the following process should work.
+
 ```bash
 pip3 uninstall psycopg2
 sudo systemctl stop home-assistant@homeassistant.service

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -393,7 +393,7 @@ pip3 install psycopg2
 ```
 
 If this doesn't work you may have to install the psycopg2 package as part of the same virtual environment that runs Home Assistant
-```
+```bash
 pip3 uninstall psycopg2
 sudo systemctl stop home-assistant@homeassistant.service
 sudo -u homeassistant -H -s

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -408,9 +408,6 @@ pip3 install psycopg2
 deactivate
 ```
 
-Then hit Control-D to exit the virtual environment.
-
-
 For using Unix Sockets, first create your user from the `postgres` user account;
 ```bash
 createuser USER_NAME

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -374,11 +374,9 @@ pip3 install mysqlclient
 If Home Assistant is installed in a virtual environment, the additional libraries should be installed in the same virtual environment. If you installed Home Assistant Core to a Raspberry Pi following the [standard installation instructions](/installation/raspberrypi) the venv can be activated like this prior to installing either `pymysql` or `mysqlclient`:
 
 ```bash
-pip3 uninstall psycopg2
-sudo systemctl stop home-assistant@homeassistant.service
-sudo -u homeassistant -H -s
 source /srv/homeassistant/bin/activate
 pip3 install mysqlclient
+deactivate
 ```
 
 After installing the dependencies, it is required to create the database manually. During the startup, Home Assistant will look for the database specified in the `db_url`. If the database doesn't exist, it will not automatically create it for you.

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -371,7 +371,7 @@ sudo apt-get install default-libmysqlclient-dev libssl-dev
 pip3 install mysqlclient
 ```
 
-If Home Assistant is installed in a virtual environment, the additional libraries should be installed in the same virtual environment. If you installed Home Assistant Core to a Raspberry Pi following the [standard installation instructions](https://www.home-assistant.io/installation/raspberrypi) the following process should work.
+If Home Assistant is installed in a virtual environment, the additional libraries should be installed in the same virtual environment. If you installed Home Assistant Core to a Raspberry Pi following the [standard installation instructions](/installation/raspberrypi) the venv can be activated like this prior to installing either `pymysql` or `mysqlclient`:
 
 ```bash
 pip3 uninstall psycopg2


### PR DESCRIPTION
As per https://community.home-assistant.io/t/postgresql-error-during-connection-setup-no-module-named-psycopg2/72568/2

## Proposed change
Install psycopg2 to the homeassistant virtual environment


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
See this thread https://community.home-assistant.io/t/postgresql-error-during-connection-setup-no-module-named-psycopg2/72568/2

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
