### PR TITLE
Fix default names of derivative and integration

### DIFF
--- a/source/_integrations/derivative.markdown
+++ b/source/_integrations/derivative.markdown
@@ -58,7 +58,7 @@ source:
 name:
   description: Name to use in the frontend.
   required: false
-  default: source entity ID meter
+  default: source entity ID derivative
   type: string
 round:
   description: Round the calculated derivative value to at most N decimal places.

--- a/source/_integrations/integration.markdown
+++ b/source/_integrations/integration.markdown
@@ -65,7 +65,7 @@ source:
 name:
   description: Name to use in the frontend.
   required: false
-  default: source entity ID meter
+  default: source entity ID integral
   type: string
 unique_id:
    description: An ID that uniquely identifies the integration sensor. Set this to a unique value to allow customization through the UI.


### PR DESCRIPTION
## Proposed change
Fix default name of `derivative` and `integration` sensors so that documentation matches the source code ([derivative](https://github.com/home-assistant/core/blob/cbe9eda0a8201c988d95a73da0f12a1b57bcf868/homeassistant/components/derivative/sensor.py#L157), [integration](https://github.com/home-assistant/core/blob/cbe9eda0a8201c988d95a73da0f12a1b57bcf868/homeassistant/components/integration/sensor.py#L156)).
I have kept the format, although I think it would be better to write something like `{source entity ID} derivative` to make it less ambiguous.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
