### PR TITLE
Update Overkiz documentation 

### DIFF
--- a/source/_integrations/overkiz.markdown
+++ b/source/_integrations/overkiz.markdown
@@ -52,16 +52,14 @@ The Overkiz (by Somfy) integration platform is used by many different vendors, l
 - Hitachi Hi Kumo
 - Nexity Eugénie
 - Rexel Energeasy Connect
+- Somfy Connection Kit
 - Somfy Connexoon IO
 - Somfy Connexoon RTS
 - Somfy TaHoma
-- Somfy TaHoma Switch [(instructions)](#tahoma-switch)
-- Somfy Connection Kit
+- Somfy TaHoma Beecon
+- Somfy TaHoma Switch
 - Thermor Cozytouch
 
-### TaHoma Switch
-
-Multiple users reported that the TaHoma Switch will work with this integration **after** you create a scene in the TaHoma app and wait for a few hours.
 
 ## Supported devices
 
@@ -83,8 +81,10 @@ During peak hours, it could happen that the Overkiz platform is unable to execut
 
 ### Internet connectivity required
 
-This integration communicates via the cloud-based Overkiz API, since Overkiz doesn't expose a local API on their hubs. If you are only using Somfy IO compatible devices, you could purchase a Velux KLF200 hub and use [the Velux integration](/integrations/velux/) which has a local API.
+This integration communicates via the cloud-based Overkiz API. The Somfy TaHoma v2 and the Somfy TaHoma Switch offer the [Somfy TaHoma Developer Mode (local API)](https://developer.somfy.com/developer-mode), which is not supported in Home Assistant yet.
+
+Another option if you are only using Somfy IO compatible devices is to purchase a Velux KLF200 hub and use [the Velux integration](/integrations/velux/) which has a local API.
 
 #### Local API via HomeKit Controller
 
-If your hub (e.g. Somfy TaHoma or Somfy Connection Kit) supports HomeKit natively, your setup code will be added as a sensor in Home Assistant. Look up your hub in Home Assistant and retrieve the value from the 'HomeKit Setup Code' sensor. You can now configure the [HomeKit Controller](/integrations/homekit_controller/) integration in Home Assistant and benefit from local support.
+If your hub (e.g. Somfy TaHoma) supports HomeKit natively, your setup code will be added as a sensor in Home Assistant. Look up your hub in Home Assistant and retrieve the value from the 'HomeKit Setup Code' sensor. You can now configure the [HomeKit Controller](/integrations/homekit_controller/) integration in Home Assistant and benefit from local support. Only a [limited amount of devices is supported](https://service.somfy.com/downloads/nl_v5/tahoma-homekitcompatibilitylist_eng.pdf).

--- a/source/_integrations/overkiz.markdown
+++ b/source/_integrations/overkiz.markdown
@@ -52,7 +52,7 @@ The Overkiz (by Somfy) integration platform is used by many different vendors, l
 - Hitachi Hi Kumo
 - Nexity Eugénie
 - Rexel Energeasy Connect
-- Somfy Connection Kit
+- Somfy Connectivity Kit
 - Somfy Connexoon IO
 - Somfy Connexoon RTS
 - Somfy TaHoma


### PR DESCRIPTION
## Proposed change

A small clean up with some additions to make the documentation more clear / up to date.

- Add supported devices list (see https://github.com/home-assistant/core/issues/77617)
- Add mention of local API (which is not supported yet)
- Remove Somfy TaHoma Switch workaround which is not applicable anymore
- Add Somfy TaHoma Beecon (reported on the forum)
- Change name to Connectivity Kit

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
