### PR TITLE
Document changed group behavior when members are unavailable or unknown

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -69,11 +69,11 @@ In short, when any group member entity is `open`, the group will also be `open`.
 - Otherwise, the group state is `closed`.
 
 ### Fan groups
-Fan groups don't support `unavailable` or `unknown` states.
+In short, when any group member entity is `on`, the group will also be `on`. A complete overview of how fan groups behave:
 
 - The group state is `unavailable` if all group members are `unavailable`.
 - Otherwise, the group state is `unknown` if all group members are `unknown` or `unavailable`.
-- The group state is `on` if at least one group member is `on`.
+- Otherwise, The group state is `on` if at least one group member is `on`.
 - Otherwise, the group state is `off`.
 
 ### Lock groups

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -61,7 +61,8 @@ Binary sensor, light, and switch groups allow you set the "All entities" option.
 ### Cover groups
 In short, when any group member entity is `open`, the group will also be `open`. A complete overview of how cover groups behave:
 
-- The group state is `unknown` if all group members are `unknown` or `unavailable`.
+- The group state is `unavailable` if all group members are `unavailable`.
+- Otherwise, the group state is `unknown` if all group members are `unknown` or `unavailable`.
 - Otherwise, the group state is `opening` if at least one group member is `opening`.
 - Otherwise, the group state is `closing` if at least one group member is `closing`.
 - Otherwise, the group state is `open` if at least one group member is `open`.
@@ -70,6 +71,8 @@ In short, when any group member entity is `open`, the group will also be `open`.
 ### Fan groups
 Fan groups don't support `unavailable` or `unknown` states.
 
+- The group state is `unavailable` if all group members are `unavailable`.
+- Otherwise, the group state is `unknown` if all group members are `unknown` or `unavailable`.
 - The group state is `on` if at least one group member is `on`.
 - Otherwise, the group state is `off`.
 
@@ -77,7 +80,7 @@ Fan groups don't support `unavailable` or `unknown` states.
 In short, when any group member entity is `unlocked`, the group will also be `unlocked`. A complete overview of how fan groups behave:
 
 - The group state is `unavailable` if all group members are `unavailable`.
-- Otherwise, the group state is `unknown` if at least one group member is `unknown` or `unavailable`.
+- Otherwise, the group state is `unknown` if all group members are `unknown` or `unavailable`.
 - Otherwise, the group state is `jammed` if at least one group member is `jammed`.
 - Otherwise, the group state is `locking` if at least one group member is `locking`.
 - Otherwise, the group state is `unlocking` if at least one group member is `unlocking`.
@@ -87,7 +90,7 @@ In short, when any group member entity is `unlocked`, the group will also be `un
 ### Media player groups
 
 - The group state is `unavailable` if all group members are `unavailable`.
-- Otherwise, the group state is `unknown` if all group members are `unknown`.
+- Otherwise, the group state is `unknown` if all group members are `unknown` or `unavailable`.
 - Otherwise, the group state is `buffering` if all group members are `buffering`.
 - Otherwise, the group state is `idle` if all group members are `idle`.
 - Otherwise, the group state is `paused` if all group members are `paused`.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document changed group behavior when members are unavailable or unknown

This PR combines changes from multiple core PRs to avoid merge issues


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
 - #74053
 - #74054
 - #74055
 - #74056
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
