### PR TITLE
prob_given_false is soon req, show in examples

### DIFF
--- a/source/_integrations/bayesian.markdown
+++ b/source/_integrations/bayesian.markdown
@@ -31,7 +31,7 @@ In the configuration use the probability of the observation (the sensor state in
 4. Use your Home Assistant history to help estimate the probabilities.
    - `prob_given_true:` - Select the sensor in question over a time range when you think the `bayesian` sensor should have been `true`. `prob_given_true:` is the fraction of the time the sensor was in `to_state:`.
    - `prob_given_false:` - Select the sensor in question over a time range when you think the `bayesian` sensor should have been `false`. `prob_given_false:` is the fraction of the time the sensor was in `to_state:`.
-5. Don't work backwards by tweaking `prob_given_true:` and `prob_given_false:` to give the results and behaviors you want, use #4 to try and get probabilities as close to the 'truth' as you can, if your behavior is not as expected consider adding more sensors or see #7.
+5. Don't work backwards by tweaking `prob_given_true:` and `prob_given_false:` to give the results and behaviors you want, use #4 to try and get probabilities as close to the 'truth' as you can, if your behavior is not as expected consider adding more sensors or see #6.
 6. If your Bayesian sensor ends up triggering `on` too easily, re-check that the probabilities set and estimated make sense, then consider increasing `probability_threshold:` and vice-versa.
 
 ## Configuration

--- a/source/_integrations/bayesian.markdown
+++ b/source/_integrations/bayesian.markdown
@@ -101,7 +101,7 @@ observations:
       required: true
       type: float
     prob_given_false:
-      description: Assuming the bayesian binary_sensor is `false` the probability of this entity state is occurring.
+      description: Assuming the bayesian binary_sensor is `false` the probability the entity state is occurring.
       required: true
       type: float
 {% endconfiguration %}
@@ -122,12 +122,12 @@ binary_sensor:
       entity_id: "sensor.living_room_motion"
       prob_given_true: 0.05 # If I am in bed then I shouldn't be in the living room, very occasionally I have guests, however
       prob_given_false: 0.2 # My sensor history shows If I am not in bed I spend about a fifth of my time in the living room
-      to_state: "off"
+      to_state: "on"
     - platform: "state"
       entity_id: "sensor.basement_motion"
       prob_given_true: 0.5 # My sensor history shows, when I am in bed, my basement motion sensor is active about half the time because of my cat
       prob_given_false: 0.3 # As above but my cat tends to spend more time upstairs or outside when I am awake and I rarely use the basement
-      to_state: "off"
+      to_state: "on"
     - platform: "state"
       entity_id: "sensor.bedroom_motion"
       prob_given_true: 0.5 # My sensor history shows when I am in bed the sensor picks me up about half the time
@@ -136,6 +136,7 @@ binary_sensor:
     - platform: "state"
       entity_id: "sun.sun"
       prob_given_true: 0.7 # If I am in bed then there is a good chance the sun will be down, but in the summer mornings I may still be in bed
+      prob_given_false: 0.45 # If I am am awake then there is a reasonable chance the sun will be below the horizon - especially in winter
       to_state: "below_horizon"
     - platform: "state"
       entity_id: "sensor.android_charger_type"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Corrects some incorrect `to_state`s and a typo
Although though it is not required in 2022.9 ([home-assistant:current](https://github.com/home-assistant/home-assistant.io)) (it will be in 2020.10) there is *no* mathematical rationale for not having `prob_given_false` in the config otherwise the use invited unexpected and buggy behaviour, therefore this should be reflected in the examples.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
