### PR TITLE
miiocli has changed option vacuum to roborockvacuum

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1487,7 +1487,7 @@ Main Brush Left*:
 Sensor Dirty Left*:
   description: How long the sensor can  be used in seconds
 Current Clean Time:
-  description: The current cleaning time of the vacuum. If the vaccuum is not cleaning, this sensor will have the same value as the "Last Clean Duration" sensor.
+  description: The current cleaning time of the vacuum. If the vacuum is not cleaning, this sensor will have the same value as the "Last Clean Duration" sensor.
 Current Clean Area:
   description: The current area that has been cleaned. If the vacuum is not cealning, this sensor will have the same value as the "Last Clean Area" sensor.
 Last Clean Area*:
@@ -1594,7 +1594,7 @@ vacuum_kitchen:
 Valid room numbers can be retrieved using miio command-line tool:
 
 ```bash
-miiocli vacuum --ip <ip of the vacuum> --token <your vacuum token> get_room_mapping
+miiocli roborockvacuum --ip <ip of the vacuum> --token <your vacuum token> get_room_mapping
 ```
 
 It will return the full mapping of room numbers to user-defined names as a list of (number,name) tuples.


### PR DESCRIPTION
## Proposed change
Documentation maintenance

Only two minor changes:

- Spelling error fixed (vaccuum to vacuum)
- Command adjusted ("miiocli vaccum" to "miiocli roborockvacuum"), because option vacuum no longer exists.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards



## Proposed change
<!-- 
