### PR TITLE
Add missing "show_icon" and "show_name" to header/footer card config

### DIFF
--- a/source/dashboards/header-footer.markdown
+++ b/source/dashboards/header-footer.markdown
@@ -79,6 +79,17 @@ entities:
       required: false
       description: Label for the button.
       type: string
+    show_icon:
+      required: false
+      description: Show entity icon.
+      type: boolean
+      default: "true"  
+    show_name:
+      required: false
+      description: Show entity name.
+      type: boolean
+      default: "false"
+    
 {% endconfiguration %}
 
 ## Graph header & footer


### PR DESCRIPTION
## Proposed change

Fields are already supported, just not documented.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
