### PR TITLE
Update efibootmgr command

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -165,7 +165,7 @@ This can be accomplished either by using a live operating system (e.g. Ubuntu) a
 
   ```text
   efibootmgr --create --disk /dev/<drivename> --part 1 --label "HAOS" \
-     --loader \EFI\BOOT\bootx64.efi
+     --loader "\EFI\BOOT\bootx64.efi"
   ```
 
 Or else, the BIOS might provide you with a tool to add boot options, there you can specify the path to the EFI file:


### PR DESCRIPTION


## Proposed change

Double quotes are needed, without them the loader will be `EFIBOOTbootx64.efi` (can be checked using `efibootmgr -v`).
Tested on ubuntu 22.04 live.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
