### PR TITLE
Update eight_sleep docs for config flow

### DIFF
--- a/source/_integrations/eight_sleep.markdown
+++ b/source/_integrations/eight_sleep.markdown
@@ -26,29 +26,7 @@ There is currently support for the following device types within Home Assistant:
 
 ## Configuration
 
-It's setup utilizing 'Sensor' platform to convey the current state of your bed and results of your sleep sessions and a 'Binary Sensor' platform to indicate your presence in the bed. A service is also provided to set the cooling/heating level and duration of the bed (cooling is only available for the POD mattress).
-
-You must have at least two sleep sessions recorded in the Eight Sleep app prior to setting up the Home Assistant component.
-
-To get started add the following information to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-eight_sleep:
-  username: YOUR_E_MAIL_ADDRESS
-  password: YOUR_PASSWORD
-```
-
-{% configuration %}
-username:
-  description: The email address associated with your Eight Sleep account.
-  required: true
-  type: string
-password:
-  description: The password associated with your Eight Sleep account.
-  required: true
-  type: string
-{% endconfiguration %}
+{% include integrations/config_flow.md %}
 
 ### Supported features
 
@@ -107,7 +85,7 @@ You can use the service eight_sleep/heat_set to adjust the target cooling/heatin
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | Entity ID of bed state to adjust.
+| `entity_id` | no | Entity ID that relates to the side to be adjusted.
 | `target` | no | Target cooling/heating level from -100 to 100.
 | `duration` | no | Duration to cool/heat at the target level in seconds.
 

--- a/source/_integrations/eight_sleep.markdown
+++ b/source/_integrations/eight_sleep.markdown
@@ -24,11 +24,9 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor - lets observe the presence state of a [Eight Sleep](https://eightsleep.com/) cover/mattress through Home Assistant.
 - Sensor - This includes bed state, sleep fitness scores, and results of the current and previous sleep sessions.
 
-## Configuration
-
 {% include integrations/config_flow.md %}
 
-### Supported features
+## Supported features
 
 Sensors and associated attributes:
 
@@ -79,13 +77,13 @@ Binary Sensors:
 
 - eight_left/right_bed_presence
 
-### Service `heat_set`
+## Service `heat_set`
 
 You can use the service eight_sleep/heat_set to adjust the target cooling/heating level and heating duration of your bed (cooling is only available for the POD mattress).
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | Entity ID that relates to the side to be adjusted.
+| `entity_id` | no | Entity ID for a sensor on the side to be adjusted.
 | `target` | no | Target cooling/heating level from -100 to 100.
 | `duration` | no | Duration to cool/heat at the target level in seconds.
 
@@ -97,12 +95,12 @@ script:
     sequence:
       - service: eight_sleep.heat_set
         target:
-          entity_id: "sensor.eight_left_bed_state"
+          entity_id: "sensor.eight_johns_bed_temperature"
         data:
           target: 35
           duration: 3600
 ```
 
-### Notice
+## Notice
 
 Please note this component relies on an undocumented API utilized by the Eight Sleep mobile app to communicate with the Eight Sleep servers.  It is not supported by Eight Sleep and may malfunction if changes are made to either the mobile app operation or the API format.


### PR DESCRIPTION
## Proposed change
Updates the docs to reflect that `eight_sleep` now uses config flows for configuration.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/71095
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
