### PR TITLE
Clarified the meaning and usage of notify.notify

### DIFF
--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -30,7 +30,7 @@ The notify integration supports specifying [templates](/topics/templating/). Thi
 
 In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) it could look like this with a customized subject.
 
-Be aware that you might want to change the actual service to whatever service your actually using since notify.notify is shorthand for the first notify service the system can find and might therefore not be working as intended.
+Be aware that you might want to change the actual service to whatever service you are actually using since `notify.notify` is shorthand for the first notify service the system can find and might therefore not be working as intended.
 
 ```yaml
 action:

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -30,6 +30,8 @@ The notify integration supports specifying [templates](/topics/templating/). Thi
 
 In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) it could look like this with a customized subject.
 
+Be aware that you might want to change the actual service to whatever service your actually using since notify.notify is shorthand for the first notify service the system can find and might therefore not be working as intended.
+
 ```yaml
 action:
   service: notify.notify


### PR DESCRIPTION
Tried to clarify the logic behind actually using notify.notify

## Proposed change
The documentation using notify.notify without any explanation might bei missleading to users. I therefore added information about the correct use of the notify service.


## Type of change
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

- This PR fixes or closes issue: fixes #23314 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
