### PR TITLE
Updates Conrad ESP32-C3 link to international site

### DIFF
--- a/source/_posts/2022-05-29-matter-in-home-assistant-workshop-announcement.markdown
+++ b/source/_posts/2022-05-29-matter-in-home-assistant-workshop-announcement.markdown
@@ -30,7 +30,7 @@ The workshop will be free but you will need a couple of things if you want to be
 
 - Home Assistant OS 8.0 or newer (Matter relies on an add-on and Bluetooth)
 - [Home Assistant Community Store](https://hacs.xyz/) installed
-- Espressif ESP32-C3-DevKitM-1 ($9 @ [Mouser](https://www.mouser.com/ProductDetail/356-ESP32-C3DEVKITM1), €17 @ [Conrad](https://www.conrad.de/de/p/espressif-entwicklungsboard-esp32-c3-devkitm-1-2490158.html)) or M5Stamp C3 ($6 @ [M5Stack](https://twitter.com/home_assistant/status/1531712479016890369))
+- Espressif ESP32-C3-DevKitM-1 ($9 @ [Mouser](https://www.mouser.com/ProductDetail/356-ESP32-C3DEVKITM1), €17 @ [Conrad](https://www.conrad.com/p/espressif-pcb-design-board-esp32-c3-devkitm-1-2490158)) or M5Stamp C3 ($6 @ [M5Stack](https://twitter.com/home_assistant/status/1531712479016890369))
 - Bluetooth. If you use a Raspberry Pi to run Home Assistant you’re set. If you have a Home Assistant Blue or another device without Bluetooth, get a Bluetooth USB adapter that is supported by Home Assistant OS ([like this one](https://www.amazon.com/gp/product/B09DMP6T22/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=B09DMP6T22&linkCode=as2&tag=homeassista0e-20&linkId=c5046239bf04d5b21835299dfb393f0e)).
 
 Even if you can’t follow along, it will still be an informative session!


### PR DESCRIPTION
## Proposed change

Conrad has an international site, this pr is changing the link from .de. to .com. site.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
