### PR TITLE
Missed breaking change to media_player in 2022.5

### DIFF
--- a/source/_posts/2022-05-04-release-20225.markdown
+++ b/source/_posts/2022-05-04-release-20225.markdown
@@ -1235,8 +1235,6 @@ In order to maintain previous behavior, replace usage of `playing` with both the
 
 [@emontnemery]: [https://github.com/emontnemery]
 [#70863]: https://github.com/home-assistant/core/pull/70863
-[#70864]: https://github.com/home-assistant/core/pull/70864
-[#70859]: https://github.com/home-assistant/core/pull/70859
 
 {% enddetails %}
 

--- a/source/_posts/2022-05-04-release-20225.markdown
+++ b/source/_posts/2022-05-04-release-20225.markdown
@@ -1229,7 +1229,7 @@ This makes the discovery of LIFX faster and more reliable.
 
 Media Player now supports a new state, `buffering`. Integrations supporting this state previously reported `playing` but may now report `buffering`. This may also introduce new state transitions between the two states during playback.
 
-In order to maintain previous behaviour, replace usage of `playing` with both the `buffering` and `playing` states, and consider how to handle transitions between the two.
+In order to maintain previous behavior, replace usage of `playing` with both the `buffering` and `playing` states, and consider how to handle transitions between the two.
 
 ([@emontnemery] - [#70863]) ([documentation](/integrations/media_player))
 

--- a/source/_posts/2022-05-04-release-20225.markdown
+++ b/source/_posts/2022-05-04-release-20225.markdown
@@ -1225,6 +1225,21 @@ This makes the discovery of LIFX faster and more reliable.
 
 {% enddetails %}
 
+{% details "Media Player" %}
+
+Media Player now supports a new state, `buffering`. Integrations supporting this state previously reported `playing` but may now report `buffering`. This may also introduce new state transitions between the two states during playback.
+
+In order to maintain previous behaviour, replace usage of `playing` with both the `buffering` and `playing` states, and consider how to handle transitions between the two.
+
+([@emontnemery] - [#70863]) ([documentation](/integrations/media_player))
+
+[@emontnemery]: [https://github.com/emontnemery]
+[#70863]: https://github.com/home-assistant/core/pull/70863
+[#70864]: https://github.com/home-assistant/core/pull/70864
+[#70859]: https://github.com/home-assistant/core/pull/70859
+
+{% enddetails %}
+
 {% details "Media Source" %}
 
 Filenames and directories starting with a `.` will no longer appear in the


### PR DESCRIPTION

## Proposed change

This adds a breaking changes section for the media_player, as additional states were added by dividing existing states. Any previous triggers that relied on playing will not trigger on buffering, and the additional transitions between playing and buffering may cause additional triggering.

@emontnemery: I ended the section with your username as you made the changes, I hope that's appropriate.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

This is the architecture document that describes the breaking change: https://github.com/home-assistant/architecture/discussions/763

## Checklist

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [ x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
