### PR TITLE
Update litterrobot documentation for v4 model

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -45,7 +45,9 @@ The following entities are created for this component and identified by a single
 | Status Code                   | `sensor` | Displays the status code (Clean Cycle in Progress, Ready, Drawer Full, etc). |
 | Waste Drawer                  | `sensor` | Displays the current waste drawer level.                                                                                                        |
 | Clean Cycle Wait Time Minutes | `select` | View and select the clean cycle wait time.                                                                                                      |
-| Reset Waste Drawer            | `button` | Button to reset the waste drawer level to 0%.                                                                                                   |
+| Reset Waste Drawer*           | `button` | Button to reset the waste drawer level to 0%.                                                                                                   |
+
+\* Litter-Robot 3 only
 
 ## Additional Attributes
 

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -26,7 +26,7 @@ The Litter-Robot integration allows you to control and monitor your Wi-Fi-enable
 
 You will need a Litter-Robot account as well as a Wi-Fi-enabled Litter-Robot unit that has already been associated with your account.
 
-The Feeder-Robot and Litter-Robot 4 are not currently supported by this integration.
+The Feeder-Robot is not currently supported by this integration.
 
 {% include integrations/config_flow.md %}
 
@@ -61,11 +61,11 @@ Some entities have attributes in addition to the default ones that are available
 
 ## Services
 
-Services are utilized for additional functionality that is available in the Litter-Robot companion app. The following are currently available:
+Services are utilized for additional functionality that is available in the Whisker (previously Litter-Robot) companion app. The following are currently available:
 
 ### set_sleep_mode
 
-Enables (with `start_time` parameter) or disables sleep mode on the Litter-Robot.
+Enables (with `start_time` parameter) or disables sleep mode on the Litter-Robot. Currently, this is limited to only the Litter-Robot 3. To make changes to the sleep schedule on your Litter-Robot 4, please continue to use the Whisker app.
 
 | Parameter  | Type   | Required | Description                                                                                                                                                                                                                                                                                                                                              |
 | ---------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update litterrobot documentation to match next release supporting Litter-Robot 4


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/75790
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
