### PR TITLE
Clarify conflict with Goodwe portal (#23157)

### DIFF
--- a/source/_integrations/goodwe.markdown
+++ b/source/_integrations/goodwe.markdown
@@ -39,21 +39,35 @@ For the other inverter families, if such sensors are not directly available by t
 
 ## Inverter polling frequency
 
-The integration will poll the inverter for new values every 10 seconds. If you wish to receive fresh inverter data less (or more) frequently, you can disable the automatic refresh in the integration's system options (Enable polling for updates) and create your own automation with your desired polling frequency.
+The integration will poll the inverter for new values every 10 seconds. If you wish to receive fresh inverter data less (or more) frequently, you can disable the automatic refresh in the integration's system options (Enable polling for updates) and create your own automation with your desired polling frequency. This may be required if the Goodwe SEMS cloud portal stops receiving updates from the inverter.
 
 ```yaml
 - alias: "Goodwe inverter data polling"
   trigger:
+    # Poll every 30 seconds.
     - platform: time_pattern
       hours: "*"
       minutes: "*"
       seconds: "/30"
+#   # Poll every 5 minutes.
+#   - platform: time_pattern
+#     hours: "*"
+#     minutes: "/5"
+#     seconds: "0"
   action:
     - service: homeassistant.update_entity
       target:
-        entity_id: sensor.ppv
+        entity_id:
+          - sensor.pv_power
+          - sensor.pv1_current
+          - sensor.pv1_power
+          - sensor.pv1_voltage
+          - sensor.pv2_current
+          - sensor.pv2_power
+          - sensor.pv2_voltage
+          - ...
 ```
 
 <div class='note'>
-It has been observed in some rare situations that frequent polling conflicts with updates to the Goodwe SEMS cloud portal and do not receive any updates anymore. Reducing polling frequency to 30 seconds or 1 minute seems to help in such cases.
+Some Goodwe inverters will stop sending updates to the Goodwe SEMS cloud portal if local polling is too frequent. If you find that the SEMS portal does not show data correctly then you may need to reduce the polling frequency of Home Assistant. Values ranging from 30 seconds to 5 minutes have been found to be effective depending on the model of inverter.
 </div>


### PR DESCRIPTION
## Proposed change

Clarification on conflicts with local polling vs cloud push to SEMS, more information on resolution including clearer configuration examples. Fixes #23157 

The configuration examples are amended in two ways:

1. Give an example of how to specify a per-five-minute polling instead of every 30 seconds. This could perhaps be replaced with a link to https://www.home-assistant.io/docs/automation/trigger/#time-pattern-trigger
2. Update the example to list multiple entities to fetch (which is a more likely usage)

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- fixes #23157

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - **I made a change to the existing documentation and used the `current` branch.**
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
