### PR TITLE
Update notify.mqtt.markdown text

### DIFF
--- a/source/_examples/notify.mqtt.markdown
+++ b/source/_examples/notify.mqtt.markdown
@@ -29,7 +29,7 @@ The same will work for automations.
 
 ### REST API
 
-Using the [`REST API`](https://developers.home-assistant.io/docs/api/rest/) to send a message to a given topic.
+Using the [REST API](https://developers.home-assistant.io/docs/api/rest/) to send a message to a given topic.
 
 ```bash
 $ curl -X POST \

--- a/source/_examples/notify.mqtt.markdown
+++ b/source/_examples/notify.mqtt.markdown
@@ -29,7 +29,7 @@ The same will work for automations.
 
 ### REST API
 
-Using the [REST API](https://developers.home-assistant.io/docs/api/rest/ to send a message to a given topic.
+Using the [`REST API`](https://developers.home-assistant.io/docs/api/rest/) to send a message to a given topic.
 
 ```bash
 $ curl -X POST \


### PR DESCRIPTION
## Proposed change
Just fixing a typo issue.


## Type of change
I just fixed a typo issue in the `notify.mqtt.markdown` documentation.

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
