### PR TITLE
Updated core integration doc for new enable/disable config entry services.

### DIFF
--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -34,6 +34,28 @@ Reloads an integration config entry.
 | `device_id`               | List of device ids used to reference a config entry.        |
 | `entry_id`                | A single config entry id used to reference a config entry.  |
 
+### Service `homeassistant.enable_config_entry`
+
+Enables an integration config entry (if the integration config entry is already enabled, this service does nothing).
+
+| Service data attribute    | Description                                                 |
+|---------------------------|-------------------------------------------------------------|
+| `entity_id`               | List of entity ids used to reference a config entry.        |
+| `area_id`                 | List of area ids used to reference a config entry.          |
+| `device_id`               | List of device ids used to reference a config entry.        |
+| `entry_id`                | A single config entry id used to reference a config entry.  |
+
+### Service `homeassistant.disable_config_entry`
+
+Disables an integration config entry (if the integration config entry is already disabled, this service does nothing).
+
+| Service data attribute    | Description                                                 |
+|---------------------------|-------------------------------------------------------------|
+| `entity_id`               | List of entity ids used to reference a config entry.        |
+| `area_id`                 | List of area ids used to reference a config entry.          |
+| `device_id`               | List of device ids used to reference a config entry.        |
+| `entry_id`                | A single config entry id used to reference a config entry.  |
+
 ### Service `homeassistant.reload_core_config`
 
 Reloads the core configuration under `homeassistant:` and all linked files. Once loaded the new configuration is applied. New `customize:` information will be applied the next time the state of the entity gets updated.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updating core integration doc for new enable/disable config entry services.

The corresponding core PR is: https://github.com/home-assistant/core/pull/77457

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/77457
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
