### PR TITLE
MQTT scene config to integration key

### DIFF
--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -16,10 +16,29 @@ To enable a MQTT scene in your installation, add the following to your `configur
 
 ```yaml
 # Example configuration.yaml entry
+mqtt:
+  scene:
+    - command_topic: zigbee2mqtt/living_room_group/set
+```
+
+<a id='new_format'></a>
+
+{% details "Previous configuration format" %}
+
+The configuration format of manual configured MQTT items has changed.
+The old format that places configurations under the `scene` platform key
+should no longer be used and is deprecated.
+
+The above example shows the new and modern way,
+this is the previous/old example:
+
+```yaml
 scene:
   - platform: mqtt
     command_topic: zigbee2mqtt/living_room_group/set
 ```
+
+{% enddetails %}
 
 {% configuration %}
 availability:
@@ -132,16 +151,16 @@ The example below shows a full configuration for a scene.
 
 ```yaml
 # Example configuration.yaml entry
-scene:
-  - platform: mqtt
-    unique_id: living_room_party_scene
-    name: "Living Room Party Scene"
-    command_topic: "home/living_room/party_scene/set"
-    availability:
-      - topic: "home/living_room/party_scene/available"
-    payload_on: "ON"
-    qos: 0
-    retain: true
+mqtt:
+  scene:
+    - unique_id: living_room_party_scene
+      name: "Living Room Party Scene"
+      command_topic: "home/living_room/party_scene/set"
+      availability:
+        - topic: "home/living_room/party_scene/available"
+      payload_on: "ON"
+      qos: 0
+      retain: true
 ```
 
 ### Use with a JSON Payload
@@ -150,10 +169,10 @@ The example below shows a configuration using a JSON payload.
 
 ```yaml
 # Example configuration.yaml entry
-scene:
-  - platform: mqtt
-    name: Living Room Blue Scene
-    unique_id: living_room_blue_scene
-    command_topic: "home/living_room/set"
-    payload_on: '{"activate_scene": "Blue Scene"}'
+mqtt:
+  scene:
+    - name: Living Room Blue Scene
+      unique_id: living_room_blue_scene
+      command_topic: "home/living_room/set"
+      payload_on: '{"activate_scene": "Blue Scene"}'
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Move manual configuration of MQTT scene to the integration key



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72273
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
