### PR TITLE
Add update OS hint to privilige error docs

### DIFF
--- a/source/more-info/unsupported/privileged.markdown
+++ b/source/more-info/unsupported/privileged.markdown
@@ -13,5 +13,6 @@ to be able to do everything it needs to do.
 If you are running an older version of our Home Assistant OS, update it in the
 {% my configuration title="Configuration" %} panel.
 
-If this is not our Home Assistant OS, you need to re-run our
+If this is not our Home Assistant OS, your operating system might be out of date. Try checking for and
+installing updates, then restarting your system. If this doesn't work, you may need to re-run our
 [convenience installation script](https://github.com/home-assistant/supervised-installer).


### PR DESCRIPTION
## Proposed change
Every ~six months I get this error, click through to the docs and go "hmm... I'm sure that's not how I usually fix this". Then I google it and all the Community posts remind me this is quite often caused by Ubuntu getting way out of date, and a sudo apt-get update && sudo apt-get upgrade fixes all my problems.

Proposing a hint to this effect in docs, while preserving the existing solutions / advice.


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
