### PR TITLE
Add documentation for Envisalink zone status binary sensor attributes…

### DIFF
--- a/source/_integrations/envisalink.markdown
+++ b/source/_integrations/envisalink.markdown
@@ -136,7 +136,7 @@ partitions:
       type: string
 {% endconfiguration %}
 
-Supported services:
+## Services
 
 The following services are supported by Envisalink and can be used to script or automate the alarm.
 
@@ -147,3 +147,14 @@ The following services are supported by Envisalink and can be used to script or 
 - **alarm_trigger**: Trigger an alarm on the Envisalink connected alarm system. For example, a newer Z-Wave / Zigbee sensor can now be integrated into a legacy alarm system using a Home Assistant automation.
 - **alarm_keypress**: Sends a string of up to 6 characters to the alarm. *Works with DSC panels, and confirmed to work with Honeywell Vista-20P (aka First Alert FA-168)*
 - **invoke_custom_function**: Invokes a custom PGM function. *DSC alarms only*
+
+## Attributes
+
+The zone status binary sensors have extra attributes representing additional
+information about each zone.
+
+| Name | Description |
+| ---- | ----------- |
+| `last_tripped_time` | Last time this zone was tripped.
+| `zone` | Zone number. Can be used in combination with `alarm_keypress` service
+to issue commands relating to this zone.


### PR DESCRIPTION
… including new zone attribute added in PR#71468

## Proposed change
Adds documentation for the last_tripped_time and zone attributes on the zone status binary sensors. Latter is being added in the following PR: https://github.com/home-assistant/core/pull/71468


## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/71468
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
