### PR TITLE
Update tank_utility.markdown

### DIFF
--- a/source/_integrations/tank_utility.markdown
+++ b/source/_integrations/tank_utility.markdown
@@ -63,7 +63,7 @@ sensor:
     email: YOUR_EMAIL_ADDRESS
     password: YOUR_PASSWORD
     devices:
-      - 000000000000000000000000
+      - "000000000000000000000000"
 ```
 
 {% configuration %}


### PR DESCRIPTION
added quotes around the device ID in config.yaml. HA throws errors without the quotes.

