### PR TITLE
Add telegram disable_web_page_preview (telegram.markdown)

### DIFF
--- a/source/_integrations/telegram.markdown
+++ b/source/_integrations/telegram.markdown
@@ -387,10 +387,14 @@ action:
   service: notify.NOTIFIER_NAME
   data:
     title: "*Send a message*"
-    message: "That's an example that sends a message with message_tag and disable_notification."
+    message: |-
+      That's an example that sends a message with message_tag, disable_notification and disable_web_page_preview.
+      <a href="https://www.home-assistant.io/">HA site</a>
     data:
+      parse_mode: html
       message_tag: "example_tag"
       disable_notification: True
+      disable_web_page_preview: True
 ```
 
 {% configuration %}
@@ -401,6 +405,10 @@ parse_mode:
 disable_notification:
   description: True/false to send the message silently. iOS users and web users will not receive a notification. Android users will receive a notification with no sound.
   required: false
+  default: false
+  type: boolean
+disable_web_page_preview:
+  description: True/false to display a webpage preview.
   default: false
   type: boolean
 message_tag:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds ability to specify disable_web_page_preview to telegram.notify


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/75898
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
