### PR TITLE
Add SensorPush integration

### DIFF
--- a/source/_integrations/sensorpush.markdown
+++ b/source/_integrations/sensorpush.markdown
@@ -1,0 +1,27 @@
+---
+title: SensorPush
+description: Instructions on how to integrate SensorPush devices into Home Assistant.
+ha_category:
+  - Sensor
+ha_zeroconf: true
+ha_release: 2022.8
+ha_iot_class: Local Push
+ha_codeowners:
+  - '@bdraco'
+ha_domain: sensorpush
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_integration_type: integration
+---
+
+Integrates [SensorPush](https://www.sensorpush.com/) devices into Home Assistant.
+
+## Supported devices
+
+- [HT.w Water-Resistant Temperature / Humidity Smart Sensor](https://www.sensorpush.com/products/p/ht-w)
+- [HTP.xw Extreme Accuracy Water-Resistant Temperature / Humidity / Barometric Pressure Smart Sensor](https://www.sensorpush.com/products/p/htp-xw)
+
+The SensorPush integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
+
+{% include integrations/config_flow.md %}

--- a/source/_integrations/sensorpush.markdown
+++ b/source/_integrations/sensorpush.markdown
@@ -3,7 +3,7 @@ title: SensorPush
 description: Instructions on how to integrate SensorPush devices into Home Assistant.
 ha_category:
   - Sensor
-ha_zeroconf: true
+ha_bluetooth: true
 ha_release: 2022.8
 ha_iot_class: Local Push
 ha_codeowners:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add SensorPush integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/75531
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3543
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
