### PR TITLE
Correct UK Transport API limits, from 1000 to 30 per day :(

### DIFF
--- a/source/_integrations/uk_transport.markdown
+++ b/source/_integrations/uk_transport.markdown
@@ -11,7 +11,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `uk_transport` sensor will display the time in minutes until the next departure in a specified direction from of a configured train station or bus stop. The sensor uses [transportAPI](https://www.transportapi.com/) to query live departure data and requires a developer application ID and key which can be obtained [here](https://developer.transportapi.com/). The [free tier]([https://www.transportapi.com/benefits/](https://www.transportapi.com/blog/2022/08/introducing-the-home-use-plan-for-transportapi/)) allows 30 requests a day, which is sufficient for a single sensor refreshing every 15 minutes.
+The `uk_transport` sensor will display the time in minutes until the next departure in a specified direction from of a configured train station or bus stop. The sensor uses [transportAPI](https://www.transportapi.com/) to query live departure data and requires a developer application ID and key which can be obtained [here](https://developer.transportapi.com/). The [free tier]([https://www.transportapi.com/benefits/](https://www.transportapi.com/blog/2022/08/introducing-the-home-use-plan-for-transportapi/)) allows 30 requests a day, which is sufficient for a single sensor refreshing every 48 minutes.
 
 <div class='note warning'>
 

--- a/source/_integrations/uk_transport.markdown
+++ b/source/_integrations/uk_transport.markdown
@@ -11,7 +11,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `uk_transport` sensor will display the time in minutes until the next departure in a specified direction from of a configured train station or bus stop. The sensor uses [transportAPI](https://www.transportapi.com/) to query live departure data and requires a developer application ID and key which can be obtained [here](https://developer.transportapi.com/). The [free tier](https://www.transportapi.com/benefits/) allows 30,000 requests a month, which is sufficient for a single sensor refreshing every 87 seconds.
+The `uk_transport` sensor will display the time in minutes until the next departure in a specified direction from of a configured train station or bus stop. The sensor uses [transportAPI](https://www.transportapi.com/) to query live departure data and requires a developer application ID and key which can be obtained [here](https://developer.transportapi.com/). The [free tier]([https://www.transportapi.com/benefits/](https://www.transportapi.com/blog/2022/08/introducing-the-home-use-plan-for-transportapi/)) allows 30 requests a day, which is sufficient for a single sensor refreshing every 15 minutes.
 
 <div class='note warning'>
 

--- a/source/_integrations/uk_transport.markdown
+++ b/source/_integrations/uk_transport.markdown
@@ -15,7 +15,7 @@ The `uk_transport` sensor will display the time in minutes until the next depart
 
 <div class='note warning'>
 
-Additional sensors can be added but at the expense of a reduced refresh rate. 2 sensors can be updated every 2*87 = 174 seconds, and so on. Calculating and setting this rate is automatically handles by the integration.
+Additional sensors can be added but at the expense of a reduced refresh rate. 2 sensors can be updated every 2*48 = 96 minutes, and so on. Calculating and setting this rate is automatically handles by the integration.
 
 </div>
 


### PR DESCRIPTION

## Proposed change
Updated numbers and link proving limit has changed from 1000 a day to 30 :(


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
