### PR TITLE
Add documentation for the Jellyfin media player

### DIFF
--- a/source/_integrations/jellyfin.markdown
+++ b/source/_integrations/jellyfin.markdown
@@ -22,9 +22,9 @@ ha_integration_type: service
 The Jellyfin integration exposes a [Jellyfin](https://jellyfin.org/) server as a Media Source in Home Assistant.
 Support is currently limited to music and movie libraries only. Other libraries will not appear in the Media Browser. This integration has been tested with Jellyfin server version 10.6.4 and later.
 
-Additionally this integration sets up every media session connected to the Jellyfin
-server as media player in Home Assistant.
-This provides media controls for the sessions from Home Assistant.
+Additionally, this integration sets up every media session connected to the Jellyfin
+server as a media player in Home Assistant to provide media controls for each session.
+
 Browsing media inside Home Assistant in a player's context provides all libraries
 of type Movie and Series.
 

--- a/source/_integrations/jellyfin.markdown
+++ b/source/_integrations/jellyfin.markdown
@@ -22,6 +22,12 @@ ha_integration_type: service
 The Jellyfin integration exposes a [Jellyfin](https://jellyfin.org/) server as a Media Source in Home Assistant.
 Support is currently limited to music and movie libraries only. Other libraries will not appear in the Media Browser. This integration has been tested with Jellyfin server version 10.6.4 and later.
 
+Additionally this integration sets up every media session connected to the Jellyfin
+server as media player in Home Assistant.
+This provides media controls for the sessions from Home Assistant.
+Browsing media inside Home Assistant in a player's context provides all libraries
+of type Movie and Series.
+
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds the documentation about the media player entity in the Jellyfin Integration to the documentation page.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/76801/
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
