### PR TITLE
Add configuration variable ssl_client_cert

### DIFF
--- a/source/_integrations/caldav.markdown
+++ b/source/_integrations/caldav.markdown
@@ -133,6 +133,10 @@ verify_ssl:
   required: false
   type: boolean
   default: true
+ssl_client_cert:
+  description: Used to enable SSL client authentication. Value points to a file on the filesystem containing both the unencrypted private key and certificate for the client. This file should be protected. Make sure the owner is set to the user Home Assistant runs as and permissions are set to be readable by that user only. You should consider putting the file outside of the Home Assistant configuration directories as well. 
+  required: optional
+  type: string
 {% endconfiguration %}
 
 ## Sensor attributes


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add configuration variable to caldav integration ssl_client_cert in support of PR https://github.com/home-assistant/core/pull/78370


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/78370
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
