### PR TITLE
Fixed two dead links from Integrations

### DIFF
--- a/source/_integrations/flux_led.markdown
+++ b/source/_integrations/flux_led.markdown
@@ -110,7 +110,7 @@ These devices have been sold under at least the following brands:
 - Mowelai
 - Nexlux
 - OBSESS
-- [Offdarks](http://offdarks.net)
+- Offdarks
 - PH LED
 - PHOPOLLO
 - [Pin Stadium Pinball Lights](https://pinstadium.com/)

--- a/source/_integrations/insteon.markdown
+++ b/source/_integrations/insteon.markdown
@@ -43,7 +43,7 @@ Overview of supported Insteon modems & hubs
 [pyinsteon]: https://github.com/pyinsteon/pyinsteon
 [2413U]: https://www.insteon.com/powerlinc-modem-usb
 [2412S]: https://www.insteon.com/powerlinc-modem-serial
-[2448A7]: https://www.smarthome.com/insteon-2448a7-portable-usb-adapter.html
+[2448A7]: https://www.insteon.com/support-knowledgebase/2014/12/10/usb-wireless-adapter-quick-start-guide
 [2245]: https://www.insteon.com/insteon-hub/
 [2242]: https://www.insteon.com/support-knowledgebase/2014/9/26/insteon-hub-owners-manual
 


### PR DESCRIPTION
## Proposed change
Insteon 2448A7 USB: This adapter seems to be deprecated, but I found a link to the USB sticks quick start guide in Insteon's knowledge base. This appears to be the most relevant doc to link to currently.

Flux LED: The link to the Offdarks website does no longer resolve. Hence, I have removed the link to the site, in line with other devices on the same page not having an active website.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
