### PR TITLE
Update Gauge to make needle required true when using segments

### DIFF
--- a/source/_dashboards/gauge.markdown
+++ b/source/_dashboards/gauge.markdown
@@ -61,7 +61,7 @@ max:
   default: 100
 needle:
   required: false
-  description: Show the gauge as a needle gauge.
+  description: Show the gauge as a needle gauge. Required to be set to true, if using segments.
   type: boolean
   default: false
 severity:
@@ -83,7 +83,7 @@ severity:
       type: integer
 segments:
   required: false
-  description: List of colors and their corresponding start values. Segments will override the severity settings.
+  description: List of colors and their corresponding start values. Segments will override the severity settings. Needle required to be true.
   type: list
   keys:
     from:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Needle is required to be true when using segments. This may change in the future and be auto set but this would require a change to the frontend functionality. For now to make the docs accurate, this change is needed


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
