### PR TITLE
Update google calendars documentation around yaml support #22881

### DIFF
--- a/source/_integrations/google.markdown
+++ b/source/_integrations/google.markdown
@@ -121,7 +121,7 @@ Using the entity state and attributes is more error prone and less flexible than
 
 ### Service `google.add_event`
 
-You can use the service `google.add_event` to create a new calendar event in a calendar. Calendar id's can be found in the file `google_calendars.yaml`. All dates and times are in your local time, the integration gets your time zone from your `configuration.yaml` file.
+You can use the service `google.add_event` to create a new calendar event in a calendar. You can find the Calendar's ID Google Calendar Settings. All dates and times are in your local time, the integration gets your time zone from your `configuration.yaml` file.
 
 {% details "Add Event Service details" %}
 
@@ -161,7 +161,8 @@ compatible with other Home Assistant features, but this documentation is availab
 for existing users.
 </div>
 
-The integration will discover new calendars and write them into a configuration file `google_calendars.yaml` in your configuration directory that can allow for additional configuration.
+The integration supports additional configuration from a file `google_calendars.yaml` which is avaialble for existing
+users before version `2022.06`. This file is no longer automatically populated.
 
 {% configuration %}
 cal_id:

--- a/source/_integrations/google.markdown
+++ b/source/_integrations/google.markdown
@@ -161,8 +161,7 @@ compatible with other Home Assistant features, but this documentation is availab
 for existing users.
 </div>
 
-The integration supports additional configuration from a file `google_calendars.yaml` which is avaialble for existing
-users before version `2022.06`. This file is no longer automatically populated.
+The integration supports additional configuration from a file `google_calendars.yaml` which is avaialble for existing users before version `2022.06`. This file is no longer automatically populated.
 
 {% configuration %}
 cal_id:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update google calendars documentation around `google_calendars.yaml` which is no longer automatically populated.




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/72340
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
