### PR TITLE
Make MQTT discovery entity_id override example accurate

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -434,16 +434,16 @@ Setting up a [light that takes JSON payloads](/integrations/light.mqtt/#json-sch
 
 The entity id is automatically generated from the entity's name. All MQTT entity components optionally support providing an `object_id` which will be used instead if provided.
 
-- Configuration topic: `homeassistant/sensor/my_super_device/config`
+- Configuration topic: `homeassistant/sensor/device1/config`
 - Example configuration payload:
 
 ```json
 {
   "name":"My Super Device",
-  "object_id":"device1",
-  "state_topic": "homeassistant/sensor/device1/state"
+  "object_id":"my_super_device",
+  "state_topic": "homeassistant/sensor/my_super_device/state"
  }
 ```
 
-In the example above, the entity_id will be `sensor.device1` instead of `sensor.my_super_device`.
+In the example above, the entity_id will be `sensor.my_super_device` instead of `sensor.device1`.
 

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -441,7 +441,7 @@ The entity id is automatically generated from the entity's name. All MQTT entity
 {
   "name":"My Super Device",
   "object_id":"my_super_device",
-  "state_topic": "homeassistant/sensor/my_super_device/state"
+  "state_topic": "homeassistant/sensor/device1/state"
  }
 ```
 

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -434,7 +434,7 @@ Setting up a [light that takes JSON payloads](/integrations/light.mqtt/#json-sch
 
 The entity id is automatically generated from the entity's name. All MQTT entity components optionally support providing an `object_id` which will be used instead if provided.
 
-- Configuration topic: `homeassistant/sensor/device1/config`
+- Configuration topic: `homeassistant/sensor/my_super_device/config`
 - Example configuration payload:
 
 ```json


### PR DESCRIPTION
The example is supposed to supposed to explain how to override the entity_id so that it is not inferred based on the configuration topic. However, I assume that at some point the docs got mixed up and no longer make sense, since it's "overriding" (device1 -> device1) rather than (my_super_device -> device1) as the example suggests. Made it so the example overrides (device1 -> my_super_device)




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
