### PR TITLE
Patch 1

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -34,11 +34,10 @@ body:
   - type: input
     attributes:
       label: Version
-      placeholder: "e.g., 2021.2.0"
+      placeholder: "e.g., 2022.7.0"
       description: >
-        Current version of the documentation. This usually matches the Home
-        Assistant Core release version, and can be found at the bottom of the
-        page.
+        Latest stable version version of Home Assistant available
+        (which does not have to match the version you are using).
   - type: textarea
     attributes:
       label: Additional information

--- a/source/_dashboards/map.markdown
+++ b/source/_dashboards/map.markdown
@@ -27,6 +27,11 @@ geo_location_sources:
   required: true
   description: List of geolocation sources. All current entities with that source will be displayed on the map. See [Geolocation](/integrations/geo_location/) platform for valid sources. Set to `all` to use all available sources. Either this or the `entities` configuration option is required.
   type: list
+auto_fit:
+  required: false
+  description: The map will follow moving `entities` by adjusting the viewport of the map each time an entity is updated. 
+  type: boolean
+  default: false
 title:
   required: false
   description: The card title.
@@ -72,6 +77,7 @@ The card can also be configured using YAML, some examples below:
 type: map
 aspect_ratio: 16:9
 default_zoom: 8
+auto_fit: true
 entities:
   - device_tracker.demo_paulus
   - zone.home

--- a/source/_includes/custom/features.html
+++ b/source/_includes/custom/features.html
@@ -2,7 +2,7 @@
   <div class="card">
     <div class="card-header">
       <i class="icon-lightbulb"></i>
-      Works with over 1900 devices
+      Works with over 1000 brands
     </div>
     <div class="card-content">
       <p>

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -77,7 +77,7 @@ In short, when any group member entity is `on`, the group will also be `on`. A c
 - Otherwise, the group state is `off`.
 
 ### Lock groups
-In short, when any group member entity is `unlocked`, the group will also be `unlocked`. A complete overview of how fan groups behave:
+In short, when any group member entity is `unlocked`, the group will also be `unlocked`. A complete overview of how lock groups behave:
 
 - The group state is `unavailable` if all group members are `unavailable`.
 - Otherwise, the group state is `unknown` if all group members are `unknown` or `unavailable`.

--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -25,7 +25,7 @@ This can be used to present statistics about Home Assistant sensors if used with
 
 See [supported engines](/integrations/recorder/#custom-database-engines) for which you can connect with this integration.
 
-The SQL integration will connect to default recorder if Database URL is not specified.
+The SQL integration will connect to the default SQLite if "Database URL" has not been specified. If you use a different database recorder (eg MariaDB or others), you will have to specify the "Database URL" manually during integration setup.
 
 There is no explicit configuration required for attributes. The integration will set all additional columns returned by the query as attributes. 
 
@@ -67,7 +67,7 @@ Use `state` as column for value.
 #### Postgres
 
 ```sql
-"SELECT (pg_database_size('dsmrreader')/1024/1024) as db_size;"
+SELECT (pg_database_size('dsmrreader')/1024/1024) as db_size;
 ```
 Use `db_size` as column for value.
 
@@ -76,7 +76,7 @@ Use `db_size` as column for value.
 Change `table_schema="hass"` to the name that you use as the database name, to ensure that your sensor will work properly.
 
 ```sql
-'SELECT table_schema "database", Round(Sum(data_length + index_length) / 1024, 1) "value" FROM information_schema.tables WHERE table_schema="hass" GROUP BY table_schema;'
+SELECT table_schema "database", Round(Sum(data_length + index_length) / 1024, 1) "value" FROM information_schema.tables WHERE table_schema="hass" GROUP BY table_schema;
 ```
 Use `value` as column for value.
 
@@ -85,7 +85,7 @@ Use `value` as column for value.
 If you are using the `recorder` integration then you don't need to specify the location of the database. For all other cases, add `sqlite:////path/to/database.db` as Database URL.
 
 ```sql
-'SELECT ROUND(page_count * page_size / 1024 / 1024, 1) as size FROM pragma_page_count(), pragma_page_size();'
+SELECT ROUND(page_count * page_size / 1024 / 1024, 1) as size FROM pragma_page_count(), pragma_page_size();
 ```
 Use `size` as column for value.
 
@@ -96,6 +96,6 @@ Use the same Database URL as for the `recorder` integration. Change `DB_NAME` to
 Example Database URL: `"mssql+pyodbc://username:password@SERVER_IP:1433/DB_NAME?charset=utf8&driver=FreeTDS"`
 
 ```sql
-"SELECT TOP 1 SUM(m.size) * 8 / 1024 as size FROM sys.master_files m INNER JOIN sys.databases d ON d.database_id=m.database_id WHERE d.name='DB_NAME';"
+SELECT TOP 1 SUM(m.size) * 8 / 1024 as size FROM sys.master_files m INNER JOIN sys.databases d ON d.database_id=m.database_id WHERE d.name='DB_NAME';
 ```
 Use `size` as column for value.


### PR DESCRIPTION
This change documents the new `auto_fit` config option for the lovelace map card.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds an auto_fit config option to the lovelace map card. This will update the documentation to keep it in line with the changes.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/13228

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
