### PR TITLE
Add section to octoprint around duplicate upnpUuids

### DIFF
--- a/source/_integrations/octoprint.markdown
+++ b/source/_integrations/octoprint.markdown
@@ -94,3 +94,15 @@ The OctoPrint integration provides the following buttons.
 - Pause Job
 - Resume Job
 - Stop Job
+
+## Troubleshooting
+
+### Device is already configured for a second instance
+
+This is typically caused by copying/backup/restoring part of the config files between OctoPrint instances.
+
+1. SSH into the OctoPrint instance that is being added.
+2. Edit the `config.yaml` for the instance (Typically `/home/pi/.octoprint`)
+3. Under `plugins/discovery`, change the value of `upnpUuid` to have a different uuid.
+4. Restart the OctoPrint service
+5. Attempt to add the instance once again.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The issue has been raised a few times about `Device already configured` errors during setup that have been caused due to copied configuration. Adding a troubleshooting section for this issue and any others that arise.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
