### PR TITLE
Add note of support for TP-Link KP125 plug

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -45,6 +45,7 @@ There is currently support for the following device types within Home Assistant:
 - HS110 (supports consumption sensors)
 - KP105
 - KP115 (supports consumption sensors)
+- KP125 (supports consumption sensors)
 
 ### Strip (Multi-Plug)
 


### PR DESCRIPTION
## Proposed change
Add note of support for KP125 plug. Plug works for remote control and power usage monitoring.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.
