### PR TITLE
Unsupported restart policy information

### DIFF
--- a/source/more-info/unsupported/restart_policy.markdown
+++ b/source/more-info/unsupported/restart_policy.markdown
@@ -1,0 +1,26 @@
+---
+title: "Restart policy"
+description: "More information on why changing the docker restart policy for containers marks the system as unsupported."
+---
+
+## The issue
+
+Supervisor needs to start the containers it manages for addons, plugins and Home Assistant in the
+correct order after a system reboot. Changing the restart policy it sets on those containers may
+cause them to start in the wrong order and create errors.
+
+## The solution
+
+If the restart policy of observer was changed, fix it from the host shell with this:
+
+```sh
+docker update hassio_observer --restart always
+```
+
+For everything else, the restart policy can be fixed with the following command:
+
+```sh
+docker update <container_name> --restart no
+```
+
+The supervisor log should contain a list of container names with incorrect restart policies.


### PR DESCRIPTION
## Proposed change

Unsupported documentation for https://github.com/home-assistant/supervisor/pull/3886

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/supervisor/pull/3886
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
