### PR TITLE
Update sensorpush to include note about activation being required

### DIFF
--- a/source/_integrations/sensorpush.markdown
+++ b/source/_integrations/sensorpush.markdown
@@ -17,6 +17,11 @@ ha_integration_type: integration
 
 Integrates [SensorPush](https://www.sensorpush.com/) devices into Home Assistant.
 
+## App Configuration Required To See Entities
+Sensor entities (temperature, humidity, barometric pressure) will not be available to Home Assistant until you have configured them from within the SensorPush app on iOS or Android.  
+
+Using the SensorPush app to configure sensors does not require creation of a SensorPush account or the provision of any information.  Communication between the sensor and Home Assistant will be purely local via BLE.
+
 ## Supported devices
 
 - [HT.w Water-Resistant Temperature / Humidity Smart Sensor](https://www.sensorpush.com/products/p/ht-w)

--- a/source/_integrations/sensorpush.markdown
+++ b/source/_integrations/sensorpush.markdown
@@ -17,7 +17,7 @@ ha_integration_type: integration
 
 Integrates [SensorPush](https://www.sensorpush.com/) devices into Home Assistant.
 
-## App Configuration Required To See Entities
+## Activation is required
 Sensor entities (temperature, humidity, barometric pressure) will not be available to Home Assistant until you have configured them from within the SensorPush app on iOS or Android.  
 
 Using the SensorPush app to configure sensors does not require creation of a SensorPush account or the provision of any information. Communication between the sensor and Home Assistant will be purely local via BLE.

--- a/source/_integrations/sensorpush.markdown
+++ b/source/_integrations/sensorpush.markdown
@@ -20,7 +20,7 @@ Integrates [SensorPush](https://www.sensorpush.com/) devices into Home Assistant
 ## App Configuration Required To See Entities
 Sensor entities (temperature, humidity, barometric pressure) will not be available to Home Assistant until you have configured them from within the SensorPush app on iOS or Android.  
 
-Using the SensorPush app to configure sensors does not require creation of a SensorPush account or the provision of any information.  Communication between the sensor and Home Assistant will be purely local via BLE.
+Using the SensorPush app to configure sensors does not require creation of a SensorPush account or the provision of any information. Communication between the sensor and Home Assistant will be purely local via BLE.
 
 ## Supported devices
 

--- a/source/_integrations/sensorpush.markdown
+++ b/source/_integrations/sensorpush.markdown
@@ -18,9 +18,8 @@ ha_integration_type: integration
 Integrates [SensorPush](https://www.sensorpush.com/) devices into Home Assistant.
 
 ## Activation is required
-Sensor entities (temperature, humidity, barometric pressure) will not be available to Home Assistant until you have configured them from within the SensorPush app on iOS or Android.  
 
-Using the SensorPush app to configure sensors does not require creation of a SensorPush account or the provision of any information. Communication between the sensor and Home Assistant will be purely local via BLE.
+Sensor entities (temperature, humidity, barometric pressure) will not be available to Home Assistant until you have activated the device with the SensorPush app on iOS or Android.
 
 ## Supported devices
 


### PR DESCRIPTION
Updated the SensorPush documentation to reflect the requirement that sensors be configured in the app before entities are available to Home Assistant.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
