### PR TITLE
Add InelNet central control unit integration documentation

### DIFF
--- a/source/_integrations/inelnet.markdown
+++ b/source/_integrations/inelnet.markdown
@@ -27,7 +27,7 @@ What's important, the unit should have a **static IP address** assigned (see DHC
 
 The approach described below uses HTTP requests to send control commands to an InelNet unit. The example defines requests to raise, lower or stop a cover associated with a particular channel. The *inelnet_program* request, on the other hand, lets you switch a cover controller to programming mode when there is a need to pair a remote control with it.
 
-The listed commands will work with cover controllers (for example **Inel ST-01R**), but are not limited to them (for example, the *inelnet_up* command may trigger an **Inel ORS-X1T** switch as well).
+The listed commands will work with cover controllers (for example **Inel ST-01R**), but are not limited to them (for example, the *inelnet_up* or *inelnet_down* commands may trigger an **Inel ORS-X1T** switch as well).
 
 
 

--- a/source/_integrations/inelnet.markdown
+++ b/source/_integrations/inelnet.markdown
@@ -1,6 +1,7 @@
 ---
 title: InelNet
 description: Instructions on how to integrate an InelNet Internet central control unit with Home Assistant by using the HTTP API the unit exposes.
+ha_release: "n/a"
 ha_category:
   - Hub
   - Cover

--- a/source/_integrations/inelnet.markdown
+++ b/source/_integrations/inelnet.markdown
@@ -1,0 +1,121 @@
+---
+title: InelNet
+description: Instructions on how to integrate an InelNet Internet central control unit with Home Assistant by using the HTTP API the unit exposes.
+ha_category:
+  - Hub
+  - Cover
+  - Switch
+ha_iot_class: "Assumed State"
+ha_quality_scale: "No score"
+---
+
+The solution described in this documentation will allow Home Assistant users who own an [InelNet Internet central control unit](https://www.inel.gda.pl/en/offer/internet-central-control-unit.html) by [Inel](https://www.inel.gda.pl/en/) to control their appliances. The unit controls blinds, roller shutters, awnings, garage doors, drive-in doors, light sources, and mains sockets.
+
+In the examples presented here, the InelNet unit is controlled by HTTP requests, so it is not a Home Assistant integration as such, but rather a set of predefined REST requests you can use to control appliances paired with the unit.
+
+
+
+## Setup
+
+Before you start, it is assumed that you have an InelNet unit already configured and paired with the appliances you want to control by Home Assistant.
+
+What's important, the unit should have a **static IP address** assigned (see DHCP settings in your router's configuration). Otherwise, the proposed configuration will stop working whenever the IP address of the unit changes. Alternatively, a host name is a valid solution as well.
+
+
+
+## Configuration
+
+The approach described below uses HTTP requests to send control commands to an InelNet unit. The example defines requests to raise, lower or stop a cover associated with a particular channel. The *inelnet_program* request, on the other hand, lets you switch a cover controller to programming mode when there is a need to pair a remote control with it.
+
+The listed commands will work with cover controllers (for example **Inel ST-01R**), but are not limited to them (for example, the *inelnet_up* command may trigger an **Inel ORS-X1T** switch as well).
+
+
+
+## Examples
+
+Before you use the example, replace the **INELNET_UNIT_IP_ADDRESS** placeholders with the static IP address or host name of your InelNet unit.
+
+```yaml
+# Example configuration.yaml entry
+rest_command:
+  # raises the cover associated with the specified channel
+  inelnet_up:
+    url: 'http://INELNET_UNIT_IP_ADDRESS/msg.htm'
+    method: post
+    content_type: 'application/x-www-form-urlencoded'
+    payload: 'send_ch={{channel}}&send_act=160'
+
+  # raises the cover associated with the specified channel (short movement)
+  inelnet_up_short:
+    url: 'http://INELNET_UNIT_IP_ADDRESS/msg.htm'
+    method: post
+    content_type: 'application/x-www-form-urlencoded'
+    payload: 'send_ch={{channel}}&send_act=176'
+
+  # lowers the cover associated with the specified channel
+  inelnet_down:
+    url: 'http://INELNET_UNIT_IP_ADDRESS/msg.htm'
+    method: post
+    content_type: 'application/x-www-form-urlencoded'
+    payload: 'send_ch={{channel}}&send_act=192'
+
+  # lowers the cover associated with the specified channel (short movement)
+  inelnet_down_short:
+    url: 'http://INELNET_UNIT_IP_ADDRESS/msg.htm'
+    method: post
+    content_type: 'application/x-www-form-urlencoded'
+    payload: 'send_ch={{channel}}&send_act=208'
+
+  # stops the cover associated with the specified channel
+  inelnet_stop:
+    url: 'http://INELNET_UNIT_IP_ADDRESS/msg.htm'
+    method: post
+    content_type: 'application/x-www-form-urlencoded'
+    payload: 'send_ch={{channel}}&send_act=144'
+
+  # switches the cover controller associated with the specified channel
+  # to programming mode so you can pair a remote control with it
+  inelnet_program:
+    url: 'http://INELNET_UNIT_IP_ADDRESS/msg.htm'
+    method: post
+    content_type: 'application/x-www-form-urlencoded'
+    payload: 'send_ch={{channel}}&send_act=224'      
+```
+
+Having defined the REST commands above, you can use them to create a cover template like in the example below. Make sure to replace the **MY_BLIND_CHANNEL_NUMBER** placeholder with a proper channel number that your cover is associated with in your InelNet unit configuration.
+
+```yaml
+# Example configuration.yaml entry
+cover:
+  - platform: template
+    covers:
+      # adjust the entity ID
+      living_room_blind:
+        device_class: blind
+        
+        # adjust the unique ID and name
+        unique_id: living_room_blind_id
+        friendly_name: "Living room blind"
+
+        # InelNet does not support positions and the states of covers,
+        # so let's use 50 to always enable cover movement in either direction
+        position_template: 50
+
+        open_cover:
+          service: rest_command.inelnet_up
+          data:
+            # replace with a proper channel number, e.g. 1
+            channel: MY_BLIND_CHANNEL_NUMBER
+
+        close_cover:
+          service: rest_command.inelnet_down
+          data:
+            # replace with a proper channel number, e.g. 1
+            channel: MY_BLIND_CHANNEL_NUMBER
+
+        stop_cover:
+          service: rest_command.inelnet_stop
+          data:
+            # replace with a proper channel number, e.g. 1
+            channel: MY_BLIND_CHANNEL_NUMBER
+```


### PR DESCRIPTION
## Proposed change

I'm adding a documentation file for those that have an [InelNet Internet central control unit](https://www.inel.gda.pl/en/offer/internet-central-control-unit.html) to control their home appliances, especially covers. **The documentation is not related to any 'integration' package as such.** It's just a set of predefined REST requests that you can paste into your Home Assistant configuration.yaml file to be able to control your covers, garage door, etc. by using the requests.

An InelNet unit is connected to a LAN and exposes an HTTP API. The documented REST requests cover the part of the API that allows sending control commands to appliances. The unit communicates unidirectionally with cover controllers (and possibly other appliances) by radio. It is manufactured by a Polish company named [Inel](https://www.inel.gda.pl/en/).

I wasn't sure of a few things though (since this is my first contribution):

- if a standalone integration document like this is acceptable, since it is not associated with any 'integration' package as such,
- what HA release (_ha_release_) to specify in the header if it's not strictly related to any version (it uses REST requests, so the first HA release that supports them would be okay),
- if I should put a link to this documentation file anywhere so it is searchable (I assume it's not necessary, but am not sure).

I also created another pull request here to add an icon and a logo for the documentation (and I assume that no other action like linking is required if I understood the guide correctly). I placed it in a directory that has the same name as the documentation file (_inelnet_).

Thank you!

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3520
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
