### PR TITLE
Add August Bluetooth as a supported brand of Yale Access Bluetooth

### DIFF
--- a/source/_integrations/august_ble.markdown
+++ b/source/_integrations/august_ble.markdown
@@ -21,10 +21,8 @@ ha_supporting_domain: yalexs_ble
 ha_supporting_integration: Yale Access Bluetooth
 ---
 
-Integrates [August](https://august.com/) locks over Bluetooth into Home Assistant. To integrate with the August cloud service, or non-lock devices, see the [August](/integrations/august) page.
+Integrates [August](https://august.com/) locks over Bluetooth into Home Assistant.
 
 Following Assa Abloy, Yale's parent company, purchasing August in 2017, most newer devices use the Yale Access branding.
 
-{% include integrations/config_flow.md domain=page.ha_supporting_domain %}
-<br><br>
-To find more information, please use the [Yale Access Bluetooth](/integrations/yalexs_ble) page.
+{% include integrations/supported_brand.md %}

--- a/source/_integrations/august_ble.markdown
+++ b/source/_integrations/august_ble.markdown
@@ -1,6 +1,6 @@
 ---
 title: August Bluetooth
-description: Instructions on how to integrate August Bluetooth devices into Home Assistant.
+description: Instructions on how to integrate August Bluetooth locks into Home Assistant.
 ha_category:
   - Binary Sensor
   - Lock

--- a/source/_integrations/august_ble.markdown
+++ b/source/_integrations/august_ble.markdown
@@ -1,0 +1,30 @@
+---
+title: August Bluetooth
+description: Instructions on how to integrate August Bluetooth devices into Home Assistant.
+ha_category:
+  - Binary Sensor
+  - Lock
+  - Sensor
+ha_bluetooth: true
+ha_release: 2022.9
+ha_iot_class: Local Push
+ha_codeowners:
+  - '@bdraco'
+ha_domain: august_ble
+ha_config_flow: true
+ha_platforms:
+  - binary_sensor
+  - lock
+  - sensor
+ha_integration_type: integration
+ha_supporting_domain: yalexs_ble
+ha_supporting_integration: Yale Access Bluetooth
+---
+
+Integrates [August](https://august.com/) locks over Bluetooth into Home Assistant. To integrate with the August cloud service, or non-lock devices, see the [August](/integrations/august) page.
+
+Following Assa Abloy, Yale's parent company, purchasing August in 2017, most newer devices use the Yale Access branding.
+
+{% include integrations/config_flow.md domain=page.ha_supporting_domain %}
+<br><br>
+To find more information, please use the [Yale Access Bluetooth](/integrations/yalexs_ble) page.

--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -56,23 +56,23 @@ The lock must be calibrated in the Yale Access App for the door sensors to funct
 
 ## Obtaining the offline key
 
-The offline key and slot number are required to operate the lock. These credentials can be found in multiple places depending on the lock model.
-
-- August branded locks: August Cloud, August iOS App, August Android App
-- Yale branded locks: Yale Access Cloud, Yale Access iOS App, Yale Access Android App
-
-The apps will only save the offline key to your device's filesystem if Auto-Unlock has been enabled and used at least once. Auto-Unlock can be disabled once the key has been loaded.
+The offline key and slot number are required to operate the lock. These credentials can be found in multiple places depending on the lock brand and model.
 
 ### Yale Access or August Cloud
 
-The [August](/integrations/august) integration will automatically provide the offline key if the configured account has the key loaded. You may need to create or use a non-primary existing account with owner-level access to the lock, as not all accounts will have the key loaded.
+The [August](/integrations/august) integration will automatically provision the offline key if the configured account has the key loaded. You may need to create or use a non-primary existing account with owner-level access to the lock, as not all accounts will have the key loaded.
 
-Yale branded locks can use the August cloud to obtain the keys. Accessing the August cloud to receive the key may not work unless the lock was purchased in a market that sells under both brands.
-### iOS
+Most Yale branded locks can use the August cloud to obtain the keys. Accessing the August cloud to receive the key may not work unless the lock was purchased in a market that sells under both brands.
+
+### iOS - Yale Access App or August App
+
+The iOS app will only save the offline key to your device's filesystem if Auto-Unlock has been enabled and used at least once. Auto-Unlock can be disabled once the key has been loaded.
 
 - Using [iMazing](https://imazing.com/) or [iPhone Backup Extractor](https://www.iphonebackupextractor.com/), find the backup files for the Yale Access app.
 - Look in the `Library/Preferences` `.plist` files for the Yale Access app and find the one with the value of `key` and `slot` using `Xcode` or any binary `plist` viewer.
 
-### Android
+### Android - Yale Access App or August App
+
+The Android app will only save the offline key to your device's filesystem if Auto-Unlock has been enabled and used at least once. Auto-Unlock can be disabled once the key has been loaded.
 
 Root access is required to read the `key` and `slot` stored in `/data/data/com.august.luna/shared_prefs/PeripheralInfoCache.xml`

--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -29,17 +29,19 @@ Devices must have a Yale Access module installed to function with this integrati
 
 ## Supported devices
 
-- YRD216
-- YRL216
-- YRD226
-- YRL226
-- YRD256
+- YRD216 (Yale Assure Lock Keypad with Physical Key)
+- YRL216 (Yale Assure Door Lever Lock with Push Button Keypad)
+- YRD226 (Yale Assure Lock Touchscreen Deadbolt with Physical Key)
+- YRL226 (Yale Assure Door Lever Lock Keypad)
+- YRD256 (Yale Assure Lock Keypad)
+- ASL-05 (August WiFi Smart Lock - Gen 4)
+- ASL-03 (August Smart Lock Pro - Gen 3)
 
 ## Limited support devices
 
 These devices do not send updates, but can be locked and unlocked.
 
-- Conexis L1
+- MD-04I (Yale Conexis L1)
 
 ## Push updates
 

--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -53,12 +53,21 @@ Alternatively, call the `homeassistant.update_entity` service to force the integ
 
 The lock must be calibrated in the Yale Access App for the door sensors to function correctly. If the door sensor has an unknown state or is not updating, try recalibrating the lock in the app.
 
+
 ## Obtaining the offline key
 
-The offline key and slot number are required to operate the lock. These credentials reside in the Yale Access app storage on iOS or Android devices with owner access to the lock.
+The offline key and slot number are required to operate the lock. These credentials can be found in multiple places depending on the lock model.
 
-The Yale Access app will only save the offline key to your device's filesystem if AutoUnlock has been enabled and used at least once.
+- August branded locks: August Cloud, August iOS App, August Android App
+- Yale branded locks: Yale Access Cloud, Yale Access iOS App, Yale Access Android App
 
+The apps will only save the offline key to your device's filesystem if Auto-Unlock has been enabled and used at least once. Auto-Unlock can be disabled once the key has been loaded.
+
+### Yale Access or August Cloud
+
+The [August](/integrations/august) integration will automatically provide the offline key if the configured account has the key loaded. You may need to create or use a non-primary existing account with owner-level access to the lock, as not all accounts will have the key loaded.
+
+Yale branded locks can use the August cloud to obtain the keys. Accessing the August cloud to receive the key may not work unless the lock was purchased in a market that sells under both brands.
 ### iOS
 
 - Using [iMazing](https://imazing.com/) or [iPhone Backup Extractor](https://www.iphonebackupextractor.com/), find the backup files for the Yale Access app.

--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -36,6 +36,7 @@ Devices must have a Yale Access module installed to function with this integrati
 - YRD256 (Yale Assure Lock Keypad)
 - ASL-05 (August WiFi Smart Lock - Gen 4)
 - ASL-03 (August Smart Lock Pro - Gen 3)
+- ASL-02 (August Smart Lock Pro - Gen 2)
 
 ## Limited support devices
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add August Bluetooth as a supported brand of Yale Access Bluetooth

Assa Abloy, Yale's parent company, purchased August in 2017, and most newer devices use the Yale Access branding.

Although Assa Abloy has not released anything new under the August brand since 2020, they still sell under the August brand in at least North America. I expect people will likely have trouble finding August Bluetooth support under Yale Access Bluetooth since they seem to have actively tried not to mix the branding.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/76625
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3583
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
