### PR TITLE
upnp: Remove manual configuration, add debug information

### DIFF
--- a/source/_integrations/upnp.markdown
+++ b/source/_integrations/upnp.markdown
@@ -30,11 +30,17 @@ Please note that UPnP or NAT-PMP needs to be enabled on your router for this int
 
 {% include integrations/config_flow.md %}
 
-## Manual configuration 
+## Debugging integration
 
-Alternatively, you can use YAML by adding the following section to your `configuration.yaml` file:
+If you have problems with this integration you can add debug prints to the log.
 
 ```yaml
-# Example configuration.yaml entry
-upnp:
+logger:
+  default: info
+  logs:
+    homeassistant.components.upnp: debug
+    async_upnp_client: debug
+    async_upnp_client.traffic: error
 ```
+
+When creating an issue, please include the (relevant) logging with the issue. Any sensitive information such as IPs can be obfuscated.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Manual configuration of the upnp component is no longer possible. Add debugging instructions.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
