### PR TITLE
Add note about assigning areas in shared household

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -279,6 +279,12 @@ For the Alarm Control Panel if a code is set it must be the same as the `secure_
 
 Entities that have not been explicitly assigned to rooms but have been placed in Home Assistant areas will return room hints to Google with the devices in those areas.
 
+<div class='note'>
+
+Some devices, such as `scene` or `script`, must be assigned to an `area` before other members of a shared Google Home Household can use them. This is because household members in a shared Google Home will not be able to view devices that are not assigned to a room _unless_ they were the user who linked the service to Google Home. This issue isn't immediately apparent because `script` and `scene` devices aren't visible in the main Google Home dashboard.
+
+</div>
+
 ### Climate Operation Modes
 
 There is not an exact 1-1 match between Home Assistant and Google Assistant for the available operation modes.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Improved documentation around assigning areas (or rooms) to `script` and `scene` devices. This would have saved myself many hours of troubleshooting as to why my family was unable to trigger the same magic scenes that _I_ could. 

In order for devices to be used by Google Home they need to be "properly" added to it. Linking devices to your account in Google Home is not enough. Devices and scenes need to be assigned to a room in order to become part of the household.

When Google Home sees any normal entity (like a light) linked to it from a service (without an area/room), it doesn't know where to place it. Without a placement, the devices is never included "in" the Google Home household and they are noted at the bottom of the dashboard as "not being added into the household yet". In this state, the person who linked the service (where that device is coming from) can still interact with it. But anyone else in the shared Google Home Household cannot until it's "properly" added into the Google Home.

Example of a non-script/non-scene entity not fully added yet:

![google_home_not_linked](https://user-images.githubusercontent.com/3487107/193408497-5ec7f739-f813-4b4d-8810-ddbb5f06c9da.jpg)


This same issue extends to other devices such as `script` and `scene`. The problem is that the issue is not apparent to any users since `script` or `scene` devices won't show up in the Google Home dashboard, and the error will not be apparent. (and only the main user will be able to invoke it).

Once an area is assigned to the `script` or `scene` in Home Assistant, then the next sync will assign that device into a 'room' in Google Home. At this point it will be considered "fully added" into Google Home and now anyone else in the shared household will be able to invoke those devices with their voice. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
