### PR TITLE
Remove options_flow from laundrify integration

### DIFF
--- a/source/_integrations/laundrify.markdown
+++ b/source/_integrations/laundrify.markdown
@@ -39,11 +39,3 @@ code:
   required: true
   type: string
 {% endconfiguration_basic %}
-
-{% include integrations/option_flow.md %}
-{% configuration_basic %}
-poll_interval:
-  description: Interval for polling the laundrify backend (in seconds)
-  default: 60
-  type: integer
-{% endconfiguration_basic %}


### PR DESCRIPTION
## Proposed change

The options flow need to be removed from the laundrify integration docs, since it has been removed during code review (see https://github.com/home-assistant/core/pull/65090#discussion_r870412189).

I am targeting the `next` branch, since the laundrify integration will be released in the upcoming 2022.6 release and is not part of the current documentation.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Adjusted missing or incorrect information in the **upcoming** documentation (`next` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the docs repository: https://github.com/home-assistant/home-assistant.io/pull/21360
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/65090

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
