### PR TITLE
Update forked-daapd documentation

### DIFF
--- a/source/_integrations/forked_daapd.markdown
+++ b/source/_integrations/forked_daapd.markdown
@@ -1,13 +1,13 @@
 ---
-title: forked-daapd
-description: Instructions on how to integrate a forked-daapd server into Home Assistant.
+title: Owntone
+description: Instructions on how to integrate an Owntone server into Home Assistant.
 ha_category:
   - Media Player
-ha_release: '0.110'
+ha_release: "0.110"
 ha_iot_class: Local Push
 ha_domain: forked_daapd
 ha_codeowners:
-  - '@uvjustin'
+  - "@uvjustin"
 ha_config_flow: true
 ha_zeroconf: true
 ha_platforms:
@@ -15,22 +15,26 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `forked_daapd` integration allows you to control your [OwnTone (previously forked-daapd)](https://github.com/owntone/owntone-server) server from Home Assistant. This integration can control the forked-daapd outputs (zones) with limited playback control (play/pause, previous/next track) and media info support. Playlist manipulation is not supported.
+The `Owntone` integration allows you to control your [OwnTone (previously forked-daapd)](https://github.com/owntone/owntone-server) server from Home Assistant. This integration can control the Owntone outputs (zones) with limited playback control (play/pause, previous/next track) and media info support. Playlist manipulation is not supported.
 
 ## Requirements
 
-The `forked_daapd` integration requires a OwnTone server built with libwebsockets enabled, version >= 27.0.
+The `Owntone` integration requires an OwnTone server built with libwebsockets enabled, version >= 27.0.
 
 {% include integrations/config_flow.md %}
 
 ## Outputs
 
-Once the `forked-daapd` integration is set up, outputs will automatically be loaded from the server and added to HA in real time.
+Once the `Owntone` integration is set up, outputs will automatically be loaded from the server and added to HA in real time.
 
 ## Pipes
 
-As OwnTone supports playing audio input via a pipe, this integration supports the forwarding of basic player controls (play, pause, next track, previous track) directly to the pipe's source. Currently only the pipe source librespot-java is supported. To use this, configure your forked-daapd server to autostart pipes and name your librespot-java pipe "librespot-java" (accompanying metadata is also supported through forked-daapd via a metadata pipe named"librespot-java.metadata"). The `forked-daapd` integration will find the librespot-java pipe in the database and will set it up as a source.
+As OwnTone supports playing audio input via a pipe, this integration supports the forwarding of basic player controls (play, pause, next track, previous track) directly to the pipe's source. Currently only the pipe source librespot-java is supported. To use this, configure your Owntone server to autostart pipes and name your librespot-java pipe "librespot-java" (accompanying metadata is also supported through Owntone via a metadata pipe named "librespot-java.metadata"). The `Owntone` integration will find the librespot-java pipe in the database and will set it up as a source.
 
 ## Playlists
 
-The `forked-daapd` integration will treat playlists in the database as sources. The number of playlists shown as sources can be set in the integration's configuration options.
+The `Owntone` integration will treat playlists in the database as sources. The number of playlists shown as sources can be set in the integration's configuration options.
+
+## Spotify
+
+The `Owntone` integration supports media browsing via the `Spotify` integration. However, to play `Spotify` content, your Owntone instance must be logged in with Spotify. This can be done through Owntone's own web interface. For more details see [Owntone's notes on Spotify](https://owntone.github.io/owntone-server/integrations/spotify/#spotify). You should login with the same Spotify account for both the Owntone server and the Home Assistant `Spotify` integration.

--- a/source/_integrations/forked_daapd.markdown
+++ b/source/_integrations/forked_daapd.markdown
@@ -37,4 +37,4 @@ The Owntone integration will treat playlists in the database as sources. The num
 
 ## Spotify
 
-The Owntone integration supports media browsing via the [Spotify integration](/integrations/spotify). However, to play Spotify content, your Owntone instance must be logged in with Spotify. This can be done through Owntone's own web interface. For more details, see [Owntone's notes on Spotify](https://owntone.github.io/owntone-server/integrations/spotify/#spotify). You should log in with the same Spotify account for both the Owntone server and the Home Assistant [Spotify integration](/integrations/spotify.
+The Owntone integration supports media browsing via the [Spotify integration](/integrations/spotify). However, to play Spotify content, your Owntone instance must be logged in with Spotify. This can be done through Owntone's own web interface. For more details, see [Owntone's notes on Spotify](https://owntone.github.io/owntone-server/integrations/spotify/#spotify). You should log in with the same Spotify account for both the Owntone server and the Home Assistant [Spotify integration](/integrations/spotify).

--- a/source/_integrations/forked_daapd.markdown
+++ b/source/_integrations/forked_daapd.markdown
@@ -15,26 +15,26 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `Owntone` integration allows you to control your [OwnTone (previously forked-daapd)](https://github.com/owntone/owntone-server) server from Home Assistant. This integration can control the Owntone outputs (zones) with limited playback control (play/pause, previous/next track) and media info support. Playlist manipulation is not supported.
+The Owntone integration allows you to control your [OwnTone (previously forked-daapd)](https://github.com/owntone/owntone-server) server from Home Assistant. This integration can control the Owntone outputs (zones) with limited playback control (play/pause, previous/next track) and media info support. Playlist manipulation is not supported.
 
 ## Requirements
 
-The `Owntone` integration requires an OwnTone server built with libwebsockets enabled, version >= 27.0.
+The Owntone integration requires an OwnTone server built with libwebsockets enabled, version >= 27.0.
 
 {% include integrations/config_flow.md %}
 
 ## Outputs
 
-Once the `Owntone` integration is set up, outputs will automatically be loaded from the server and added to HA in real time.
+Once the Owntone integration is set up, outputs will automatically be loaded from the server and added to HA in real-time.
 
 ## Pipes
 
-As OwnTone supports playing audio input via a pipe, this integration supports the forwarding of basic player controls (play, pause, next track, previous track) directly to the pipe's source. Currently only the pipe source librespot-java is supported. To use this, configure your Owntone server to autostart pipes and name your librespot-java pipe "librespot-java" (accompanying metadata is also supported through Owntone via a metadata pipe named "librespot-java.metadata"). The `Owntone` integration will find the librespot-java pipe in the database and will set it up as a source.
+As OwnTone supports playing audio input via a pipe, this integration supports the forwarding of basic player controls (play, pause, next track, previous track) directly to the pipe's source. Currently, only the pipe source librespot-java is supported. To use this, configure your Owntone server to autostart pipes and name your librespot-java pipe "librespot-java" (accompanying metadata is also supported through Owntone via a metadata pipe named "librespot-java.metadata"). The Owntone integration will find the librespot-java pipe in the database and will set it up as a source.
 
 ## Playlists
 
-The `Owntone` integration will treat playlists in the database as sources. The number of playlists shown as sources can be set in the integration's configuration options.
+The Owntone integration will treat playlists in the database as sources. The number of playlists shown as sources can be set in the integration's configuration options.
 
 ## Spotify
 
-The `Owntone` integration supports media browsing via the `Spotify` integration. However, to play `Spotify` content, your Owntone instance must be logged in with Spotify. This can be done through Owntone's own web interface. For more details see [Owntone's notes on Spotify](https://owntone.github.io/owntone-server/integrations/spotify/#spotify). You should login with the same Spotify account for both the Owntone server and the Home Assistant `Spotify` integration.
+The Owntone integration supports media browsing via the [Spotify integration](/integrations/spotify). However, to play Spotify content, your Owntone instance must be logged in with Spotify. This can be done through Owntone's own web interface. For more details, see [Owntone's notes on Spotify](https://owntone.github.io/owntone-server/integrations/spotify/#spotify). You should log in with the same Spotify account for both the Owntone server and the Home Assistant [Spotify integration](/integrations/spotify.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Rename remaining uses of forked-daapd to Owntone
Add note on Spotify

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/79136
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
