### PR TITLE
Add information about lifx homekit_controller discoveries

### DIFF
--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -113,9 +113,13 @@ Run an effect that does nothing, thereby stopping any other effect that might be
 | ---------------------- | ----------- |
 | `entity_id` | String or list of strings that point at `entity_id`s of lights. Use `entity_id: all` to target all.
 
+## HomeKit Accessory Protocol
+
+Many LIFX devices also support being controlled via HomeKit Accessory Protocol. If the LIFX device supports it and has not already paired with an `iOS` device, it can be paired using HomeKit Accessory Protocol. If the LIFX device supports HomeKit and the `lifx` integration does not yet support the device, it can be controlled via the [`homekit_controller`](/integrations/homekit_controller) integration. The `lifx` integration currently has to poll the device every few seconds, as opposed to using the [`homekit_controller`](/integrations/homekit_controller) integration, which offers push updates, encrypted communications, and significantly less network traffic.
+
 ## LIFX Switch
 
-The `lifx` integration does not support the LIFX Switch. However, the `homekit_controller` integration can be used instead for
+The `lifx` integration does not support the LIFX Switch. However, the [`homekit_controller`](/integrations/homekit_controller) integration can be used instead for
 [LIFX Switch running firmware 3.90](https://support.lifx.com/en_us/switch-3-90-update-rk4zYiXVq) or higher. Follow the LIFX
 documentation to obtain a HomeKit code prior to integrating the Switch with Home Assistant as it will be needed during the process.
 

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -115,7 +115,11 @@ Run an effect that does nothing, thereby stopping any other effect that might be
 
 ## HomeKit Accessory Protocol
 
-Many LIFX devices also support being controlled via HomeKit Accessory Protocol. If the LIFX device supports it and has not already paired with an `iOS` device, it can be paired using HomeKit Accessory Protocol. If the LIFX device supports HomeKit and the `lifx` integration does not yet support the device, it can be controlled via the [`homekit_controller`](/integrations/homekit_controller) integration. The `lifx` integration currently has to poll the device every few seconds, as opposed to using the [`homekit_controller`](/integrations/homekit_controller) integration, which offers push updates, encrypted communications, and significantly less network traffic.
+Many LIFX devices also support being controlled via HomeKit Accessory Protocol. If the LIFX device supports it and has not already paired with an `iOS` device, it can be paired using HomeKit Accessory Protocol. 
+
+If the `lifx` integration does not yet support the device but supports HomeKit Accessory Protocol, it can be controlled via the [`homekit_controller`](/integrations/homekit_controller) integration. 
+
+The `lifx` integration currently has to poll the device every few seconds, as opposed to using the [`homekit_controller`](/integrations/homekit_controller) integration, which offers push updates, encrypted communications, and significantly less network traffic.
 
 ## LIFX Switch
 

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -115,11 +115,11 @@ Run an effect that does nothing, thereby stopping any other effect that might be
 
 ## HomeKit Accessory Protocol
 
-Many LIFX devices also support being controlled via HomeKit Accessory Protocol. If the LIFX device supports it and has not already paired with an `iOS` device, it can be paired using HomeKit Accessory Protocol via the [`homekit_controller`](/integrations/homekit_controller) integration. 
+Many LIFX devices also support being controlled via HomeKit Accessory Protocol. If the LIFX device supports it and has not already paired with an `iOS` device, it can be paired using HomeKit Accessory Protocol via the [HomeKit Controller](/integrations/homekit_controller) integration. 
 
-If the `lifx` integration does not yet support the device but supports HomeKit Accessory Protocol, this method enables control of the device from Home Assistant. See below for specific details on controlling LIFX Switches.
+If the LIFX integration does not yet support the device but supports HomeKit Accessory Protocol, this method enables control of the device from Home Assistant. See below for specific details on controlling LIFX Switches.
 
-The `lifx` integration currently has to poll the device every few seconds, as opposed to using the [`homekit_controller`](/integrations/homekit_controller) integration, which offers push updates, encrypted communications, and significantly less network traffic.
+The LIFX integration currently has to poll the device every few seconds, as opposed to using the [HomeKit Controller](/integrations/homekit_controller) integration, which offers push updates, encrypted communications, and significantly less network traffic.
 
 Discoveries from control protocols that are not desired can be ignored in the UI. LIFX devices that support the LAN protocol and the HomeKit Accessory Protocol may be discovered by both methods if they are unpaired with an `iOS` device. It is possible to simultaneously set up control of the device with both protocols.
 

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -121,6 +121,8 @@ If the `lifx` integration does not yet support the device but supports HomeKit A
 
 The `lifx` integration currently has to poll the device every few seconds, as opposed to using the [`homekit_controller`](/integrations/homekit_controller) integration, which offers push updates, encrypted communications, and significantly less network traffic.
 
+LIFX devices that support the LAN protocol and the HomeKit Accessory Protocol may be discovered by both methods if they are unpaired with an `iOS` device. It is possible to control the device with both protocols. Discoveries from control protocols that are not desired can be ignored in the UI.
+
 ## LIFX Switch
 
 The `lifx` integration does not support the LIFX Switch. However, the [`homekit_controller`](/integrations/homekit_controller) integration can be used instead for

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -115,9 +115,9 @@ Run an effect that does nothing, thereby stopping any other effect that might be
 
 ## HomeKit Accessory Protocol
 
-Many LIFX devices also support being controlled via HomeKit Accessory Protocol. If the LIFX device supports it and has not already paired with an `iOS` device, it can be paired using HomeKit Accessory Protocol. 
+Many LIFX devices also support being controlled via HomeKit Accessory Protocol. If the LIFX device supports it and has not already paired with an `iOS` device, it can be paired using HomeKit Accessory Protocol via the [`homekit_controller`](/integrations/homekit_controller) integration. 
 
-If the `lifx` integration does not yet support the device but supports HomeKit Accessory Protocol, it can be controlled via the [`homekit_controller`](/integrations/homekit_controller) integration. 
+If the `lifx` integration does not yet support the device but supports HomeKit Accessory Protocol, this method enables control of the device from Home Assistant. See below for specific details on controlling LIFX Switches.
 
 The `lifx` integration currently has to poll the device every few seconds, as opposed to using the [`homekit_controller`](/integrations/homekit_controller) integration, which offers push updates, encrypted communications, and significantly less network traffic.
 

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -115,13 +115,13 @@ Run an effect that does nothing, thereby stopping any other effect that might be
 
 ## HomeKit Accessory Protocol
 
-Many LIFX devices also support being controlled via HomeKit Accessory Protocol. If the LIFX device supports it and has not already paired with an `iOS` device, it can be paired using HomeKit Accessory Protocol via the [HomeKit Controller](/integrations/homekit_controller) integration. 
+Most LIFX devices support Apple HomeKit via the HomeKit Accessory Protocol (HAP). If a LIFX device has not already been added to HomeKit natively using an Apple iOS or macOS device, it can be paired with Home Assistant using via the [HomeKit Controller](/integrations/homekit_controller) integration which uses HAP.
 
-If the LIFX integration does not yet support the device but supports HomeKit Accessory Protocol, this method enables control of the device from Home Assistant. See below for specific details on controlling LIFX Switches.
+This enables the use of LIFX devices in Home Assistant that are not supported by the LIFX integration. See below for specific details on controlling LIFX Switches.
 
 The LIFX integration currently has to poll the device every few seconds, as opposed to using the [HomeKit Controller](/integrations/homekit_controller) integration, which offers push updates, encrypted communications, and significantly less network traffic.
 
-Discoveries from control protocols that are not desired can be ignored in the UI. LIFX devices that support the LAN protocol and the HomeKit Accessory Protocol may be discovered by both methods if they are unpaired with an `iOS` device. It is possible to simultaneously set up control of the device with both protocols.
+Discoveries from control protocols that are not desired can be ignored in the UI. LIFX devices that support HAP will be discovered by both methods if they have not been added to native HomeKit using an Apple iOS or macOS device. It is possible to set up control of the device in Home Assistant using both protocols simultaneously by configuring both the LIFX integration and the HomeKit Controller integration for the same device.
 
 ## LIFX Switch
 

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -121,7 +121,7 @@ If the `lifx` integration does not yet support the device but supports HomeKit A
 
 The `lifx` integration currently has to poll the device every few seconds, as opposed to using the [`homekit_controller`](/integrations/homekit_controller) integration, which offers push updates, encrypted communications, and significantly less network traffic.
 
-LIFX devices that support the LAN protocol and the HomeKit Accessory Protocol may be discovered by both methods if they are unpaired with an `iOS` device. It is possible to control the device with both protocols. Discoveries from control protocols that are not desired can be ignored in the UI.
+Discoveries from control protocols that are not desired can be ignored in the UI. LIFX devices that support the LAN protocol and the HomeKit Accessory Protocol may be discovered by both methods if they are unpaired with an `iOS` device. It is possible to simultaneously set up control of the device with both protocols.
 
 ## LIFX Switch
 

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -129,7 +129,7 @@ The LIFX integration does not support the LIFX Switch. However, the [HomeKit Con
 [LIFX Switch running firmware 3.90](https://support.lifx.com/en_us/switch-3-90-update-rk4zYiXVq) or higher. Follow the LIFX
 documentation to obtain a HomeKit code prior to integrating the Switch with Home Assistant as it will be needed during the process.
 
-When using the `homekit_controller` integration, each button on the LIFX Switch is discovered as a
+When using the [HomeKit Controller](/integrations/homekit_controller) integration, each button on the LIFX Switch is discovered as a
 [stateless switch](/integrations/homekit_controller#stateless-switches-and-sensors) and will not appear as an entity in Home Assistant.
 Relays that are configured as wired to non-LIFX devices will appear as normal switches in Home Assistant.
 

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -125,7 +125,7 @@ Discoveries from control protocols that are not desired can be ignored in the UI
 
 ## LIFX Switch
 
-The `lifx` integration does not support the LIFX Switch. However, the [`homekit_controller`](/integrations/homekit_controller) integration can be used instead for
+The LIFX integration does not support the LIFX Switch. However, the [HomeKit Controller](/integrations/homekit_controller) integration can be used instead for
 [LIFX Switch running firmware 3.90](https://support.lifx.com/en_us/switch-3-90-update-rk4zYiXVq) or higher. Follow the LIFX
 documentation to obtain a HomeKit code prior to integrating the Switch with Home Assistant as it will be needed during the process.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add information about homekit_controller discoveries

Related https://github.com/home-assistant/core/issues/75826
## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
