### PR TITLE
Add Yale Assure Lock 2 to August

### DIFF
--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -40,6 +40,7 @@ The `august` integration allows you to integrate your [August](https://august.co
 | August Doorbell Cam (Gen 1, Gen2) | no |
 | August View | no |
 | Yale Assure Lock | yes |
+| Yale Assure Lock 2 | yes |
 | Yale Conexis L1 | yes |
 | Yale Linus | yes |
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Yale Assure Lock 2 to August

These arrived today and tested and working as expected with no changes

Looks like the cloud needs the model numbers loaded but it works
<img width="324" alt="Screen Shot 2022-09-30 at 4 35 47 PM" src="https://user-images.githubusercontent.com/663432/193379987-5cc1597a-d9d9-4c16-8ff9-169c79e99f09.png">

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
