### PR TITLE
add new jinja test and filters

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -113,7 +113,7 @@ Entities that are on
 
 {% raw %}
 
-```
+```text
 {{ ['light.kitchen', 'light.dinig_room'] | select('is_state', 'on') | list }}
 ```
 
@@ -198,7 +198,7 @@ List of friendly names
 
 {% raw %}
 
-```
+```text
 {{ ['binary_sensor.garage_door', 'binary_sensor.front_door'] | map('state_attr', 'friendly_name') | list }}
 ```
 
@@ -208,7 +208,7 @@ List of lights that are on with a brightness of 255
 
 {% raw %}
 
-```
+```text
 {{ ['light.kitchen', 'light.dinig_room'] | select('is_state', 'on') | select('is_state_attr', 'brightness', 255) | list }}
 ```
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -109,7 +109,7 @@ Print out a list of all the sensor states:
 
 {% endraw %}
 
-Entities that are on
+Entities that are on:
 
 {% raw %}
 
@@ -152,7 +152,7 @@ Other state examples:
 
 {{ states('sensor.expires') | as_datetime }}
 
-#make a list of states
+# Make a list of states
 {{ ['light.kitchen', 'light.dinig_room'] | map('states') | list }}
 ```
 
@@ -194,7 +194,7 @@ With strings:
 
 {% endraw %}
 
-List of friendly names
+List of friendly names:
 
 {% raw %}
 
@@ -204,7 +204,7 @@ List of friendly names
 
 {% endraw% }
 
-List of lights that are on with a brightness of 255
+List of lights that are on with a brightness of 255:
 
 {% raw %}
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -109,6 +109,16 @@ Print out a list of all the sensor states:
 
 {% endraw %}
 
+Entities that are on
+
+{% raw %}
+
+```
+{{ ['light.kitchen', 'light.dinig_room'] | select('is_state', 'on') | list }}
+```
+
+{% endraw% }
+
 Other state examples:
 {% raw %}
 
@@ -141,6 +151,9 @@ Other state examples:
 {{ as_local(states.sensor.time.last_changed) }}
 
 {{ states('sensor.expires') | as_datetime }}
+
+#make a list of states
+{{ ['light.kitchen', 'light.dinig_room'] | map('states') | list }}
 ```
 
 {% endraw %}
@@ -180,6 +193,26 @@ With strings:
 ```
 
 {% endraw %}
+
+List of friendly names
+
+{% raw %}
+
+```
+{{ ['binary_sensor.garage_door', 'binary_sensor.front_door'] | map('state_attr', 'friendly_name') | list }}
+```
+
+{% endraw% }
+
+List of lights that are on with a brightness of 255
+
+{% raw %}
+
+```
+{{ ['light.kitchen', 'light.dinig_room'] | select('is_state', 'on') | select('is_state_attr', 'brightness', 255) | list }}
+```
+
+{% endraw% }
 
 ### Working with Groups
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

for WTH <https://community.home-assistant.io/t/wth-state-based-jinja-functions-are-not-filters-or-tests/468187>
for <https://github.com/home-assistant/core/pull/79473>

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
