### PR TITLE
Add Support for Session Ended Requests

### DIFF
--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -304,6 +304,48 @@ intent_script:
       text: OK
 ```
 
+### Support for Session Ended Requests
+
+There may be times when you want to act to a session ended request initiated from a lack of voice response.
+
+To start, you need to get the skill id:
+
+- Log into [Amazon developer console][amazon-dev-console]
+- Click the Alexa button at the top of the console
+- Click the Alexa Skills Kit Get Started button
+  - Locate the skill for which you would like Launch Request support
+  - Click the "View Skill ID" link and copy the ID
+
+The configuration is the same as an intent with the exception being you will use your skill ID instead of the intent name.
+
+```yaml
+intent_script:
+  amzn1.ask.skill.08888888-7777-6666-5555-444444444444:
+    speech:
+      text: It is late already. Do I turn off lights ?
+    reprompt:
+      text: Do I turn off lights ?
+  AMAZON.YesIntent:
+    speech:
+      text: Done. Good night!
+    action:
+      service: switch.turn_off
+      target:
+        entity_id:
+          - switch.room1
+          - switch.room2
+  AMAZON.NoIntent:
+    speech:
+      text: Alright
+  amzn1.ask.skill.08888888-7777-6666-5555-444444444444.SessionEndedRequest:
+    action:
+      service: switch.turn_off
+      target:
+        entity_id:
+          - switch.room1
+          - switch.room2
+```
+
 ## Giving Alexa Some Personality
 
 In the examples above, we told Alexa to say `OK` when she successfully completed the task. This is effective but a little dull! We can again use [templates] to spice things up a little.


### PR DESCRIPTION
Related to https://github.com/home-assistant/core/pull/72218

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Support for Session Ended Requests


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72218
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
