### PR TITLE
MQTT cover config to integration key

### DIFF
--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -31,10 +31,29 @@ To use your MQTT cover in your installation, add the following to your `configur
 
 ```yaml
 # Example configuration.yaml entry
+mqtt:
+  cover:
+    - command_topic: "home-assistant/cover/set"
+```
+
+<a id='new_format'></a>
+
+{% details "Previous configuration format" %}
+
+The configuration format of manual configured MQTT items has changed.
+The old format that places configurations under the `cover` platform key
+should no longer be used and is deprecated.
+
+The above example shows the new and modern way,
+this is the previous/old example:
+
+```yaml
 cover:
   - platform: mqtt
     command_topic: "home-assistant/cover/set"
 ```
+
+{% enddetails %}
 
 {% configuration %}
 availability:
@@ -324,26 +343,26 @@ The example below shows a full configuration for a cover without tilt with state
 
 ```yaml
 # Example configuration.yaml entry
-cover:
-  - platform: mqtt
-    name: "MQTT Cover"
-    command_topic: "home-assistant/cover/set"
-    state_topic: "home-assistant/cover/state"
-    availability:
-      - topic: "home-assistant/cover/availability"
-    qos: 0
-    retain: true
-    payload_open: "OPEN"
-    payload_close: "CLOSE"
-    payload_stop: "STOP"
-    state_open: "open"
-    state_opening: "opening"
-    state_closed: "closed"
-    state_closing: "closing"
-    payload_available: "online"
-    payload_not_available: "offline"
-    optimistic: false
-    value_template: "{{ value.x }}"
+mqtt:
+  cover:
+    - name: "MQTT Cover"
+      command_topic: "home-assistant/cover/set"
+      state_topic: "home-assistant/cover/state"
+      availability:
+        - topic: "home-assistant/cover/availability"
+      qos: 0
+      retain: true
+      payload_open: "OPEN"
+      payload_close: "CLOSE"
+      payload_stop: "STOP"
+      state_open: "open"
+      state_opening: "opening"
+      state_closed: "closed"
+      state_closing: "closing"
+      payload_available: "online"
+      payload_not_available: "offline"
+      optimistic: false
+      value_template: "{{ value.x }}"
 ```
 
 {% endraw %}
@@ -356,25 +375,25 @@ The example below shows a full configuration for a cover without tilt with posit
 
 ```yaml
 # Example configuration.yaml entry
-cover:
-  - platform: mqtt
-    name: "MQTT Cover"
-    command_topic: "home-assistant/cover/set"
-    position_topic: "home-assistant/cover/position"
-    availability:
-      - topic: "home-assistant/cover/availability"
-    set_position_topic: "home-assistant/cover/set_position"
-    qos: 0
-    retain: true
-    payload_open: "OPEN"
-    payload_close: "CLOSE"
-    payload_stop: "STOP"
-    position_open: 100
-    position_closed: 0
-    payload_available: "online"
-    payload_not_available: "offline"
-    optimistic: false
-    value_template: "{{ value.x }}"
+mqtt:
+  cover:
+    - name: "MQTT Cover"
+      command_topic: "home-assistant/cover/set"
+      position_topic: "home-assistant/cover/position"
+      availability:
+        - topic: "home-assistant/cover/availability"
+      set_position_topic: "home-assistant/cover/set_position"
+      qos: 0
+      retain: true
+      payload_open: "OPEN"
+      payload_close: "CLOSE"
+      payload_stop: "STOP"
+      position_open: 100
+      position_closed: 0
+      payload_available: "online"
+      payload_not_available: "offline"
+      optimistic: false
+      value_template: "{{ value.x }}"
 ```
 
 {% endraw %}
@@ -387,35 +406,35 @@ The example below shows a full configuration for a cover with position, state & 
 
 ```yaml
 # Example configuration.yaml entry
-cover:
-  - platform: mqtt
-    name: "MQTT Cover"
-    command_topic: "home-assistant/cover/set"
-    state_topic: "home-assistant/cover/state"
-    position_topic: "home-assistant/cover/position"
-    availability:
-      - topic: "home-assistant/cover/availability"
-    qos: 0
-    retain: true
-    payload_open: "OPEN"
-    payload_close: "CLOSE"
-    payload_stop: "STOP"
-    state_open: "open"
-    state_opening: "opening"
-    state_closed: "closed"
-    state_closing: "closing"
-    payload_available: "online"
-    payload_not_available: "offline"
-    optimistic: false
-    value_template: "{{ value.x }}"
-    position_template: "{{ value.y }}"
-    tilt_command_topic: "home-assistant/cover/tilt"
-    tilt_status_topic: "home-assistant/cover/tilt-state"
-    tilt_status_template: "{{ value_json["PWM"]["PWM1"] }}"
-    tilt_min: 0
-    tilt_max: 180
-    tilt_closed_value: 70
-    tilt_opened_value: 180
+mqtt:
+  cover:
+    - name: "MQTT Cover"
+      command_topic: "home-assistant/cover/set"
+      state_topic: "home-assistant/cover/state"
+      position_topic: "home-assistant/cover/position"
+      availability:
+        - topic: "home-assistant/cover/availability"
+      qos: 0
+      retain: true
+      payload_open: "OPEN"
+      payload_close: "CLOSE"
+      payload_stop: "STOP"
+      state_open: "open"
+      state_opening: "opening"
+      state_closed: "closed"
+      state_closing: "closing"
+      payload_available: "online"
+      payload_not_available: "offline"
+      optimistic: false
+      value_template: "{{ value.x }}"
+      position_template: "{{ value.y }}"
+      tilt_command_topic: "home-assistant/cover/tilt"
+      tilt_status_topic: "home-assistant/cover/tilt-state"
+      tilt_status_template: "{{ value_json["PWM"]["PWM1"] }}"
+      tilt_min: 0
+      tilt_max: 180
+      tilt_closed_value: 70
+      tilt_opened_value: 180
 ```
 
 {% endraw %}
@@ -428,27 +447,27 @@ The example below shows a full configuration for a cover using stopped state.
 
 ```yaml
 # Example configuration.yaml entry
-cover:
-  - platform: mqtt
-    name: "MQTT Cover"
-    command_topic: "home-assistant/cover/set"
-    state_topic: "home-assistant/cover/state"
-    position_topic: "home-assistant/cover/position"
-    availability:
-      - topic: "home-assistant/cover/availability"
-    qos: 0
-    retain: true
-    payload_open: "OPEN"
-    payload_close: "CLOSE"
-    payload_stop: "STOP"
-    state_opening: "opening"
-    state_closed: "closed"
-    state_stopped: "stopped"
-    payload_available: "online"
-    payload_not_available: "offline"
-    optimistic: false
-    value_template: "{{ value.x }}"
-    position_template: "{{ value.y }}"
+mqtt:
+  cover:
+    - name: "MQTT Cover"
+      command_topic: "home-assistant/cover/set"
+      state_topic: "home-assistant/cover/state"
+      position_topic: "home-assistant/cover/position"
+      availability:
+        - topic: "home-assistant/cover/availability"
+      qos: 0
+      retain: true
+      payload_open: "OPEN"
+      payload_close: "CLOSE"
+      payload_stop: "STOP"
+      state_opening: "opening"
+      state_closed: "closed"
+      state_stopped: "stopped"
+      payload_available: "online"
+      payload_not_available: "offline"
+      optimistic: false
+      value_template: "{{ value.x }}"
+      position_template: "{{ value.y }}"
 ```
 
 {% endraw %}
@@ -462,11 +481,11 @@ Setting `payload_close` empty or to `null` disables the close command and will n
 
 ```yaml
 # Example configuration.yaml entry
-cover:
-  - platform: mqtt
-    payload_open: "on"
-    payload_close: 
-    payload_stop: "on"
+mqtt:
+  cover:
+    - payload_open: "on"
+      payload_close: 
+      payload_stop: "on"
 ```
 
 {% endraw %}
@@ -479,7 +498,6 @@ For auto discovery message the payload needs to be set to `null`, example for co
 {
   "cover": [
     {
-      "platform": "mqtt",
       "payload_open": "on",
       "payload_close": null,
       "payload_stop": "on"
@@ -498,30 +516,30 @@ The example below shows an example of how to correct the state of the blind depe
 
 ```yaml
 # Example configuration.yaml entry
-cover:
-  - platform: mqtt
-    name: "MQTT Cover"
-    command_topic: "home-assistant/cover/set"
-    state_topic: "home-assistant/cover/state"
-    position_topic: "home-assistant/cover/position"
-    set_position_topic: "home-assistant/cover/position/set"
-    payload_open:  "open"
-    payload_close: "close"
-    payload_stop:  "stop"
-    state_opening: "open"
-    state_closing: "close"
-    state_stopped: "stop"
-    optimistic: false
-    position_template: |-
-      {% if not state_attr(entity_id, "current_position") %}
-        {{ value }}
-      {% elif state_attr(entity_id, "current_position") < (value | int) %}
-        {{ (value | int + 1) }}
-      {% elif state_attr(entity_id, "current_position") > (value | int) %}
-        {{ (value | int - 1) }}
-      {% else %}
-        {{ value }}
-      {% endif %}
+mqtt:
+  cover:
+    - name: "MQTT Cover"
+      command_topic: "home-assistant/cover/set"
+      state_topic: "home-assistant/cover/state"
+      position_topic: "home-assistant/cover/position"
+      set_position_topic: "home-assistant/cover/position/set"
+      payload_open:  "open"
+      payload_close: "close"
+      payload_stop:  "stop"
+      state_opening: "open"
+      state_closing: "close"
+      state_stopped: "stop"
+      optimistic: false
+      position_template: |-
+        {% if not state_attr(entity_id, "current_position") %}
+          {{ value }}
+        {% elif state_attr(entity_id, "current_position") < (value | int) %}
+          {{ (value | int + 1) }}
+        {% elif state_attr(entity_id, "current_position") > (value | int) %}
+          {{ (value | int - 1) }}
+        {% else %}
+          {{ value }}
+        {% endif %}
 ```
 
 {% endraw %}
@@ -542,60 +560,60 @@ Following variable might be used in `position_template`, `set_position_template`
 
 ```yaml
 # Example configuration.yaml entry
-cover:
-  - platform: mqtt
-    name: "MQTT Cover"
-    command_topic: "home-assistant/cover/set"
-    state_topic: "home-assistant/cover/state"
-    position_topic: "home-assistant/cover/position"
-    set_position_topic: "home-assistant/cover/position/set"
-    tilt_command_topic: "home-assistant/cover/position/set" # same as `set_position_topic`
-    qos: 1
-    retain: false
-    payload_open:  "open"
-    payload_close: "close"
-    payload_stop:  "stop"
-    state_opening: "open"
-    state_closing: "close"
-    state_stopped: "stop"
-    position_open: 100
-    position_closed: 0
-    tilt_min: 0
-    tilt_max: 6
-    tilt_opened_value: 3
-    tilt_closed_value: 0
-    optimistic: false
-    position_template: |-
-      {% if not state_attr(entity_id, "current_position") %}
-        {
-          "position" : value,
-          "tilt_value" : 0
-        }
-      {% else %}
-        {% set position = state_attr(entity_id, "current_position") %}
-        {% set tilt_percent = (state_attr(entity_id, "current_tilt_position")) %}
+mqtt:
+  cover:
+    - name: "MQTT Cover"
+      command_topic: "home-assistant/cover/set"
+      state_topic: "home-assistant/cover/state"
+      position_topic: "home-assistant/cover/position"
+      set_position_topic: "home-assistant/cover/position/set"
+      tilt_command_topic: "home-assistant/cover/position/set" # same as `set_position_topic`
+      qos: 1
+      retain: false
+      payload_open:  "open"
+      payload_close: "close"
+      payload_stop:  "stop"
+      state_opening: "open"
+      state_closing: "close"
+      state_stopped: "stop"
+      position_open: 100
+      position_closed: 0
+      tilt_min: 0
+      tilt_max: 6
+      tilt_opened_value: 3
+      tilt_closed_value: 0
+      optimistic: false
+      position_template: |-
+        {% if not state_attr(entity_id, "current_position") %}
+          {
+            "position" : value,
+            "tilt_value" : 0
+          }
+        {% else %}
+          {% set position = state_attr(entity_id, "current_position") %}
+          {% set tilt_percent = (state_attr(entity_id, "current_tilt_position")) %}
 
-        {% set movement = value | int - position %}
-        {% set tilt = (tilt_percent / 100 * (tilt_max - tilt_min)) %}
-        {% set tilt_value = min(max((tilt + movement), tilt_min), max) %}
- 
-        {
-           "position": value,
-           "pos": position,
-           "tilt": tilt,
-           "tilt_value": tilt_value,
-           "tilt_percent" : tilt_percent,
-           "mov" : movement
-        }
-      {% endif %}
-   tilt_command_template: >-
-      {% set position = state_attr(entity_id, "current_position") %}
-      {% set tilt = state_attr(entity_id, "current_tilt_position") %}
-      {% set movement = (tilt_position - tilt) / 100 * tilt_max %}
-      {{ position + movement }}
-    payload_open: "on"
-    payload_close: 
-    payload_stop: "on"
+          {% set movement = value | int - position %}
+          {% set tilt = (tilt_percent / 100 * (tilt_max - tilt_min)) %}
+          {% set tilt_value = min(max((tilt + movement), tilt_min), max) %}
+  
+          {
+            "position": value,
+            "pos": position,
+            "tilt": tilt,
+            "tilt_value": tilt_value,
+            "tilt_percent" : tilt_percent,
+            "mov" : movement
+          }
+        {% endif %}
+    tilt_command_template: >-
+        {% set position = state_attr(entity_id, "current_position") %}
+        {% set tilt = state_attr(entity_id, "current_tilt_position") %}
+        {% set movement = (tilt_position - tilt) / 100 * tilt_max %}
+        {{ position + movement }}
+      payload_open: "on"
+      payload_close: 
+      payload_stop: "on"
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Move manual configuration of MQTT cover to the integration key

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72268
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
