### PR TITLE
Docs: add detail to if-actions

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -602,12 +602,14 @@ script:
 When testing for a state, you cannot use a template for the `entity_id` as it has to be a constant.
   
 If you need to check a dynamically changing entity use a template check instead:
+{% raw %}
 ```yaml
 if:
   condition: template
   value_template: "{{ is_state(repeat.item, 'off') }}"
 
 ```
+{% endraw %}
 </div>
 
 This action supports nesting, however, if you find yourself using nested if-then

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -598,6 +598,18 @@ script:
           message: "Skipped cleaning, someone is home!"
 ```
 
+<div class='note'>
+When testing for a state, you cannot use a template for the `entity_id` and it has to be a constant.
+  
+If you need to check a dynamically changing entity use a template check instead:
+```yaml
+if:
+  condition: template
+  value_template: "{{ is_state(repeat.item, 'off') }}"
+
+```
+</div>
+
 This action supports nesting, however, if you find yourself using nested if-then
 actions in the `else` part, you may want to consider using
 [choose](#choose-a-group-of-actions) instead.

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -608,7 +608,7 @@ If you need to check a dynamically changing entity use a template check instead:
 ```yaml
 if:
   condition: template
-  value_template: "{{ is_state('zone_home', 0) }}"
+  value_template: "{{ is_state('zone.home', 0) }}"
 ```
 {% endraw %}
 

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -599,7 +599,7 @@ script:
 ```
 
 <div class='note'>
-When testing for a state, you cannot use a template for the `entity_id` and it has to be a constant.
+When testing for a state, you cannot use a template for the `entity_id` as it has to be a constant.
   
 If you need to check a dynamically changing entity use a template check instead:
 ```yaml

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -599,17 +599,19 @@ script:
 ```
 
 <div class='note'>
+
 When testing for a state, you cannot use a template for the `entity_id` as it has to be a constant.
   
 If you need to check a dynamically changing entity use a template check instead:
+  
 {% raw %}
 ```yaml
 if:
   condition: template
-  value_template: "{{ is_state(repeat.item, 'off') }}"
-
+  value_template: "{{ is_state('zone_home', 0) }}"
 ```
 {% endraw %}
+
 </div>
 
 This action supports nesting, however, if you find yourself using nested if-then


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
As this [forum post](https://community.home-assistant.io/t/automation-with-for-each-and-if/422732/8) makes clear. One can not use a template in the `entity_id` in the condition of an if when checking for a state. This change adds a note in the documentation about this behaviour and includes a work-around.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
