### PR TITLE
Add documentation of selecting source for Spotify 

### DIFF
--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -21,6 +21,7 @@ The Spotify media player integration allows you to control [Spotify](https://www
 
 - Spotify account
 - (Optional) Spotify developer application configured for Home Assistant (see [below](#create-a-spotify-application))
+- Spotify compatible playback [source](#selecting-output-source) device
 
 <div class='note'>
   Spotify integrated media controls (pause, play, next, etc.) require a Premium account.
@@ -92,6 +93,20 @@ accounts can be linked to a _single_ Spotify application. You will have to add t
 
 To add an additional Spotify account to Home Assistant, go to the Spotify website and log out, then repeat _only_ the steps
 in the [Configuration](#configuration) section. 
+
+## Selecting output source
+
+To play media Spotify first needs a device selected for audio output known as the `source`.
+
+```yaml
+# Example code to select an AV receiver as the output device
+service: media_player.select_source
+entity_id: media_player.spotify
+data:
+  source: "Denon AVR-X2000"
+```
+
+The Spotify API cannot initiate playback to a device not already known to the Spotify API. The source list of available devices can be found in the Details section of the Spotify Media Player Control and the `source_list` attribute in the {% my developer_states title="Developer Tools States" %}.
 
 ## Playing Spotify playlists
 

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -126,7 +126,7 @@ script:
           media_content_type: playlist
 ```
 
-The `media_content_id` value can be obtained from the Spotify desktop app by clicking on the more options ("...") next to the album art picture, selecting "Share" and then "Copy Spotify URI" or "Copy Playlist Link" (also available in the Spotify phone and web app).
+The `media_content_id` value can be obtained from the Spotify desktop app by clicking on the more options ("...") next to the album art picture, selecting "Share" and then "Copy Spotify URI" or "Copy Playlist Link" (also available in the Spotify phone and web app). Alternatively a Spotify URI string (e.g. `spotify:playlist:5xddIVAtLrZKtt4YGLM1SQ`) can be supplied for the `media_content_id`.
 
 ## Unsupported Devices
 


### PR DESCRIPTION
## Proposed change

The Spotify integration does not function ("No active playback device found") without first selecting a source. I added documentation on how to select a source

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #69306

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
