### PR TITLE
Update Slack documentation to fix incorrect button description

### DIFF
--- a/source/_integrations/slack.markdown
+++ b/source/_integrations/slack.markdown
@@ -24,7 +24,7 @@ The `slack` platform allows you to deliver notifications from Home Assistant to 
 1. Create a [new app](https://api.slack.com/apps) under your Slack.com account.
 2. Click the `OAuth & Permissions` link in the sidebar, under the Features heading.
 3. In the Scopes section, add the `chat:write` scope, `Send messages as user`. If you get a `missing_scope` error when trying to send a message, check these permissions.
-4. Scroll up to `OAuth Tokens & Redirect URLs` and click `Add to Workspace`.
+4. Scroll up to `OAuth Tokens & Redirect URLs` and click `Install to Workspace`.
 5. Copy your `OAuth Access Token` and put that key into the config flow.
 
 <div class='note'>


### PR DESCRIPTION
## Proposed change

Simple change to the documentation for the Slack integration.

Swaps “Add” with “Install” to bring the documentation current with the Slack API website.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

Note the button title in the Slack API interface:

![IMG_0038](https://user-images.githubusercontent.com/25037981/192761907-73b75217-d79d-45b3-bcbe-08d503005c1b.jpeg)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
