### PR TITLE
Allow setting set_percentage and set_preset_mode of template fan without turning on

### DIFF
--- a/source/_integrations/fan.template.markdown
+++ b/source/_integrations/fan.template.markdown
@@ -13,6 +13,8 @@ The `template` platform creates fans that combine integrations and provides the
 ability to run scripts or invoke services for each of the `turn_on`, `turn_off`, `set_percentage`,
 `set_preset_mode`, `set_oscillating`, and `set_direction` commands of a fan.
 
+## Configuration
+
 To enable Template Fans in your installation, add the following to your
 `configuration.yaml` file:
 
@@ -146,3 +148,110 @@ When converting a fan with 3 speeds from the old fan entity model, the following
 33 - `low`
 66 - `medium`
 100 - `high`
+
+## Examples
+
+### Helper Fan
+
+This example uses an input_boolean and an input_number to mimic a fan, and 
+the example shows multiple service calls for set_percentage.  
+
+{% raw %}
+
+```yaml
+fan:
+  - platform: template
+    fans:
+      helper_fan:
+        friendly_name: Helper Fan
+        value_template: "{{ states('input_boolean.state') }}"
+        turn_on:
+        - service: input_boolean.turn_on
+          target:
+            entity_id: input_boolean.state
+        turn_off:
+        - service: input_boolean.turn_off
+          target:
+            entity_id: input_boolean.state
+        percentage_template: >
+          {{ states('input_number.percentage') if is_state('input_boolean.state', 'on') else 0 }}
+        speed_count: 6
+        set_percentage:
+        - service: input_boolean.turn_{{ 'on' if percentage > 0 else 'off' }}
+          target:
+            entity_id: input_boolean.state
+        - service: input_number.set_value
+          target:
+            entity_id: input_number.percentage
+          data:
+            value: "{{ percentage }}"
+```
+
+{% endraw %}
+
+### Preset Modes Fan
+
+This example uses an existing fan with only a percentage.  It extends the 
+percentage value into useable preset modes without a helper entity.
+
+{% raw %}
+
+```yaml
+fan:
+  - platform: template
+    fans:
+      preset_mode_fan:
+        friendly_name: Preset Mode Fan Example
+        value_template: "{{ states('fan.percentage_fan') }}"
+        turn_on:
+          service: fan.turn_on
+          target:
+            entity_id: fan.percentage_fan
+        turn_off:
+          service: fan.turn_off
+          target:
+            entity_id: fan.percentage_fan
+        percentage_template: >
+          {{ state_attr('fan.percentage_fan', 'percentage') }}
+        speed_count: 3
+        set_percentage:
+          service: fan.set_percentage
+          target:
+            entity_id: fan.percentage_fan
+          data:
+            percentage: "{{ percentage }}"
+        preset_modes:
+        - 'off'
+        - low
+        - medium
+        - high
+        preset_mode_template: >
+          {% if is_state('fan.percentage_fan', 'on') %}
+            {% if state_attr('fan.percentage_fan', 'percentage') == 100  %}
+              high
+            {% elif state_attr('fan.percentage_fan', 'percentage') == 66 %}
+              medium
+            {% else %}
+              low
+            {% endif %}
+          {% else %}
+            off
+          {% endif %}
+        set_preset_mode:
+          service: fan.set_percentage
+          target:
+            entity_id: fan.percentage_fan
+          data:
+            percentage: >-
+              {% if preset_mode == 'high' %}
+                100
+              {% elif preset_mode == 'medium' %}
+                66
+              {% elif preset_mode == 'low' %}
+                33
+              {% else %}
+                0
+              {% endif %}
+```
+
+{% endraw %}

--- a/source/_integrations/fan.template.markdown
+++ b/source/_integrations/fan.template.markdown
@@ -163,35 +163,35 @@ fan:
   - platform: template
     fans:
       helper_fan:
-        friendly_name: Helper Fan
+        friendly_name: "Helper Fan"
         value_template: "{{ states('input_boolean.state') }}"
         turn_on:
-        - service: input_boolean.turn_on
-          target:
-            entity_id: input_boolean.state
+          - service: input_boolean.turn_on
+            target:
+              entity_id: input_boolean.state
         turn_off:
-        - service: input_boolean.turn_off
-          target:
-            entity_id: input_boolean.state
+          - service: input_boolean.turn_off
+            target:
+              entity_id: input_boolean.state
         percentage_template: >
           {{ states('input_number.percentage') if is_state('input_boolean.state', 'on') else 0 }}
         speed_count: 6
         set_percentage:
-        - service: input_boolean.turn_{{ 'on' if percentage > 0 else 'off' }}
-          target:
-            entity_id: input_boolean.state
-        - service: input_number.set_value
-          target:
-            entity_id: input_number.percentage
-          data:
-            value: "{{ percentage }}"
+          - service: input_boolean.turn_{{ 'on' if percentage > 0 else 'off' }}
+            target:
+              entity_id: input_boolean.state
+          - service: input_number.set_value
+            target:
+              entity_id: input_number.percentage
+            data:
+              value: "{{ percentage }}"
 ```
 
 {% endraw %}
 
 ### Preset Modes Fan
 
-This example uses an existing fan with only a percentage.  It extends the 
+This example uses an existing fan with only a percentage. It extends the 
 percentage value into useable preset modes without a helper entity.
 
 {% raw %}
@@ -201,30 +201,30 @@ fan:
   - platform: template
     fans:
       preset_mode_fan:
-        friendly_name: Preset Mode Fan Example
+        friendly_name: "Preset Mode Fan Example"
         value_template: "{{ states('fan.percentage_fan') }}"
         turn_on:
-          service: fan.turn_on
-          target:
-            entity_id: fan.percentage_fan
+          - service: fan.turn_on
+            target:
+              entity_id: fan.percentage_fan
         turn_off:
-          service: fan.turn_off
-          target:
-            entity_id: fan.percentage_fan
+          - service: fan.turn_off
+            target:
+              entity_id: fan.percentage_fan
         percentage_template: >
           {{ state_attr('fan.percentage_fan', 'percentage') }}
         speed_count: 3
         set_percentage:
-          service: fan.set_percentage
-          target:
-            entity_id: fan.percentage_fan
-          data:
-            percentage: "{{ percentage }}"
+          - service: fan.set_percentage
+            target:
+              entity_id: fan.percentage_fan
+            data:
+              percentage: "{{ percentage }}"
         preset_modes:
-        - 'off'
-        - low
-        - medium
-        - high
+          - "off"
+          - "low"
+          - "medium"
+          - "high"
         preset_mode_template: >
           {% if is_state('fan.percentage_fan', 'on') %}
             {% if state_attr('fan.percentage_fan', 'percentage') == 100  %}
@@ -238,20 +238,20 @@ fan:
             off
           {% endif %}
         set_preset_mode:
-          service: fan.set_percentage
-          target:
-            entity_id: fan.percentage_fan
-          data:
-            percentage: >-
-              {% if preset_mode == 'high' %}
-                100
-              {% elif preset_mode == 'medium' %}
-                66
-              {% elif preset_mode == 'low' %}
-                33
-              {% else %}
-                0
-              {% endif %}
+          - service: fan.set_percentage
+            target:
+              entity_id: fan.percentage_fan
+            data:
+              percentage: >-
+                {% if preset_mode == 'high' %}
+                  100
+                {% elif preset_mode == 'medium' %}
+                  66
+                {% elif preset_mode == 'low' %}
+                  33
+                {% else %}
+                  0
+                {% endif %}
 ```
 
 {% endraw %}


### PR DESCRIPTION
for https://github.com/home-assistant/core/pull/75656

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
