### PR TITLE
Add docs for lifx infrared brightness entity

### DIFF
--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -39,15 +39,8 @@ Change the light to a new state.
 | `entity_id` | String or list of strings that point at `entity_id`s of lights. Use `entity_id: all` to target all.
 | `transition` | Duration (in seconds) for the light to fade to the new state.
 | `zones` | List of integers for the zone numbers to affect (each LIFX Z strip has 8 zones, starting at 0).
-| `infrared` | **Deprecated.** Automatic infrared level (0..255) when light brightness is low (for compatible bulbs).
 | `power` | Turn the light on (`True`) or off (`False`). Leave out to keep the power as it is.
 | `...` | Use `color_name`, `brightness` etc. from [`light.turn_on`](/integrations/light/#service-lightturn_on) to specify the new state.
-
-<div class='note warning'>
-
-  The `infrared` attribute is deprecated and will be removed in Home Assistant 2022.11. Automations or scripts that adjust this value should be modified to target the Infrared Brightness select entity instead.
-
-</div>
 
 ## Set HEV cycle state
 
@@ -139,8 +132,6 @@ Run an effect that does nothing, thereby stopping any other effect that might be
 ## Infrared brightness
 
 Home Assistant will automatically create an Infrared Brightness configuration entity for LIFX Night Vision bulbs. Changing the state of this entity will change the brightness of the LEDs on the bulb.
-
-Using the `lifx.set_state` service to modify the infrared brightness of Night Vision bulbs was deprecated in Home Assistant 2022.9 and the `infrared` attribute will be removed from the service in 2022.11.
 
 ## Buttons
 

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -39,9 +39,15 @@ Change the light to a new state.
 | `entity_id` | String or list of strings that point at `entity_id`s of lights. Use `entity_id: all` to target all.
 | `transition` | Duration (in seconds) for the light to fade to the new state.
 | `zones` | List of integers for the zone numbers to affect (each LIFX Z strip has 8 zones, starting at 0).
-| `infrared` | Automatic infrared level (0..255) when light brightness is low (for compatible bulbs).
+| `infrared` | **Deprecated.** Automatic infrared level (0..255) when light brightness is low (for compatible bulbs).
 | `power` | Turn the light on (`True`) or off (`False`). Leave out to keep the power as it is.
 | `...` | Use `color_name`, `brightness` etc. from [`light.turn_on`](/integrations/light/#service-lightturn_on) to specify the new state.
+
+<div class='note warning'>
+
+  The `infrared` attribute is deprecated and will be removed in Home Assistant 2022.11. Automations or scripts that adjust this value should be modified to target the Infrared Brightness select entity instead.
+
+</div>
 
 ## Set HEV cycle state
 
@@ -130,15 +136,21 @@ Run an effect that does nothing, thereby stopping any other effect that might be
 | ---------------------- | ----------- |
 | `entity_id` | String or list of strings that point at `entity_id`s of lights. Use `entity_id: all` to target all.
 
+## Infrared brightness
+
+Home Assistant will automatically create an Infrared Brightness configuration entity for LIFX Night Vision bulbs. Changing the state of this entity will change the brightness of the LEDs on the bulb.
+
+Using the `lifx.set_state` service to modify the infrared brightness of Night Vision bulbs was deprecated in Home Assistant 2022.9 and the `infrared` attribute will be removed from the service in 2022.11.
+
 ## Buttons
 
 The LIFX button platform creates two buttons for each LIFX device.
 
-### Identify Button
+### Identify button
 
 The Identify button will flash the bulb three times at maximum brightness then return the bulb to the state it was in prior. Successful identification requires the bulb to be powered on and already configured in Home Assistant.
 
-### Restart Button
+### Restart button
 
 The Restart button triggers the bulb to restart in exactly the same way as a physical power cycle, which makes it ideal for triggering a new DHCP request from the bulb.
 


### PR DESCRIPTION
Signed-off-by: Avi Miller <me@dje.li>

## Proposed change

Add documentation for the Infrared Brightness entity and deprecation of the `infrared` attribute of the `lifx.set_state` service.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/77943
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
