### PR TITLE
Reflect integration only works on Core Installation

### DIFF
--- a/source/_integrations/bluetooth_tracker.markdown
+++ b/source/_integrations/bluetooth_tracker.markdown
@@ -13,6 +13,12 @@ ha_integration_type: integration
 
 This tracker discovers new devices on boot and tracks Bluetooth devices periodically based on `interval_seconds` value. It is not required to pair the devices with each other! Devices discovered are stored with 'bt_' as the prefix for device MAC addresses in `known_devices.yaml`.
 
+{% details "Notes for all Home Assistant Installations, apart from Home Assistant Core" %}
+
+This integration currently does NOT work for any Home Assistant Installations, apart from Home Assistant Core Installations, since it relies on the bluepy and pybluez libraries, which no longer work in newer versions of Python. bluepy has seen its last update in December 2018 and hasn’t kept up with changes in the Python world. Similar story with pybluez.
+
+{% enddetails %}
+
 {% details "Notes for Home Assistant Core Installations" %}
 
 This platform requires `pybluez` to be installed. On Debian based installs, run


### PR DESCRIPTION
As kindly requested here; https://github.com/home-assistant/home-assistant.io/issues/24115#issuecomment-1249349649 ❤️ Be the change

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
