### PR TITLE
Fix typo harmony hub remote example code

### DIFF
--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -279,29 +279,29 @@ media_player:
       turn_on:
         service: remote.turn_on
         target:
-          entity_id: remote.remote.harmony_hub
+          entity_id: remote.harmony_hub
       turn_off:
         service: remote.turn_off
         target:
-          entity_id: remote.remote.harmony_hub
+          entity_id: remote.harmony_hub
       volume_up:
         service: remote.send_command
         target:
-          entity_id: remote.remote.harmony_hub
+          entity_id: remote.harmony_hub
         data:
           device: Receiver
           command: VolumeUp
       volume_down:
         service: remote.send_command
         target:
-          entity_id: remote.remote.harmony_hub
+          entity_id: remote.harmony_hub
         data:
           device: Receiver
           command: VolumeDown
       select_source:
         service: remote.turn_on
         target:
-          entity_id: remote.remote.harmony_hub
+          entity_id: remote.harmony_hub
         data:
           activity: "{{ source }}"
     device_class: tv


### PR DESCRIPTION
I was (lazy) copy-pasting the wrong example and thought why not fix it :) 

Cheers,
Robbert (A happy home assistant user for years ❤️ )

## Proposed change
Removed double prefix of remote entities in harmony hub example of the universal media player documentation page


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
