### PR TITLE
Fixed broken link to Queensland Bushfire Alert website

### DIFF
--- a/source/_integrations/qld_bushfire.markdown
+++ b/source/_integrations/qld_bushfire.markdown
@@ -14,8 +14,7 @@ ha_integration_type: integration
 ---
 
 The `qld_bushfire` platform lets you integrate a 
-[GeoRSS feed](https://www.ruralfire.qld.gov.au/map/Pages/default.aspx) 
-containing bushfire alerts for Queensland. It retrieves alerts from a feed 
+GeoRSS feed containing [bushfire alerts](https://www.qfes.qld.gov.au/Current-Incidents) for Queensland. It retrieves alerts from a feed 
 and shows information of those alerts filtered by distance to Home Assistant's 
 location.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The Queensland Bushfire Alert website has been moved to a new domain, and the current URL does not resolve. Using WaybackMachine on the old URL, I was redirected to the new URL, which I have now updated in the documentation accordingly. As neither the old nor the new endpoint links to a GeoRSS feed, I have changed the link text to reflect this.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
