### PR TITLE
Remove Sonos group services documentation

### DIFF
--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -121,7 +121,7 @@ data:
 
 ## Services
 
-The Sonos integration makes various custom services available.
+The Sonos integration makes various custom services available in addition to the [standard Media Player services](https://next.home-assistant.io/integrations/media_player/#services).
 
 ### Service `sonos.snapshot`
 
@@ -156,23 +156,6 @@ A cloud queue cannot be restarted. This includes queues started from within Spot
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of `entity_id`s that should have their snapshot restored. To target all Sonos devices, use `all`.
 | `with_group` | yes | Should we also restore the group layout and the state of other speakers in the group, defaults to true.
-
-### Service `sonos.join`
-
-Group players together under a single coordinator. This will make a new group or join to an existing group.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `master` | no | A single `entity_id` that will become/stay the coordinator speaker.
-| `entity_id` | yes | String or list of `entity_id`s to join to the master.
-
-### Service `sonos.unjoin`
-
-Remove one or more speakers from their group of speakers.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of `entity_id`s to separate from their coordinator speaker.
 
 ### Service `sonos.set_sleep_timer`
 

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -121,7 +121,7 @@ data:
 
 ## Services
 
-The Sonos integration makes various custom services available in addition to the [standard Media Player services](https://next.home-assistant.io/integrations/media_player/#services).
+The Sonos integration makes various custom services available in addition to the [standard Media Player services](/integrations/media_player/#services).
 
 ### Service `sonos.snapshot`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
As the `sonos.join` and `sonos.unjoin` services have been deprecated, remove the documentation mentioning them. Add a note pointing to the standard Media Player services which include the replacement `media_player.join` and `media_player.unjoin` services.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/71226
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
