### PR TITLE
Correct grammar in selectors documentation

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -641,10 +641,10 @@ the select value.
 ![Screenshot of a number selector](/images/blueprints/selector-number.png)
 
 On the user interface, the input can either be in a slider or number mode.
-Both modes limit the user input by a minimal and maximum value, and can
+Both modes limit the user input by a minimum and maximum value, and can
 have a unit of measurement to go with it.
 
-In its most basic form, this selector requires a minimal and maximum value:
+In its most basic form, this selector requires a minimum and maximum value:
 
 ```yaml
 number:
@@ -654,7 +654,7 @@ number:
 
 {% configuration number %}
 min:
-  description: The minimal user-settable number value.
+  description: The minimum user-settable number value.
   type: [integer, float]
   required: true
 max:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Minimum and maximum go together

Minimal and maximal go together

It is very rare for minimal and maximum to be used together.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
