### PR TITLE
Fix error about unit of average power.

### DIFF
--- a/source/_docs/energy/faq.markdown
+++ b/source/_docs/energy/faq.markdown
@@ -13,7 +13,7 @@ Electrical Power is measured in Watts (W) and Electrical Energy is measured in k
 
 Think of this in a parallel to speed and distance: Power is the speed you are going and Energy is the distance driven.
 
-Therefore Energy (kiloWatt-hour) is not an average of the Power you are consuming over a given period of time (that would be kiloWatt/hour). Energy is the integral (mathematical operation) of the Power function.
+Therefore Energy (kiloWatt-hour) is not an average of the Power you are consuming over a given period of time (the unit of the average power would be Watt or kiloWatt again). Energy is the integral (mathematical operation) of the Power function.
 
 This difference is very important as you need to use the proper entities in our Energy Panel.
 


### PR DESCRIPTION
The average of something has the same unit of that something. So the average power also has the unit Watt. In fact, to get the average, you would integrate the power, yielding the total energy in kWh, and then divide that by the total time: kWh / h = kW.

The only instance where you would get a unit of W/h (Watt per hour) I can think of, is when you look at the speed at which power consumption changes, i.e. the differential of the power function.

## Proposed change

Just fixing a side note about the unit of average power.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
