### PR TITLE
Update generic documentation for use_wallclock_as_timestamps option

### DIFF
--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -25,23 +25,28 @@ You must enter a URL in at least one of the fields **Still Image URL** or **Stre
 
 [Templates](/topics/templating/) are allowed in the URL fields, which can be used to select different images or parameterize the URL depending on the status of sensors.  Template validity and network access are checked during the configuration steps.
 
-### Generic Camera Configuration
-
-You can configure additional Generic Camera options for each camera through the configuration options in the GUI. The configure button can be found after clicking into the camera name under Generic Camera on the integration details page.
-
-| Option | Description |
-| -------| ----------- |
-| Still Image URL | The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/topics/templating/). At least one of still_image_url or stream_source must be provided. |
-| Stream Source | The URL your camera serves the live stream on, e.g., `rtsp://user:pass@192.168.1.21:554/`. Can be a [template](/topics/templating/). Usernames and passwords must be embedded in the URL. At least one of still_image_url or stream_source must be provided. Note that a stream_source without a still_image_url can only be used if the [stream integration](/integrations/stream/) is configured. |
-| Username | The username for accessing your camera. Note that this username applies only to still_image_url and not to stream_source. |
-| Password | The password for accessing your camera. Note that this password applies only to still_image_url and not to stream_source. |
-| Authentication | Type for authenticating the requests `basic` or `digest`. |
-| Limit refetch to URL change | Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image. |
-| Frame Rate | The number of frames-per-second (FPS) of the stream. Can cause heavy traffic on the network and/or heavy load on the camera. |
-| Verify SSL certificate | Enable or disable SSL certificate verification. Set to false to use an http-only camera, or you have a self-signed SSL certificate and haven't installed the CA certificate to enable verification. |
-| RTSP transport protocol | Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`. |
-| Use wallclock as timestamps | ([Advanced Mode](https://www.home-assistant.io/blog/2019/07/17/release-96/#advanced-mode) only) Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ). |
-
+{% configuration_basic %}
+Still Image URL:
+  description: "The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/topics/templating/). At least one of still_image_url or stream_source must be provided."
+Stream Source:
+  description: "The URL your camera serves the live stream on, e.g., `rtsp://user:pass@192.168.1.21:554/`. Can be a [template](/topics/templating/). Usernames and passwords must be embedded in the URL. At least one of still_image_url or stream_source must be provided. Note that a stream_source without a still_image_url can only be used if the [stream integration](/integrations/stream/) is configured."
+Username:
+  description: The username for accessing your camera. Note that this username applies only to still_image_url and not to stream_source.
+Password:
+  description: The password for accessing your camera. Note that this password applies only to still_image_url and not to stream_source.
+Authentication:
+  description: "Type for authenticating the requests `basic` or `digest`."
+Limit refetch to URL change:
+  description: Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image.
+Frame Rate:
+  description: The number of frames-per-second (FPS) of the stream. Can cause heavy traffic on the network and/or heavy load on the camera.
+Verify SSL certificate:
+  description: Enable or disable SSL certificate verification. Set to false to use an http-only camera, or you have a self-signed SSL certificate and haven't installed the CA certificate to enable verification.
+RTSP transport protocol:
+  description: "Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`."
+Use wallclock as timestamps:
+  descriptions: ([Advanced Mode](https://www.home-assistant.io/blog/2019/07/17/release-96/#advanced-mode) only) Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ).
+{% endconfiguration_basic %}
 
 <p class='img'>
   <a href='/examples/google_maps_card/'>

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -40,7 +40,7 @@ You can configure additional Generic Camera options for each camera through the 
 | Frame Rate | The number of frames-per-second (FPS) of the stream. Can cause heavy traffic on the network and/or heavy load on the camera. |
 | Verify SSL certificate | Enable or disable SSL certificate verification. Set to false to use an http-only camera, or you have a self-signed SSL certificate and haven't installed the CA certificate to enable verification. |
 | RTSP transport protocol | Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`. |
-| Use wallclock as timestamps | (Advanced Mode only) Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ). |
+| Use wallclock as timestamps | ([Advanced Mode](https://www.home-assistant.io/blog/2019/07/17/release-96/#advanced-mode) only) Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ). |
 
 
 <p class='img'>

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -45,7 +45,7 @@ Verify SSL certificate:
 RTSP transport protocol:
   description: "Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`."
 Use wallclock as timestamps:
-  descriptions: ([Advanced Mode](https://www.home-assistant.io/blog/2019/07/17/release-96/#advanced-mode) only) Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ).
+  description: ([Advanced Mode](https://www.home-assistant.io/blog/2019/07/17/release-96/#advanced-mode) only) Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ).
 {% endconfiguration_basic %}
 
 <p class='img'>

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -40,7 +40,7 @@ You can configure additional Generic Camera options for each camera through the 
 | Frame Rate | The number of frames-per-second (FPS) of the stream. Can cause heavy traffic on the network and/or heavy load on the camera. |
 | Verify SSL certificate | Enable or disable SSL certificate verification. Set to false to use an http-only camera, or you have a self-signed SSL certificate and haven't installed the CA certificate to enable verification. |
 | RTSP transport protocol | Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`. |
-| Use wallclock as timestamps | Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ). |
+| Use wallclock as timestamps | (Advanced Mode only) Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ). |
 
 
 <p class='img'>

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -26,24 +26,26 @@ You must enter a URL in at least one of the fields **Still Image URL** or **Stre
 [Templates](/topics/templating/) are allowed in the URL fields, which can be used to select different images or parameterize the URL depending on the status of sensors.  Template validity and network access are checked during the configuration steps.
 
 {% configuration_basic %}
-still_image_url:
+Still Image URL:
   description: "The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/topics/templating/). At least one of still_image_url or stream_source must be provided."
-stream_source:
+Stream Source:
   description: "The URL your camera serves the live stream on, e.g., `rtsp://user:pass@192.168.1.21:554/`. Can be a [template](/topics/templating/). Usernames and passwords must be embedded in the URL. At least one of still_image_url or stream_source must be provided. Note that a stream_source without a still_image_url can only be used if the [stream integration](/integrations/stream/) is configured."
-username:
+Username:
   description: The username for accessing your camera. Note that this username applies only to still_image_url and not to stream_source.
-password:
+Password:
   description: The password for accessing your camera. Note that this password applies only to still_image_url and not to stream_source.
-authentication:
+Authentication:
   description: "Type for authenticating the requests `basic` or `digest`."
-limit_refetch_to_url_change:
+Limit refetch to url change:
   description: Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image.
-framerate:
+Frame Rate:
   description: The number of frames-per-second (FPS) of the stream. Can cause heavy traffic on the network and/or heavy load on the camera.
-verify_ssl:
+Verify SSL certificate:
   description: Enable or disable SSL certificate verification. Set to false to use an http-only camera, or you have a self-signed SSL certificate and haven't installed the CA certificate to enable verification.
-rtsp_transport:
+RTSP transport protocol:
   description: "Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`."
+Use wallclock as timestamps:
+  description: "Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ)."
 {% endconfiguration_basic %}
 
 <p class='img'>

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -45,7 +45,7 @@ Verify SSL certificate:
 RTSP transport protocol:
   description: "Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`."
 Use wallclock as timestamps:
-  description: ([Advanced Mode](https://www.home-assistant.io/blog/2019/07/17/release-96/#advanced-mode) only) Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ).
+  description: ([Advanced Mode](/blog/2019/07/17/release-96/#advanced-mode) only) Rewrite the camera timestamps. This may help with playback or crashing issues from Wi-Fi cameras or cameras of certain brands (e.g., EZVIZ).
 {% endconfiguration_basic %}
 
 <p class='img'>

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -36,7 +36,7 @@ You can configure additional Generic Camera options for each camera through the 
 | Username | The username for accessing your camera. Note that this username applies only to still_image_url and not to stream_source. |
 | Password | The password for accessing your camera. Note that this password applies only to still_image_url and not to stream_source. |
 | Authentication | Type for authenticating the requests `basic` or `digest`. |
-| Limit refetch to url change | Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image. |
+| Limit refetch to URL change | Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image. |
 | Frame Rate | The number of frames-per-second (FPS) of the stream. Can cause heavy traffic on the network and/or heavy load on the camera. |
 | Verify SSL certificate | Enable or disable SSL certificate verification. Set to false to use an http-only camera, or you have a self-signed SSL certificate and haven't installed the CA certificate to enable verification. |
 | RTSP transport protocol | Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`. |

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -25,28 +25,23 @@ You must enter a URL in at least one of the fields **Still Image URL** or **Stre
 
 [Templates](/topics/templating/) are allowed in the URL fields, which can be used to select different images or parameterize the URL depending on the status of sensors.  Template validity and network access are checked during the configuration steps.
 
-{% configuration_basic %}
-Still Image URL:
-  description: "The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/topics/templating/). At least one of still_image_url or stream_source must be provided."
-Stream Source:
-  description: "The URL your camera serves the live stream on, e.g., `rtsp://user:pass@192.168.1.21:554/`. Can be a [template](/topics/templating/). Usernames and passwords must be embedded in the URL. At least one of still_image_url or stream_source must be provided. Note that a stream_source without a still_image_url can only be used if the [stream integration](/integrations/stream/) is configured."
-Username:
-  description: The username for accessing your camera. Note that this username applies only to still_image_url and not to stream_source.
-Password:
-  description: The password for accessing your camera. Note that this password applies only to still_image_url and not to stream_source.
-Authentication:
-  description: "Type for authenticating the requests `basic` or `digest`."
-Limit refetch to url change:
-  description: Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image.
-Frame Rate:
-  description: The number of frames-per-second (FPS) of the stream. Can cause heavy traffic on the network and/or heavy load on the camera.
-Verify SSL certificate:
-  description: Enable or disable SSL certificate verification. Set to false to use an http-only camera, or you have a self-signed SSL certificate and haven't installed the CA certificate to enable verification.
-RTSP transport protocol:
-  description: "Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`."
-Use wallclock as timestamps:
-  description: "Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ)."
-{% endconfiguration_basic %}
+### Generic Camera Configuration
+
+You can configure additional Generic Camera options for each camera through the configuration options in the GUI. The configure button can be found after clicking into the camera name under Generic Camera on the integration details page.
+
+| Option | Description |
+| -------| ----------- |
+| Still Image URL | The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/topics/templating/). At least one of still_image_url or stream_source must be provided. |
+| Stream Source | The URL your camera serves the live stream on, e.g., `rtsp://user:pass@192.168.1.21:554/`. Can be a [template](/topics/templating/). Usernames and passwords must be embedded in the URL. At least one of still_image_url or stream_source must be provided. Note that a stream_source without a still_image_url can only be used if the [stream integration](/integrations/stream/) is configured. |
+| Username | The username for accessing your camera. Note that this username applies only to still_image_url and not to stream_source. |
+| Password | The password for accessing your camera. Note that this password applies only to still_image_url and not to stream_source. |
+| Authentication | Type for authenticating the requests `basic` or `digest`. |
+| Limit refetch to url change | Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image. |
+| Frame Rate | The number of frames-per-second (FPS) of the stream. Can cause heavy traffic on the network and/or heavy load on the camera. |
+| Verify SSL certificate | Enable or disable SSL certificate verification. Set to false to use an http-only camera, or you have a self-signed SSL certificate and haven't installed the CA certificate to enable verification. |
+| RTSP transport protocol | Set the RTSP transport protocol to `tcp`, `udp`, `udp_multicast` or `http`. |
+| Use wallclock as timestamps | Rewrite the camera timestamps. This may help with playback or crashing issues from WiFi cameras or cameras of certain brands (e.g. EZVIZ). |
+
 
 <p class='img'>
   <a href='/examples/google_maps_card/'>


### PR DESCRIPTION
Also put options in table and change option names to match the options displayed in GUI

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for use_wallclock_as_timestamps option in generic.
Also change option names to match the options displayed in GUI.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#71245](https://github.com/home-assistant/core/pull/71245)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
