### PR TITLE
Starline api change

### DIFF
--- a/source/_integrations/starline.markdown
+++ b/source/_integrations/starline.markdown
@@ -30,7 +30,7 @@ This integration provides the following platforms:
 - Binary Sensors: Hand brake, hood, trunk, alarm status and doors lock state.
 - Device tracker: The location of your car.
 - Lock: Control the lock of your car.
-- Sensors: Battery level, SIM card balance, GSM signal level, Fuel Volume, Mileage, interior temperature and engine temperature.
+- Sensors: Battery level, SIM card balance, GSM signal level, Fuel Volume, Mileage, GPS Satellites, interior temperature and engine temperature.
 - Switches: Start/stop engine, heater (webasto) and additional channel.
 - Buttons: Sound the horn.
 - Services: Update the state, set update frequency. More details can be found [here](#services).

--- a/source/_integrations/starline.markdown
+++ b/source/_integrations/starline.markdown
@@ -30,8 +30,9 @@ This integration provides the following platforms:
 - Binary Sensors: Hand brake, hood, trunk, alarm status and doors lock state.
 - Device tracker: The location of your car.
 - Lock: Control the lock of your car.
-- Sensors: Battery level, SIM card balance, GSM signal level, Fuel Volume, Mileage, OBD Errors, interior temperature and engine temperature.
-- Switches: Start/stop engine, heater (webasto), additional channel and sound the horn.
+- Sensors: Battery level, SIM card balance, GSM signal level, Fuel Volume, Mileage, interior temperature and engine temperature.
+- Switches: Start/stop engine, heater (webasto) and additional channel.
+- Buttons: Sound the horn.
 - Services: Update the state, set update frequency. More details can be found [here](#services).
 
 ## Prerequisites
@@ -41,7 +42,7 @@ Create a new application in the [StarLine developer profile](https://my.starline
 <div class='note'>
 
 You can make up to 1000 API calls per day, which means you could make one approximately every 86 seconds.
-By default, the state of integration will be updated every 3 minutes and OBD information will be updated every 3 hours, making 488 calls per day.
+By default, the state of integration will be updated every 3 minutes, making 480 calls per day.
 It is not recommended to set an update interval of less than 90 seconds.
 
 </div>
@@ -59,14 +60,6 @@ This service does not require any attributes.
 ### Set scan interval
 
 The service `starline.set_scan_interval` sets update frequency for entities.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `scan_interval` | no | Update frequency in seconds.
-
-### Set scan OBD interval
-
-The service `starline.set_scan_obd_interval` sets update frequency for OBD information.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Starline API was updated, look at https://github.com/home-assistant/core/pull/75712


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/75712
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
