### PR TITLE
update Polly docs; add AWS doc links and cleanup

### DIFF
--- a/source/_integrations/amazon_polly.markdown
+++ b/source/_integrations/amazon_polly.markdown
@@ -42,7 +42,7 @@ aws_secret_access_key:
   required: true
   type: string
 profile_name:
-  description: A credentials profile name.
+  description: A credentials profile name. If provided, you must **not** provide an `aws_access_key_id` nor an `aws_secrete_access_key`. 
   required: false
   type: string
 region_name:
@@ -51,12 +51,12 @@ region_name:
   type: [string, list]
   default: us-east-1
 text_type:
-  description: "Specify wherever to use text (default) or ssml markup by default."
+  description: "Whether to interpret messages as `text` or as [`ssml`](https://docs.aws.amazon.com/polly/latest/dg/ssml.html) by default."
   required: false
   type: string
   default: text
 voice:
-  description: Voice name to be used.
+  description: The [Voice Name/ID](https://docs.aws.amazon.com/polly/latest/dg/voicelist.html) to be used for generated speech by default. 
   required: false
   type: string
 output_format:


### PR DESCRIPTION
## Proposed change

This change updates the documentation page for the Amazon Polly TTS integration by:
1. explicitly warning the user that the `profile_name` is incompatible with secret/key authentication,
2. adding an external link to  documentation of Amazon Polly's SSML implementation,
3. adding an external link to documentation of Amazon Polly's available voice Name/IDs

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - **I made a change to the existing documentation and used the `current` branch.**
  - ~~I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.~~
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
