### PR TITLE
Update switcher_kis network setup notes

### DIFF
--- a/source/_integrations/switcher_kis.markdown
+++ b/source/_integrations/switcher_kis.markdown
@@ -66,4 +66,5 @@ Note: This does not affect the auto off timer.
 
 ## Notes
 
-If Home Assistant and your Switcher are not on the same network, you need to create a firewall rule, which allows a connection on port 20002 with the UDP protocol from Switcher to your Home Assistant and port 9957 with the TCP protocol from Home Assistant to your Switcher.
+Make sure that Home Assistant host's firewall allows incoming traffic on UDP port 20002 and outgoing connections to Switcher device(s) on TCP port 9957.
+If Home Assistant and the Switcher device(s) are not on the same network, you will also need to have their traffic properly forwarded between the two networks.


### PR DESCRIPTION
## Proposed change

The firewall step is required whenever a firewall is present, even if HA and the device share the same network. A misconfigured firewall prevents the library from discovering devices and sending out commands.
The previous phrasing of the note implied that if HA and the device are on the same network, then no action is needed, which may be misleading.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - ~I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.~
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
