### PR TITLE
Fix the anchor links (and some others) in RSS

### DIFF
--- a/source/atom.xml
+++ b/source/atom.xml
@@ -20,7 +20,7 @@ layout: none
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
-    <content type="html"><![CDATA[{{ post.content | absolute_url | cdata_escape }}]]></content>
+    <content type="html"><![CDATA[{{ post.content | expand_url | full_urls | cdata_escape }}]]></content>
   </entry>
   {% endfor %}
 </feed>

--- a/source/atom.xml
+++ b/source/atom.xml
@@ -20,7 +20,7 @@ layout: none
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
-    <content type="html"><![CDATA[{{ post.content | full_urls | cdata_escape }}]]></content>
+    <content type="html"><![CDATA[{{ post.content | absolute_url | cdata_escape }}]]></content>
   </entry>
   {% endfor %}
 </feed>

--- a/source/atom.xml
+++ b/source/atom.xml
@@ -20,7 +20,7 @@ layout: none
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
-    <content type="html"><![CDATA[{{ post.content | expand_url | full_urls | cdata_escape }}]]></content>
+    <content type="html"><![CDATA[{{ post.content | expand_url(post.url) | full_urls | cdata_escape }}]]></content>
   </entry>
   {% endfor %}
 </feed>


### PR DESCRIPTION
I noticed in the RSS feed that the anchor links take me to `https://www.home-assistant.io/#new-automation--script-features` rather than say `https://www.home-assistant.io/blog/2022/05/04/release-20225/#new-automation--script-features`, ideally these would be absolute URLs rather than full, which ought to fix the issue.

## Proposed change
Swap the `full_urls` filter for `absolute_url`, this is what the [jekyll-feed plugin](https://github.com/jekyll/jekyll-feed/blob/master/lib/jekyll-feed/feed.xml) does.


## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].
^(Yes, but not applicable I think?)

[standards]: https://developers.home-assistant.io/docs/documenting/standards
