### PR TITLE
Add battery attribute to lcn transmitter event

### DIFF
--- a/source/_integrations/lcn.markdown
+++ b/source/_integrations/lcn.markdown
@@ -534,7 +534,7 @@ Further examples can be found in the [event section](#events).
 To use LCN remote controls (e.g., LCN-RT or LCN-RT16) ensure that the corresponding module's I-port property
 is enabled in the LCN-PRO software and its behavior is properly configured as "IR access control".
 With this configuration each remote control is identified by a six value hexadecimal code (e.g. *123abc*).
-If a command from a remote control is received a corresponding event ([transponder event](#event-lcn_transponder))
+If a command from a remote control is received a corresponding event ([transmitter event](#event-lcn_transmitter))
 is fired and can be used to trigger an automation. Along with the transmitted code, the pressed key and the key action
 are transmitted.
 Alternatively, you can use the corresponding [device triggers](#device-triggers).

--- a/source/_integrations/lcn.markdown
+++ b/source/_integrations/lcn.markdown
@@ -596,6 +596,7 @@ The `lcn_transmitter` event is fired if a LCN remote control command is received
 | `level` | Key level | 0..4 |
 | `key` | Key | 0..4 |
 | `action` | Key action | `hit`, `make`, `break` |
+| `battery` | Battery status | `full`, `weak` |
 
 Example:
 


### PR DESCRIPTION
## Proposed change
Add battery attribute to lcn transmitter event



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Add battery attribute to lcn transmitter event.

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/73019
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
