### PR TITLE
Remove incorrect 'when dark' condition example

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -420,15 +420,6 @@ A visual timeline is provided below showing an example of when these conditions 
 
 ![Graphic showing an example of sun conditions](/images/docs/scripts/sun-conditions.svg)
 
-Note: the following is supposed to specify 'when dark' using a more intuitive syntax but as of 2022.7 it is not working (https://github.com/home-assistant/core/issues/70781)
-
-```yaml
-condition:
-  - condition: sun
-    after: sunset
-    before: sunrise
-```
-
 ## Template condition
 
 The template condition tests if the [given template][template] renders a value equal to true. This is achieved by having the template result in a true boolean expression or by having the template render 'true'.

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -376,9 +376,9 @@ condition:
 
 ### Sunset/sunrise condition
 
-The sun condition can also test if the sun has already set or risen when a trigger occurs. The `before` and `after` keys can only be set to `sunset` or `sunrise`. They have a corresponding optional offset value (`before_offset`, `after_offset`) that can be added, similar to the [sun trigger][sun_trigger]. When both keys are used, the result is a logical `and` of separate conditions.
+The sun condition can also test if the sun has already set or risen when a trigger occurs. The `before` and `after` keys can only be set to `sunset` or `sunrise`. They have a corresponding optional offset value (`before_offset`, `after_offset`) that can be added, similar to the [sun trigger][sun_trigger].
 
-Note that if only `before` key is used, the condition will be `true` _from midnight_ until sunrise/sunset. If only `after` key is used, the condition will be `true` from sunset/sunrise _until midnight_. Therefore, to cover time between sunset and sunrise one need to use `after: sunset` and `before: sunrise` as 2 separate conditions and combine them using `or`.
+Note that if only `before` key is used, the condition will be `true` _from midnight_ until sunrise/sunset. If only `after` key is used, the condition will be `true` from sunset/sunrise _until midnight_. If both `before: sunrise` and `after: sunset` keys are used, the condition will be `true` _from midnight_ until sunrise and from sunset _until midnight_. If both `after: sunrise` and `before: sunset` keys are used, the condition will be `true`  sunrise until.
 
 [sun_trigger]: /docs/automation/trigger/#sun-trigger
 
@@ -404,16 +404,13 @@ condition:
     before: sunset
 ```
 
-This is 'when dark' - equivalent to a state condition on `sun.sun` of `below_horizon`. We cannot use both keys in this case as it would always be `false`:
+This is 'when dark' - equivalent to a state condition on `sun.sun` of `below_horizon`:
 
 ```yaml
 condition:
-  condition: or
-  conditions:
-    - condition: sun
-      after: sunset
-    - condition: sun
-      before: sunrise
+  - condition: sun
+    before: sunrise
+    after: sunset
 ```
 
 A visual timeline is provided below showing an example of when these conditions are true. In this chart, sunrise is at 6:00, and sunset is at 18:00 (6:00 PM). The green areas of the chart indicate when the specified conditions are true.

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -378,7 +378,7 @@ condition:
 
 The sun condition can also test if the sun has already set or risen when a trigger occurs. The `before` and `after` keys can only be set to `sunset` or `sunrise`. They have a corresponding optional offset value (`before_offset`, `after_offset`) that can be added, similar to the [sun trigger][sun_trigger].
 
-Note that if only `before` key is used, the condition will be `true` _from midnight_ until sunrise/sunset. If only `after` key is used, the condition will be `true` from sunset/sunrise _until midnight_. If both `before: sunrise` and `after: sunset` keys are used, the condition will be `true` _from midnight_ until sunrise and from sunset _until midnight_. If both `after: sunrise` and `before: sunset` keys are used, the condition will be `true`  sunrise until.
+Note that if only `before` key is used, the condition will be `true` _from midnight_ until sunrise/sunset. If only `after` key is used, the condition will be `true` from sunset/sunrise _until midnight_. If both `before: sunrise` and `after: sunset` keys are used, the condition will be `true` _from midnight_ until sunrise **and** from sunset _until midnight_. If both `after: sunrise` and `before: sunset` keys are used, the condition will be `true`  from sunrise until sunset.
 
 [sun_trigger]: /docs/automation/trigger/#sun-trigger
 

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -404,7 +404,7 @@ condition:
     before: sunset
 ```
 
-This is 'when dark' - equivalent to a state condition on `sun.sun` of `below_horizon`. We cannot use both keys in this case as it will always be `false`:
+This is 'when dark' - equivalent to a state condition on `sun.sun` of `below_horizon`. We cannot use both keys in this case as it would always be `false`:
 
 ```yaml
 condition:
@@ -419,6 +419,15 @@ condition:
 A visual timeline is provided below showing an example of when these conditions are true. In this chart, sunrise is at 6:00, and sunset is at 18:00 (6:00 PM). The green areas of the chart indicate when the specified conditions are true.
 
 ![Graphic showing an example of sun conditions](/images/docs/scripts/sun-conditions.svg)
+
+Note: the following is supposed to specify 'when dark' using a more intuitive syntax but as of 2022.7 it is not working (https://github.com/home-assistant/core/issues/70781)
+
+```yaml
+condition:
+  - condition: sun
+    after: sunset
+    before: sunrise
+```
 
 ## Template condition
 

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -383,26 +383,16 @@ Note that if only `before` key is used, the condition will be `true` _from midni
 [sun_trigger]: /docs/automation/trigger/#sun-trigger
 
 <div class='note warning'>
-The sunset/sunrise conditions do not work in locations inside the polar circles, and also not in locations with a highly skewed local time zone.
-
-In those cases it is advised to use conditions evaluating the solar elevation instead of the before/after sunset/sunrise conditions.
+The sunset/sunrise conditions do not work in locations inside the polar circles, and also not in locations with a highly skewed local time zone. In those cases it is advised to use conditions evaluating the solar elevation instead of the before/after sunset/sunrise conditions.
 </div>
 
 This is an example of 1 hour offset before sunset:
+
 ```yaml
 condition:
   condition: sun
   after: sunset
   after_offset: "-01:00:00"
-```
-
-This is 'when dark' - equivalent to a state condition on `sun.sun` of `below_horizon`:
-
-```yaml
-condition:
-  - condition: sun
-    after: sunset
-    before: sunrise
 ```
 
 This is 'when light' - equivalent to a state condition on `sun.sun` of `above_horizon`:
@@ -414,7 +404,7 @@ condition:
     before: sunset
 ```
 
-We cannot use both keys in this case as it will always be `false`.
+This is 'when dark' - equivalent to a state condition on `sun.sun` of `below_horizon`. We cannot use both keys in this case as it will always be `false`:
 
 ```yaml
 condition:


### PR DESCRIPTION
## Proposed change
<!-- 
    'when dark' example was explicitly described earlier as incorrect, then shown correctly a little lower.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
