### PR TITLE
Update Sun docs with new "previous" solar event attributes

### DIFF
--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -81,6 +81,12 @@ which event (sunset or sunrise) and the offset.
 | `next_dusk` | Date and time of the next dusk (in UTC).
 | `next_noon` | Date and time of the next solar noon (in UTC).
 | `next_midnight` | Date and time of the next solar midnight (in UTC).
+| `previous_rising` | Date and time of the previous sun rising (in UTC).
+| `previous_setting` | Date and time of the previous sun setting (in UTC).
+| `previous_dawn` | Date and time of the previous dawn (in UTC).
+| `previous_dusk` | Date and time of the previous dusk (in UTC).
+| `previous_noon` | Date and time of the previous solar noon (in UTC).
+| `previous_midnight` | Date and time of the previous solar midnight (in UTC).
 | `elevation` |  Solar elevation. This is the angle between the sun and the horizon. Negative values mean the sun is below the horizon.
 | `azimuth` | Solar azimuth. The angle is shown clockwise from north.
 | `rising` | True if the Sun is currently rising, after solar midnight and before solar noon.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The Sun integration provides a set of attributes for the next datetime of certain solar events; for example, next sunrise, sunset, noon, etc. Core PR #77733 adds corresponding attributes for the previous datetime that these events occurred. This unlocks capabilities like measuring the progress of the sun through a day, measuring the length of a day, and showing how long it has been since a given solar event.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/77733
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
