### PR TITLE
2022.6: Add missing init system breaking change

### DIFF
--- a/source/_includes/installation/container/alternative.md
+++ b/source/_includes/installation/container/alternative.md
@@ -89,24 +89,3 @@ The steps would be:
 - Your Home Assistant within Docker should now run and will serve the web interface from port 8123 on your Docker host (this will be your Qnap NAS IP address - for example `http://192.xxx.xxx.xxx:8123`)
 
 Remark: To update your Home Assistant on your Docker within Qnap NAS, you just remove container and image and do steps again (Don't remove "config" folder).
-
-If you want to use a USB Bluetooth adapter or Z-Wave USB stick with Home Assistant on Qnap Docker, follow those steps:
-
-#### Bluetooth
-
-- Connect to your NAS over SSH
-- Run Docker command:
-
-  ```bash
-  docker run --name homeassistant --net=host --privileged -itd -v /share/CACHEDEV1_DATA/Public/homeassistant/config:/config -e TZ=Europe/London -v /dev/bus/usb:/dev/bus/usb -v /var/run/dbus:/var/run/dbus {{ site.installation.container }}:stable
-  ```
-
-  First `-v` is your configuration path
-  `-e` is set timezone
-
-- Edit the `configuration.yaml` file
-
-```yaml
-device_tracker:
-  - platform: bluetooth_tracker
-```

--- a/source/_includes/installation/container/alternative.md
+++ b/source/_includes/installation/container/alternative.md
@@ -92,40 +92,13 @@ Remark: To update your Home Assistant on your Docker within Qnap NAS, you just r
 
 If you want to use a USB Bluetooth adapter or Z-Wave USB stick with Home Assistant on Qnap Docker, follow those steps:
 
-#### Z-Wave
-
-- Connect to your NAS over SSH
-- Load cdc-acm kernel module(when NAS restart need to run this command)
-  `insmod /usr/local/modules/cdc-acm.ko`
-- Find USB devices attached. Type command:
-  `ls /dev/tty*`
-  The above command should show you any USB devices plugged into your NAS. If you have more than one, you may get multiple items returned. Like : `ttyACM0`
-
-- Run Docker command:
-
-  ```bash
-  docker run --init --name homeassistant --net=host --privileged -itd -v /share/CACHEDEV1_DATA/Public/homeassistant/config:/config -e TZ=Europe/London --device /dev/ttyACM0 {{ site.installation.container }}:stable
-  ```
-
-  `-v` is your configuration path
-  `-e` is set timezone
-
-- Edit `configuration.yaml`
-
-```yaml
-zwave:
-  usb_path: /dev/ttyACM0
-```
-
-That will tell Home Assistant where to look for our Z-Wave radio.
-
 #### Bluetooth
 
 - Connect to your NAS over SSH
 - Run Docker command:
 
   ```bash
-  docker run --init --name homeassistant --net=host --privileged -itd -v /share/CACHEDEV1_DATA/Public/homeassistant/config:/config -e TZ=Europe/London -v /dev/bus/usb:/dev/bus/usb -v /var/run/dbus:/var/run/dbus {{ site.installation.container }}:stable
+  docker run --name homeassistant --net=host --privileged -itd -v /share/CACHEDEV1_DATA/Public/homeassistant/config:/config -e TZ=Europe/London -v /dev/bus/usb:/dev/bus/usb -v /var/run/dbus:/var/run/dbus {{ site.installation.container }}:stable
   ```
 
   First `-v` is your configuration path

--- a/source/_posts/2022-06-01-release-20226.markdown
+++ b/source/_posts/2022-06-01-release-20226.markdown
@@ -464,6 +464,26 @@ the documentation of the specific integration on how to configure this.
 
 {% enddetails %}
 
+{% details "Home Assistant Container" %}
+
+If you run Home Assistant Container in Docker (e.g., using Portainer,
+Docker (Compose), QNAP, and others), please make sure you are not specifying
+an init process. 
+
+This can be an `init` configuration option in your Docker management tools or
+Docker Compose, or the `--init` command line flag on the raw Docker command.
+These should **NOT** be set, as Home Assistant ships with the S6 init system.
+
+While you are at it, make sure you also do not set a `cmd` or `entrypoint`.
+Setting these are not breaking, however, you should not set them.
+
+([@pvizeli] - [#72425]) ([documentation](/installation))
+
+[@pvizeli]: https://github.com/pvizeli
+[#72425]: https://github.com/home-assistant/core/pull/72425
+
+{% enddetails %}
+
 {% details "1-Wire" %}
 
 Using the 1-Wire via SysBus, previously deprecated, has been removed;


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds a missing breaking change on Container-based installation types.

Apparently, we had occurrences using an init in our documentation (of which one is obsolete at least). This PR cleans it up, and adds a breaking change warning (as we already had some reports on these).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes [#72838](https://github.com/home-assistant/core/issues/72838)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
