### PR TITLE
Add a missing description field

### DIFF
--- a/source/_docs/blueprint/tutorial.markdown
+++ b/source/_docs/blueprint/tutorial.markdown
@@ -126,6 +126,7 @@ Blueprints are easier to use if it's easy to see what each field is used for. We
 ```yaml
 blueprint:
   name: Motion Light Tutorial
+  description: Turn a light on based on detected motion
   domain: automation
   input:
     motion_sensor:


### PR DESCRIPTION
## Proposed change

Add a missing description field in the yaml which was already set at the beginning.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
