### PR TITLE
Repair broken links August integration

### DIFF
--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -107,20 +107,20 @@ If you have an August Keypad, once you have enabled the August component, you sh
 
 Following Assa Abloy, Yale's parent company, purchasing August in 2017, most newer devices use the Yale Access branding. 
 
-The [Yale Access Bluetooth](/integrations/yalexe_ble) provides local control over Bluetooth of many Yale Access locks and some August locks that use the same system. 
+The [Yale Access Bluetooth](/integrations/yalexs_ble) provides local control over Bluetooth of many Yale Access locks and some August locks that use the same system. 
 
 For locks that support the Yale Access system, the August integration can keep your offline access keys up to date to ensure you can operate your lock over Bluetooth. The following requirements must be met for the offline key updates to work:
 
 - The August integration must support the lock.
-- The [Yale Access Bluetooth integration](/integrations/yalexe_ble) must support the lock.
+- The [Yale Access Bluetooth integration](/integrations/yalexs_ble) must support the lock.
 - The Bluetooth integration must be active and functional.
-- The lock must be discoverable by the [Yale Access Bluetooth integration](/integrations/yalexe_ble).
+- The lock must be discoverable by the [Yale Access Bluetooth integration](/integrations/yalexs_ble).
 - The account logged in with the August integration must have the offline keys.
 
 ### Troubleshooting offline keys updates
 
 - If you do not know which account has the offline keys, configure August integration with each different Owner account until you find the one that holds the keys. You may need to make a new owner account and grant the account access to your lock to force the keys to synchronize with the cloud service.
-- Ensure the lock is in range and discoverable by the [Yale Access Bluetooth integration](/integrations/yalexe_ble).
+- Ensure the lock is in range and discoverable by the [Yale Access Bluetooth integration](/integrations/yalexs_ble).
 
 ## Presence Detection with Lock Operation
 

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -107,7 +107,7 @@ If you have an August Keypad, once you have enabled the August component, you sh
 
 Following Assa Abloy, Yale's parent company, purchasing August in 2017, most newer devices use the Yale Access branding. 
 
-The [Yale Access Bluetooth](/integrations/yalexs_ble) provides local control over Bluetooth of many Yale Access locks and some August locks that use the same system. 
+The [Yale Access Bluetooth](/integrations/yalexs_ble) integration provides local control over Bluetooth of many Yale Access locks and some August locks that use the same system. 
 
 For locks that support the Yale Access system, the August integration can keep your offline access keys up to date to ensure you can operate your lock over Bluetooth. The following requirements must be met for the offline key updates to work:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I noticed that there are some broken links on the August integration page, pointing to Yale Access Bluetooth integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
