### PR TITLE
MQTT humidifier config to integration key

### DIFF
--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -22,11 +22,31 @@ To enable MQTT humidifiers in your installation, add the following to your `conf
 
 ```yaml
 # Example configuration.yaml entry
+mqtt:
+  humidifier:
+    - command_topic: "bedroom_humidifier/on/set"
+      target_humidity_command_topic: "bedroom_humidifier/humidity/set"
+```
+
+<a id='new_format'></a>
+
+{% details "Previous configuration format" %}
+
+The configuration format of manual configured MQTT items has changed.
+The old format that places configurations under the `light` platform key
+should no longer be used and is deprecated.
+
+The above example shows the new and modern way,
+this is the previous/old example:
+
+```yaml
 humidifier:
   - platform: mqtt
     command_topic: "bedroom_humidifier/on/set"
     target_humidity_command_topic: "bedroom_humidifier/humidity/set"
 ```
+
+{% enddetails %}
 
 {% configuration %}
 availability:
@@ -279,31 +299,31 @@ The example below shows a full configuration for a MQTT humidifier including mod
 
 ```yaml
 # Example configuration.yaml
-humidifier:
-  - platform: mqtt
-    name: "Bedroom humidifier"
-    device_class: "humidifier"
-    state_topic: "bedroom_humidifier/on/state"
-    command_topic: "bedroom_humidifier/on/set"
-    target_humidity_command_topic: "bedroom_humidifier/humidity/set"
-    target_humidity_state_topic: "bedroom_humidifier/humidity/state"
-    mode_state_topic: "bedroom_humidifier/mode/state"
-    mode_command_topic: "bedroom_humidifier/preset/preset_mode"
-    modes:
-      - "normal"
-      - "eco"
-      - "away"
-      - "boost"
-      - "comfort"
-      - "home"
-      - "sleep"
-      - "auto"
-      - "baby"
-    qos: 0
-    payload_on: "true"
-    payload_off: "false"
-    min_humidity: 30
-    max_humidity: 80
+mqtt:
+  humidifier:
+    - name: "Bedroom humidifier"
+      device_class: "humidifier"
+      state_topic: "bedroom_humidifier/on/state"
+      command_topic: "bedroom_humidifier/on/set"
+      target_humidity_command_topic: "bedroom_humidifier/humidity/set"
+      target_humidity_state_topic: "bedroom_humidifier/humidity/state"
+      mode_state_topic: "bedroom_humidifier/mode/state"
+      mode_command_topic: "bedroom_humidifier/preset/preset_mode"
+      modes:
+        - "normal"
+        - "eco"
+        - "away"
+        - "boost"
+        - "comfort"
+        - "home"
+        - "sleep"
+        - "auto"
+        - "baby"
+      qos: 0
+      payload_on: "true"
+      payload_off: "false"
+      min_humidity: 30
+      max_humidity: 80
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Move manual configuration of MQTT humidifier to the integration key

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72270
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
