### PR TITLE
Add input mapping for Pioneer VSX-1021

### DIFF
--- a/source/_integrations/pioneer.markdown
+++ b/source/_integrations/pioneer.markdown
@@ -177,3 +177,31 @@ sources:
   'Favorites': '45'
   'Game': '49'
 ```
+
+#### VSX-1021
+
+```yaml
+port: 8102
+sources:
+  'Phono': '00'
+  'CD': '01'
+  'Tuner': '02'
+  'CD-R/Tape': '03'
+  'DVD': '04'
+  'TV/Sat': '05'
+  'Video 1': '10'
+  'Multi Channel In': '12'
+  'Video 2': '14'
+  'DVR/BDR': '15'
+  'iPod/USB': '17'
+  'XM Radio': '18'
+  'HDMI 1': '19'
+  'HDMI 2': '20'
+  'HDMI 3': '21'
+  'HDMI 4': '22'
+  'HDMI 5': '23'
+  'Blu-Ray': '25'
+  'Home Media Gallery (Internet Radio)': '26'
+  'Sirius': '27'
+  'Adapter Port': '33'
+```


### PR DESCRIPTION
## Proposed change
Documentation-only change, add source input mapping details for VSX-1021 receiver.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Not sure if this is correct from the documentation standards point of view, I just followed the existing formatting for other receiver models.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
