### PR TITLE
Minor improvement: Add explicit ref to the "Create backup" button

### DIFF
--- a/source/_includes/common-tasks/backups.md
+++ b/source/_includes/common-tasks/backups.md
@@ -15,10 +15,11 @@ A partial backup consists of any number of the above default directories and ins
 ### Making a Backup from the UI
 
 1. Go to {% my supervisor_backups title="Settings > System > Backups" %} in the UI.
-2. Provide a name for the backup.
-3. Choose full or partial.
-4. Choose to password protect or not. Password-protected backups cannot easily be browsed outside of Home Assistant OS.
-5. Click "Create" to begin the backup.
+2. Click the **Create backup** button in the lower right.
+3. Provide a name for the backup.
+4. Choose full or partial.
+5. Choose to password protect or not. Password-protected backups cannot easily be browsed outside of Home Assistant OS.
+6. Click "Create" to begin the backup.
 
 ### Restoring a Backup on a new install
 


### PR DESCRIPTION
For Markdown styling for the reference to the button I checked first in the [Documentation Standards](https://developers.home-assistant.io/docs/documenting/standards/) and took the lead from [the way the "Add integration" button was referred to](https://github.com/home-assistant/home-assistant.io/blob/651b6e757734ff264dabe89285f6a973cf1b4b7a/source/getting-started/onboarding.markdown?plain=1#L24) in `source/getting-started/onboarding.markdown`.

## Proposed change
Add an extra step to the backup procedure to be more explicit and clear.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
