### PR TITLE
Add T3950 to Venstar devices

### DIFF
--- a/source/_integrations/venstar.markdown
+++ b/source/_integrations/venstar.markdown
@@ -26,8 +26,10 @@ Currently supported and tested thermostats:
 - ColorTouch T7900  
 - ColorTouch T7850  (No Humidity control)
 - Explorer Mini T2000
+- Explorer IAQ T3950
 
 Currently supported functionality:
+
 - Setting heat/cool temperature when the thermostat is in the appropriate mode.
 - Changing the operation mode of the thermostat (heat/cool/off/auto)
 - Turning the fan on/off
@@ -36,8 +38,10 @@ Currently supported functionality:
 - Turning on hold mode preset
 - Remote temperature sensors
 - Thermostat alerts (Filter replacement/etc)
+- Reading IAQ and CO2 levels (on supported devices, e.g. T3950, only)
 
 The following values are supported for the preset_mode state attribute:
+
 - `none`: *Enables* the scheduling functionality.
 - `temperature`: *Disables* the schedule and holds the set temperature indefinitely.
 - `away`: Places the thermostat in away mode


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding the T3950 Venstar thermostat to the list of tested devices.

This device supports new sensors (IAQ and CO2) that were added in this PR (included in the 2022.06 release): https://github.com/home-assistant/core/pull/71467


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
