### PR TITLE
Update tank_utility.markdown

### DIFF
--- a/source/_integrations/tank_utility.markdown
+++ b/source/_integrations/tank_utility.markdown
@@ -63,7 +63,7 @@ sensor:
     email: YOUR_EMAIL_ADDRESS
     password: YOUR_PASSWORD
     devices:
-      - 000000000000000000000000
+      - "000000000000000000000000"
 ```
 
 {% configuration %}
@@ -75,8 +75,8 @@ password:
   description: "Your [https://app.tankutility.com](https://app.tankutility.com) password."
   required: true
   type: string
-unit_of_measurement:
-  description: All devices to monitor.
+devices:
+  description: All devices to monitor.  Double quotes have been reported as required around each device string to configure the integration.
   required: true
   type: map
 {% endconfiguration %}

--- a/source/_integrations/tank_utility.markdown
+++ b/source/_integrations/tank_utility.markdown
@@ -76,7 +76,7 @@ password:
   required: true
   type: string
 devices:
-  description: All devices to monitor.  Double quotes have been reported as required around each device string to configure the integration.
+  description: All devices to monitor.
   required: true
   type: map
 {% endconfiguration %}


### PR DESCRIPTION
Provided clarity on requirement for double quotes on each device ID in the configuration.yaml file.  Also corrected configuration markdown to property denote the devices stanza, and not "unit_of_measurement" which is not part of this integration.  Fixed example YAML to include double quotes for those copying and pasting.

## Proposed change
<!-- 
    New users of the Tank Utility integration have reporting needing to place double
    quotes around the device ID for the integration to initialize.  This is documented 
    in https://github.com/home-assistant/core/issues/73296 with the quotes 
    confirming it will correct the problem.  This pull request simply updates the 
    documentation to reflect the possible need for quotes, and corrects an error in the
    configuration markdown section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    NA
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #73296

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
