### PR TITLE
Update Fronius documentation to include new entity naming style

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -69,10 +69,9 @@ Each device adds a set of sensors to Home Assistant.
   Detailed information about current, voltage, state, cycle count, capacity and more about installed batteries. Updated every minute.
 
 Note that some data (like photovoltaic production) is only provided by the Fronius device when non-zero.
-The corresponding sensors are added to Home Assistant as entities as soon as they are available.
-This means for example that when Home Assistant is started at night, there might be no sensor providing photovoltaic related data.
-This does not need to be problematic as the values will be added on sunrise, when the Fronius devices begins providing more data.
-When a device is not responding correctly the update interval will increase to 10 minutes (3 minutes for power flow) until valid data is received again. This reduces the amount of requests to Fronius devices using night mode (shutdown when no PV power is produced).
+When the integration is added at night, there might be no sensors added providing photovoltaic related data. Entities will be added on sunrise, when the Fronius devices begin to provide more data.
+
+When an endpoint is not responding correctly the update interval will increase to 10 minutes (3 minutes for power flow) until valid data is received again. This reduces the amount of requests to Fronius devices using night mode (shutdown when no PV power is produced).
 
 ## Energy dashboard
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -18,12 +18,12 @@ ha_dhcp: true
 ha_integration_type: integration
 ---
 
-The `fronius` integration polls a [Fronius](https://www.fronius.com/) solar inverter or datalogger to allow you to get details from your Fronius SolarNet setup and integrate it in your Home Assistant installation.
+The Fronius integration polls a [Fronius](https://www.fronius.com/) solar inverter or datalogger for details of your Fronius SolarNet setup and integrate it in your Home Assistant installation.
 
 ## Prerequisites
 
-You will need to either set a static IP on the Fronius device or assign a static DHCP lease for it, or alternatively access it through the local DNS name if your network is properly configured for this.
-For Gen24 devices (delivered with Firmware >= 1.14.1) make sure to activate the "Solar API" in the inverters web interface.
+You should either set a static IP or assign a static DHCP lease for the Fronius device, or alternatively access it through the local DNS name if your network is configured accordingly.
+For Gen24 devices (delivered with Firmware >= 1.14.1) make sure to activate "Solar API" in the inverters web interface.
 
 {% include integrations/config_flow.md %}
 
@@ -33,71 +33,69 @@ Each device adds a set of sensors to Home Assistant.
 
 - SolarNet device
   
-  - `logger_info`
+  - Logger information
 
     General information about the Fronius Datalogger. Not available on "Gen24" devices. Updated every hour.
 
-    - The serial number and software and hardware platforms
-    - The current price of energy consumed from the grid ("cash factor")
-    - The current price of energy returned to the grid ("delivery factor")
+    - Serial number, software and hardware platforms
+    - Current price of energy consumed and returned to grid and the CO₂ factor as set in the Dataloggers settings
 
-  - `power_flow`
+  - Power flow
 
-    Cumulative data such as the energy produced in the current day or year and overall produced energy. Updated every 10 seconds.
-    Also, live values such as:
+    Cumulative data of the SolarNet system. Updated every 10 seconds.
 
-    - Power fed to the grid (if positive) or taken from the grid (if negative).
-    - Power load as a generator (if positive) or consumer (if negative).
-    - Battery charging power (if positive) or discharging power (if negative) and information about backup or standby mode.
-    - Photovoltaic production.
-    - Current relative self-consumption of produced energy.
-    - Current relative autonomy.
+    - Energy produced on the current day, year and total produced energy
+    - Power fed to the grid (if positive) or consumed from the grid (if negative)
+    - Power load as a generator (if positive) or consumer (if negative)
+    - Battery charging power (if positive) or discharging power (if negative) and information about backup or standby mode
+    - Photovoltaic production
+    - Current relative self-consumption of produced energy
+    - Current relative autonomy
 
-- `inverter`
+- Inverter
 
-  Cumulative data such as the energy produced in the current day or year and overall produced energy. Updated every minute.
-  Also, live values about AC/DC power, current, voltage and frequency.
+  Energy produced on the current day, year and total produced energy, power, current, voltage, frequency and status for an individual inverter. Updated every minute.
 
-- `meter`
+- Meter
 
   Detailed information about power, current and voltage, if supported split among the phases. Updated every minute.
 
-- `ohmpilot`
+- Ohmpilot
 
   Detailed information about energy, power, and temperature of your Ohmpilots. Updated every minute.
 
-- `storage`
+- Storage
 
   Detailed information about current, voltage, state, cycle count, capacity and more about installed batteries. Updated every minute.
 
 Note that some data (like photovoltaic production) is only provided by the Fronius device when non-zero.
 The corresponding sensors are added to Home Assistant as entities as soon as they are available.
 This means for example that when Home Assistant is started at night, there might be no sensor providing photovoltaic related data.
-This does not need to be problematic as the values will be added on sunrise, when the Fronius devices begins providing the needed data.
-When a device is not responding correctly the update interval will increase to 10 minutes (3 minutes for power flow) until valid data is received again.
+This does not need to be problematic as the values will be added on sunrise, when the Fronius devices begins providing more data.
+When a device is not responding correctly the update interval will increase to 10 minutes (3 minutes for power flow) until valid data is received again. This reduces the amount of requests to the Fronius devices using night mode (shutdown when no PV power is produced).
 
 ## Energy dashboard
 
-- For `Solar production`: 
+- For _"Solar production"_: 
   - If no battery is connected to an inverter: Add each inverters `Energy total` entity.
-  - If a battery is connected to an inverter: Use [Riemann sum](/integrations/integration/) over `Power photovoltaics` entity (from power_flow endpoint found in your `SolarNet` device)
-- `Battery systems` aren't supported directly. Use [Template](/integrations/template) to split and invert negative values of `Power battery` entity (from power_flow) for charging power (W) and positive values for discharging power (W). Then use [Riemann sum](/integrations/integration/) to integrate each into energy values (kWh).
-- For `Devices` use the Ohmpilots `Energy consumed` entity.
+  - If a battery is connected to an inverter: Use [Riemann sum](/integrations/integration/) over `Power photovoltaics` entity (from your `SolarNet` device).
+- _"Battery systems"_ aren't supported directly. Use [Template](/integrations/template) to split and invert negative values of `Power battery` entity (from `SolarNet` device) for charging power (W) and positive values for discharging power (W). Then use [Riemann sum](/integrations/integration/) to integrate each into energy values (kWh).
+- For _"Devices"_ use the Ohmpilots `Energy consumed` entity.
 
-The energy meter integrated with Fronius devices can be installed (and configured) in two different installation positions: _"feed in path"_ (`meter_location` = 0) or _"consumption path"_ (`meter_location` = 1). In the first case, the meter provides all data you need but, in the second case, it doesn't so you need to calculate some of them by using helpers.
+The energy meter integrated with Fronius devices can be installed (and configured) in two different installation positions: _"feed in path"_ (`Meter location` = 0) or _"consumption path"_ (`Meter location` = 1).
 
 ### Feed in path meter
 
 Recommended energy dashboard configuration for meter location in feed in path:
 
-- For `Grid consumption` use the meters `Energy real consumed` entity.
-- For `Return to grid` use the meters `Energy real produced` entity.
+- For _"Grid consumption"_ use the meters `Energy real consumed` entity.
+- For _"Return to grid"_ use the meters `Energy real produced` entity.
 
 ### Consumption path meter
 
 Recommended energy dashboard configuration for meter location in consumption path:
 
-- The "Power Grid" entity provided by the Fronius API is positive on import and negative on export. Split it up into import- and export-power entities by using helpers with templates `max(states(sensor.power_grid) | float, 0)` and `max(0 - states(sensor.power_grid) | float, 0)`.
+- The `Power grid` entity provided by the Fronius API is positive on import and negative on export. Split it up into import- and export-power entities by using helpers with templates `max(states(sensor.solarnet_power_grid) | float, 0)` and `max(0 - states(sensor.solarnet_power_grid) | float, 0)`.
 - Then use [Riemann sum](/integrations/integration/) to integrate these import-/export-power entities into energy values (kWh).
 - Use these energy entities for `Grid consumption` and `Return to grid` in the energy dashboard configuration.
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -18,7 +18,7 @@ ha_dhcp: true
 ha_integration_type: integration
 ---
 
-The Fronius integration polls a [Fronius](https://www.fronius.com/) solar inverter or datalogger for details of your Fronius SolarNet setup and integrate it in your Home Assistant installation.
+The Fronius integration polls a [Fronius](https://www.fronius.com/) solar inverter or datalogger for details of a Fronius SolarNet setup and integrate it in your Home Assistant installation.
 
 ## Prerequisites
 
@@ -72,11 +72,11 @@ Note that some data (like photovoltaic production) is only provided by the Froni
 The corresponding sensors are added to Home Assistant as entities as soon as they are available.
 This means for example that when Home Assistant is started at night, there might be no sensor providing photovoltaic related data.
 This does not need to be problematic as the values will be added on sunrise, when the Fronius devices begins providing more data.
-When a device is not responding correctly the update interval will increase to 10 minutes (3 minutes for power flow) until valid data is received again. This reduces the amount of requests to the Fronius devices using night mode (shutdown when no PV power is produced).
+When a device is not responding correctly the update interval will increase to 10 minutes (3 minutes for power flow) until valid data is received again. This reduces the amount of requests to Fronius devices using night mode (shutdown when no PV power is produced).
 
 ## Energy dashboard
 
-- For _"Solar production"_: 
+- For _"Solar production"_:
   - If no battery is connected to an inverter: Add each inverters `Energy total` entity.
   - If a battery is connected to an inverter: Use [Riemann sum](/integrations/integration/) over `Power photovoltaics` entity (from your `SolarNet` device).
 - _"Battery systems"_ aren't supported directly. Use [Template](/integrations/template) to split and invert negative values of `Power battery` entity (from `SolarNet` device) for charging power (W) and positive values for discharging power (W). Then use [Riemann sum](/integrations/integration/) to integrate each into energy values (kWh).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update Fronius documentation to include new entity naming style and spread some general documentation love 💛.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/74974
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
