### PR TITLE
Update Fully Kiosk docs for Screen Off switch

### DIFF
--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -48,11 +48,12 @@ The following controls are available:
 - Load the start URL
 - Restart the Fully Kiosk Browser app
 - Reboot your device (requires root)
-- Screensaver on/off
 - Maintenance mode on/off
 - Lock/unlock kiosk mode
 - Motion detection on/off
+- Screensaver on/off
 - Screensaver timer
+- Screensaver brightness
+- Screen on/off
 - Screen off timer
 - Screen brightness
-- Screensaver brightness


### PR DESCRIPTION
## Proposed change
Update the Fully Kiosk docs to mention the new "screen on/off" switch & move screen and screensaver features together in the control list.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/76957
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
