### PR TITLE
Update climate.mqtt.markdown

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -456,3 +456,45 @@ mqtt:
       swing_mode_command_topic: "study/ac/swing/set"
       precision: 1.0
 ```
+
+## Example of multiple devices
+
+{% raw %}
+
+```yaml
+mqtt:
+  climate:
+    - name: Study
+      modes:
+        - "off"
+        - "heat"
+        - "auto"
+      mode_command_topic: "study/ac/mode/set"
+      mode_state_topic: "study/ac/mode/state"
+      mode_state_template: "{{ value_json }}"
+
+    - name: Living
+      modes:
+        - "off"
+        - "auto"
+        - "cool"
+        - "heat"
+        - "dry"
+        - "fan_only
+      swing_modes:
+        - "on"
+        - "off"
+      fan_modes:
+        - "quiet"
+        - "lvl_1"
+        - "lvl_2"
+        - "lvl_3"
+        - "lvl_4"
+        - "lvl_5"
+        - "auto"
+      mode_command_topic: "living/ac/mode/set"
+      mode_state_topic: "living/ac/mode/state"
+      mode_state_template: "{{ value_json }}"
+```
+
+{% endraw %}


### PR DESCRIPTION
Updated documentation with a "multi" hvac example. It took me a bit to understand it breaks when you put "climate:" before every device. It will confuse other users. I hope the addition will explain it more clearly.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
