### PR TITLE
Use more inclusive terminology in airzone

### DIFF
--- a/source/_integrations/airzone.markdown
+++ b/source/_integrations/airzone.markdown
@@ -21,9 +21,9 @@ ha_integration_type: integration
 
 This integration interacts with the Local API of [Airzone HVAC zoning systems](https://www.airzone.es/en/).
 
-A typical Airzone device has a *master zone* (Master Thermostat) per HVAC system, which is the only zone where the HVAC mode can be changed. The rest are *slave zones* (Slave Thermostats) which can only enable or disable the HVAC and adjust the desired temperature on that specific zone.
+A typical Airzone device has a *parent zone* (Master Thermostat) per HVAC system, which is the only zone where the HVAC mode can be changed. The rest are *child zones* which can only enable or disable the HVAC and adjust the desired temperature on that specific zone.
 
-Note that multiple HVAC systems can be connected to the same Airzone WebServer. In this case, there will be a *master zone* per HVAC system and there may also be *slave zones* for each HVAC system.
+Note that multiple HVAC systems can be connected to the same Airzone WebServer. In this case, there will be a *parent zone* per HVAC system and there may also be *child zones* for each HVAC system.
 
 {% include integrations/config_flow.md %}
 
@@ -57,9 +57,9 @@ For each Airzone zone (Thermostat), the following *binary sensors* are created:
 
 For each Airzone zone (Thermostat) a *climate entity* is created.
 
-**HVAC mode can only be changed on a *master zone*.**
+**HVAC mode can only be changed on a *parent zone*.**
 
-*Slave zones* can only enable/disable the current HVAC mode selected on the corresponding *master zone*. Attempting to change the HVAC mode on a *slave zone* will result on a Home Assistant error.
+*Slave zones* can only enable/disable the current HVAC mode selected on the corresponding *parent zone*. Attempting to change the HVAC mode on a *child zone* will result on a Home Assistant error.
 
 ## Sensors
 


### PR DESCRIPTION
## Proposed change

Continuing on #23529 I did a search to see where the term "slave" appears in HA documentation to see if there was any other places it could be easily removed. I don't believe it is necessary here in Airzone so I changed it to the more friendly "parent zone" and "child zone".

Note that I did keep "Master Thermostat" in one place because that term actually does appear in airzone's documentation (you can find it on [this page](https://www.airzonecontrol.com/na/en/products/thermostats/)). Since they use it we should at least reference it once to make the connection. The term "Slave Thermostat" does not appear in their documentation from what I can tell so there is no reason to use it here.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
