### PR TITLE
MQTT binary_sensor config to integration key

### DIFF
--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -25,10 +25,29 @@ add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
+mqtt:
+  binary_sensor:
+    - state_topic: "home-assistant/window/contact"
+```
+
+<a id='new_format'></a>
+
+{% details "Previous configuration format" %}
+
+The configuration format of manual configured MQTT items has changed.
+The old format that places configurations under the `binary_sensor` platform key
+should no longer be used and is deprecated.
+
+The above example shows the new and modern way,
+this is the previous/old example:
+
+```yaml
 binary_sensor:
   - platform: mqtt
     state_topic: "home-assistant/window/contact"
 ```
+
+{% enddetails %}
 
 {% configuration %}
 availability:
@@ -223,18 +242,18 @@ The example below shows a full configuration for a binary sensor:
 
 ```yaml
 # Example configuration.yaml entry
-binary_sensor:
-  - platform: mqtt
-    name: "Window Contact Sensor"
-    state_topic: "home-assistant/window/contact"
-    payload_on: "ON"
-    availability:
-      - topic: "home-assistant/window/availability"
-        payload_available: "online"
-        payload_not_available: "offline"
-    qos: 0
-    device_class: opening
-    value_template: "{{ value_json.state }}"
+mqtt:
+  binary_sensor:
+    - name: "Window Contact Sensor"
+      state_topic: "home-assistant/window/contact"
+      payload_on: "ON"
+      availability:
+        - topic: "home-assistant/window/availability"
+          payload_available: "online"
+          payload_not_available: "offline"
+      qos: 0
+      device_class: opening
+      value_template: "{{ value_json.state }}"
 ```
 
 {% endraw %}
@@ -245,10 +264,10 @@ binary_sensor:
 
 ```yaml
 # Example configuration.yaml entry
-binary_sensor:
-  - platform: mqtt
-    state_topic: "lab_button/cmnd/POWER"
-    value_template: "{%if is_state(entity_id,\"on\")-%}OFF{%-else-%}ON{%-endif%}"
+mqtt:
+  binary_sensor:
+    - state_topic: "lab_button/cmnd/POWER"
+      value_template: "{%if is_state(entity_id,\"on\")-%}OFF{%-else-%}ON{%-endif%}"
 ```
 
 {% endraw %}
@@ -269,10 +288,10 @@ The configuration will look like the example below:
 
 ```yaml
 # Example configuration.yaml entry
-binary_sensor:
-  - platform: mqtt
-    name: Bathroom
-    state_topic: "home/bathroom/switch/button"
-    payload_on: "1"
-    payload_off: "0"
+mqtt:
+  binary_sensor:
+    - name: Bathroom
+      state_topic: "home/bathroom/switch/button"
+      payload_on: "1"
+      payload_off: "0"
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Move manual configuration of MQTT binary_sensor to the integration key

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72183
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
