### PR TITLE
Add alternative lutron_caseta brands

### DIFF
--- a/source/_integrations/lutron_caseta_pro.markdown
+++ b/source/_integrations/lutron_caseta_pro.markdown
@@ -1,0 +1,35 @@
+---
+title: Lutron Caséta Pro
+description: Instructions on how to use Lutron Caséta Pro devices with Home Assistant.
+featured: true
+ha_category:
+  - Binary Sensor
+  - Cover
+  - Fan
+  - Hub
+  - Light
+  - Scene
+  - Switch
+ha_release: 0.41
+ha_iot_class: Local Push
+ha_domain: lutron_caseta
+ha_config_flow: true
+ha_codeowners:
+  - '@swails'
+  - '@bdraco'
+ha_zeroconf: true
+ha_homekit: true
+ha_platforms:
+  - binary_sensor
+  - cover
+  - diagnostics
+  - fan
+  - light
+  - scene
+  - switch
+ha_integration_type: integration
+ha_supporting_domain: lutron_caseta
+ha_supporting_integration: Lutron Caséta
+---
+
+{% include integrations/supported_brand.md %}

--- a/source/_integrations/lutron_ra2_select.markdown
+++ b/source/_integrations/lutron_ra2_select.markdown
@@ -1,0 +1,35 @@
+---
+title: Lutron RA2 Select
+description: Instructions on how to use Lutron RA2 Select devices with Home Assistant.
+featured: true
+ha_category:
+  - Binary Sensor
+  - Cover
+  - Fan
+  - Hub
+  - Light
+  - Scene
+  - Switch
+ha_release: 0.41
+ha_iot_class: Local Push
+ha_domain: lutron_caseta
+ha_config_flow: true
+ha_codeowners:
+  - '@swails'
+  - '@bdraco'
+ha_zeroconf: true
+ha_homekit: true
+ha_platforms:
+  - binary_sensor
+  - cover
+  - diagnostics
+  - fan
+  - light
+  - scene
+  - switch
+ha_integration_type: integration
+ha_supporting_domain: lutron_caseta
+ha_supporting_integration: Lutron Caséta
+---
+
+{% include integrations/supported_brand.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add alternative lutron_caseta brands

Its about to get even more confusing with RA3 and we already have enough questions about which lutron integration to use so I figured it would be good to clean this up before RA3 support is merged. 

Its going to get even more confusing after that when QSX support is added since `HomeWorks QS` will use `lutron` and `HomeWorks QSX` will use `lutron_caseta`


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/77424
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3615
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
