### PR TITLE
Add new utc_offset_hours configuration option.

### DIFF
--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -28,6 +28,7 @@ To integrate Todoist in Home Assistant, add the following section to your `confi
 calendar:
   - platform: todoist
     token: YOUR_API_TOKEN
+    utc_offset_hours: -7
 ```
 
 {% configuration %}
@@ -35,6 +36,10 @@ token:
   description: The API token used to authorize Home Assistant to access your projects. Above you have more info about it.
   required: true
   type: string
+utc_offset_hours:
+  description: The number of [hours offset from UTC](https://en.wikipedia.org/wiki/List_of_UTC_offsets) for your time zone. If not provided, the timezone of your Home Assistant instance will be used. This value is used for setting the timezone correctly on due dates imported from todoist.
+  required: false
+  type: integer
 custom_projects:
   description: Details on any "custom" binary sensor projects you want to create.
   required: false

--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -37,9 +37,10 @@ token:
   required: true
   type: string
 utc_offset_hours:
-  description: The number of [hours offset from UTC](https://en.wikipedia.org/wiki/List_of_UTC_offsets) for your time zone. If not provided, the timezone of your Home Assistant instance will be used. This value is used for setting the timezone correctly on due dates imported from todoist.
+  description: The number of [hours offset from UTC](https://en.wikipedia.org/wiki/List_of_UTC_offsets) for your time zone. This value is used for setting the timezone correctly on due dates imported from todoist.
   required: false
   type: integer
+  default: The UTC offset based on your Home Assistant instance's time zone.
 custom_projects:
   description: Details on any "custom" binary sensor projects you want to create.
   required: false


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This adds a new optional configuration option for the todoist integration to support updating that component to use their official rest API.  The previous library has been deprecated and will stop functioning on 10/31.  The rest API does not have the ability to return the user's configured timezone so it will now use the HA instance's timezone or the user provided value.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/79481/
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
