### PR TITLE
Fix platform variables for device platform

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -44,9 +44,10 @@ The following describes trigger data associated with all platforms.
 | Template variable | Data |
 | ---- | ---- |
 | `trigger.platform` | Hardcoded: `device`.
-| `trigger.event` | Event object that matched.
-| `trigger.event.event_type` | Event type.
-| `trigger.event.data` | Optional event data.
+| `trigger.entity_id` | Entity ID that we observe.
+| `trigger.from_state` | The previous [state object] of the entity.
+| `trigger.to_state` | The new [state object] that triggered trigger.
+| `trigger.for` | Timedelta object how long state has been to state, if any.
 
 ### Event
 

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -41,13 +41,11 @@ The following describes trigger data associated with all platforms.
 
 ### Device
 
+Inherites template variables from [event](#event) or [state](#state) template based on the type of trigger selected for the device.
+
 | Template variable | Data |
 | ---- | ---- |
 | `trigger.platform` | Hardcoded: `device`.
-| `trigger.entity_id` | Entity ID that we observe.
-| `trigger.from_state` | The previous [state object] of the entity.
-| `trigger.to_state` | The new [state object] that triggered trigger.
-| `trigger.for` | Timedelta object how long state has been to state, if any.
 
 ### Event
 


### PR DESCRIPTION
## Proposed change
Changed template variables for device platform in available trigger data block to the actual ones which are simillar with state platform but was incorrectly duplicating event platform variables.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
