### PR TITLE
Add warning about 700 series controllers

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -7,6 +7,20 @@ description: "Extended instructions how to setup Z-Wave."
 
 You need to have a compatible Z-Wave stick or module installed. The following devices have been confirmed to work with Z-Wave JS:
 
+<div class='note warning'>
+
+Until recently, 700 series Z-Wave Controllers had a bug that could cause the mesh to be flooded on some networks and the controller to become unresponsive. At present, all 700 series controllers share the same firmware and are subject to this bug. It appears that this bug is largely, if not completely, resolved as of firmware version 7.17.2.
+
+Users should upgrade the firmware on all 700 series controllers to version 7.17.2 or greater. Firmware can be upgraded using the below directions:
+
+Via Linux: https://github.com/kpine/zwave-js-server-docker/wiki/700-series-Controller-Firmware-Updates-(Linux)
+
+Via Windows:
+- Aeotec - https://help.aeotec.com/support/solutions/articles/6000252296-update-z-stick-7-with-windows
+- Zooz - https://www.support.getzooz.com/kb/article/931-how-to-perform-an-ota-firmware-update-on-your-zst10-700-z-wave-stick/
+
+</div>
+
 - 700 series controllers
   - Aeotec Z-Stick 7 USB stick (ZWA010)
   - Aeotec Z-Pi 7 Raspberry Pi HAT/Shield (ZWA025)

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -13,11 +13,9 @@ Until recently, 700 series Z-Wave Controllers had a bug that could cause the mes
 
 Users should upgrade the firmware on all 700 series controllers to version 7.17.2 or greater. Firmware can be upgraded using the below directions:
 
-Via Linux: https://github.com/kpine/zwave-js-server-docker/wiki/700-series-Controller-Firmware-Updates-(Linux)
-
-Via Windows:
-- Aeotec - https://help.aeotec.com/support/solutions/articles/6000252296-update-z-stick-7-with-windows
-- Zooz - https://www.support.getzooz.com/kb/article/931-how-to-perform-an-ota-firmware-update-on-your-zst10-700-z-wave-stick/
+- [Upgrade instructions using Linux](https://github.com/kpine/zwave-js-server-docker/wiki/700-series-Controller-Firmware-Updates-(Linux))
+- [Upgrade instructions using Windows (Aeotec)](https://help.aeotec.com/support/solutions/articles/6000252296-update-z-stick-7-with-windows)
+- [Upgrade instructions using Windows (Zooz)](https://www.support.getzooz.com/kb/article/931-how-to-perform-an-ota-firmware-update-on-your-zst10-700-z-wave-stick/)
 
 </div>
 

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -44,10 +44,6 @@ Via Windows:
 If you are just starting out, we recommend that you purchase a 500 series controller. At the very least, you should purchase a [Z-Wave Plus](https://z-wavealliance.org/z-wave_plus_certification/) controller.
 
 <div class='note'>
-  Not all of the above devices are supported by the deprecated Z-Wave integration.
-</div>
-
-<div class='note'>
   If you're using Home Assistant OS, Supervised, or Container, it's recommended to use a USB stick, not a module. Passing a module through Docker is more complicated than passing a USB stick through.
 </div>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- Add Z-Wave 700 series warning.
- Remove note about deprecated zwave integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
