### PR TITLE
Update litterrobot documentation for Feeder-Robot model

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -51,13 +51,9 @@ You will need a Litter-Robot account as well as a Wi-Fi-enabled Litter-Robot or 
 
 ### Feeder-Robot
 
-| Entity           | Domain   | Description                                                                      |
-| ---------------- | -------- | -------------------------------------------------------------------------------- |
-| Give snack       | `button` | Button to dispense a single snack portion.                                       |
-| Meal insert size | `select` | View and select the meal insert size.                                            |
-| Food level       | `sensor` | Displays the approximate food level remaining in the hopper.                     |
-| Night light mode | `switch` | When turned on, automatically turns on the night light in darker settings.       |
-| Panel lockout    | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
+| Entity     | Domain   | Description                                                  |
+| ---------- | -------- | ------------------------------------------------------------ |
+| Food level | `sensor` | Displays the approximate food level remaining in the hopper. |
 
 ## Additional Attributes
 

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -24,32 +24,40 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The Litter-Robot integration allows you to control and monitor your Wi-Fi-enabled, automatic, self-cleaning litter box for cats.
+The Litter-Robot integration allows you to control and monitor your Wi-Fi-enabled, automatic, self-cleaning litter box and pet feeders.
 
-You will need a Litter-Robot account as well as a Wi-Fi-enabled Litter-Robot unit that has already been associated with your account.
-
-The Feeder-Robot is not currently supported by this integration.
+You will need a Litter-Robot account as well as a Wi-Fi-enabled Litter-Robot or Feeder-Robot unit that has already been associated with your account.
 
 {% include integrations/config_flow.md %}
 
 ## Entities
 
-The following entities are created for this component and identified by a single device per Litter-Robot unit:
+### Litter-Robot
 
-| Entity                        | Domain   | Description                                                                                                                                     |
-| ----------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| Litter Box                    | `vacuum` | Main entity that represents a Litter-Robot unit.                                                                                                |
-| Night Light Mode              | `switch` | When turned on, automatically turns on the night light in darker settings.                                                                      |
-| Panel Lockout                 | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings.                                                                |
-| Last Seen                     | `sensor` | Displays the time the unit was last seen / reported an update.                                                                                  |
-| Sleep Mode Start Time         | `sensor` | When sleep mode is enabled, displays the current or next sleep mode start time.                                                                 |
-| Sleep Mode End Time           | `sensor` | When sleep mode is enabled, displays the current or last sleep mode end time.                                                                   |
-| Status Code                   | `sensor` | Displays the status code (Clean Cycle in Progress, Ready, Drawer Full, etc). |
-| Waste Drawer                  | `sensor` | Displays the current waste drawer level.                                                                                                        |
-| Clean Cycle Wait Time Minutes | `select` | View and select the clean cycle wait time.                                                                                                      |
-| Reset Waste Drawer*           | `button` | Button to reset the waste drawer level to 0%.                                                                                                   |
+| Entity                        | Domain   | Description                                                                      |
+| ----------------------------- | -------- | -------------------------------------------------------------------------------- |
+| Litter Box                    | `vacuum` | Main entity that represents a Litter-Robot unit.                                 |
+| Night Light Mode              | `switch` | When turned on, automatically turns on the night light in darker settings.       |
+| Panel Lockout                 | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
+| Last Seen                     | `sensor` | Displays the time the unit was last seen / reported an update.                   |
+| Sleep Mode Start Time         | `sensor` | When sleep mode is enabled, displays the current or next sleep mode start time.  |
+| Sleep Mode End Time           | `sensor` | When sleep mode is enabled, displays the current or last sleep mode end time.    |
+| Status Code                   | `sensor` | Displays the status code (Clean Cycle in Progress, Ready, Drawer Full, etc).     |
+| Waste Drawer                  | `sensor` | Displays the current waste drawer level.                                         |
+| Clean Cycle Wait Time Minutes | `select` | View and select the clean cycle wait time.                                       |
+| Reset Waste Drawer*           | `button` | Button to reset the waste drawer level to 0%.                                    |
 
 \* Litter-Robot 3 only
+
+### Feeder-Robot
+
+| Entity           | Domain   | Description                                                                      |
+| ---------------- | -------- | -------------------------------------------------------------------------------- |
+| Give snack       | `button` | Button to dispense a single snack portion.                                       |
+| Meal insert size | `select` | View and select the meal insert size.                                            |
+| Food level       | `sensor` | Displays the approximate food level remaining in the hopper.                     |
+| Night light mode | `switch` | When turned on, automatically turns on the night light in darker settings.       |
+| Panel lockout    | `switch` | When turned on, disables the buttons on the unit to prevent changes to settings. |
 
 ## Additional Attributes
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update litterrobot documentation for Feeder-Robot model


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/77395
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
