### PR TITLE
Update filter precision info

### DIFF
--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -78,16 +78,16 @@ filters:
       description: Algorithm to be used to filter data. Available filters are  `lowpass`, `outlier`, `range`, `throttle`, `time_throttle` and `time_simple_moving_average`.
       required: true
       type: string
+    precision:
+      description: Defines the precision of the filtered state, through the argument of round().
+      required: false
+      type: integer
+      default: 2
     window_size:
       description: Size of the window of previous states. Time based filters such as `time_simple_moving_average` will require a time period (size in time), while other filters such as `outlier` will require an integer (size in number of states). Time periods are in _hh:mm_ format and must be quoted.
       required: false
       type: [integer, time]
       default: 1
-    precision:
-      description: See [_lowpass_](#low-pass) filter. Defines the precision of the filtered state, through the argument of round().
-      required: false
-      type: integer
-      default: None
     time_constant:
       description: See [_lowpass_](#low-pass) filter. Loosely relates to the amount of time it takes for a state to influence the output.
       required: false
@@ -128,8 +128,6 @@ B = 1.0 / time_constant
 A = 1.0 - B
 LowPass(state) = A * previous_state + B * state
 ```
-
-The returned value is rounded to the number of decimals defined in (`precision`).
 
 ### Outlier
 


### PR DESCRIPTION
## Proposed change
- The documentation currently specifies the default value of `precision` as `None`, when it is actually 2 ([sensor.py#L74](https://github.com/home-assistant/core/blob/f4e7436421479d902569c919d8e7279812cd9571/homeassistant/components/filter/sensor.py#L74))
- The documentation currently implies that `precision` is only applied to `lowpass`, when it is actually applied to all filters ([sensor.py#471](https://github.com/home-assistant/core/blob/f4e7436421479d902569c919d8e7279812cd9571/homeassistant/components/filter/sensor.py#L471))

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
