### PR TITLE
Update bluetooth requirements in documentation

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -34,7 +34,7 @@ For Bluetooth to function on Linux systems:
 
 - The [D-Bus](https://en.wikipedia.org/wiki/D-Bus) socket must be accessible to Home Assistant. 
 - The Bluetooth adapter must be accessible to D-Bus and running [BlueZ](http://www.bluez.org/) >= 5.43. It is highly recommended to use BlueZ >= 5.63 as older versions have been reported to be unreliable.
-- The DBus implementation should be [dbus-broker](https://github.com/bus1/dbus-broker)
+- The D-Bus implementation should be [dbus-broker](https://github.com/bus1/dbus-broker)
 - The host system should be running Linux kernel 5.15.62 or later
 
 ### Additional requirements by install method

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -34,8 +34,8 @@ For Bluetooth to function on Linux systems:
 
 - The [D-Bus](https://en.wikipedia.org/wiki/D-Bus) socket must be accessible to Home Assistant. 
 - The Bluetooth adapter must be accessible to D-Bus and running [BlueZ](http://www.bluez.org/) >= 5.43. It is highly recommended to use BlueZ >= 5.63 as older versions have been reported to be unreliable.
-- The D-Bus implementation should be [dbus-broker](https://github.com/bus1/dbus-broker)
-- The host system should be running Linux kernel 5.15.62 or later
+- The D-Bus implementation should be [dbus-broker](https://github.com/bus1/dbus-broker).
+- The host system should be running Linux kernel 5.15.62 or later.
 
 ### Additional requirements by install method
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -28,16 +28,23 @@ While this integration is part of [`default_config:`](/integrations/default_conf
 bluetooth:
 ```
 
-## D-Bus and BlueZ are required on Linux
+## Requirements for Linux systems
 
-For Bluetooth to function on Linux systems, the [D-Bus](https://en.wikipedia.org/wiki/D-Bus) socket must be accessible to Home Assistant. The Bluetooth adapter must be accessible to D-Bus and running [BlueZ](http://www.bluez.org/) >= 5.43.
+For Bluetooth to function on Linux systems:
 
-- Home Assistant Operating System: no additional steps are required. Home Assistant OS version 8.4 or later is recommended for performance reasons.
+- The [D-Bus](https://en.wikipedia.org/wiki/D-Bus) socket must be accessible to Home Assistant. 
+- The Bluetooth adapter must be accessible to D-Bus and running [BlueZ](http://www.bluez.org/) >= 5.43. It is highly recommended to use BlueZ >= 5.63 as older versions have been reported to be unreliable.
+- The DBus implementation should be [dbus-broker](https://github.com/bus1/dbus-broker)
+- The host system should be running Linux kernel 5.15.62 or later
+
+### Additional requirements by install method
+
+- Home Assistant Operating System: Upgrade to Home Assistant OS version 9.0 or later.
 - Home Assistant Container: The host system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant **inside** the container.
 - Home Assistant Supervised: The host system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant **inside** the container.
 - Home Assistant Core: The system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant.
 
-### Additional details for Container installs
+### Additional details for Container, Core, and Supervised installs
 
 {% details Making the DBus socket available in the Docker container %}
 
@@ -45,7 +52,11 @@ For most systems, the Dbus socket is in `/run/dbus`. The socket must be availabl
 
 {% enddetails %}
 
-### Additional details for Container and Supervised installs
+{% details Switching from dbus-daemon to dbus-broker %}
+
+Follow [the instructions](https://github.com/bus1/dbus-broker/wiki) to switch to dbus-broker.
+
+{% enddetails %}
 
 {% details Installing BlueZ %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updates minimums versions to the known working ones as problems have been reported with older BlueZ versions, dbus-daemon, and linux kernels.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
