### PR TITLE
Correct link to github user - kingy444

### DIFF
--- a/source/_posts/2022-07-06-release-20227.markdown
+++ b/source/_posts/2022-07-06-release-20227.markdown
@@ -272,7 +272,7 @@ noteworthy changes this release:
   supported by [ZHA]! 
 - [@ghedo] has been busy improving the [Area Card]. It can now show
   moisture/flood alerts, humidity, and shows an icon for temperature. Nice!
-- [@king444] added support for Top/Down, Bottom/Up to [Hunter Douglas PowerView].
+- [@kingy444] added support for Top/Down, Bottom/Up to [Hunter Douglas PowerView].
   Additionally, buttons to calibrate and jog (identify) have been added. [@bdraco]
   added support for polling in case the device is mains powered.
 - Thanks to [@thrawnarn], you can now send polls via [Telegram bot]!
@@ -294,7 +294,7 @@ noteworthy changes this release:
 [@iAutom8]: https://github.com/@iAutom8
 [@j-stienstra]: https://github.com/j-stienstra
 [@jjlawren]: https://github.com/jjlawren
-[@king444]: https://github.com/king444
+[@kingy444]: https://github.com/kingy444
 [@matrixd2]: https://github.com/matrixd2
 [@mdegat01]: https://github.com/mdegat01
 [@thrawnarn]: https://github.com/thrawnarn


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fixing 2022.7 markdown - linked to wrong github user
was correct in the breaking changes but wrong in noteworthy changes


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/62788
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
