### PR TITLE
Corrected spelling of laser in binary sensor

### DIFF
--- a/source/_integrations/brother.markdown
+++ b/source/_integrations/brother.markdown
@@ -51,7 +51,7 @@ template:
         {{ is_state('sensor.hl_l2340d_status', 'no paper') }}
 
   - binary_sensor:
-    - name: 'Later Printer Paper Jam'
+    - name: 'Laser Printer Paper Jam'
       state: >
         {{ is_state('sensor.hl_l2340d_status', 'paper jam') }}
 ```


### PR DESCRIPTION
## Proposed change
The example binary sensor has a spelling mistake

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
