### PR TITLE
MQTT alarm_control_panel config to integration key

### DIFF
--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -31,11 +31,31 @@ To enable this platform, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry
+mqtt:
+  alarm_control_panel:
+    - state_topic: "home/alarm"
+      command_topic: "home/alarm/set"
+```
+
+<a id='new_format'></a>
+
+{% details "Previous configuration format" %}
+
+The configuration format of manual configured MQTT items has changed.
+The old format that places configurations under the `alarm_control_panel` platform key
+should no longer be used and is deprecated.
+
+The above example shows the new and modern way,
+this is the previous/old example:
+
+```yaml
 alarm_control_panel:
   - platform: mqtt
     state_topic: "home/alarm"
     command_topic: "home/alarm/set"
 ```
+
+{% enddetails %}
 
 {% configuration %}
 availability:
@@ -260,13 +280,13 @@ The example below shows a full configuration with local code validation.
 
 ```yaml
 # Example using text based code with local validation configuration.yaml
-alarm_control_panel:
-  - platform: mqtt
-    name: "Alarm Panel With Numeric Keypad"
-    state_topic: "alarmdecoder/panel"
-    value_template: "{{value_json.state}}"
-    command_topic: "alarmdecoder/panel/set"
-    code: mys3cretc0de
+mqtt:
+  alarm_control_panel:
+    - name: "Alarm Panel With Numeric Keypad"
+      state_topic: "alarmdecoder/panel"
+      value_template: "{{value_json.state}}"
+      command_topic: "alarmdecoder/panel/set"
+      code: mys3cretc0de
 ```
 
 {% endraw %}
@@ -279,26 +299,26 @@ The example below shows a full configuration with remote code validation and `co
 
 ```yaml
 # Example using text code with remote validation configuration.yaml
-alarm_control_panel:
-  - platform: mqtt
-    name: "Alarm Panel With Text Code Dialog"
-    state_topic: "alarmdecoder/panel"
-    value_template: "{{ value_json.state }}"
-    command_topic: "alarmdecoder/panel/set"
-    code: REMOTE_CODE_TEXT
-    command_template: "{ action: '{{ action }}', code: '{{ code }}'}"
+mqtt:
+  alarm_control_panel:
+    - name: "Alarm Panel With Text Code Dialog"
+      state_topic: "alarmdecoder/panel"
+      value_template: "{{ value_json.state }}"
+      command_topic: "alarmdecoder/panel/set"
+      code: REMOTE_CODE_TEXT
+      command_template: "{ action: '{{ action }}', code: '{{ code }}'}"
 ```
 
 ```yaml
 # Example using numeric code with remote validation configuration.yaml
-alarm_control_panel:
-  - platform: mqtt
-    name: "Alarm Panel With Numeric Keypad"
-    state_topic: "alarmdecoder/panel"
-    value_template: "{{ value_json.state }}"
-    command_topic: "alarmdecoder/panel/set"
-    code: REMOTE_CODE
-    command_template: "{ action: '{{ action }}', code: '{{ code }}'}"
+mqtt:
+  alarm_control_panel:
+    - name: "Alarm Panel With Numeric Keypad"
+      state_topic: "alarmdecoder/panel"
+      value_template: "{{ value_json.state }}"
+      command_topic: "alarmdecoder/panel/set"
+      code: REMOTE_CODE
+      command_template: "{ action: '{{ action }}', code: '{{ code }}'}"
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Move manual configuration of MQTT alarm_control_panel to the integration key

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72165
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
