### PR TITLE
Add tilt_position to Motion Blinds service

### DIFF
--- a/source/_integrations/motion_blinds.markdown
+++ b/source/_integrations/motion_blinds.markdown
@@ -122,12 +122,15 @@ Therefore it is always safe to use any of the services in Home Assistant with th
 ## Service `motion_blinds.set_absolute_position`
 
 For simple blinds the `motion_blinds.set_absolute_position` does the same as `cover.set_cover_position` service.
+
 ### TDBU blinds
+
 For TDBU blinds `motion_blinds.set_absolute_position` will set the absolute position relative to the window itself.
 The `cover.set_cover_position` will set the scaled position relative to the space in which the TDBU blind is allowed to move.
+
 ### Tilt capable blinds
-For tilt capable blinds a new position and tilt can be specified and the blind will move to the new position and then adjust its tilt.
-If the normal `cover.set_cover_position` is issued and emidiatly after a `cover.set_cover_tilt_position` is issued, the blind will stop moving and start adjusting the tilt before it reaches the intended position.
+
+For tilt capable blinds a new position and tilt can be specified and the blind will move to the new position and then adjust its tilt. If the normal `cover.set_cover_position` is issued and immediately after a `cover.set_cover_tilt_position` is issued, the blind will stop moving and start adjusting the tilt before it reaches the intended position.
 
 | Service data attribute | Optional | Description                                                                                       |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------- |

--- a/source/_integrations/motion_blinds.markdown
+++ b/source/_integrations/motion_blinds.markdown
@@ -121,14 +121,19 @@ Therefore it is always safe to use any of the services in Home Assistant with th
 
 ## Service `motion_blinds.set_absolute_position`
 
-For most blinds the `motion_blinds.set_absolute_position` does the same as `cover.set_cover_position` service.
-However, for TDBU blinds it will set the absolute position relative to the window itself.
+For simple blinds the `motion_blinds.set_absolute_position` does the same as `cover.set_cover_position` service.
+### TDBU blinds
+For TDBU blinds `motion_blinds.set_absolute_position` will set the absolute position relative to the window itself.
 The `cover.set_cover_position` will set the scaled position relative to the space in which the TDBU blind is allowed to move.
+### Tilt capable blinds
+For tilt capable blinds a new position and tilt can be specified and the blind will move to the new position and then adjust its tilt.
+If the normal `cover.set_cover_position` is issued and emidiatly after a `cover.set_cover_tilt_position` is issued, the blind will stop moving and start adjusting the tilt before it reaches the intended position.
 
 | Service data attribute | Optional | Description                                                                                       |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `entity_id`            |      yes | Name of the motion blind cover entity to control. For example `cover.TopDownBottomUp-Bottom-0001` |
 | `absolute_position`    |       no | Absolute position to move to. For example 70                                                      |
+| `tilt_position`        |      yes | Tilt position to move to. For example 50                                                          |
 | `width`                |      yes | Optionally specify the width that is covered, only for TDBU Combined entities. For example 30     |
 
 ## Troubleshooting


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add tilt_position to motion_blinds.set_absolute_position service


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/71790
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
