### PR TITLE
Update Discord Notify docs with URL attribute

### DIFF
--- a/source/_integrations/discord.markdown
+++ b/source/_integrations/discord.markdown
@@ -112,8 +112,8 @@ To include messages with embedding, use these attributes underneath the `embed` 
   data:
     message: "A message from Home Assistant"
     target: ["1234567890", "0987654321"]
-    verify_ssl: False
     data:
+      verify_ssl: False
       urls: 
       - "https://example.com/image.jpg"
       - "https://example.com/video.mp4"

--- a/source/_integrations/discord.markdown
+++ b/source/_integrations/discord.markdown
@@ -74,6 +74,8 @@ The following attributes can be placed inside the `data` key of the service call
 | Attribute              | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `images`               |      yes | The file(s) to attach to message.
+| `urls`                 |      yes | The file(s) to download from a remote URL and attach to message.
+| `verify_ssl`           |      yes | A boolean to determine if SSL certs should be verified when calling the remote URLs in the `url` attribute. Defaults to `True`.
 | `embed`                |      yes | Array of [Discord embeds](https://discordpy.readthedocs.io/en/latest/api.html#embed). *NOTE*: if using `embed`, `message` is still required.
 
 To include messages with embedding, use these attributes underneath the `embed` key:
@@ -102,6 +104,22 @@ To include messages with embedding, use these attributes underneath the `embed` 
       - "/tmp/garage_cam"
       - "/tmp/garage.jpg"
 ```
+
+### Example service call with attachments sourced from remote URLs
+
+```yaml
+- service: notify.discord
+  data:
+    message: "A message from Home Assistant"
+    target: ["1234567890", "0987654321"]
+    verify_ssl: False
+    data:
+      urls: 
+      - "https://example.com/image.jpg"
+      - "https://example.com/video.mp4"
+```
+
+Note that `verify_ssl` defaults to `True`, and that any remote hosts will need to be in your [`allowlist_external_urls`](/docs/configuration/basic/#allowlist_external_urls) list. Discord limits attachment size to 8MB, so anything exceeding this will be skipped and noted in the error log.
 
 ### Example embed service call
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add details on the new `urls` attribute to be added in a new PR.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/74811
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
