### PR TITLE
Update connectivity check solution for uri not set

### DIFF
--- a/source/more-info/unsupported/connectivity_check.markdown
+++ b/source/more-info/unsupported/connectivity_check.markdown
@@ -10,8 +10,35 @@ Without this check you will face an increased number of errors and performance i
 
 ## The solution
 
-From the host shell execute the following command to re-enable Network Manager's connectivity check:
+From the host shell, first execute the following:
+
+```sh
+busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager ConnectivityCheckAvailable
+```
+
+If the output of this is `b true` then you just need to re-enable connectivity checks by executing this command:
 
 ```sh
 busctl set-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager ConnectivityCheckEnabled b true
+```
+
+It may take a bit to see the message go away after as all checks are scheduled on timers. You can force it by executing the following commands:
+
+```sh
+ha host reload
+ha resolution healthcheck
+```
+
+If the output of the first `busctl` command is `b false` then you need to set the connectivity uri in Network Manager's config. You can do this by adding the following to `/etc/NetworkManager/NetworkManager.conf`:
+
+```
+[connectivity]
+uri=http://checkonline.home-assistant.io/online.txt
+interval=600
+```
+
+Afterwards you will need to restart NetworkManager by either rebooting the host or executing this command:
+
+```sh
+systemctl restart NetworkManager
 ```

--- a/source/more-info/unsupported/connectivity_check.markdown
+++ b/source/more-info/unsupported/connectivity_check.markdown
@@ -16,22 +16,26 @@ From the host shell, first execute the following:
 busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager ConnectivityCheckAvailable
 ```
 
-If the output of this is `b true` then you just need to re-enable connectivity checks by executing this command:
+### Output is `b true`
+
+You just need to re-enable connectivity checks by executing this command:
 
 ```sh
 busctl set-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager ConnectivityCheckEnabled b true
 ```
 
-It may take a bit to see the message go away after as all checks are scheduled on timers. You can force it by executing the following commands:
+It may take a bit for the message to go away as all checks are scheduled on timers. You can force it to recheck immediately by executing the following commands:
 
 ```sh
 ha host reload
 ha resolution healthcheck
 ```
 
-If the output of the first `busctl` command is `b false` then you need to set the connectivity uri in Network Manager's config. You can do this by adding the following to `/etc/NetworkManager/NetworkManager.conf`:
+### Output is `b false`
 
-```
+You need to set the connectivity uri in Network Manager's config. You can do this by adding the following to `/etc/NetworkManager/NetworkManager.conf`:
+
+```txt
 [connectivity]
 uri=http://checkonline.home-assistant.io/online.txt
 interval=600
@@ -42,3 +46,5 @@ Afterwards you will need to restart NetworkManager by either rebooting the host 
 ```sh
 systemctl restart NetworkManager
 ```
+
+As mentioned above, the checks are on timers so the message may not go away immediately unless you force an immediate re-check. If you continue to see the message after a while or after forcing a re-check then start over at the top of this solution. You may need to separately enable the check now that it is available.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

If the connectivity uri is not set at all then the command shown for the solution will not work. Updated to include what to do in that situation.

Fixes https://github.com/home-assistant/supervisor/issues/3876

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/supervisor/issues/3876

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
