### PR TITLE
Sensibo custom service to switch for Pure Boost

### DIFF
--- a/source/_integrations/sensibo.markdown
+++ b/source/_integrations/sensibo.markdown
@@ -111,7 +111,7 @@ The switch uses a timer of 60 minutes delay. You can choose a custom delay using
 
 For Pure devices, this integration provides support to enable/disable Pure Boost.
 
-To customize the settings of Pure Boost you can use the custom `sensibo.enable_pure_boost` service. See [Pure Boost](#pure-boost)
+To customize the settings of Pure Boost, you can use the custom `sensibo.enable_pure_boost` service. See [Pure Boost](#pure-boost)
 
 ## Custom Services
 

--- a/source/_integrations/sensibo.markdown
+++ b/source/_integrations/sensibo.markdown
@@ -105,18 +105,21 @@ For climate devices, these sensors are available:
 
 ## Switch Entities
 
-For supported devices, this integration provides support to enable/disable a timer to delay a start or stop (depending on the current state) of your device.
+For climate devices, this integration provides support to enable/disable a timer to delay a start or stop (depending on the current state) of your device.
 
 The switch uses a timer of 60 minutes delay. You can choose a custom delay using the custom `sensibo.enable_timer` service. See [Timer](#timer).
+
+For Pure devices, this integration provides support to enable/disable Pure Boost.
+
+To customize the settings of Pure Boost you can use the custom `sensibo.enable_pure_boost` service. See [Pure Boost](#pure-boost)
 
 ## Custom Services
 
 ### Pure Boost
 
-You can configure your Pure Boost settings by using the services `sensibo.enable_pure_boost` and `sensibo.disable_pure_boost`.
+You can configure your Pure Boost settings by using the services `sensibo.enable_pure_boost`.
 
-- Enable Pure Boost will enable the service; optionally, you can configure the settings
-- Disable Pure Boost will disable the service and leave settings intact, so a later enable will use settings already in place if not new are configured.
+- Enable Pure Boost will enable the service with configured settings
 
 Using Geo integration for Pure Boost is only possible by pre-configuration of Presence within the app.
 

--- a/source/_integrations/sensibo.markdown
+++ b/source/_integrations/sensibo.markdown
@@ -117,7 +117,7 @@ To customize the settings of Pure Boost you can use the custom `sensibo.enable_p
 
 ### Pure Boost
 
-You can configure your Pure Boost settings by using the services `sensibo.enable_pure_boost`.
+You can configure your Pure Boost settings using the services `sensibo.enable_pure_boost`.
 
 - Enable Pure Boost will enable the service with configured settings
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This removes partially the custom services for Pure Boost and enable a switch instead.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/73833
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
