### PR TITLE
Migrate HomeWizard entity names to new naming style

### DIFF
--- a/source/_integrations/homewizard.markdown
+++ b/source/_integrations/homewizard.markdown
@@ -49,25 +49,25 @@ The HomeWizard Energy API only exposes properties that are used within the HomeW
 
 | Name | Unit | Availability | Description |
 | --- | --- | --- | --- |
-| Wifi SSID | | HWE-P1, HWE-SKT, HWE-WTR, SDM230-wifi, SDM630-wifi  | The SSID of the connected network. |
-| Wifi Strength | % | HWE-P1, HWE-SKT, HWE-WTR, SDM230-wifi, SDM630-wifi  | Percentage of the Wi-Fi connection. |
-| Total Energy Import_t1 | kWh | HWE-P1, HWE-SKT, SDM230-wifi, SDM630-wifi  | Energy import reading. |
-| Total Energy Import_t2 | kWh | HWE-P1 | Energy import reading for other tariff. |
-| Total Energy Export_t1 | kWh | HWE-P1, HWE-SKT, SDM230-wifi, SDM630-wifi  | Energy export reading. |
-| Total Energy Export_t2 | kWh | HWE-P1 | Energy export reading for other tariff. |
-| Active Power | w | HWE-P1, HWE-SKT, SDM230-wifi, SDM630-wifi  | Active power usage. |
-| Active Power_l1 | w | HWE-P1, HWE-SKT, SDM230-wifi, SDM630-wifi  | Active power usage Line 1, for `SDM230-wifi` and`HWE-SKT` this value is the same as `Active Power`. |
-| Active Power_l2 | w | HWE-P1, SDM630-wifi | Active power usage Line 2. |
-| Active Power_l3 | w | HWE-P1, SDM630-wifi | Active power usage Line 3. |
-| Total Gas | m3 | HWE-P1 | Current gas import reading, only available when your smart meter is connected to a gas meter. |
-| DSMR Version | | HWE-P1 | The detected DSMR version. |
-| Smart Meter Model | | HWE-P1 | The detected smart meter model. |
-| Active Water Usage | liter per minute | HWE-WTR | The current usage of water. |
-| Total Water Usage | m3 | HWE-WTR | Total of water measured since installation. |
+| Wi-Fi SSID | | HWE-P1, HWE-SKT, HWE-WTR, SDM230-wifi, SDM630-wifi  | The SSID of the connected network. |
+| Wi-Fi strength | % | HWE-P1, HWE-SKT, HWE-WTR, SDM230-wifi, SDM630-wifi  | Percentage of the Wi-Fi connection. |
+| Total energy import T1 | kWh | HWE-P1, HWE-SKT, SDM230-wifi, SDM630-wifi  | Energy import reading. |
+| Total energy import T2 | kWh | HWE-P1 | Energy import reading for other tariff. |
+| Total energy export T1 | kWh | HWE-P1, HWE-SKT, SDM230-wifi, SDM630-wifi  | Energy export reading. |
+| Total energy export T2 | kWh | HWE-P1 | Energy export reading for other tariff. |
+| Active power | w | HWE-P1, HWE-SKT, SDM230-wifi, SDM630-wifi  | Active power usage. |
+| Active power L1 | w | HWE-P1, HWE-SKT, SDM230-wifi, SDM630-wifi  | Active power usage line 1, for `SDM230-wifi` and`HWE-SKT` this value is the same as `Active power`. |
+| Active power L2 | w | HWE-P1, SDM630-wifi | Active power usage line 2. |
+| Active power L3 | w | HWE-P1, SDM630-wifi | Active power usage line 3. |
+| Total gas | m3 | HWE-P1 | Current gas import reading, only available when your smart meter is connected to a gas meter. |
+| DSMR version | | HWE-P1 | The detected DSMR version. |
+| Smart meter model | | HWE-P1 | The detected smart meter model. |
+| Active water usage | liter per minute | HWE-WTR | The current usage of water. |
+| Total water usage | m3 | HWE-WTR | Total of water measured since installation. |
 
 ## Switches
 
 The Wifi Energy Socket (`HWE-SKT`) outlet state can be controlled the switch platform. There are two switches:
 
 - **Switch**: Controls the outlet state of the Energy Socket. This switch is locked out when `Switch Lock` is turned on. 
-- **Switch Lock**: Forces the outlet state in the `on` position and disables the physical button. This option is useful when the socket is used for a device that must not be turned off, such as a refrigerator.
+- **Switch lock**: Forces the outlet state in the `on` position and disables the physical button. This option is useful when the socket is used for a device that must not be turned off, such as a refrigerator.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updated the names in Core, so we update them here to ;)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/74958
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
