### PR TITLE
Update alarm_control_panel.mqtt.markdown

### DIFF
--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -306,7 +306,8 @@ mqtt:
       value_template: "{{ value_json.state }}"
       command_topic: "alarmdecoder/panel/set"
       code: REMOTE_CODE_TEXT
-      command_template: "{ action: '{{ action }}', code: '{{ code }}'}"
+      command_template: >
+        { "action": "{{ action }}", "code": "{{ code }}" }
 ```
 
 ```yaml
@@ -318,7 +319,8 @@ mqtt:
       value_template: "{{ value_json.state }}"
       command_topic: "alarmdecoder/panel/set"
       code: REMOTE_CODE
-      command_template: "{ action: '{{ action }}', code: '{{ code }}'}"
+      command_template: >
+        { "action": "{{ action }}", "code": "{{ code }}" }
 ```
 
 {% endraw %}


### PR DESCRIPTION
The previous command template was not generating a real json object, thus some client parser (ex. Nodered) was not able to parse it as a JSON object.

## Proposed change
We would need to add double quote on JSON fields to be interpreted as string by JSON parser.
I've also added double quote for the numeric example but one option would be to remove quote to be directly interpreted as integer by JSON parser.

I have also used YAML fold so that we don't need to add double quote for YAML string definition thus, we do not mix double quote for YAML and double quote for JSON message.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
I've made this modification as I use Nodered to receive message and make action.
Nodered was not able to parse the JSON message correctly.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
