### PR TITLE
Changed OpenUV update automation example to be more realistic

### DIFF
--- a/source/_integrations/openuv.markdown
+++ b/source/_integrations/openuv.markdown
@@ -102,7 +102,7 @@ To perform an optimal amount of API calls you need to know the hours of daylight
 
 ```yaml
 automation:
-  - alias: "OpenUV Update"
+  - alias: "Update OpenUV"
     trigger:
       # Time pattern of /45 will not work as expected, it will trigger on the whole hour and on the whole hour + 45 minutes.
       # Using more frequent time pattern and a condition to get the intended behavior.
@@ -118,7 +118,7 @@ automation:
       # We check if the last trigger has been 40 minutes or more ago so we don't run into timing issues.
       # By checking for 40 minutes or greater we ensure this is only true at the 45 minute mark.
       - condition: template
-        value_template: "{{ (now() - state_attr('automation.openuv_update', 'last_triggered')) >= timedelta(hours = 0, minutes = 40)  }}"
+        value_template: "{{ (now() - state_attr('automation.update_openuv', 'last_triggered')) >= timedelta(hours = 0, minutes = 40)  }}"
     action:
       - service: openuv.update_data
 

--- a/source/_integrations/openuv.markdown
+++ b/source/_integrations/openuv.markdown
@@ -120,7 +120,11 @@ automation:
       # We check if the last trigger has been 40 minutes or more ago so we don't run into timing issues.
       # By checking for 40 minutes or greater we ensure this is only true at the 45 minute mark.
       - condition: template
-        value_template: "{{ (now() - state_attr('automation.update_openuv', 'last_triggered')) >= timedelta(hours = 0, minutes = 40)  }}"
+        value_template: >- 
+          {{
+            state_attr('automation.openuv_update', 'last_triggered') == None or
+            (now() - state_attr('automation.openuv_update', 'last_triggered')) >= timedelta(hours = 0, minutes = 40)
+          }}
     action:
       - service: openuv.update_data
 

--- a/source/_integrations/openuv.markdown
+++ b/source/_integrations/openuv.markdown
@@ -98,24 +98,30 @@ Perform an on-demand update of OpenUV `uv_protection_window` data, but not the s
 
 ## Examples of Updating Data
 
-One method to retrieve data every 30 minutes and still leave plenty of API key
-usage is to only retrieve data during the daytime:
+To perform an optimal amount of API calls you need to know the hours of daylight on the longest day of the year. If for example this is 17 hours, you can perform 2 calls around every 45 minutes without running into the 50 API call limit per day:
 
 ```yaml
 automation:
-  - alias: "Update OpenUV every 30 minutes during the daytime"
+  - alias: "OpenUV Update"
     trigger:
-      platform: time_pattern
-      minutes: "/30"
+      # Time pattern of /45 will not work as expected, it will trigger on the whole hour and on the whole hour + 45 minutes.
+      # Using more frequent time pattern and a condition to get the intended behavior.
+      - platform: time_pattern
+        minutes: "/15"
     condition:
-      condition: and
-      conditions:
-        - condition: sun
-          after: sunrise
-        - condition: sun
-          before: sunset
+      - condition: sun
+        after: sunrise
+        before: sunset
+        # The last call will most likely fall before the sunset, thus leaving an UV index value not at 0 for the remaining night.
+        # To fix this, we allow one more service call after the sun has set.
+        before_offset: "+00:45:00"
+      # We check if the last trigger has been 40 minutes or more ago so we don't run into timing issues.
+      # By checking for 40 minutes or greater we ensure this is only true at the 45 minute mark.
+      - condition: template
+        value_template: "{{ (now() - state_attr('automation.openuv_update', 'last_triggered')) >= timedelta(hours = 0, minutes = 40)  }}"
     action:
-      service: openuv.update_data
+      - service: openuv.update_data
+
 ```
 
 Update the UV index data every 20 minutes while the sun is at least 10 degrees above the horizon:
@@ -157,7 +163,7 @@ etc.) might be to simply query the API less often:
 
 ```yaml
 automation:
-  - alias: "Update OpenUV every hour (24 of 50 calls per day)"
+  - alias: "Update OpenUV every hour (48 of 50 calls per day)"
     trigger:
       platform: time_pattern
       hours: "*"

--- a/source/_integrations/openuv.markdown
+++ b/source/_integrations/openuv.markdown
@@ -100,6 +100,8 @@ Perform an on-demand update of OpenUV `uv_protection_window` data, but not the s
 
 To perform an optimal amount of API calls you need to know the hours of daylight on the longest day of the year. If for example this is 17 hours, you can perform 2 calls around every 45 minutes without running into the 50 API call limit per day:
 
+{% raw %}
+
 ```yaml
 automation:
   - alias: "Update OpenUV"
@@ -123,6 +125,8 @@ automation:
       - service: openuv.update_data
 
 ```
+
+{% endraw %}
 
 Update the UV index data every 20 minutes while the sun is at least 10 degrees above the horizon:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I have changed the automation that would exceed the 50 API request limit to a more realistic automation while still using as many API calls as possible.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #23538

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
