### PR TITLE
Add information about Bluetooth interference

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -43,3 +43,12 @@ Some systems may not come with Bluetooth and require a USB adapter. Installing a
 While newer integrations can share the Bluetooth Adapter, some legacy integrations require exclusive use of the adapter. Enabling this integration may prevent an integration that has not been updated to use newer methods from functioning.
 
 Deleting the config entry for this integration will release control of the adapter and allow another integration to gain exclusive use of the Bluetooth adapter. If you have manually added `bluetooth:` to your `configuration.yaml`, you must also remove it to prevent the configuration from being recreated.
+
+## Bluetooth interference with other devices
+
+Devices that are using the 2.4 GHz band, like Wifi, Zigbee and USB3 devices (and its cable connections) are known to affect Bluetooth reception. Especially external SSD-drives with USB3 cables are known to block the Bluetooth signal. Also, metal casings can decrease Bluetooth performance of internal Bluetooth Adapters. The following tips may improve reception of the Bluetooth Adapter.
+
+- Try to place USB3 devices (SSD, etc.) as far away as possible from your Bluetooth Adapter, e.g., by using an extension cable.
+- Use an USB3 extension cable with proper shielding and ferrite clamps
+- Use a (good quality) external Bluetooth adapter with antenna
+

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -46,7 +46,9 @@ Deleting the config entry for this integration will release control of the adapt
 
 ## Bluetooth interference with other devices
 
-Devices that are using the 2.4 GHz band, like Wifi, Zigbee and USB3 devices (and its cable connections) are known to affect Bluetooth reception. Especially external SSD-drives with USB3 cables are known to block the Bluetooth signal. Also, metal casings can decrease Bluetooth performance of internal Bluetooth Adapters. The following tips may improve reception of the Bluetooth Adapter.
+Devices that are using the 2.4 GHz band, like Wi-Fi, Zigbee, and USB3 devices (and their cable connections) are known to affect Bluetooth reception. Especially external SSD drives with USB3 cables are known to block the Bluetooth signal. Also, metal casings can decrease the Bluetooth performance of internal Bluetooth Adapters.
+
+The following tips may improve reception of the Bluetooth Adapter:
 
 - Try to place USB3 devices (SSD, etc.) as far away as possible from your Bluetooth Adapter, e.g., by using an extension cable.
 - Use an USB3 extension cable with proper shielding and ferrite clamps

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -51,6 +51,6 @@ Devices that are using the 2.4 GHz band, like Wi-Fi, Zigbee, and USB3 devices (a
 The following tips may improve reception of the Bluetooth Adapter:
 
 - Try to place USB3 devices (SSD, etc.) as far away as possible from your Bluetooth Adapter, e.g., by using an extension cable.
-- Use an USB3 extension cable with proper shielding and ferrite clamps
-- Use a (good quality) external Bluetooth adapter with antenna
+- Use a USB3 extension cable with proper shielding and ferrite clamps.
+- Use a (good quality) external Bluetooth adapter with an antenna.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add information about Bluetooth interference with other devices in the bluetooth integration docs


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#74653](https://github.com/home-assistant/core/pull/74653)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
