### PR TITLE
Fix details block in Bravia TV

### DIFF
--- a/source/_integrations/braviatv.markdown
+++ b/source/_integrations/braviatv.markdown
@@ -39,28 +39,7 @@ The integration supports `remote` platform. The remote allows you to send key co
 The commands that can be sent to the TV depends on the model of your TV. To display a list of supported commands for your TV, call the service `remote.send_command` with non-valid command (e.g. `Test`). A list of available commands will be displayed in [Home Assistant System Logs](https://my.home-assistant.io/redirect/logs).
 
 {% details "Some commonly used commands" %}
-- Up
-- Down
-- Left
-- Right
-- Confirm
-- Return
-- Home
-- Exit
-- Rewind
-- Forward
-- ActionMenu
-- SyncMenu
-- Num0
-- Num1
-- Num2
-- Num3
-- Num4
-- Num5
-- Num6
-- Num7
-- Num8
-- Num9
+Up, Down, Left, Right, Confirm, Return, Home, Exit, Rewind, Forward, ActionMenu, SyncMenu, Num0, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9
 {% enddetails %}
 
 {% include integrations/option_flow.md %}

--- a/source/_integrations/braviatv.markdown
+++ b/source/_integrations/braviatv.markdown
@@ -40,7 +40,28 @@ The commands that can be sent to the TV depends on the model of your TV. To disp
 
 {% details "Some commonly used commands" %}
 
-Up, Down, Left, Right, Confirm, Return, Home, Exit, Rewind, Forward, ActionMenu, SyncMenu, Num0, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9
+- Up
+- Down
+- Left
+- Right
+- Confirm
+- Return
+- Home
+- Exit
+- Rewind
+- Forward
+- ActionMenu
+- SyncMenu
+- Num0
+- Num1
+- Num2
+- Num3
+- Num4
+- Num5
+- Num6
+- Num7
+- Num8
+- Num9
 
 {% enddetails %}
 

--- a/source/_integrations/braviatv.markdown
+++ b/source/_integrations/braviatv.markdown
@@ -39,7 +39,9 @@ The integration supports `remote` platform. The remote allows you to send key co
 The commands that can be sent to the TV depends on the model of your TV. To display a list of supported commands for your TV, call the service `remote.send_command` with non-valid command (e.g. `Test`). A list of available commands will be displayed in [Home Assistant System Logs](https://my.home-assistant.io/redirect/logs).
 
 {% details "Some commonly used commands" %}
+
 Up, Down, Left, Right, Confirm, Return, Home, Exit, Rewind, Forward, ActionMenu, SyncMenu, Num0, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9
+
 {% enddetails %}
 
 {% include integrations/option_flow.md %}

--- a/source/_integrations/braviatv.markdown
+++ b/source/_integrations/braviatv.markdown
@@ -39,28 +39,28 @@ The integration supports `remote` platform. The remote allows you to send key co
 The commands that can be sent to the TV depends on the model of your TV. To display a list of supported commands for your TV, call the service `remote.send_command` with non-valid command (e.g. `Test`). A list of available commands will be displayed in [Home Assistant System Logs](https://my.home-assistant.io/redirect/logs).
 
 {% details "Some commonly used commands" %}
-- `Up`
-- `Down`
-- `Left`
-- `Right`
-- `Confirm`
-- `Return`
-- `Home`
-- `Exit`
-- `Rewind`
-- `Forward`
-- `ActionMenu`
-- `SyncMenu`
-- `Num0`
-- `Num1`
-- `Num2`
-- `Num3`
-- `Num4`
-- `Num5`
-- `Num6`
-- `Num7`
-- `Num8`
-- `Num9`
+- Up
+- Down
+- Left
+- Right
+- Confirm
+- Return
+- Home
+- Exit
+- Rewind
+- Forward
+- ActionMenu
+- SyncMenu
+- Num0
+- Num1
+- Num2
+- Num3
+- Num4
+- Num5
+- Num6
+- Num7
+- Num8
+- Num9
 {% enddetails %}
 
 {% include integrations/option_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
https://rc.home-assistant.io/integrations/braviatv/

It looks like the details block doesn't support code blocks.

Bugfix for: https://github.com/home-assistant/core/pull/77329

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
