### PR TITLE
Add HmIP-WGC to homematicip_cloud integration

### DIFF
--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -4,6 +4,7 @@ description: Instructions for integrating HomematicIP into Home Assistant.
 ha_category:
   - Alarm
   - Binary Sensor
+  - Button
   - Climate
   - Cover
   - Hub
@@ -18,6 +19,7 @@ ha_domain: homematicip_cloud
 ha_platforms:
   - alarm_control_panel
   - binary_sensor
+  - button
   - climate
   - cover
   - light
@@ -33,6 +35,7 @@ There is currently support for the following device types within Home Assistant:
 
 * Alarm
 * Binary Sensor
+* Button
 * Climate
 * Cover
 * Light
@@ -111,6 +114,9 @@ Within this delay the device registration should be completed in the App, otherw
   * Remote Control for brand switches – 2x buttons (*HmIP-BRC2*) (battery only)
   * Pluggable Power Supply Monitoring (*HmIP-PMFS*)
   * Wired Inbound module – 32x channels (*HMIPW-DRI32*)
+
+* homematicip_cloud.button
+  * Wall Mounted Garage Door Controller (*HmIP-WGC*)
 
 * homematicip_cloud.climate
   * Climate group (*HmIP-HeatingGroup*)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for button HmIP-WGC to homematicip_cloud integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#75733
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
