### PR TITLE
Fix Cache-Control max-age syntax

### DIFF
--- a/source/_headers
+++ b/source/_headers
@@ -1,5 +1,5 @@
 /*
-  Cache-Control: public, max-age: 0, s-maxage=3600, must-revalidate
+  Cache-Control: public, max-age=0, s-maxage=3600, must-revalidate
   Content-Security-Policy: form-action https:
   Feature-Policy: geolocation 'none'; midi 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; payment 'none'
   Permissions-Policy: geolocation=(), midi=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), payment=()
@@ -7,14 +7,14 @@
   X-Content-Type-Options: nosniff
   X-XSS-Protection: 1; mode=block
 /*.css
-  Cache-Control: public, max-age: 604800, s-maxage=604800
+  Cache-Control: public, max-age=604800, s-maxage=604800
 /*.js
-  Cache-Control: public, max-age: 604800, s-maxage=604800
+  Cache-Control: public, max-age=604800, s-maxage=604800
 /assets/*
-  Cache-Control: public, max-age: 0, s-maxage=604800, must-revalidate
+  Cache-Control: public, max-age=0, s-maxage=604800, must-revalidate
 /fonts/*
-  Cache-Control: public, max-age: 1800, s-maxage=604800, must-revalidate
+  Cache-Control: public, max-age=1800, s-maxage=604800, must-revalidate
 /images/*
-  Cache-Control: public, max-age: 1800, s-maxage=604800, must-revalidate
+  Cache-Control: public, max-age=1800, s-maxage=604800, must-revalidate
 /static/*
-  Cache-Control: public, max-age: 1800, s-maxage=604800, must-revalidate
+  Cache-Control: public, max-age=1800, s-maxage=604800, must-revalidate


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The max-age syntax in the Cache-Control header seems wrong. I'm not sure what type of change this falls under.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
