### PR TITLE
Add range to min-max integration

### DIFF
--- a/source/_integrations/min_max.markdown
+++ b/source/_integrations/min_max.markdown
@@ -17,7 +17,7 @@ ha_platforms:
 ha_integration_type: helper
 ---
 
-The Min/Max integration consumes the state from other sensors to determine the minimum, maximum, latest (last), mean and median of the collected states.
+The Min/Max integration consumes the state from other sensors to determine the minimum, maximum, latest (last), mean, median, and range of the collected states.
 
 The sensor provided by this integration will always show you the lowest/highest/latest value which was received from all monitored sensors. If you have spikes in your values, it's recommended to filter/equalize your values with a [statistics sensor](/integrations/statistics) first.
 
@@ -30,7 +30,7 @@ Name:
 Input entities:
   description: At least two entities to monitor. All entities must use the same unit of measurement.
 Type:
-  description: The type of the sensor, this can be either "min", "max", "last", "mean", or "median".
+  description: The type of the sensor, this can be either "min", "max", "last", "mean", "median", or "range".
 Precision:
   description: Round the calculated mean or median value to at most N decimal places.
 {% endconfiguration_basic %}
@@ -57,7 +57,7 @@ entity_ids:
   required: true
   type: [list, string]
 type:
-  description: "The type of sensor: `min`, `max`, `last`, `mean` or `median`."
+  description: "The type of sensor: `min`, `max`, `last`, `mean`, `median`, or `range`."
   required: false
   default: max
   type: string


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add statistical range (`max - min`) as an option for the min_max calculated sensor. This makes it easy to taken action based on variance of values. For example: if the warmest room is much warmer than the coolest room, circulate air


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/78282
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
