### PR TITLE
Elaborate on the port setting for Pioneer AVRs

### DIFF
--- a/source/_integrations/pioneer.markdown
+++ b/source/_integrations/pioneer.markdown
@@ -50,7 +50,7 @@ sources:
 
 Notes:
 
-- Some Pioneer AVRs use the port 23 default and some are reported to use 8102.
+- Some Pioneer AVRs use the port 23 default and some are reported to use 8102. Depending on the model you may be able to configure the port setting through the receiver's http interface, e.g. `http://192.168.0.10/1000/port_number.asp`. On models that can listen to multiple ports you could consider leaving the default port for use by hardcoded tools, and open another port for configurable tools such as Home Assistant.
 - `timeout` is a socket level option and should only be configured if you know what you are doing.
 
 ### Source codes

--- a/source/_integrations/pioneer.markdown
+++ b/source/_integrations/pioneer.markdown
@@ -50,7 +50,7 @@ sources:
 
 Notes:
 
-- Some Pioneer AVRs use the port 23 default and some are reported to use 8102. Depending on the model you may be able to configure the port setting through the receiver's http interface, e.g. `http://192.168.0.10/1000/port_number.asp`. On models that can listen to multiple ports you could consider leaving the default port for use by hardcoded tools, and open another port for configurable tools such as Home Assistant.
+- Some Pioneer AVRs use the port 23 default and some are reported to use 8102. Depending on the model you may be able to configure the port setting through the receiver's HTTP interface, e.g. `http://192.168.0.10/1000/port_number.asp`. On models that can listen to multiple ports you could consider leaving the default port for use by hardcoded tools, and open another port for configurable tools such as Home Assistant.
 - `timeout` is a socket level option and should only be configured if you know what you are doing.
 
 ### Source codes


### PR DESCRIPTION
## Proposed change
In the section discussing the port number used by Pioneer AVRs, add a suggestion for how to configure multiple ports to allow different tools to connect at the same time without blocking each other. This is useful when connecting to the receiver with Home Assistant concurrently with other tools such as Pioneer's official iPhone app.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Verified on Pioneer SC-2023 but the suggestion is probably valid for most (or all?) network-capable Pioneer AVRs of the same era. I left the language open to accommodate the possibility that some Pioneer AVR models are missing this feature.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
