### PR TITLE
Fix incorrect event data keys in SimpliSafe docs

### DIFF
--- a/source/_integrations/simplisafe.markdown
+++ b/source/_integrations/simplisafe.markdown
@@ -95,14 +95,14 @@ Set one or more system properties.
 web and mobile apps. When received, they come with event data that contains the
 following keys:
 
-* `changed_by`: the PIN that triggered the event (if appropriate)
-* `event_type`: the type of event
-* `info`: a human-friendly string describing the event in more detail
-* `sensor_name`: the sensor that triggered the event (if appropriate)
-* `sensor_serial`: the serial number of the sensor that triggered the event (if appropriate)
-* `sensor_type`: the type of sensor that triggered the event (if appropriate)
+* `last_event_changed_by`: the PIN that triggered the event (if appropriate)
+* `last_event_type`: the type of event
+* `last_event_info`: a human-friendly string describing the event in more detail
+* `last_event_sensor_name`: the sensor that triggered the event (if appropriate)
+* `last_event_sensor_serial`: the serial number of the sensor that triggered the event (if appropriate)
+* `last_event_sensor_type`: the type of sensor that triggered the event (if appropriate)
 * `system_id`: the system ID to which the event belongs
-* `timestamp`: the UTC datetime at which the event was received
+* `last_event_timestamp`: the UTC datetime at which the event was received
 
 For example, when someone rings the doorbell, a
 `SIMPLISAFE_EVENT` event will fire with the following event data:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR fixes some incorrect event data keys in the SimpliSafe docs. Tagging this for the 2022.8 beta.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
