### PR TITLE
Xiaomi BLE: Document behaviour for new entities

### DIFF
--- a/source/_integrations/xiaomi_ble.markdown
+++ b/source/_integrations/xiaomi_ble.markdown
@@ -44,6 +44,8 @@ It also supports the following classes of binary sensors:
 - Smoke
 - Moisture
 
+The entities for the sensor classes are added only after the values are actually received. This means entities for values that are broadcasted at an lower interval (e.g. battery) might show up later.
+
 ## Encryption
 
 Some devices use AES encryption to protect the sensor values they are broadcasting.

--- a/source/_integrations/xiaomi_ble.markdown
+++ b/source/_integrations/xiaomi_ble.markdown
@@ -44,7 +44,7 @@ It also supports the following classes of binary sensors:
 - Smoke
 - Moisture
 
-The entities for the sensor classes are added only after the values are actually received. This means entities for values that are broadcasted at an lower interval (e.g. battery) might show up later.
+The entities for the sensor classes are added after the values are first received. This means entities for values that are broadcasted at a lower interval (e.g., battery) might show up later.
 
 ## Encryption
 


### PR DESCRIPTION

# Proposed change
This PR documents that new entities are only added after the initial value is received, which was the problem in 
https://github.com/home-assistant/core/issues/79400


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes [#79400](https://github.com/home-assistant/core/issues/79400)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
