### PR TITLE
Cgroup adjustment

### DIFF
--- a/source/more-info/unsupported/docker_configuration.markdown
+++ b/source/more-info/unsupported/docker_configuration.markdown
@@ -10,6 +10,8 @@ The Supervisor has some expectations of how the Docker daemon is configured to m
 The logging driver for the Docker daemon needs to be set to `journald` and the storage driver
 needs to be set to `overlay2`.
 
+We only support cgroup version 1 on our Hardware handling.
+
 ## The solution
 
 If you are running an older version of our Home Assistant OS, update it to the latest version in the {% my configuration title="Configuration" %} panel.
@@ -28,5 +30,7 @@ following contents:
 
 When the Docker configuration file is changed and saved, you need to restart the
 Docker service on the host machine.
+
+To fix issues with the cgroup level, addjust the /etc/default/grub and add `systemd.unified_cgroup_hierarchy=false` to `GRUB_CMDLINE_LINUX_DEFAULT`. After this you have to complete reboot the host.
 
 You can also just re-run our [convenience installation script](https://github.com/home-assistant/supervised-installer).

--- a/source/more-info/unsupported/docker_configuration.markdown
+++ b/source/more-info/unsupported/docker_configuration.markdown
@@ -10,7 +10,7 @@ The Supervisor has some expectations of how the Docker daemon is configured to m
 The logging driver for the Docker daemon needs to be set to `journald` and the storage driver
 needs to be set to `overlay2`.
 
-We only support cgroup version 1 on our Hardware handling.
+We only support cgroup version 1 on our hardware handling.
 
 ## The solution
 
@@ -31,6 +31,6 @@ following contents:
 When the Docker configuration file is changed and saved, you need to restart the
 Docker service on the host machine.
 
-To fix issues with the cgroup level, addjust the /etc/default/grub and add `systemd.unified_cgroup_hierarchy=false` to `GRUB_CMDLINE_LINUX_DEFAULT`. After this you have to complete reboot the host.
+To fix issues with the cgroup level, addjust the `/etc/default/grub` and add `systemd.unified_cgroup_hierarchy=false` to `GRUB_CMDLINE_LINUX_DEFAULT`. After this change is made, you need to reboot the host completely.
 
 You can also just re-run our [convenience installation script](https://github.com/home-assistant/supervised-installer).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
