### PR TITLE
MQTT climate config to integration key

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -16,9 +16,31 @@ To enable this climate platform in your installation, first add the following to
 
 ```yaml
 # Example configuration.yaml entry
+mqtt:
+  climate:
+    - name: Study
+      mode_command_topic: "study/ac/mode/set"
+```
+
+<a id='new_format'></a>
+
+{% details "Previous configuration format" %}
+
+The configuration format of manual configured MQTT items has changed.
+The old format that places configurations under the `climate` platform key
+should no longer be used and is deprecated.
+
+The above example shows the new and modern way,
+this is the previous/old example:
+
+```yaml
 climate:
   - platform: mqtt
+    name: Study
+    mode_command_topic: "study/ac/mode/set"
 ```
+
+{% enddetails %}
 
 {% configuration %}
 action_template:
@@ -380,16 +402,16 @@ Say you receive the operation mode `"auto"` via your `mode_state_topic`, but the
 {% raw %}
 
 ```yaml
-climate:
-  - platform: mqtt
-    name: Study
-    modes:
-      - "off"
-      - "heat"
-      - "auto"
-    mode_command_topic: "study/ac/mode/set"
-    mode_state_topic: "study/ac/mode/state"
-    mode_state_template: "{{ value_json }}"
+mqtt:
+  climate:
+    - name: Study
+      modes:
+        - "off"
+        - "heat"
+        - "auto"
+      mode_command_topic: "study/ac/mode/set"
+      mode_state_topic: "study/ac/mode/state"
+      mode_state_template: "{{ value_json }}"
 ```
 
 {% endraw %}
@@ -404,29 +426,29 @@ A full configuration example looks like the one below.
 
 ```yaml
 # Full example configuration.yaml entry
-climate:
-  - platform: mqtt
-    name: Study
-    modes:
-      - "off"
-      - "cool"
-      - "fan_only"
-    swing_modes:
-      - "on"
-      - "off"
-    fan_modes:
-      - "high"
-      - "medium"
-      - "low"
-    preset_modes:
-      - "eco"
-      - "sleep"
-      - "activity"
-    power_command_topic: "study/ac/power/set"
-    preset_mode_command_topic: "study/ac/preset_mode/set"
-    mode_command_topic: "study/ac/mode/set"
-    temperature_command_topic: "study/ac/temperature/set"
-    fan_mode_command_topic: "study/ac/fan/set"
-    swing_mode_command_topic: "study/ac/swing/set"
-    precision: 1.0
+mqtt:
+  climate:
+    - name: Study
+      modes:
+        - "off"
+        - "cool"
+        - "fan_only"
+      swing_modes:
+        - "on"
+        - "off"
+      fan_modes:
+        - "high"
+        - "medium"
+        - "low"
+      preset_modes:
+        - "eco"
+        - "sleep"
+        - "activity"
+      power_command_topic: "study/ac/power/set"
+      preset_mode_command_topic: "study/ac/preset_mode/set"
+      mode_command_topic: "study/ac/mode/set"
+      temperature_command_topic: "study/ac/temperature/set"
+      fan_mode_command_topic: "study/ac/fan/set"
+      swing_mode_command_topic: "study/ac/swing/set"
+      precision: 1.0
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Move manual configuration of MQTT climate to the integration key


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72251
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
