### PR TITLE
Add Yale Access Bluetooth integration

### DIFF
--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -1,0 +1,47 @@
+---
+title: Yale Access Bluetooth
+description: Instructions on how to integrate Yale Access Bluetooth devices into Home Assistant.
+ha_category:
+  - Lock
+ha_bluetooth: true
+ha_release: 2022.9
+ha_iot_class: Local Push
+ha_codeowners:
+  - '@bdraco'
+ha_domain: yalexs_ble
+ha_config_flow: true
+ha_platforms:
+  - lock
+ha_integration_type: integration
+---
+
+Integrates [Yale Access](https://www.yalehome.com/us/en/products/smart-technology/yale-access) Bluetooth devices into Home Assistant.
+
+{% include integrations/config_flow.md %}
+
+The Yale Access Bluetooth integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
+
+## Supported devices
+
+Devices must have the Yale Access module installed.
+
+- YRD216
+- YRL216
+- YRD226
+- YRL226
+- YRD256
+
+## Obtaining the offline key
+
+The offline key and slot number are required to operate the lock. These credentials reside in the Yale Access app storage on iOS or Android devices with owner access to the lock.
+
+The Yale Access app will only save the offline key to your device's filesystem if AutoUnlock has been enabled and used at least once.
+
+### iOS
+
+- Using [iMazing](https://imazing.com/) or [iPhone Backup Extractor](https://www.iphonebackupextractor.com/), find the backup files for the Yale Access app.
+- Look in the `Library/Preferences` `.plist` files for the Yale Access app and find the one with the value of `key` and `slot` using `Xcode` or any binary `plist` viewer.
+
+### Android
+
+Root access is required to read the `key` and `slot` stored in `/data/data/com.august.luna/shared_prefs/PeripheralInfoCache.xml`

--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -33,7 +33,9 @@ Devices must have the Yale Access module installed.
 
 ## Push updates
 
-Some locks only sends push updates when they have an active HomeKit pairing. If your lock is not getting push updates, make sure its paired with a HomeKit controller. The lock cannot be paired via HomeKit Controller and the Yale Access Bluetooth integration on the same Home Assistant instance as they will both try to access the lock at the same time and fail.
+Some locks only send push updates when they have an active HomeKit pairing. If your lock is not sending push updates, ensure it's paired with a HomeKit using an iOS device or the HomeKit controller integration. The lock cannot be paired via HomeKit Controller and the Yale Access Bluetooth integration on the same Home Assistant instance as they will both try to access the lock simultaneously and fail.
+
+Alternatively, call the `homeassistant.update_entity` service to force the integration to update the lock state.
 
 ## Obtaining the offline key
 

--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -31,6 +31,10 @@ Devices must have the Yale Access module installed.
 - YRL226
 - YRD256
 
+## Push updates
+
+Some locks only sends push updates when they have an active HomeKit pairing. If your lock is not getting push updates, make sure its paired with a HomeKit controller. The lock cannot be paired via HomeKit Controller and the Yale Access Bluetooth integration on the same Home Assistant instance as they will both try to access the lock at the same time and fail.
+
 ## Obtaining the offline key
 
 The offline key and slot number are required to operate the lock. These credentials reside in the Yale Access app storage on iOS or Android devices with owner access to the lock.

--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -21,15 +21,21 @@ Integrates [Yale Access](https://www.yalehome.com/us/en/products/smart-technolog
 
 The Yale Access Bluetooth integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
 
-## Supported devices
+Devices must have a Yale Access module installed to function with this integration if one is not already built-in.
 
-Devices must have the Yale Access module installed.
+## Supported devices
 
 - YRD216
 - YRL216
 - YRD226
 - YRL226
 - YRD256
+
+## Limited support devices
+
+These devices do not send updates, but can be locked and unlocked.
+
+- Conexis L1
 
 ## Push updates
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Yale Access Bluetooth integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/76182
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3570
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
