### PR TITLE
Update xiaomi_ble.markdown mention Pink HHCCJCY10

### DIFF
--- a/source/_integrations/xiaomi_ble.markdown
+++ b/source/_integrations/xiaomi_ble.markdown
@@ -62,9 +62,11 @@ There are a few ways to obtain a bindkey for your device:
 
 ## Devices
 
-### Plant sensor: Flower Care / MiFlora (HHCCJCY01)
+### Plant sensor: Flower Care / MiFlora (model HHCCJCY01)
 
-HHCCJCY01, also known as MiFlora or "Flower Care", should be automatically discovered. However, if the firmware is too old, it won't send the right BLE beacons and an update via the app is required. The lowest confirmed working firmware version is 3.2.1 (a lower 3.x version could also be alright).
+Model HHCCJCY01, also known as "MiFlora", "Mi Flora", or "Flower Care", should be automatically discovered. However, if the firmware is too old, it won't send the right BLE beacons and an update via the app is required. The lowest confirmed working firmware version is 3.2.1 (a lower 3.x version could also be alright).
+
+Note! Before buying, be aware that there are also other models in the HHCC series that look identical or similar but may not yet be supported. For example the Pink-colored version have model HHCCJCY10 instead and is not yet supported by this Xiaomi BLE integration.
 
 Flower Care firmware update steps:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Mentioning model HHCCJCY10 (Pink coloured) variant of MiFlora Flower Care is not yet supported by this Xiaomi BLE integration. 

Did not mention, FYI, one workaround is to use pinks with BLE Monitor instead for now -> https://github.com/custom-components/ble_monitor/issues/809

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
