### PR TITLE
Add docs for Guardian migration of certain services to buttons

### DIFF
--- a/source/_integrations/guardian.markdown
+++ b/source/_integrations/guardian.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to integrate SimpliSafe into Home Assistant.
 ha_iot_class: Local Polling
 ha_release: '0.111'
 ha_category:
+  - Button
   - Binary Sensor
   - Sensor
   - Switch
@@ -14,6 +15,7 @@ ha_domain: guardian
 ha_zeroconf: true
 ha_platforms:
   - binary_sensor
+  - button
   - diagnostics
   - sensor
   - switch
@@ -27,6 +29,7 @@ The `guardian` integration integrates
 There is currently support for the following device types within Home Assistant:
 
 - **Binary Sensor**: reports the status of the onboard leak detector and access point
+- **Button**: add various configuration controls
 - **Sensor**: reports on the device's detected temperature and uptime
 - **Switch**: allows the user to open and close the valve
 
@@ -49,14 +52,6 @@ Add a new paired sensor to the valve controller.
 | Service Data Attribute | Optional | Description                                      |
 | ---------------------- | -------- | ------------------------------------------------ |
 | `uid`                    | yes      | The unique device ID on the bottom of the sensor.|
-
-### `guardian.reboot`
-
-Reboot the device.
-
-### `guardian.reset_valve_diagnostics`
-
-Fully (and irrecoverably) reset all valve diagnostics.
 
 ### `guardian.unpair_sensor`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR updates the Guardian docs to reflect the migration of two services to buttons.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/75028
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: fixes N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
