### PR TITLE
Change google sheets data example from List to Dictionary

### DIFF
--- a/source/_integrations/google_sheets.markdown
+++ b/source/_integrations/google_sheets.markdown
@@ -81,6 +81,6 @@ You can use the service `google_sheets.append_sheet` to add a row of data to the
 | ---------------------- | -------- | ----------- | --------|
 | `config_entry` | no | Config entry to use.
 | `worksheet` | yes | Name of the worksheet. Defaults to the first one in the document. | Sheet1
-| `data` | no | Data to be appended to the worksheet. This puts the data on a new row, one value per column. | ["foo"]
+| `data` | no | Data to be appended to the worksheet. This puts the data on a new row, one value per column. | {"hello": world, "cool": True, "count": 5}
 
 {% enddetails %}


### PR DESCRIPTION
## Proposed change
Change google sheets data example from List to Dictionary datatype to match the working example used in https://github.com/home-assistant/core/blob/dev/homeassistant/components/google_sheets/services.yaml

if example in documentation is used ["foo"] an error is returned
_websocket_api script: Error executing script. Invalid data for call_service at pos 1: expected dict for dictionary value @ data['data']_

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
