### PR TITLE
Update roomba docs for newer models

### DIFF
--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -63,3 +63,18 @@ docker exec -it CONTAINER_NAME_OR_ID python -c 'import roombapy.entry_points; ro
 The command to retrieve the credentials does not need any additional software to be installed because it uses the built-in [roombapy](https://github.com/pschmitt/roombapy) package and [password](https://github.com/pschmitt/roombapy/blob/1.6.1/roomba/entry_points.py#L20) function deployed with Home Assistant.
 
 </div>
+
+#### Retrieving credentials from the cloud with dorita980
+
+The underlying Python library is currently unable to retrieve the credentials from some newer models (e.g. J7). See [this issue](https://github.com/pschmitt/roombapy/issues/97) for details. Luckily, the password can be retrieved from the cloud using a tool provided by the [dorita980](https://github.com/koalazak/dorita980) library. Follow [these instructions](https://github.com/koalazak/dorita980#how-to-get-your-usernameblid-and-password) to do this, you should receive output of the form:
+
+```
+Found 1 robot(s)!
+Robot "RoombaJ7" (sku: j715800 SoftwareVer: sapphire+22.21.1+2022-06-02-570490a425b+Firmware-Production+70):
+BLID=> XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Password=> XXXXXXXXXXXXXXXXXXXXXXXXXXXXX <= Yes, all this string.
+
+Use this credentials in dorita980 lib :)
+```
+
+Copy the password (everthing between `=>` and `<=`, not including leading and trailing whitespace) into the Home Assistant password dialog.

--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -68,7 +68,7 @@ The command to retrieve the credentials does not need any additional software to
 
 The underlying Python library is currently unable to retrieve the credentials from some newer models (e.g. J7). See [this issue](https://github.com/pschmitt/roombapy/issues/97) for details. Luckily, the password can be retrieved from the cloud using a tool provided by the [dorita980](https://github.com/koalazak/dorita980) library. Follow [these instructions](https://github.com/koalazak/dorita980#how-to-get-your-usernameblid-and-password) to do this, you should receive output of the form:
 
-```
+```shell
 Found 1 robot(s)!
 Robot "RoombaJ7" (sku: j715800 SoftwareVer: sapphire+22.21.1+2022-06-02-570490a425b+Firmware-Production+70):
 BLID=> XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -77,4 +77,4 @@ Password=> XXXXXXXXXXXXXXXXXXXXXXXXXXXXX <= Yes, all this string.
 Use this credentials in dorita980 lib :)
 ```
 
-Copy the password (everthing between `=>` and `<=`, not including leading and trailing whitespace) into the Home Assistant password dialog.
+Copy the password (everything between `=>` and `<=`, not including leading and trailing whitespace) into the Home Assistant password dialog.


### PR DESCRIPTION
Roomba credential recovery seems to be broken/unsupported for newer models (an issue with the underlying roombapy library). I've updated the docs to include another way to retrieve the credentials from the cloud service, which works fine on my J7.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
