### PR TITLE
deprecate some YAML configs in volvooncall integration

### DIFF
--- a/source/_integrations/volvooncall.markdown
+++ b/source/_integrations/volvooncall.markdown
@@ -73,14 +73,6 @@ mutable:
   required: false
   default: true
   type: boolean
-name:
-  description: "Make it possible to provide a name for the vehicles. Note: Use all lower case letters when inputting your VIN number."
-  required: false
-  type: string
-resources:
-  description: A list of resources to display (defaults to all available).
-  required: false
-  type: list
 scandinavian_miles:
   description: If set to true, Scandinavian miles ("mil") are used for distances and fuel range.
   required: false
@@ -130,20 +122,3 @@ The list of currently available resources:
 - `tyre_pressure_rear_right_tyre_pressure`
 - `any_door_open`
 - `any_window_open`
-
-## Advanced Examples
-
-A more advanced example for setting the vehicle name and selecting what resources to display:
-
-```yaml
-# Example configuration.yaml entry
-volvooncall:
-  username: YOUR_USERNAME
-  password: YOUR_PASSWORD
-  name:
-    YOUR_VIN_NUMBER: "NEW_NAME"
-  resources:
-    - odometer
-    - lock
-    - heater
-```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove/deprecate YAML config options that are now configurable via the UI. I've refactored the volvooncall component to use DataUpdateController, and have thus deprecated these YAML configurations at the same time.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [X] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/75885

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
