### PR TITLE
MQTT vacuum config to integration key

### DIFF
--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -21,9 +21,29 @@ To add your MQTT vacuum to your installation, add the following to your `configu
 
 ```yaml
 # Example configuration.yaml entry
+mqtt:
+  vacuum:
+    - command_topic: "vacuum/command"
+```
+
+<a id='new_format'></a>
+
+{% details "Previous configuration format" %}
+
+The configuration format of manual configured MQTT items has changed.
+The old format that places configurations under the `vacuum` platform key
+should no longer be used and is deprecated.
+
+The above example shows the new and modern way,
+this is the previous/old example:
+
+```yaml
 vacuum:
   - platform: mqtt
+    command_topic: "vacuum/command"
 ```
+
+{% enddetails %}
 
 ## Legacy Configuration
 
@@ -243,41 +263,41 @@ unique_id:
 
 ```yaml
 # Example configuration.yaml entry
-vacuum:
-  - platform: mqtt
-    name: "MQTT Vacuum"
-    supported_features:
-      - turn_on
-      - turn_off
-      - pause
-      - stop
-      - return_home
-      - battery
-      - status
-      - locate
-      - clean_spot
-      - fan_speed
-      - send_command
-    command_topic: "vacuum/command"
-    battery_level_topic: "vacuum/state"
-    battery_level_template: "{{ value_json.battery_level }}"
-    charging_topic: "vacuum/state"
-    charging_template: "{{ value_json.charging }}"
-    cleaning_topic: "vacuum/state"
-    cleaning_template: "{{ value_json.cleaning }}"
-    docked_topic: "vacuum/state"
-    docked_template: "{{ value_json.docked }}"
-    error_topic: "vacuum/state"
-    error_template: "{{ value_json.error }}"
-    fan_speed_topic: "vacuum/state"
-    fan_speed_template: "{{ value_json.fan_speed }}"
-    set_fan_speed_topic: "vacuum/set_fan_speed"
-    fan_speed_list:
-      - min
-      - medium
-      - high
-      - max
-    send_command_topic: "vacuum/send_command"
+mqtt:
+  vacuum:
+    - name: "MQTT Vacuum"
+      supported_features:
+        - turn_on
+        - turn_off
+        - pause
+        - stop
+        - return_home
+        - battery
+        - status
+        - locate
+        - clean_spot
+        - fan_speed
+        - send_command
+      command_topic: "vacuum/command"
+      battery_level_topic: "vacuum/state"
+      battery_level_template: "{{ value_json.battery_level }}"
+      charging_topic: "vacuum/state"
+      charging_template: "{{ value_json.charging }}"
+      cleaning_topic: "vacuum/state"
+      cleaning_template: "{{ value_json.cleaning }}"
+      docked_topic: "vacuum/state"
+      docked_template: "{{ value_json.docked }}"
+      error_topic: "vacuum/state"
+      error_template: "{{ value_json.error }}"
+      fan_speed_topic: "vacuum/state"
+      fan_speed_template: "{{ value_json.fan_speed }}"
+      set_fan_speed_topic: "vacuum/set_fan_speed"
+      fan_speed_list:
+        - min
+        - medium
+        - high
+        - max
+      send_command_topic: "vacuum/send_command"
 ```
 
 {% endraw %}
@@ -512,30 +532,30 @@ unique_id:
 
 ```yaml
 # Example configuration.yaml entry
-vacuum:
-  - platform: mqtt
-    name: "MQTT Vacuum"
-    schema: state
-    supported_features:
-      - start
-      - pause
-      - stop
-      - return_home
-      - battery
-      - status
-      - locate
-      - clean_spot
-      - fan_speed
-      - send_command
-    command_topic: "vacuum/command"
-    state_topic: "vacuum/state"
-    set_fan_speed_topic: "vacuum/set_fan_speed"
-    fan_speed_list:
-      - min
-      - medium
-      - high
-      - max
-    send_command_topic: "vacuum/send_command"
+mqtt:
+  vacuum:
+    - name: "MQTT Vacuum"
+      schema: state
+      supported_features:
+        - start
+        - pause
+        - stop
+        - return_home
+        - battery
+        - status
+        - locate
+        - clean_spot
+        - fan_speed
+        - send_command
+      command_topic: "vacuum/command"
+      state_topic: "vacuum/state"
+      set_fan_speed_topic: "vacuum/set_fan_speed"
+      fan_speed_list:
+        - min
+        - medium
+        - high
+        - max
+      send_command_topic: "vacuum/send_command"
 ```
 
 ### State MQTT Protocol


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Move manual configuration of MQTT legacy and state vacuum items to the integration key

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72281
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
