### PR TITLE
Formatting Changes

### DIFF
--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -22,7 +22,7 @@ You can also click the following button to be redirected to the Helpers page of 
 
 {% my helpers badge %}
 
-To be able to add Helpers via the user interface you should have default_config: in your configuration.yaml, it should already be there by default unless you removed it. If you removed default_config: from your configuration, you must add timer: to your configuration.yaml first, then you can use the UI.
+To be able to add Helpers via the user interface you should have `default_config:` in your `configuration.yaml`, it should already be there by default unless you removed it. If you removed `default_config:` from your configuration, you must add `timer:` to your `configuration.yaml` first, then you can use the UI.
 
 Timers can also be configured via configuration.yaml:
 To add a timer to your installation, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
To match other items like `input_button` and `scheduler`

## Proposed change
Standardises `timer` alongside similar integrations in terms of formatting this paragraph around the inclusion of `default_config` or their own integration in `configuration.yaml`

## Type of change

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
