### PR TITLE
Added tip that RouterOS uses ping

### DIFF
--- a/source/_integrations/mikrotik.markdown
+++ b/source/_integrations/mikrotik.markdown
@@ -24,7 +24,8 @@ There is currently support for the following device types within Home Assistant:
 ## Prerequisites
 
 You have to enable accessing the RouterOS API on your router to use this platform.
-RouterOS uses ping test to determine client presence, make sure you are not blocking this on the client (Windows firewall default behaviour), as this will result in Homeassistant `device_tracker` having state `Not_home`.
+
+RouterOS uses a ping test to determine client presence, make sure you are not blocking this on the client (Windows firewall default behavior), as this will result in the provided `device_tracker` having the state `not_home`.
 
 Terminal:
 

--- a/source/_integrations/mikrotik.markdown
+++ b/source/_integrations/mikrotik.markdown
@@ -24,6 +24,7 @@ There is currently support for the following device types within Home Assistant:
 ## Prerequisites
 
 You have to enable accessing the RouterOS API on your router to use this platform.
+RouterOS uses ping test to determine client presence, make sure you are not blocking this on the client (Windows firewall default behaviour), as this will result in Homeassistant `device_tracker` having state `Not_home`.
 
 Terminal:
 
@@ -37,6 +38,7 @@ Web Frontend:
 Go to **IP** -> **Services** -> **API** and enable it.
 
 Make sure that port 8728 or the port you choose is accessible from your network.
+
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I couldn't figure out why my RouterOS was having an active DHCP lease, homeassistant was seeing the lease, but the ` device_tracker`  stayed not_home.
Turns out RouterOS still uses ICMP and is not strictly using the DHCP leases only. 



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
