### PR TITLE
Clarify which credentials are needed for the Envisalink configuration

### DIFF
--- a/source/_integrations/envisalink.markdown
+++ b/source/_integrations/envisalink.markdown
@@ -70,11 +70,11 @@ panel_type:
   required: true
   type: string
 user_name:
-  description: Which username to authenticate with when connecting to the device. On a Honeywell alarm panel, the username/password are the same.
+  description: Which username to authenticate with when connecting to the device. This must be the username for connecting directly to the device and not the username for your EyezOn account.  On a Honeywell alarm panel, the username/password are the same.
   required: true
   type: string
 password:
-  description: Which password to authenticate with when connecting to the device. EVL3 only works with max. 6 characters.
+  description: Which password to authenticate with when connecting to the device. This must be the password for connceting directly to the device and not the password for your EyezOn account.  EVL3 only works with max. 6 characters.
   required: true
   type: string
 code:

--- a/source/_integrations/envisalink.markdown
+++ b/source/_integrations/envisalink.markdown
@@ -30,7 +30,7 @@ There is currently support for the following device types within Home Assistant:
 
 This is a fully event-based component. Any event sent by the Envisalink device will be immediately reflected within Home Assistant.
 
-As of 0.29, the alarm_trigger service is supported.  It is possible to fire off an envisalink-based alarm directly from Home Assistant.  For example, a newer Z-Wave / Zigbee sensor can now be integrated into a legacy alarm system using a Home Assistant automation.
+As of 0.29, the alarm_trigger service is supported.  It is possible to fire off an envisalink-based alarm directly from Home Assistant. For example, a newer Z-Wave/Zigbee sensor can now be integrated into a legacy alarm system using a Home Assistant automation.
 
 An `envisalink` section must be present in the `configuration.yaml` file and contain the following options as required:
 
@@ -70,11 +70,11 @@ panel_type:
   required: true
   type: string
 user_name:
-  description: Which username to authenticate with when connecting to the device. This must be the username for connecting directly to the device and not the username for your EyezOn account.  On a Honeywell alarm panel, the username/password are the same.
+  description: Which username to authenticate with when connecting to the device. This must be the username for connecting directly to the device and not the username for your EyezOn account. On a Honeywell alarm panel, the username/password are the same.
   required: true
   type: string
 password:
-  description: Which password to authenticate with when connecting to the device. This must be the password for connceting directly to the device and not the password for your EyezOn account.  EVL3 only works with max. 6 characters.
+  description: Which password to authenticate with when connecting to the device. This must be the password for connceting directly to the device and not the password for your EyezOn account. EVL3 only works with max. 6 characters.
   required: true
   type: string
 code:


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added clarification that the username/password required for configuration of the Envisalink integration are for connecting directly to the device and not the credentials for the user's EyezOn account.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: NA
- Link to parent pull request in the Brands repository: NA
- This PR fixes or closes issue: fixes #22934 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
