### PR TITLE
Update Life360 breaking change notes

### DIFF
--- a/source/_posts/2022-07-06-release-20227.markdown
+++ b/source/_posts/2022-07-06-release-20227.markdown
@@ -687,7 +687,8 @@ that _are_ functional.
 remove any Life360-related entries. Or, if there are only Life360 entries in
 this file, simply delete the file entirely.
 2. Restart Home Assistant. All the old, non-functional Life360 entities
-should now be gone.
+should now be gone. (If you are still seeing the old entities, try refreshing
+your browser.)
 3. Go to the Entities page (under Settings -> Devices & Services -> Entities)
 and change the entity IDs for the new Life360 entities as desired.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
After removing the old life360 entries from known_devices.yaml and restarting HA,
multiple users have become confused because they are still seeing the old entities.
The problem is caused by their browser caching the page (e.g., the STATES tab of
the Developer Tools page.)

This change adds a note that if they are still seeing the old entities after restarting HA
that they should try refreshing their browser.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
