### PR TITLE
Add section on supported remote Bluetooth adapters

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -87,6 +87,25 @@ The following methods are known to work to add multiple adapters:
 
 Integrations that have followed the [Best practices for library authors](https://developers.home-assistant.io/docs/network_discovery?_highlight=bluetooth#best-practices-for-library-authors) will automatically connect via the adapter with the best signal and failover to an active adapter if one becomes unavailable.
 
+## Remote adapters
+
+The Bluetooth integration supports receiving advertisement data from external adapters for devices and sensors that do not need an active connection. The number of remote scanners is limited only by the performance of the host system.
+
+The following remote adapters are supported:
+
+- ESPHome
+
+### ESPHome requirements
+
+Devices with an ESP32 chip running [ESPHome](/integrations/esphome/) must enable the `bluetooth_proxy` component and be added to Home Assistant before advertisements are forwarded.
+
+```yaml
+esp32_ble_tracker:
+bluetooth_proxy:
+```
+
+Many integrations require an active scan for discovery. By default, the [ESPHome tracker](https://esphome.io/components/esp32_ble_tracker.html) runs in active mode. Adding ESPHome remotes that have active scanning disabled may cause some integrations to malfunction.
+
 ## Troubleshooting
 
 ### Integrations that require exclusive use of the Bluetooth Adapter

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -93,11 +93,11 @@ The Bluetooth integration supports receiving advertisement data from external ad
 
 The following remote adapters are supported:
 
-- ESPHome
+- [ESPHome](https://esphome.io)
 
 ### ESPHome requirements
 
-Devices with an ESP32 chip running [ESPHome](/integrations/esphome/) must enable the `bluetooth_proxy` component and be added to Home Assistant before advertisements are forwarded.
+Devices with an ESP32 chip running ESPHome must enable the `bluetooth_proxy` component and be added to Home Assistant before advertisements are forwarded.
 
 ```yaml
 esp32_ble_tracker:


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add section on supported remote Bluetooth adapters

Currently only ESPHome is supported


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/77123
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
