### PR TITLE
Add config flow to Bose SoundTouch documentation

### DIFF
--- a/source/_integrations/soundtouch.markdown
+++ b/source/_integrations/soundtouch.markdown
@@ -14,7 +14,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `soundtouch` platform allows you to control your [Bose SoundTouch](https://www.soundtouch.com/) speakers from Home Assistant.
+The Bose SoundTouch integration allows you to control your [Bose SoundTouch](https://www.soundtouch.com/) speakers from Home Assistant.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/soundtouch.markdown
+++ b/source/_integrations/soundtouch.markdown
@@ -1,62 +1,24 @@
 ---
-title: Bose Soundtouch
-description: Instructions on how to integrate Bose Soundtouch devices into Home Assistant.
+title: Bose SoundTouch
+description: Instructions on how to integrate Bose SoundTouch devices into Home Assistant.
 ha_category:
   - Media Player
 ha_release: 0.34
 ha_iot_class: Local Polling
 ha_domain: soundtouch
+ha_config_flow: true
+ha_codeowners:
+  - '@kroimon'
 ha_platforms:
   - media_player
 ha_integration_type: integration
 ---
 
-The `soundtouch` platform allows you to control your [Bose Soundtouch](https://www.soundtouch.com/) speakers from Home Assistant.
+The `soundtouch` platform allows you to control your [Bose SoundTouch](https://www.soundtouch.com/) speakers from Home Assistant.
 
-By default it supports auto-discovery provided by Home Assistant, and you don't need to add anything to your `configuration.yaml`.
+{% include integrations/config_flow.md %}
 
-Alternatively, you can add the following to your `configuration.yaml` file.
-
-```yaml
-# Example configuration.yaml
-media_player:
-  - platform: soundtouch
-    host: 192.168.1.1
-    port: 8090
-    name: Soundtouch Living Room
-```
-
-Or for multiple hosts
-
-```yaml
-# Example configuration.yaml with many devices
-media_player:
-  - platform: soundtouch
-    host: 192.168.1.1
-    port: 8090
-    name: Soundtouch Living Room
-  - platform: soundtouch
-    host: 192.168.1.1
-    port: 8090
-    name: Soundtouch kitchen
-```
-
-{% configuration %}
-host:
-  description: The host name or address of the Soundtouch device.
-  required: true
-  type: string
-name:
-  description: The name of the device used in the frontend.
-  required: true
-  default: Bose Soundtouch
-  type: string
-port:
-  description: The port number.
-  required: false
-  default: 8090
-  type: integer
-{% endconfiguration %}
+## Playing media
 
 You can switch between one of your 6 pre-configured presets using ```media_player.play_media```
 
@@ -86,7 +48,9 @@ You can also play HTTP (not HTTPS) URLs:
 
 You can use TTS services like [Google Text-to-Speech](/integrations/google_translate) or [Amazon Polly](/integrations/amazon_polly) only if your Home Assistant is configured in HTTP and not HTTPS (current device limitation, a firmware upgrade is planned).
 
-A workaround if you want to publish your Home Assistant installation on Internet in SSL is to configure an HTTPS Web Server as a reverse proxy ([NGINX](/docs/ecosystem/nginx/) for example) and let your Home Assistant configuration in HTTP on your local network. The Soundtouch devices will be available to access the TTS files in HTTP in local and your configuration will be in HTTPS on the Internet.
+A workaround if you want to publish your Home Assistant installation on Internet in SSL is to configure an HTTPS Web Server as a reverse proxy ([NGINX](/docs/ecosystem/nginx/) for example) and let your Home Assistant configuration in HTTP on your local network. The SoundTouch devices will be available to access the TTS files in HTTP in local and your configuration will be in HTTPS on the Internet.
+
+## Services
 
 ### Service `play_everywhere`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add config flow to Bose SoundTouch documentation.

Fixed the spelling of SoundTouch to match the brand name according to the standards.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/72967
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
