### PR TITLE
The LIFX integration depends on the network config being correct

### DIFF
--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -15,7 +15,15 @@ ha_codeowners:
   - '@Djelibeybi'
 ---
 
-The `lifx` integration allows you to integrate your [LIFX](https://www.lifx.com) bulbs into Home Assistant.
+The `lifx` integration automatically discovers [LIFX](https://www.lifx.com) bulbs on your network and adds them to Home Assistant.
+
+<div class="note info">
+
+  Automatic discovery relies on the Home Assistant [network configuration](/integrations/network) being correct.
+
+</div>
+
+If Home Assistant does not automatically discover your bulbs, please ensure you have enabled a network interface on the same subnet as your LIFX bulbs. If you use a segregated IoT network and do not have an interface connected to that network, use the manual configuration documented below to bypass the discovery process.
 
 {% include integrations/config_flow.md %}
 
@@ -41,6 +49,7 @@ Change the light to a new state.
 ## Light effects
 
 The LIFX platform supports several light effects. You can start these effects with default options by using the `effect` attribute of the normal [`light.turn_on`](/integrations/light/#service-lightturn_on) service, for example like this:
+
 ```yaml
 automation:
   - alias: "..."
@@ -55,6 +64,7 @@ automation:
 ```
 
 However, if you want to fully control a light effect, you have to use its dedicated service call, like this:
+
 ```yaml
 script:
   colorloop_start:
@@ -148,7 +158,7 @@ When using the `homekit_controller` integration, each button on the LIFX Switch 
 [stateless switch](/integrations/homekit_controller#stateless-switches-and-sensors) and will not appear as an entity in Home Assistant.
 Relays that are configured as wired to non-LIFX devices will appear as normal switches in Home Assistant.
 
-### Troubleshooting discovery
+### Troubleshooting Switch Discovery
 
 If your switch is not automatically discovered or you get a "_Cannot add pairing as device can no longer be found_" error
 during the config process, [reboot your LIFX Switch](https://support.lifx.com/troubleshooting-switch-Hk6RWujLd) as they

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -17,14 +17,6 @@ ha_codeowners:
 
 The LIFX integration automatically discovers [LIFX](https://www.lifx.com) bulbs on your network and adds them to Home Assistant.
 
-<div class="note info">
-
-  Automatic discovery relies on the Home Assistant [network configuration](/integrations/network) being correct.
-
-</div>
-
-If Home Assistant does not automatically discover your bulbs, please ensure you have enabled a network interface on the same subnet as your LIFX bulbs. If you use a segregated IoT network and do not have an interface connected to that network, use the manual configuration documented below to bypass the discovery process.
-
 {% include integrations/config_flow.md %}
 
 ## Set state
@@ -158,7 +150,15 @@ When using the `homekit_controller` integration, each button on the LIFX Switch 
 [stateless switch](/integrations/homekit_controller#stateless-switches-and-sensors) and will not appear as an entity in Home Assistant.
 Relays that are configured as wired to non-LIFX devices will appear as normal switches in Home Assistant.
 
-### Troubleshooting Switch Discovery
+## Troubleshooting Discovery
+
+### Lights
+
+Automated discovery of LIFX bulbs relies on Home Assistant having a [network interface](/integrations/network) connected to the same subnet as your LIFX bulbs. If you use a segregated IoT network to which Home Assistant is not directly connected, use the manual configuration method documented above to bypass discovery.
+
+If you have multiple network interfaces, ensure that the interface connected to the same subnet as your LIFX bulbs is enabled in Home Assistant's [network configuration](/integrations/network).
+
+### Switches
 
 If your switch is not automatically discovered or you get a "_Cannot add pairing as device can no longer be found_" error
 during the config process, [reboot your LIFX Switch](https://support.lifx.com/troubleshooting-switch-Hk6RWujLd) as they

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -15,7 +15,7 @@ ha_codeowners:
   - '@Djelibeybi'
 ---
 
-The `lifx` integration automatically discovers [LIFX](https://www.lifx.com) bulbs on your network and adds them to Home Assistant.
+The LIFX integration automatically discovers [LIFX](https://www.lifx.com) bulbs on your network and adds them to Home Assistant.
 
 <div class="note info">
 


### PR DESCRIPTION
## Proposed change

The LIFX integration depends on the network config being correct, so I've added a note calling out that requirement, as most folks reporting issues weren't even aware of the network configuration page in Home Assistant.

Also, from 2022.7.0 onwards, the LIFX integration is automatically enabled and configured if bulbs are discovered, which is different  behaviour to the current release which requires the user to confirm configuration of the integration, so I reworded the opening line to be explicit about that behaviour.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72213 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
