### PR TITLE
Updated navigation to check YAML configuration

### DIFF
--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -13,10 +13,7 @@ The steps below do not apply to Home Assistant Core & Container installations, f
 
 We are going to help you make your first changes to `configuration.yaml`. To do this, we are going to install an add-on from the Home Assistant add-on store: the File editor. To get to the add-on store, click on the menu icon in the top left, then open {% my supervisor title="Settings > Add-ons" %}. On the new page, open the add-on store tab.
 
-<p class='img'>
-<img src='/images/hassio/screenshots/dashboard.png' />
-From the {% my supervisor title="Settings > Add-ons" %} panel, open the add-on store.
-</p>
+![Add-on store.](/images/hassio/screenshots/dashboard.png)
 
 Under the "Official add-ons" section you will find the File editor add-on.
 
@@ -47,10 +44,7 @@ Now let's make a change using the file editor: we are going to change the name, 
  - Most changes in `configuration.yaml` require Home Assistant to be restarted to see the changes. You can verify that your changes are acceptable by running a configuration check. Do this by clicking on Configuration in the sidebar, click on "Settings", "Server Controls" and click on the "CHECK configuration" button. When it's valid, it will show the text "Configuration valid!". In order for the "CHECK configuration" button to be visible, you must enable "Advanced Mode" on your user profile.
  - Now Restart Home Assistant using the "RESTART" button in the Server management section on the same page.
 
-<p class='img'>
-<img src='/images/screenshots/configuration-validation.png' />
-Screenshot of the "General" page in the configuration panel.
-</p>
+![Screenshot of the "General" page in the configuration panel.](/images/screenshots/configuration-validation.png)
 
 <div class='note'>
 

--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -17,9 +17,9 @@ We are going to help you make your first changes to `configuration.yaml`. To do 
 
 Under the "Official add-ons" section you will find the File editor add-on.
 
- - Click on File Editor and click on INSTALL. When installation is complete, the UI will go to the add-on details page for the file editor.
- - Now start the add-on by clicking on START.
- - Open the user interface by clicking on OPEN WEB UI.
+ - Click on File Editor and click on **Install**. When installation is complete, the UI will go to the add-on details page for the file editor.
+ - Now start the add-on by clicking on **Start**.
+ - Open the user interface by clicking on **Open Web UI**.
 
 Now let's make a change using the file editor: we are going to change the name, location, unit system, and time zone of your Home Assistant installation.
 
@@ -41,8 +41,8 @@ Now let's make a change using the file editor: we are going to change the name, 
 </div>
 
  - Click the save icon in the top right to commit changes.
- - Most changes in `configuration.yaml` require Home Assistant to be restarted to see the changes. You can verify that your changes are acceptable by running a configuration check. Do this by clicking on Configuration in the sidebar, click on "Settings", "Server Controls" and click on the "CHECK configuration" button. When it's valid, it will show the text "Configuration valid!". In order for the "CHECK configuration" button to be visible, you must enable "Advanced Mode" on your user profile.
- - Now Restart Home Assistant using the "RESTART" button in the Server management section on the same page.
+ - Most changes in `configuration.yaml` require Home Assistant to be restarted to see the changes. You can verify that your changes are acceptable by running a configuration check. Do this by clicking on Configuration in the sidebar, click on `Developer-Tools -> YAML` and click on the **Check configuration** button. When it's valid, it will show the text "Configuration valid!". In order for the **Check Configuration**" button to be visible, you must enable "Advanced Mode" on your user profile.
+ - Now Restart Home Assistant using the **Restart** button in the Server management section on the same page.
 
 ![Screenshot of the "General" page in the configuration panel.](/images/screenshots/configuration-validation.png)
 


### PR DESCRIPTION
## Proposed change
Updated the navigation steps to perform a check YAML from configuration/settings to developer-tools.

Reformatted some of the button references from all capitals to bold style which I believe is inline with other pages.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #22751

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
