### PR TITLE
Improve documentation for service google.create_event

### DIFF
--- a/source/_integrations/google.markdown
+++ b/source/_integrations/google.markdown
@@ -135,7 +135,7 @@ This will only be available if you have given Home Assistant `read-write` access
 
 </div>
 
-A calendar `target` is selected with a [Target Selector](https://www.home-assistant.io/docs/blueprint/selectors/#target-selector) and the `data` payload supports the following fields:
+A calendar `target` is selected with a [Target Selector](/docs/blueprint/selectors/#target-selector) and the `data` payload supports the following fields:
 
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
@@ -153,14 +153,14 @@ You either use `start_date_time` and `end_date_time`, or `start_date` and `end_d
 
 </div>
 
-This is a full example of service call yaml:
+This is a full example of service call in YAML:
 
 ```yaml
 service: google.create_event
 target:
   entity_id: calendar.device_automation_schedules
 data:
-  summary: Example
+  summary: "Example"
   start_date: "2022-10-1"
   end_date: "2022-10-2"
 ```

--- a/source/_integrations/google.markdown
+++ b/source/_integrations/google.markdown
@@ -135,6 +135,8 @@ This will only be available if you have given Home Assistant `read-write` access
 
 </div>
 
+A calendar `target` is selected with a [Target Selector](https://www.home-assistant.io/docs/blueprint/selectors/#target-selector) and the `data` payload supports the following fields:
+
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
 | `summary` | no | Acts as the title of the event. | Bowling
@@ -150,6 +152,18 @@ This will only be available if you have given Home Assistant `read-write` access
 You either use `start_date_time` and `end_date_time`, or `start_date` and `end_date`, or `in`.
 
 </div>
+
+This is a full example of service call yaml:
+
+```yaml
+service: google.create_event
+target:
+  entity_id: calendar.device_automation_schedules
+data:
+  summary: Example
+  start_date: "2022-10-1"
+  end_date: "2022-10-2"
+```
 
 {% enddetails %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Improve documentation for service google.create_event by explaining where to learn more about target selectors, and giving a full example.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #23608

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
