### PR TITLE
Document new configuration options for SNMP sensor

### DIFF
--- a/source/_integrations/snmp.markdown
+++ b/source/_integrations/snmp.markdown
@@ -115,30 +115,11 @@ sensor:
 ```
 
 {% configuration %}
-host:
-  description: The IP address of your host, e.g., `192.168.1.32`.
+accept_errors:
+  description: "Determines whether the sensor should start and keep working even if the SNMP host is unreachable or not responding. This allows the sensor to be initialized properly even if, for example, your printer is not on when you start Home Assistant."
   required: false
   type: string
-  default: 'localhost'
-baseoid:
-  description: The OID where the information is located. It's advised to use the numerical notation.
-  required: true
-  type: string
-port:
-  description: The SNMP port of your host.
-  required: false
-  type: string
-  default: '161'
-community:
-  description: "The SNMP community which is set for the device for SNMP v1 and v2c. Most devices have a default community set to `public` with read-only permission (which is sufficient)."
-  required: false
-  type: string
-  default: 'public'
-username:
-  description: Username to use for authentication.
-  required: false
-  type: string
-  default: ''
+  default: false
 auth_key:
   description: Authentication key to use for SNMP v3.
   required: false
@@ -149,6 +130,44 @@ auth_protocol:
   required: false
   type: string
   default: 'none'
+baseoid:
+  description: The OID where the information is located. It's advised to use the numerical notation.
+  required: true
+  type: string
+community:
+  description: "The SNMP community which is set for the device for SNMP v1 and v2c. Most devices have a default community set to `public` with read-only permission (which is sufficient)."
+  required: false
+  type: string
+  default: 'public'
+default_value:
+  description: "Determines what value the sensor should take if `accept_errors` is set and the host is unreachable or not responding. If not set, the sensor will have value `unknown` in case of errors."
+  required: false
+  type: string
+device_class:
+  description: Sets the [class of the device](/integrations/sensor#device-class), changing the device state and icon that is displayed on the frontend.
+host:
+  description: The IP address of your host, e.g., `192.168.1.32`.
+  required: false
+  type: string
+  default: 'localhost'
+icon:
+  description: Defines a template for the icon of the SNMP sensor.
+  required: false
+  type: template
+name:
+  description: Defines a template for the name of the SNMP sensor.
+  required: false
+  type: template
+  default: SNMP
+picture:
+  description: Defines a template for the entity picture of the SNMP sensor.
+  required: false
+  type: template
+port:
+  description: The SNMP port of your host.
+  required: false
+  type: string
+  default: '161'
 priv_key:
   description: Privacy key to use for SNMP v3.
   required: false
@@ -159,32 +178,32 @@ priv_protocol:
   required: false
   type: string
   default: 'none'
+state_class:
+  description: The [state_class](https://developers.home-assistant.io/docs/core/entity/sensor#available-state-classes) of the sensor.
+  required: false
+  type: string
+unique_id:
+  description: An ID that uniquely identifies this entity. This allows changing the `name`, `icon` and `entity_id` from the web interface.
+  required: false
+  type: string
+unit_of_measurement:
+  description: Defines the units of measurement of the sensor, if any.
+  required: false
+  type: string
+username:
+  description: Username to use for authentication.
+  required: false
+  type: string
+  default: ''
+value_template:
+  description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to parse the value."
+  required: false
+  type: template
 version:
   description: "Version of SNMP protocol, `1`, `2c` or `3`. Version `2c` or higher is needed to read data from 64-bit counters."
   required: false
   type: string
   default: '1'
-name:
-  description: Name of the SNMP sensor.
-  required: false
-  type: string
-unit_of_measurement:
-  description: Defines the unit of measurement of the sensor, if any.
-  required: false
-  type: string
-value_template:
-  description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to parse the value."
-  required: false
-  type: template
-accept_errors:
-  description: "Determines whether the sensor should start and keep working even if the SNMP host is unreachable or not responding. This allows the sensor to be initialized properly even if, for example, your printer is not on when you start Home Assistant."
-  required: false
-  type: string
-  default: false
-default_value:
-  description: "Determines what value the sensor should take if `accept_errors` is set and the host is unreachable or not responding. If not set, the sensor will have value `unknown` in case of errors."
-  required: false
-  type: string
 {% endconfiguration %}
 
 Valid values for `auth_protocol`:

--- a/source/_integrations/snmp.markdown
+++ b/source/_integrations/snmp.markdown
@@ -145,6 +145,8 @@ default_value:
   type: string
 device_class:
   description: Sets the [class of the device](/integrations/sensor#device-class), changing the device state and icon that is displayed on the frontend.
+  required: false
+  type: string
 host:
   description: The IP address of your host, e.g., `192.168.1.32`.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document new configuration options for SNMP sensor


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/73324
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
