### PR TITLE
Support GSM alphabet when sending SMS

### DIFF
--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -26,7 +26,7 @@ This integration provides the following platforms:
 
 ## Notifications
 
-An SMS message can be send by calling the `notify.sms`. It will send the message to all phone numbers specified in the `target` parameter.
+An SMS message can be sent by calling the `notify.sms`. It will send the message to all phone numbers specified in the `target` parameter.
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
 

--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -42,7 +42,7 @@ action:
 
 ### Sending SMS as ANSI
 
-Some devices (recieving or sending) do not support Unicode (the default encoding). For these you can disable Unicode:
+Some devices (receiving or sending) do not support Unicode (the default encoding). For these you can disable Unicode:
 
 ```yaml
 action:

--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -36,8 +36,8 @@ To use notifications, please see the [getting started with automation page](/get
 action:
   service: notify.sms
   data:
-    message: 'This is a message for you!'
-    target: '+5068081-8181'
+    message: "This is a message for you!"
+    target: "+5068081-8181"
 ```
 
 ### Sending SMS using GSM alphabet
@@ -48,8 +48,8 @@ Some devices (receiving or sending) do not support Unicode (the default encoding
 action:
   service: notify.sms
   data:
-    message: 'This is a message for you in ANSI'
-    target: '+5068081-8181'
+    message: "This is a message for you in ANSI"
+    target: "+5068081-8181"
     data:
       unicode: False
 ```

--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -40,7 +40,7 @@ action:
     target: '+5068081-8181'
 ```
 
-### Sending SMS as ANSI
+### Sending SMS using GSM alphabet
 
 Some devices (receiving or sending) do not support Unicode (the default encoding). For these you can disable Unicode:
 
@@ -66,8 +66,6 @@ notify:
   - platform: sms
     name: sms_person2
     recipient: PHONE_NUMBER
-  - platform: sms
-    name: sms
 ```
 
 ### Getting SMS messages

--- a/source/_integrations/sms.markdown
+++ b/source/_integrations/sms.markdown
@@ -26,6 +26,36 @@ This integration provides the following platforms:
 
 ## Notifications
 
+An SMS message can be send by calling the `notify.sms`. It will send the message to all phone numbers specified in the `target` parameter.
+
+To use notifications, please see the [getting started with automation page](/getting-started/automation/).
+
+### Send message
+
+```yaml
+action:
+  service: notify.sms
+  data:
+    message: 'This is a message for you!'
+    target: '+5068081-8181'
+```
+
+### Sending SMS as ANSI
+
+Some devices (recieving or sending) do not support Unicode (the default encoding). For these you can disable Unicode:
+
+```yaml
+action:
+  service: notify.sms
+  data:
+    message: 'This is a message for you in ANSI'
+    target: '+5068081-8181'
+    data:
+      unicode: False
+```
+
+### Manual confiration
+
 To configure the notification service, edit your `configuration.yaml` file:
 
 ```yaml
@@ -36,12 +66,16 @@ notify:
   - platform: sms
     name: sms_person2
     recipient: PHONE_NUMBER
+  - platform: sms
+    name: sms
 ```
+
+### Getting SMS messages
 
 You can also receive SMS messages that are sent to the SIM card number in your device.
 Every time there is a message received, `event: sms.incoming_sms` is fired with date, phone number and text message.
 
-To use notifications, please see the [getting started with automation page](/getting-started/automation/).
+## Notes about the operation system
 
 If the integration is used with the Home Assistant Operating System, then version [3.6](https://github.com/home-assistant/hassos/releases/tag/3.6) or higher is required.
 


### PR DESCRIPTION
Document ANSI support

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- Document sending SMS using the GSM alphabet


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/76834
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
