### PR TITLE
MQTT lock config to integration key

### DIFF
--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -24,10 +24,29 @@ To enable MQTT locks in your installation, add the following to your `configurat
 
 ```yaml
 # Example configuration.yaml entry
+mqtt:
+  lock:
+    - command_topic: "home/frontdoor/set"
+```
+
+<a id='new_format'></a>
+
+{% details "Previous configuration format" %}
+
+The configuration format of manual configured MQTT items has changed.
+The old format that places configurations under the `lock` platform key
+should no longer be used and is deprecated.
+
+The above example shows the new and modern way,
+this is the previous/old example:
+
+```yaml
 lock:
   - platform: mqtt
     command_topic: "home/frontdoor/set"
 ```
+
+{% enddetails %}
 
 {% configuration %}
 availability:
@@ -229,19 +248,19 @@ The example below shows a full configuration for a MQTT lock.
 
 ```yaml
 # Example configuration.yaml entry
-lock:
-  - platform: mqtt
-    name: Frontdoor
-    state_topic: "home-assistant/frontdoor/"
-    command_topic: "home-assistant/frontdoor/set"
-    payload_lock: "LOCK"
-    payload_unlock: "UNLOCK"
-    state_locked: "LOCK"
-    state_unlocked: "UNLOCK"
-    optimistic: false
-    qos: 1
-    retain: true
-    value_template: "{{ value.x }}"
+mqtt:
+  lock:
+    - name: Frontdoor
+      state_topic: "home-assistant/frontdoor/"
+      command_topic: "home-assistant/frontdoor/set"
+      payload_lock: "LOCK"
+      payload_unlock: "UNLOCK"
+      state_locked: "LOCK"
+      state_unlocked: "UNLOCK"
+      optimistic: false
+      qos: 1
+      retain: true
+      value_template: "{{ value.x }}"
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Move manual configuration of MQTT lock to the integration key


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72271
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
