### PR TITLE
Docs about Bravia TV Button platform

### DIFF
--- a/source/_integrations/braviatv.markdown
+++ b/source/_integrations/braviatv.markdown
@@ -2,6 +2,7 @@
 title: Sony Bravia TV
 description: Instructions on how to integrate a Sony Bravia TV into Home Assistant.
 ha_category:
+  - Button
   - Media Player
   - Remote
 ha_release: 0.23
@@ -12,6 +13,7 @@ ha_codeowners:
 ha_domain: braviatv
 ha_config_flow: true
 ha_platforms:
+  - button
   - media_player
   - remote
 ha_integration_type: integration
@@ -64,6 +66,10 @@ The commands that can be sent to the TV depends on the model of your TV. To disp
 - Num9
 
 {% enddetails %}
+
+## Buttons
+
+The integration supports `button` platform and allows you to reboot the device or terminate all running applications.
 
 {% include integrations/option_flow.md %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Docs about the new `button` platform in Bravia TV integration:
https://github.com/home-assistant/core/pull/78093


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/78093
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
