### PR TITLE
Add documentation for hatchrest

### DIFF
--- a/source/_integrations/hatchrest.markdown
+++ b/source/_integrations/hatchrest.markdown
@@ -1,6 +1,6 @@
 ---
 title: Hatch Rest
-description: Instructions on how to control a Hatch Rest bluetooth device with Home Assistant
+description: Instructions on how to control a Hatch Rest Bluetooth device with Home Assistant
 ha_category:
   - Switch
   - Light
@@ -27,10 +27,10 @@ The Hatch Rest will be automatically discovered after enabling the [Bluetooth](/
 
 ## Features
 
-The integration will add a light entity allowing full control of the light, a media player entitity allowing control of the white noise, and a switch to control device power.
+The integration will add a light entity allowing full control of the light, a media player entity allowing control of the white noise, and a switch to control device power.
 
 ## Turning off entities
 
-The Hatch Rest only really has one on/off state despite having a light and a sound element. This component is implemented so that turning off a particular entity, Light or Media Player, when the other entitiy is currently on will not power off the device. It will only turn off the light or sound on the device. If the entitiy you are turning off is the last remaining entity, it will power off the device.
+The Hatch Rest only really has one on/off state despite having a light and a sound element. This component is implemented so that turning off a particular entity, Light or Media Player, when the other entity is currently on will not power off the device. It will only turn off the light or sound on the device. If the entity you are turning off is the last remaining entity, it will power off the device.
 
 In other words, powering off the device requires turning off both Light and Media Player or using the dedicated Switch entity controlling device power to turn off or on device power directly.

--- a/source/_integrations/hatchrest.markdown
+++ b/source/_integrations/hatchrest.markdown
@@ -1,0 +1,36 @@
+---
+title: Hatch Rest
+description: Instructions on how to control a Hatch Rest bluetooth device with Home Assistant
+ha_category:
+  - Switch
+  - Light
+  - Health
+ha_bluetooth: true
+ha_config_flow: true
+ha_iot_class: Local Polling
+ha_release: 2022.10
+ha_codeowners:
+  - '@vividboarder'
+ha_domain: hatchrest
+ha_platforms:
+  - switch
+  - light
+  - media_player
+ha_integration_type: integration
+---
+
+Integrates [Hatch Rest](https://www.hatch.co/rest) Bluetooth sound machine into Home Assistant.
+
+{% include integrations/config_flow.md %}
+
+The Hatch Rest will be automatically discovered after enabling the [Bluetooth](/integrations/bluetooth) integration.
+
+## Features
+
+The integration will add a light entity allowing full control of the light, a media player entitity allowing control of the white noise, and a switch to control device power.
+
+## Turning off entities
+
+The Hatch Rest only really has one on/off state despite having a light and a sound element. This component is implemented so that turning off a particular entity, Light or Media Player, when the other entitiy is currently on will not power off the device. It will only turn off the light or sound on the device. If the entitiy you are turning off is the last remaining entity, it will power off the device.
+
+In other words, powering off the device requires turning off both Light and Media Player or using the dedicated Switch entity controlling device power to turn off or on device power directly.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding documentation for the Hatch Rest integration that I'm working on in https://github.com/home-assistant/core/pull/77381



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/77381
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3654
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
