### PR TITLE
improve clarity on scope (scenes only)

### DIFF
--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -16,7 +16,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-[Velux](https://www.velux.com/) integration for Home Assistant allows you to connect to a Velux KLF 200 interface, to control [io-homecontrol](http://www.io-homecontrol.com) devices like windows and blinds. The module allows you to start scenes configured within KLF 200.
+[Velux](https://www.velux.com/) integration for Home Assistant allows you to connect to a Velux KLF 200 interface, to control [io-homecontrol](http://www.io-homecontrol.com) devices like windows and blinds. The integration discovers *programs* defined within the KLF 200 web interface and allows to control them as [scenes](https://www.home-assistant.io/integrations/scene/) within Home Assistant. The integration currently does not discover KLF200 controlled devices. Thus they don't appear as entities / devices. 
 
 At least firmware version > 2.0.0.0 is required on the KLF 200 device. The firmware images may be obtained [here](https://www.velux.com/klf200) and may be imported via the webinterface of your KLF 200.
 
@@ -34,7 +34,7 @@ A `velux` section must be present in the `configuration.yaml` file and contain t
 # Example configuration.yaml entry
 velux:
   host: IP_ADDRESS
-  password: VELUX_PASSWORD
+  password: VELUX_WIFI_PASSWORD
 ```
 
 {% configuration %}


### PR DESCRIPTION
## Proposed change

I am proposing some wording improvements to ease getting started with the integration. They aim to reduce struggle points that I experienced when starting with the integration. To highlight that the WIFI password (and not the website password is used), I suggest to change  VELUX_PASSWORD -> VELUX_WIFI_PASSWORD. Otherwise it is only visible in the note (which I promptly missed). Also suggest more clearly state the scope of the integration: currently scene only, not devices. While the last sentence in the intro already hinted to the same facts those did not enter my brain. I expected the devices to appear and had to enable debugging logs before realizing only the KLF 200 programs appear as scenes but not the devices themselves. 

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
