### PR TITLE
Update sun condition

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -396,15 +396,6 @@ condition:
   after_offset: "-01:00:00"
 ```
 
-This is 'when dark' - equivalent to a state condition on `sun.sun` of `below_horizon`:
-
-```yaml
-condition:
-  - condition: sun
-    after: sunset
-    before: sunrise
-```
-
 This is 'when light' - equivalent to a state condition on `sun.sun` of `above_horizon`:
 
 ```yaml
@@ -414,7 +405,16 @@ condition:
     before: sunset
 ```
 
-We cannot use both keys in this case as it will always be `false`.
+This is (invalid) 'when dark' - equivalent to a state condition on `sun.sun` of `below_horizon`:
+
+```yaml
+condition:
+  - condition: sun
+    after: sunset
+    before: sunrise
+```
+
+However, we cannot use both keys in this case as it will always be `false`, so instead you have to use:
 
 ```yaml
 condition:


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

At some point the sun condition docs had their order reworked so the problem with the "after dark" condition is now confusing. I've restructured it and make it clearer that the example isn't valid.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
