### PR TITLE
Update litterrobot documentation to match current implementation

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -26,7 +26,7 @@ The Litter-Robot integration allows you to control and monitor your Wi-Fi-enable
 
 You will need a Litter-Robot account as well as a Wi-Fi-enabled Litter-Robot unit that has already been associated with your account.
 
-The Feeder-Robot is not currently supported by this integration.
+The Feeder-Robot and Litter-Robot 4 are not currently supported by this integration.
 
 {% include integrations/config_flow.md %}
 
@@ -42,7 +42,7 @@ The following entities are created for this component and identified by a single
 | Last Seen                     | `sensor` | Displays the time the unit was last seen / reported an update.                                                                                  |
 | Sleep Mode Start Time         | `sensor` | When sleep mode is enabled, displays the current or next sleep mode start time.                                                                 |
 | Sleep Mode End Time           | `sensor` | When sleep mode is enabled, displays the current or last sleep mode end time.                                                                   |
-| Status Code                   | `sensor` | Displays the [status code](https://github.com/natekspencer/pylitterbot/blob/884944b011f5fea9639b7d21d19fa3f7708e25a7/pylitterbot/enums.py#L44). |
+| Status Code                   | `sensor` | Displays the status code (Clean Cycle in Progress, Ready, Drawer Full, etc). |
 | Waste Drawer                  | `sensor` | Displays the current waste drawer level.                                                                                                        |
 | Clean Cycle Wait Time Minutes | `select` | View and select the clean cycle wait time.                                                                                                      |
 | Reset Waste Drawer            | `button` | Button to reset the waste drawer level to 0%.                                                                                                   |

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -34,16 +34,18 @@ The Feeder-Robot is not currently supported by this integration.
 
 The following entities are created for this component and identified by a single device per Litter-Robot unit:
 
-| Entity                        | Domain   | Description                                                                      |
-| ----------------------------- | -------- | -------------------------------------------------------------------------------- |
-| Litter Box                    | `vacuum` | Main entity that represents a Litter-Robot unit.                                 |
-| Night Light Mode              | `switch` | When turned on, automatically turns on the night light in darker settings.       |
-| Panel Lockout                 | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
-| Sleep Mode Start Time         | `sensor` | When sleep mode is enabled, displays the current or next sleep mode start time.  |
-| Sleep Mode End Time           | `sensor` | When sleep mode is enabled, displays the current or last sleep mode end time.    |
-| Waste Drawer                  | `sensor` | Displays the current waste drawer level.                                         |
-| Clean Cycle Wait Time Minutes | `select` | View and select the clean cycle wait time.                                       |
-| Reset Waste Drawer            | `button` | Button to reset the waste drawer level to 0%.                                    |
+| Entity                        | Domain   | Description                                                                                                                                     |
+| ----------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Litter Box                    | `vacuum` | Main entity that represents a Litter-Robot unit.                                                                                                |
+| Night Light Mode              | `switch` | When turned on, automatically turns on the night light in darker settings.                                                                      |
+| Panel Lockout                 | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings.                                                                |
+| Last Seen                     | `sensor` | Displays the time the unit was last seen / reported an update.                                                                                  |
+| Sleep Mode Start Time         | `sensor` | When sleep mode is enabled, displays the current or next sleep mode start time.                                                                 |
+| Sleep Mode End Time           | `sensor` | When sleep mode is enabled, displays the current or last sleep mode end time.                                                                   |
+| Status Code                   | `sensor` | Displays the [status code](https://github.com/natekspencer/pylitterbot/blob/884944b011f5fea9639b7d21d19fa3f7708e25a7/pylitterbot/enums.py#L44). |
+| Waste Drawer                  | `sensor` | Displays the current waste drawer level.                                                                                                        |
+| Clean Cycle Wait Time Minutes | `select` | View and select the clean cycle wait time.                                                                                                      |
+| Reset Waste Drawer            | `button` | Button to reset the waste drawer level to 0%.                                                                                                   |
 
 ## Additional Attributes
 
@@ -51,14 +53,11 @@ Some entities have attributes in addition to the default ones that are available
 
 ### Litter Box `vacuum` entity
 
-| Attribute                     | Type    | Description                                                                                                                                                                             |
-| ----------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| clean_cycle_wait_time_minutes | integer | Current wait time, in minutes, between when your cat uses the Litter-Robot and when the unit cycles automatically.                                                                      |
-| is_sleeping                   | boolean | Whether or not the unit is currently in sleep mode.                                                                                                                                     |
-| sleep_mode_enabled            | boolean | Whether or not sleep mode is enabled.                                                                                                                                                   |
-| power_status                  | string  | Current power status of the unit. `AC` indicates normal power, `DC` indicates battery backup and `NC` indicates that the unit is not connected and/or powered off.                      |
-| status_code                   | string  | The [status code](https://github.com/natekspencer/pylitterbot/blob/884944b011f5fea9639b7d21d19fa3f7708e25a7/pylitterbot/enums.py#L44) associated with the current status of the vacuum. |
-| last_seen                     | string  | UTC datetime the unit last reported its status.                                                                                                                                         |
+| Attribute          | Type    | Description                                                                                                                                                        |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| is_sleeping        | boolean | Whether or not the unit is currently in sleep mode.                                                                                                                |
+| sleep_mode_enabled | boolean | Whether or not sleep mode is enabled.                                                                                                                              |
+| power_status       | string  | Current power status of the unit. `AC` indicates normal power, `DC` indicates battery backup and `NC` indicates that the unit is not connected and/or powered off. |
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update litterrobot documentation to match current implementation


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/71760
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
