### PR TITLE
Add Sonos favorites notes

### DIFF
--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -40,6 +40,7 @@ Speaker-level controls are exposed as `number` or `switch` entities. Additionall
 
 ### Sensors
 
+- **Each Sonos system**: Sonos Favorites
 - **Devices with battery**: Battery level, Power state
 - **Home theater devices**: Audio Input Format
 - **Voice-enabled devices**: Microphone Enabled
@@ -63,6 +64,34 @@ The Sonos integration adds one `switch` for each alarm set in the Sonos app. The
 ### Microphone support notes
 
 The microphone can only be enabled/disabled from physical buttons on the Sonos device and cannot be controlled from Home Assistant. A `binary_sensor` reports its current state.
+
+### Sonos Favorites support notes
+
+The favorites sensor provides the names and `media_content_id` values for each of the favorites saved to My Sonos in the native Sonos app. This replaces the legacy `source_list` attribute previously available on the media player entities. This sensor is intended for users that need to access the favorites in a custom template. For most users, accessing favorites by using the Media Browser functionality and "Play media" script/automation action is recommended.
+
+Example templates:
+```yaml
+# Get all favorite names as a list (old behavior)
+{{ state_attr("sensor.sonos_favorites", "items").values() | list }}
+
+# Pick a specific favorite name by position
+{{ (state_attr("sensor.sonos_favorites", "items").values() | list)[3] }}
+
+# Pick a random item's `media_content_id`
+{{ state_attr("sensor.sonos_favorites", "items") | list | random }}
+
+# Loop through and grab name & media_content_id
+{% for media_id, name in state_attr("sensor.sonos_favorites", "items").items() %}
+  {{ name, media_id }}
+{% endfor %}
+```
+
+<div class='note'>
+
+The Sonos favorites sensor (`sensor.sonos_favorites`) is disabled by default. It can be found and enabled from the entities associated with the Sonos integration on your [Integrations](https://my.home-assistant.io/redirect/integrations/) page.
+  
+</div>
+
 
 ## Playing media
 

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -70,7 +70,10 @@ The microphone can only be enabled/disabled from physical buttons on the Sonos d
 The favorites sensor provides the names and `media_content_id` values for each of the favorites saved to My Sonos in the native Sonos app. This replaces the legacy `source_list` attribute previously available on the media player entities. This sensor is intended for users that need to access the favorites in a custom template. For most users, accessing favorites by using the Media Browser functionality and "Play media" script/automation action is recommended.
 
 Example templates:
-```
+
+{% raw %}
+
+```yaml
 # Get all favorite names as a list (old behavior)
 {{ state_attr("sensor.sonos_favorites", "items").values() | list }}
 
@@ -85,6 +88,8 @@ Example templates:
   {{ name, media_id }}
 {% endfor %}
 ```
+
+{% endraw %}
 
 <div class='note'>
 

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -70,7 +70,7 @@ The microphone can only be enabled/disabled from physical buttons on the Sonos d
 The favorites sensor provides the names and `media_content_id` values for each of the favorites saved to My Sonos in the native Sonos app. This replaces the legacy `source_list` attribute previously available on the media player entities. This sensor is intended for users that need to access the favorites in a custom template. For most users, accessing favorites by using the Media Browser functionality and "Play media" script/automation action is recommended.
 
 Example templates:
-```yaml
+```
 # Get all favorite names as a list (old behavior)
 {{ state_attr("sensor.sonos_favorites", "items").values() | list }}
 

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -69,6 +69,8 @@ The microphone can only be enabled/disabled from physical buttons on the Sonos d
 
 The favorites sensor provides the names and `media_content_id` values for each of the favorites saved to My Sonos in the native Sonos app. This replaces the legacy `source_list` attribute previously available on the media player entities. This sensor is intended for users that need to access the favorites in a custom template. For most users, accessing favorites by using the Media Browser functionality and "Play media" script/automation action is recommended.
 
+If using the provided `media_content_id` with the `media_player.play_media` service, the `media_content_type` must be set to "favorite_item_id".
+
 Example templates:
 
 {% raw %}

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -95,7 +95,7 @@ Example templates:
 
 <div class='note'>
 
-The Sonos favorites sensor (`sensor.sonos_favorites`) is disabled by default. It can be found and enabled from the entities associated with the Sonos integration on your [Integrations](https://my.home-assistant.io/redirect/integrations/) page.
+The Sonos favorites sensor (`sensor.sonos_favorites`) is disabled by default. It can be found and enabled from the entities associated with the Sonos integration on your {% my integrations %} page.
   
 </div>
 

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -67,7 +67,7 @@ The microphone can only be enabled/disabled from physical buttons on the Sonos d
 
 ### Sonos Favorites support notes
 
-The favorites sensor provides the names and `media_content_id` values for each of the favorites saved to My Sonos in the native Sonos app. This replaces the legacy `source_list` attribute previously available on the media player entities. This sensor is intended for users that need to access the favorites in a custom template. For most users, accessing favorites by using the Media Browser functionality and "Play media" script/automation action is recommended.
+The favorites sensor provides the names and `media_content_id` values for each of the favorites saved to My Sonos in the native Sonos app. This sensor is intended for users that need to access the favorites in a custom template. For most users, accessing favorites by using the Media Browser functionality and "Play media" script/automation action is recommended.
 
 If using the provided `media_content_id` with the `media_player.play_media` service, the `media_content_type` must be set to "favorite_item_id".
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds a description and example usage of the new Sonos favorites sensor added in https://github.com/home-assistant/core/pull/70235.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
