### PR TITLE
Zigbee backup and restore in ZHA docs

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -408,7 +408,7 @@ Zigbee Home Automation (ZHA) integration now features Zigbee network backup, res
 
 After restoring a Home Assistant backup, you can re-configure ZHA and migrate to a new Zigbee Coordinator adapter without any loss of your settings or devices that were connected. This is helpful if your current radio fails or a new radio adapter type and model comes out that you may want to migrate to.
 
-Within ZHA is possible to use this backup and restore feature to migrate between some different radio types, if the respective radio library supports it. Currently, ZHA supports migrating the Zigbee network between based Zigbee Coordinator adapters based on Silicon Labs, Texas Instruments, or ConBee/RaspBee if the backup was made from inside ZHA.
+Within ZHA is possible to use this backup and restore feature to migrate between some different radio types, if the respective radio library supports it. Currently, ZHA supports migrating the Zigbee network between different Zigbee Coordinator adapters based on chips from Silicon Labs, Texas Instruments, or ConBee/RaspBee if the backup was made from inside ZHA.
 
 ## Troubleshooting
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -408,9 +408,9 @@ Zigbee Home Automation (ZHA) integration now features Zigbee network backup, res
 
 After restoring a Home Assistant backup, you can re-configure ZHA and migrate to a new Zigbee Coordinator adapter without any loss of your settings or devices that were connected. This is helpful if your current radio fails or a new radio adapter type and model comes out that you may want to migrate to.
 
-ZHA saves the Zigbee network backups using the "[Open ZigBee Coordinator Backup Format](https://github.com/zigpy/open-coordinator-backup)" which is an open standard and hardware-independent non-proprietary specification for Zibgee coordinator backup using JSON formatting, meaning that backup files could possibly be cross-platform compatible if other Zigbee aplications use the same backup format.
+The ZHA integration currently store and export the Zigbee network backup files in a [zigpy](https://github.com/zigpy/zigpy) specific format.
 
-It is possible to use this backup and restore feature to migrate between some different radio types if the respective radio livrary supports it, and currently ZHA support migrating Zigbee network between based Zigbee Coordinator adapters based on Silicon Labs, Texas Instruments, or ConBee/RaspBee if the backup was made from inside ZHA.
+Within ZHA is possible to use this backup and restore feature to migrate between some different radio types if the respective radio livrary supports it, and currently ZHA support migrating Zigbee network between based Zigbee Coordinator adapters based on Silicon Labs, Texas Instruments, or ConBee/RaspBee if the backup was made from inside ZHA.
 
 ## Troubleshooting
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -408,8 +408,6 @@ Zigbee Home Automation (ZHA) integration now features Zigbee network backup, res
 
 After restoring a Home Assistant backup, you can re-configure ZHA and migrate to a new Zigbee Coordinator adapter without any loss of your settings or devices that were connected. This is helpful if your current radio fails or a new radio adapter type and model comes out that you may want to migrate to.
 
-The ZHA integration currently store and export the Zigbee network backup files in a [zigpy](https://github.com/zigpy/zigpy) specific format.
-
 Within ZHA is possible to use this backup and restore feature to migrate between some different radio types, if the respective radio library supports it. Currently, ZHA supports migrating the Zigbee network between based Zigbee Coordinator adapters based on Silicon Labs, Texas Instruments, or ConBee/RaspBee if the backup was made from inside ZHA.
 
 ## Troubleshooting

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -404,7 +404,7 @@ Binding a remote directly to a bulb or group has the benefit of faster response 
 
 ## Zigbee backup and restore in ZHA
 
-Zigbee Home Automation (ZHA) integration now features Zigbee network backup, restore/recovery, and migrating between Zigbee coordinators since Home Assistant 2022.9 release. Backups are taken automatically however a single backup to file for easy download can also be manually created from the configuration page under Network Settings.
+Zigbee Home Automation (ZHA) integration now features Zigbee network backup, restore/recovery, and migrating between Zigbee coordinators. Backups are taken automatically however, a single backup to a file for easy download can also be manually created from the configuration page under Network Settings.
 
 After restoring a Home Assistant backup, you can re-configure ZHA and migrate to a new Zigbee Coordinator adapter without any loss of your settings or devices that were connected. This is helpful if your current radio fails or a new radio adapter type and model comes out that you may want to migrate to.
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -410,7 +410,7 @@ After restoring a Home Assistant backup, you can re-configure ZHA and migrate to
 
 The ZHA integration currently store and export the Zigbee network backup files in a [zigpy](https://github.com/zigpy/zigpy) specific format.
 
-Within ZHA is possible to use this backup and restore feature to migrate between some different radio types if the respective radio livrary supports it, and currently ZHA support migrating Zigbee network between based Zigbee Coordinator adapters based on Silicon Labs, Texas Instruments, or ConBee/RaspBee if the backup was made from inside ZHA.
+Within ZHA is possible to use this backup and restore feature to migrate between some different radio types, if the respective radio library supports it. Currently, ZHA supports migrating the Zigbee network between based Zigbee Coordinator adapters based on Silicon Labs, Texas Instruments, or ConBee/RaspBee if the backup was made from inside ZHA.
 
 ## Troubleshooting
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -402,6 +402,16 @@ Note that not all devices support binding as it depends on the Zigbee implementa
 
 Binding a remote directly to a bulb or group has the benefit of faster response time and smoother control. This greatly improves user feedback experience functions like dimming as the remote then directly dims the lightbulb and thus does not have to make the software roundtrip via the ZHA coordinator.
 
+## Zigbee backup and restore in ZHA
+
+Zigbee Home Automation (ZHA) integration now features Zigbee network backup, restore/recovery, and migrating between Zigbee coordinators since Home Assistant 2022.9 release. Backups are taken automatically however a single backup to file for easy download can also be manually created from the configuration page under Network Settings.
+
+After restoring a Home Assistant backup, you can re-configure ZHA and migrate to a new Zigbee Coordinator adapter without any loss of your settings or devices that were connected. This is helpful if your current radio fails or a new radio adapter type and model comes out that you may want to migrate to.
+
+ZHA saves the Zigbee network backups using the "[Open ZigBee Coordinator Backup Format](https://github.com/zigpy/open-coordinator-backup)" which is an open standard and hardware-independent non-proprietary specification for Zibgee coordinator backup using JSON formatting, meaning that backup files could possibly be cross-platform compatible if other Zigbee aplications use the same backup format.
+
+It is possible to use this backup and restore feature to migrate between some different radio types if the respective radio livrary supports it, and currently ZHA support migrating Zigbee network between based Zigbee Coordinator adapters based on Silicon Labs, Texas Instruments, or ConBee/RaspBee if the backup was made from inside ZHA.
+
 ## Troubleshooting
 
 To help resolve any kinks or compatibility problems, report bugs as issues with debug logs. Please follow the instructions in this troubleshooting section.


### PR DESCRIPTION
## Proposed change

Mention Zigbee backup and restore in ZHA docs, inspired by https://www.home-assistant.io/blog/2022/09/07/release-20229/#zigbee-backup-and-restore--migration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
