### PR TITLE
Update stream technical details

### DIFF
--- a/source/_integrations/stream.markdown
+++ b/source/_integrations/stream.markdown
@@ -59,7 +59,7 @@ stream:
 
 ## Technical Details
 
-The integration currently supports proxying H.264 and H.265 source streams to the HLS protocol and requires at least FFmpeg >= 4. Note that H.265 support is limited to Safari, iOS, and Android. H.265 also works in Edge on Windows when "HEVC Video Extensions" is installed. Chrome versions >= 104 may also work when started with the "--enable-features=PlatformHEVCDecoderSupport" option.
+The integration currently supports proxying H.264 and H.265 source streams to the HLS (and LL-HLS) protocol. Note that while H.265 works on Android and iOS, it does not work in many browsers. This is a browser limitation and not a Home Assistant issue. Safari has native H.265 support, and H.265 also works in Edge on Windows when "HEVC Video Extensions" is installed. Chrome versions >= 104 may also work when started with the "--enable-features=PlatformHEVCDecoderSupport" option. For testing HEVC browser support, do not rely on the https://www.caniuse.com charts or the https://html5test.com site. They are wrong. You can instead use the ["Unprefixed tests" from caniuse.com](https://tests.caniuse.com/?feat=hevc) or the [hls.js demo app with an HEVC HLS stream](https://hls-js.netlify.app/demo/?src=https%3A%2F%2Fbitmovin-a.akamaihd.net%2Fcontent%2Fdataset%2Fmulti-codec%2Fhevc%2Fstream_fmp4.m3u8). The videos there should play if your browser supports H.265.
 The `stream` integration supports AAC and MP3 audio. PCM codecs (e.g. G.711/G.723/G.726/G.729) are not supported.
 
 ## Troubleshooting

--- a/source/_integrations/stream.markdown
+++ b/source/_integrations/stream.markdown
@@ -61,20 +61,3 @@ stream:
 
 The integration currently supports proxying H.264 and H.265 source streams to the HLS (and LL-HLS) protocol. Note that while H.265 works on Android and iOS, it does not work in many browsers. This is a browser limitation and not a Home Assistant issue. Safari has native H.265 support, and H.265 also works in Edge on Windows when "HEVC Video Extensions" is installed. Chrome versions >= 104 may also work when started with the "--enable-features=PlatformHEVCDecoderSupport" option. For testing HEVC browser support, do not rely on the https://www.caniuse.com charts or the https://html5test.com site. They are wrong. You can instead use the ["Unprefixed tests" from caniuse.com](https://tests.caniuse.com/?feat=hevc) or the [hls.js demo app with an HEVC HLS stream](https://hls-js.netlify.app/demo/?src=https%3A%2F%2Fbitmovin-a.akamaihd.net%2Fcontent%2Fdataset%2Fmulti-codec%2Fhevc%2Fstream_fmp4.m3u8). The videos there should play if your browser supports H.265.
 The `stream` integration supports AAC and MP3 audio. PCM codecs (e.g. G.711/G.723/G.726/G.729) are not supported.
-
-## Troubleshooting
-
-Users on manual installs with FFmpeg < 4 may see an error similar to:
-
-```text
-2020-04-28 13:35:43 ERROR (SyncWorker_5) [homeassistant.util.package] Unable to install package av==7.0.1: ERROR: Command errored out with exit status 1:
-     command: /mnt/c/dev/home-assistant/venv/bin/python3.7 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-twd7glz2/av/setup.py'"'"'; __file__='"'"'/tmp/pip-install-twd7glz2/av/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-x9tw2ql2/install-record.txt --single-version-externally-managed --compile --install-headers /mnt/c/dev/home-assistant/venv/include/site/python3.7/av
-         cwd: /tmp/pip-install-twd7glz2/av/
-```
-
-You can solve this by running the following steps to update FFmpeg >= 4:
-
-```text
-sudo add-apt-repository ppa:jonathonf/ffmpeg-4
-sudo apt upgrade
-```

--- a/source/_integrations/stream.markdown
+++ b/source/_integrations/stream.markdown
@@ -59,7 +59,8 @@ stream:
 
 ## Technical Details
 
-The integration currently supports proxying H.264 and H.265 source streams to the HLS protocol and requires at least FFmpeg >= 4. Note that H.265 support is limited to Safari, iOS, and Android. The `stream` integration also provides limited support for audio. PCM codecs (e.g. G.711/G.723/G.726/G.729) are not supported. ADTS AAC audio is also currently not supported. Most other AAC and MP3 encoded audio should work.
+The integration currently supports proxying H.264 and H.265 source streams to the HLS protocol and requires at least FFmpeg >= 4. Note that H.265 support is limited to Safari, iOS, and Android. H.265 also works in Edge on Windows when "HEVC Video Extensions" is installed. Chrome versions >= 104 may also work when started with the "--enable-features=PlatformHEVCDecoderSupport" option.
+The `stream` integration supports AAC and MP3 audio. PCM codecs (e.g. G.711/G.723/G.726/G.729) are not supported.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updated the technical details to reflect better audio support after #74151 and #75166. Also included more information on H.265.
Also removed outdated information regarding old ffmpeg versions / manual PyAV installation. PyAV itself no longer supports ffmpeg < 4 and the vast majority of installs should have binary wheels available.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#75166](https://github.com/home-assistant/core/pull/75166)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
