### PR TITLE
Add lutron alternate brands

### DIFF
--- a/source/_integrations/lutron_homeworks_qs.markdown
+++ b/source/_integrations/lutron_homeworks_qs.markdown
@@ -1,0 +1,26 @@
+---
+title: Lutron Homeworks QS
+description: Instructions on how to use Lutron devices with Home Assistant.
+ha_category:
+  - Cover
+  - Hub
+  - Light
+  - Scene
+  - Switch
+ha_release: 0.37
+ha_iot_class: Local Polling
+ha_codeowners:
+  - '@JonGilmore'
+ha_domain: lutron
+ha_platforms:
+  - binary_sensor
+  - cover
+  - light
+  - scene
+  - switch
+ha_integration_type: integration
+ha_supporting_domain: lutron
+ha_supporting_integration: Lutron
+---
+
+{% include integrations/supported_brand.md %}

--- a/source/_integrations/lutron_homeworks_qs.markdown
+++ b/source/_integrations/lutron_homeworks_qs.markdown
@@ -1,5 +1,5 @@
 ---
-title: Lutron Homeworks QS
+title: Lutron HomeWorks QS
 description: Instructions on how to use Lutron devices with Home Assistant.
 ha_category:
   - Cover

--- a/source/_integrations/lutron_ra2.markdown
+++ b/source/_integrations/lutron_ra2.markdown
@@ -1,5 +1,5 @@
 ---
-title: Lutron Homeworks QS
+title: Lutron RA2
 description: Instructions on how to use Lutron devices with Home Assistant.
 ha_category:
   - Cover

--- a/source/_integrations/lutron_ra2.markdown
+++ b/source/_integrations/lutron_ra2.markdown
@@ -1,0 +1,26 @@
+---
+title: Lutron Homeworks QS
+description: Instructions on how to use Lutron devices with Home Assistant.
+ha_category:
+  - Cover
+  - Hub
+  - Light
+  - Scene
+  - Switch
+ha_release: 0.37
+ha_iot_class: Local Polling
+ha_codeowners:
+  - '@JonGilmore'
+ha_domain: lutron
+ha_platforms:
+  - binary_sensor
+  - cover
+  - light
+  - scene
+  - switch
+ha_integration_type: integration
+ha_supporting_domain: lutron
+ha_supporting_integration: Lutron
+---
+
+{% include integrations/supported_brand.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add alternative lutron brands

Its about to get even more confusing with RA3 and we already have enough questions about which lutron integration to use so I figured it would be good to clean this up before RA3 support is merged.

Its going to get even more confusing after that when QSX support is added since `HomeWorks QS` will use `lutron` and `HomeWorks QSX` will use `lutron_caseta`

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/77425
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3616
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
