### PR TITLE
Add section on BlueZ and getting the Dbus socket in the container to bluetooth

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -38,13 +38,17 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 ### Additional details for Container installs
 
 {% details Making the DBus socket available in the Docker container %}
+
 For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
+
 {% enddetails %}
 
 ### Additional details for Container and Supervised installs
 
 {% details Installing BlueZ %}
+
 On Debian based host systems, the `sudo apt-get -y install bluez` command will install BlueZ.
+
 {% enddetails %}
 
 ## Installing a USB Bluetooth Adapter

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -35,7 +35,7 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 - Home Assistant Supervised: The host system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant **inside** the container.
 - Home Assistant Core: The system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant.
 
-## Additional setup for Container and Supervised
+## Additional setup for Container installs
 
 ### Making the DBus socket available in the docker container
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -43,6 +43,9 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 
 For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
 
+## Additional setup for Container and Supervised installs
+
+{% details Instructions %}
 ### Installing BlueZ
 
 On debian based host systems, the `sudo apt-get -y install bluez` command will install BlueZ.

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -37,6 +37,8 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 
 ## Additional setup for Container installs
 
+{% details Instructions %}
+
 ### Making the DBus socket available in the docker container
 
 For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
@@ -45,6 +47,7 @@ For most systems, the Dbus socket is in `/run/dbus`. The socket must be availabl
 
 On debian based host systems, the `sudo apt-get -y install bluez` command will install BlueZ.
 
+{% enddetails %}
 ## Installing a USB Bluetooth Adapter
 
 Some systems may not come with Bluetooth and require a USB adapter. Installing an adapter for the first time may require multiple restarts for the device to be fully recognized.

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -35,13 +35,13 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 - Home Assistant Supervised: The host system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant **inside** the container.
 - Home Assistant Core: The system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant.
 
-## Additional details for Container installs
+### Additional details for Container installs
 
 {% details Making the DBus socket available in the docker container %}
 For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
 {% enddetails %}
 
-## Additional details for Container and Supervised installs
+### Additional details for Container and Supervised installs
 
 {% details Installing BlueZ %}
 On debian based host systems, the `sudo apt-get -y install bluez` command will install BlueZ.

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -35,25 +35,18 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 - Home Assistant Supervised: The host system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant **inside** the container.
 - Home Assistant Core: The system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant.
 
-## Additional setup for Container installs
+## Additional details for Container installs
 
-{% details Instructions %}
-
-### Making the DBus socket available in the docker container
-
+{% details Making the DBus socket available in the docker container %}
 For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
-
 {% enddetails %}
 
+## Additional details for Container and Supervised installs
 
-## Additional setup for Container and Supervised installs
-
-{% details Instructions %}
-### Installing BlueZ
-
+{% details Installing BlueZ %}
 On debian based host systems, the `sudo apt-get -y install bluez` command will install BlueZ.
-
 {% enddetails %}
+
 ## Installing a USB Bluetooth Adapter
 
 Some systems may not come with Bluetooth and require a USB adapter. Installing an adapter for the first time may require multiple restarts for the device to be fully recognized.

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -35,11 +35,13 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 - Home Assistant Supervised: The host system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant **inside** the container.
 - Home Assistant Core: The system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant.
 
-## Making the DBus socket available in the docker container
+## Additional setup for Container and Supervised
+
+### Making the DBus socket available in the docker container
 
 For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
 
-## Installing BlueZ
+### Installing BlueZ
 
 On debian based host systems, the `sudo apt-get -y install bluez` command will install BlueZ.
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -39,7 +39,7 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 
 For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
 
-# Installing BlueZ
+## Installing BlueZ
 
 On debian based host systems, the `sudo apt-get -y install bluez` command will install BlueZ.
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -43,6 +43,9 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 
 For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
 
+{% enddetails %}
+
+
 ## Additional setup for Container and Supervised installs
 
 {% details Instructions %}

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -35,6 +35,14 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 - Home Assistant Supervised: The host system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant **inside** the container.
 - Home Assistant Core: The system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant.
 
+## Making the DBus socket available in the docker container
+
+For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
+
+# Installing BlueZ
+
+On debian based host systems, the `sudo apt-get -y install bluez` command will install BlueZ.
+
 ## Installing a USB Bluetooth Adapter
 
 Some systems may not come with Bluetooth and require a USB adapter. Installing an adapter for the first time may require multiple restarts for the device to be fully recognized.

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -37,7 +37,7 @@ For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org
 
 ### Additional details for Container installs
 
-{% details Making the DBus socket available in the docker container %}
+{% details Making the DBus socket available in the Docker container %}
 For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
 {% enddetails %}
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -44,7 +44,7 @@ For most systems, the Dbus socket is in `/run/dbus`. The socket must be availabl
 ### Additional details for Container and Supervised installs
 
 {% details Installing BlueZ %}
-On debian based host systems, the `sudo apt-get -y install bluez` command will install BlueZ.
+On Debian based host systems, the `sudo apt-get -y install bluez` command will install BlueZ.
 {% enddetails %}
 
 ## Installing a USB Bluetooth Adapter


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add section on BlueZ and getting the Dbus socket in the container to bluetooth


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
