### PR TITLE
Add sensor platform to Melnor Bluetooth docs

### DIFF
--- a/source/_integrations/melnor.markdown
+++ b/source/_integrations/melnor.markdown
@@ -2,6 +2,7 @@
 title: Melnor Bluetooth
 description: Instructions on setting up Melnor Bluetooth devices within Home Assistant.
 ha_category:
+  - Sensor
   - Switch
 ha_iot_class: Local Polling
 ha_bluetooth: true
@@ -11,6 +12,7 @@ ha_codeowners:
   - '@vanstinator'
 ha_domain: melnor
 ha_platforms:
+  - sensor
   - switch
 ha_integration_type: integration
 ---


### PR DESCRIPTION
## Proposed change
I'm adding sensor support to Melnor Bluetooth, and the docs need to be updated to reflect the new platform.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/77576
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
