### PR TITLE
Update caldav.markdown with Radicale example

### DIFF
--- a/source/_integrations/caldav.markdown
+++ b/source/_integrations/caldav.markdown
@@ -46,6 +46,15 @@ calendar:
 ```
 
 ```yaml
+# Example configuration.yaml entry for Radicale, calendars will be found automatically
+calendar:
+  - platform: caldav
+    username: john.doe
+    password: !secret caldav
+    url: https://radicale.example.com/
+```
+
+```yaml
 # Example configuration.yaml entry for iCloud, calendars will be found automatically
 calendar:
   - platform: caldav


### PR DESCRIPTION
## Proposed change
Adds an example for configuring the caldav integration for use with [Radicale v3](https://radicale.org/v3.html).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Assuming Radicale is run on it's own subdomain and not in a subdirectory.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
