### PR TITLE
Update switchbot to be local push

### DIFF
--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -2,7 +2,9 @@
 title: SwitchBot
 description: Instructions on how to set up SwitchBot Devices.
 ha_category:
+  - Binary Sensor
   - Cover
+  - Sensor
   - Switch
 ha_release: 0.78
 ha_iot_class: Local Push
@@ -10,6 +12,7 @@ ha_codeowners:
   - '@danielhiversen'
   - '@RenierM26'
 ha_domain: switchbot
+ha_bluetooth: true
 ha_platforms:
   - binary_sensor
   - cover

--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -5,7 +5,7 @@ ha_category:
   - Cover
   - Switch
 ha_release: 0.78
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ha_codeowners:
   - '@danielhiversen'
   - '@RenierM26'
@@ -42,18 +42,18 @@ There are three attributes available on the SwitchBot entity to give you more in
 
 - `last_run_success`: If `true` if the last action sent to the SwitchBot succeeded. This attribute is useful for error trapping when Bluetooth connectivity is intermittent. If `false`, see home-assistant.log for specific error messages.
 - `Switch mode`: Specifies the mode of the SwitchBot. If `true` the the SwitchBot is in Pull/Retract mode for toggle switches otherwise the bot is in momentary switch mode.
-- `MAC address`: The BTLE MAC for the device.
+- `address`: The BTLE address for the device.
 
 ## SwitchBot Options
 
 There are four options that can be configured for the SwitchBot entities. Setting any of these options will apply to all of your SwitchBot devices.
 
-- `Time between updates (seconds)`: Increase/Decrease the update interval for the device. (Could impact battery life)
 - `Retry count`: How many times to retry sending commands and retry polling your SwitchBot devices.
 - `Timeout between retries`: How long to wait before retries.
-- `How long to scan for advertisement data`: Bluetooth LE uses advertisement data for device statuses and/or attributes. This setting specifies how long the scan should run.
 
 ### Error codes and troubleshooting
+
+The SwitchBot integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
 
 {% configuration_basic %}
 "Config flow could not be loaded":


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update switchbot to be local push

Fixes references to mac addresses since MacOS uses UUIDs instead.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/75645
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
