### PR TITLE
Add Yale Smart Cabinet Lock to Yale Access Bluetooth

### DIFF
--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -34,7 +34,6 @@ Devices must have a Yale Access module installed to function with this integrati
 - YRD226 (Yale Assure Lock Touchscreen Deadbolt with Physical Key)
 - YRL226 (Yale Assure Door Lever Lock Keypad)
 - YRD256 (Yale Assure Lock Keypad)
-- YRCB-490 (Yale Smart Cabinet Lock)
 - ASL-05 (August WiFi Smart Lock - Gen 4)
 - ASL-03 (August Smart Lock Pro - Gen 3)
 - ASL-02 (August Smart Lock Pro - Gen 2)
@@ -44,6 +43,7 @@ Devices must have a Yale Access module installed to function with this integrati
 These devices do not send updates, but can be locked and unlocked.
 
 - MD-04I (Yale Conexis L1)
+- YRCB-490 (Yale Smart Cabinet Lock)
 
 ## Push updates
 

--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -34,6 +34,7 @@ Devices must have a Yale Access module installed to function with this integrati
 - YRD226 (Yale Assure Lock Touchscreen Deadbolt with Physical Key)
 - YRL226 (Yale Assure Door Lever Lock Keypad)
 - YRD256 (Yale Assure Lock Keypad)
+- YRCB-490 (Yale Smart Cabinet Lock)
 - ASL-05 (August WiFi Smart Lock - Gen 4)
 - ASL-03 (August Smart Lock Pro - Gen 3)
 - ASL-02 (August Smart Lock Pro - Gen 2)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add Yale Smart Cabinet Lock to Yale Access Bluetooth
Worked out of box

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
