### PR TITLE
KNX climate preset mode - clarify correct values

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -624,11 +624,11 @@ The following values are valid for the Home Assistant [Climate](/integrations/cl
 
 The following presets are valid for the Home Assistant [Climate](/integrations/climate/) `preset_mode` attribute. Supported values for your KNX thermostats can be specified via `operation_modes` configuration variable:
 
-- `Auto` (maps internally to `PRESET_NONE` within Home Assistant)
-- `Comfort` (maps internally to `PRESET_COMFORT` within Home Assistant)
-- `Standby` (maps internally to `PRESET_AWAY` within Home Assistant)
-- `Night` (maps internally to `PRESET_SLEEP` within Home Assistant)
-- `Frost` Protection (maps internally to `PRESET_ECO` within Home Assistant)
+- `Auto` (maps to `none` of the Home Assistant [Climate](/integrations/climate/) `preset_mode` attribute)
+- `Comfort` (maps to `comfort` of the Home Assistant [Climate](/integrations/climate/) `preset_mode` attribute)
+- `Standby` (maps to `away` of the Home Assistant [Climate](/integrations/climate/) `preset_mode` attribute)
+- `Night` (maps to `sleep` of the Home Assistant [Climate](/integrations/climate/) `preset_mode` attribute)
+- `Frost Protection` (maps to `eco` of the Home Assistant [Climate](/integrations/climate/) `preset_mode` attribute)
 
 {% configuration %}
 name:


### PR DESCRIPTION
## Proposed change
The documentation should indicate what the right value is to set the value when using the service 'climate.set_preset_mode', since they differ from what is used within KNX. The errors in the log-files are not helpful. The only acceptable lowercase values seem to be: 'none', 'comfort', 'away', 'sleep' and 'eco'. It might be helpful to indicate these values in the documentation.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- This PR fixes or closes issue: fixes [issue 24190](https://github.com/home-assistant/home-assistant.io/issues/24190)

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].
