### PR TITLE
Revert part of #22840

### DIFF
--- a/source/_dashboards/picture-elements.markdown
+++ b/source/_dashboards/picture-elements.markdown
@@ -254,7 +254,7 @@ service:
   required: true
   description: "`light.turn_on`"
   type: string
-data:
+service_data:
   required: false
   description: The service data to use.
   type: map
@@ -521,7 +521,7 @@ elements:
       top: 95%
       left: 60%
     service: homeassistant.turn_off
-    data:
+    service_data:
       entity_id: group.all_lights
   - type: icon
     icon: mdi:home

--- a/source/_integrations/xbox.markdown
+++ b/source/_integrations/xbox.markdown
@@ -116,7 +116,7 @@ elements:
   - type: service-button
     title: ""
     service: remote.send_command
-    data:
+    service_data:
       entity_id: remote.xboxone_remote
       command: Up
     style:
@@ -128,7 +128,7 @@ elements:
   - type: service-button
     title: ""
     service: remote.send_command
-    data:
+    service_data:
       entity_id: remote.xboxone_remote
       command: Down
     style:
@@ -140,7 +140,7 @@ elements:
   - type: service-button
     title: ""
     service: remote.send_command
-    data:
+    service_data:
       entity_id: remote.xboxone_remote
       command: Left
     style:
@@ -152,7 +152,7 @@ elements:
   - type: service-button
     title: ""
     service: remote.send_command
-    data:
+    service_data:
       entity_id: remote.xboxone_remote
       command: Right
     style:
@@ -164,7 +164,7 @@ elements:
   - type: service-button
     title: ""
     service: remote.send_command
-    data:
+    service_data:
       entity_id: remote.xboxone_remote
       command: "A"
     style:
@@ -177,7 +177,7 @@ elements:
   - type: service-button
     title: ""
     service: remote.send_command
-    data:
+    service_data:
       entity_id: remote.xboxone_remote
       command: "X"
     style:
@@ -190,7 +190,7 @@ elements:
   - type: service-button
     title: ""
     service: remote.send_command
-    data:
+    service_data:
       entity_id: remote.xboxone_remote
       command: "B"
     style:
@@ -203,7 +203,7 @@ elements:
   - type: service-button
     title: ""
     service: remote.send_command
-    data:
+    service_data:
       entity_id: remote.xboxone_remote
       command: "Y"
     style:
@@ -216,7 +216,7 @@ elements:
   - type: service-button
     title: ""
     service: remote.toggle
-    data:
+    service_data:
       entity_id: remote.xboxone_remote
     style:
       top: 80.2%
@@ -228,7 +228,7 @@ elements:
   - type: service-button
     title: ""
     service: media_player.play_media
-    data:
+    service_data:
       entity_id: media_player.xboxone
       media_content_type: ""
       media_content_id: "Home"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

#22840 was merged before being updated with the last changes to the parent PR.

`service_data` should remain outside of `tap_action` definitions.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
