### PR TITLE
Update ecobee.markdown

### DIFF
--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -34,7 +34,7 @@ The `ecobee` integration lets you control and view sensor data from [ecobee](htt
 You will need to obtain an API key from ecobee's [developer site](https://www.ecobee.com/developers/) to use this integration. To get the key, your thermostat must be registered on ecobee's website (which you likely would have already done while installing your thermostat). Once you have done that, perform the following steps.
 
 1. Click on the **Become a developer** link on the [developer site](https://www.ecobee.com/home/developer/loginDeveloper.jsp).
-2. Log in with your ecobee credentials. (Make sure your password is at most 16 characters and multifactor authentication is disabled to meet the developer login form's limits. If you've already enabled MFA, the web portal and iOS apps don't support disabling it. The Android app does under Account > Account Security. You can re-enable MFA after becoming a developer.)
+2. Log in with your ecobee credentials. (Make sure multifactor authentication is disabled to meet the developer login form's limits. If you've already enabled MFA, the web portal doesn't support disabling it. The iOS and Android apps do under Account > Account Security. You can re-enable MFA after becoming a developer.)
 3. Accept the SDK agreement.
 4. Fill in the fields.
 5. Click **save**.


### PR DESCRIPTION
Developer account no longer limits passwords to 16 characters, and iOS app can now disable MFA.

## Proposed change
Update docs to reflect changes in ecobee integration process.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
I just went through this setup process myself.  I was able to disable 2FA from the iOS app, and I was able to create a developer account with my current password which is longer than 16 characters.  

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
