### PR TITLE
Link Utility integration for non-negative derivatives

### DIFF
--- a/source/_integrations/derivative.markdown
+++ b/source/_integrations/derivative.markdown
@@ -21,6 +21,8 @@ ha_integration_type: helper
 The derivative ([Wikipedia](https://en.wikipedia.org/wiki/Derivative)) integration creates a sensor that estimates the derivative of the
 values provided by another sensor (the **source sensor**). Derivative sensors are updated upon changes of the **source sensor**.
 
+For sensors that reset to zero after a power interruption and need a "non-negative derivative", such as bandwidth counters in routers, or rain gauges, consider using the [Utility Meter](https://www.home-assistant.io/integrations/utility_meter/) integration instead. Otherwise, each reset will register a significant change in the derivative sensor.
+
 {% include integrations/config_flow.md %}
 {% configuration_basic %}
 Name:

--- a/source/_integrations/derivative.markdown
+++ b/source/_integrations/derivative.markdown
@@ -21,7 +21,7 @@ ha_integration_type: helper
 The derivative ([Wikipedia](https://en.wikipedia.org/wiki/Derivative)) integration creates a sensor that estimates the derivative of the
 values provided by another sensor (the **source sensor**). Derivative sensors are updated upon changes of the **source sensor**.
 
-For sensors that reset to zero after a power interruption and need a "non-negative derivative", such as bandwidth counters in routers, or rain gauges, consider using the [Utility Meter](https://www.home-assistant.io/integrations/utility_meter/) integration instead. Otherwise, each reset will register a significant change in the derivative sensor.
+For sensors that reset to zero after a power interruption and need a "non-negative derivative", such as bandwidth counters in routers, or rain gauges, consider using the [Utility Meter](/integrations/utility_meter/) integration instead. Otherwise, each reset will register a significant change in the derivative sensor.
 
 {% include integrations/config_flow.md %}
 {% configuration_basic %}


### PR DESCRIPTION
Following up from the feedback at https://community.home-assistant.io/t/non-negative-derivative-for-rain-sensors/435474.

## Proposed change

This links to Utility and adds a keyword ("non-negative derivative") which I hope will be picked up by search engines.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
