### PR TITLE
Add documentation for state_translated jinja function

### DIFF
--- a/source/_docs/configuration/basic.markdown
+++ b/source/_docs/configuration/basic.markdown
@@ -27,6 +27,8 @@ homeassistant:
     media: "/media"
     recordings: "/mnt/recordings"
   legacy_templates: false
+  preload_translations:
+    - en
 ```
 
 <div class='note'>
@@ -105,6 +107,10 @@ legacy_templates:
   required: false
   type: boolean
   default: false
+preload_translations:
+  description: A list of languages to preload. Required for [`state_translated`](/docs/configuration/templating#state-translated) template function.
+  required: false
+  type: list
 {% endconfiguration %}
 
 ## Reload Core Service

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -181,6 +181,40 @@ With strings:
 
 {% endraw %}
 
+### State translated
+
+Not supported in [limited templates](#limited-templates).
+
+Returns translated state of an entity if available or its state string otherwise.
+
+#### State translated examples
+
+{% raw %}
+
+```text
+{{ state_translated("sun.sun", "en") }}  # Below horizon
+{{ state_translated("sun.sun", "nl") }}  # Onder de horizon
+```
+
+{% endraw %}
+
+<div class='note warning'>
+
+In order to use this function you have to define `preload_translations` in [basic configuration](/docs/configuration/basic) to enable preloading translations for selected languages after a start of Home Assistant.
+
+{% raw %}
+
+```text
+homeassistant:
+  preload_translations:
+    - en
+    - nl
+```
+
+{% endraw %}
+
+</div>
+
 ### Working with Groups
 
 Not supported in [limited templates](#limited-templates).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds a documentation for `state_translated` jinja function.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/65743
- ~~Link to parent pull request in the Brands repository:~~
- ~~This PR fixes or closes issue: fixes #~~

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
