### PR TITLE
Fix Home Connect integration redirect URI

### DIFF
--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -41,7 +41,7 @@ Note that it depends on the appliance and on API permissions which of the featur
 
 - Application ID: Home Assistant (or whatever name makes sense to you)
 - OAuth Flow: Authorization Code Grant Flow
-- Redirect URI: `https://my.home-assistant.io/redirect/oauth`
+- Redirect URI: `https://my.home-assistant.io/auth/external/callback`
 
 {% details "I have manually disabled My Home Assistant" %}
 


### PR DESCRIPTION

## Proposed change
Change redirect URI to `auth/external/callback`, the old one did not work at all, resulted into this error: 

```
unauthorized_client: client or redirection URI not authorized
```

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
- [x] I made a change to the existing documentation and used the `current` branch.
- [ ]  I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
