### PR TITLE
Add timer to sensibo

### DIFF
--- a/source/_integrations/sensibo.markdown
+++ b/source/_integrations/sensibo.markdown
@@ -85,6 +85,12 @@ For Pure devices, these sensors are available:
 - PM2.5
 - Pure Boost Sensitivity
 
+## Switch Entities
+
+For supported devices, this integration provides support to enable/disable a timer to delay a start or stop (depending on current state) of your device.
+
+The switch uses a timer of 60 minutes delay. You can choose a custom delay by using the custom `sensibo.enable_timer` service. See [Timer](#timer).
+
 ## Custom Services
 
 ### Pure Boost
@@ -95,6 +101,10 @@ You can configure your Pure Boost settings by using the services `sensibo.enable
 - Disable Pure Boost will disable the service and leave settings intact, so a later enable will use settings already in place if not new are configured.
 
 Using Geo integration for Pure Boost is only possible by pre-configuration of Presence within the app.
+
+### Timer
+
+You can enable a timer with a custom delay using the service `sensibo.enable_timer` that is provided.
 
 ## Adding a quick switch example
 

--- a/source/_integrations/sensibo.markdown
+++ b/source/_integrations/sensibo.markdown
@@ -91,7 +91,7 @@ For Pure devices, these sensors are available:
 
 For supported devices, this integration provides support to enable/disable a timer to delay a start or stop (depending on current state) of your device.
 
-The switch uses a timer of 60 minutes delay. You can choose a custom delay by using the custom `sensibo.enable_timer` service. See [Timer](#timer).
+The switch uses a timer of 60 minutes delay. You can choose a custom delay using the custom `sensibo.enable_timer` service. See [Timer](#timer).
 
 ## Custom Services
 

--- a/source/_integrations/sensibo.markdown
+++ b/source/_integrations/sensibo.markdown
@@ -89,7 +89,7 @@ For Pure devices, these sensors are available:
 
 ## Switch Entities
 
-For supported devices, this integration provides support to enable/disable a timer to delay a start or stop (depending on current state) of your device.
+For supported devices, this integration provides support to enable/disable a timer to delay a start or stop (depending on the current state) of your device.
 
 The switch uses a timer of 60 minutes delay. You can choose a custom delay using the custom `sensibo.enable_timer` service. See [Timer](#timer).
 

--- a/source/_integrations/sensibo.markdown
+++ b/source/_integrations/sensibo.markdown
@@ -8,6 +8,7 @@ ha_category:
   - Number
   - Select
   - Sensor
+  - Switch
   - Updates
 ha_release: 0.44
 ha_iot_class: Cloud Polling
@@ -23,6 +24,7 @@ ha_platforms:
   - number
   - select
   - sensor
+  - switch
   - update
 ha_homekit: true
 ha_dhcp: true


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add timer to Sensibo.
Replace previous PR which I managed to rebase completely wrong. https://github.com/home-assistant/home-assistant.io/pull/23014


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/73684
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
