### PR TITLE
Use more inclusive terminology in mqtt eventstream

### DIFF
--- a/source/_integrations/mqtt_eventstream.markdown
+++ b/source/_integrations/mqtt_eventstream.markdown
@@ -39,30 +39,30 @@ ignore_event:
 
 ## Multiple Instances
 
-Events from multiple instances can be aggregated to a single master instance by subscribing to a wildcard topic from the master instance.
+Events from multiple instances can be aggregated to a single parent instance by subscribing to a wildcard topic from the parent instance.
 
 ```yaml
-# Example master instance configuration.yaml entry
+# Example parent instance configuration.yaml entry
 mqtt_eventstream:
-  publish_topic: master/topic
-  subscribe_topic: slaves/#
+  publish_topic: parent/topic
+  subscribe_topic: child/#
   ignore_event:
     - call_service
     - state_changed
 ```
 
-For a multiple instance setup, each slave would publish to their own topic.
+For a multiple instance setup, each child instance would publish to their own topic.
 
 ```yaml
-# Example slave instance configuration.yaml entry
+# Example child instance configuration.yaml entry
 mqtt_eventstream:
-  publish_topic: slaves/upstairs
-  subscribe_topic: master/topic
+  publish_topic: child/upstairs
+  subscribe_topic: parent/topic
 ```
 
 ```yaml
-# Example slave instance configuration.yaml entry
+# Example child instance configuration.yaml entry
 mqtt_eventstream:
-  publish_topic: slaves/downstairs
-  subscribe_topic: master/topic
+  publish_topic: child/downstairs
+  subscribe_topic: parent/topic
 ```


### PR DESCRIPTION
## Proposed change

We should avoid the terms "master" and "slave" in our documentation. It's definitely unnecessary here, propose changing to "parent" and "child".

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
