### PR TITLE
Update ibeacon.markdown

### DIFF
--- a/source/_integrations/ibeacon.markdown
+++ b/source/_integrations/ibeacon.markdown
@@ -41,6 +41,10 @@ Consider setting up your iBeacons with a schema similar to the following:
 
 iBeacon devices that do not have stable Major and Minor values are not supported. The system automatically removes iBeacon devices with unstable Major and Minor values once ten (10) or more Major and Minor values have been seen with the same UUID from an iBeacon device with a fixed MAC address.
 
+## Considering an iBeacon Away
+
+iBeacons will be marked as "Away" after 180 seconds of not being seen.
+
 ## Fixed MAC addresses
 
 iBeacons with a fixed MAC address will get their own set of entities for each UUID, major, minor, and MAC address combination, enabling distance and presence detection per physical device basis. In this type of setup, it is permissible to have multiple iBeacons broadcasting the same UUID, Major, and Minor combination as long as you do not exceed five devices.

--- a/source/_integrations/ibeacon.markdown
+++ b/source/_integrations/ibeacon.markdown
@@ -43,7 +43,7 @@ iBeacon devices that do not have stable Major and Minor values are not supported
 
 ## Considering an iBeacon Away
 
-iBeacons will be marked as "Away" after 180 seconds of not being seen.
+Due to various factors such as individual system settings and iBeacon firmware, iBeacons may not be marked as "Away" immediately. This could take several minutes.
 
 ## Fixed MAC addresses
 

--- a/source/_integrations/ibeacon.markdown
+++ b/source/_integrations/ibeacon.markdown
@@ -43,7 +43,7 @@ iBeacon devices that do not have stable Major and Minor values are not supported
 
 ## Considering an iBeacon Away
 
-Due to various factors such as individual system settings and iBeacon firmware, iBeacons may not be marked as "Away" immediately. This could take several minutes.
+Due to various factors such as individual system settings and iBeacon firmware, iBeacons will not be marked as "Away" immediately. This could take several minutes.
 
 ## Fixed MAC addresses
 


### PR DESCRIPTION
## Proposed change
The `UNAVAILABLE_TIMEOUT` is currently set to 180 seconds. I couldn't ascertain why, after disabling an iBeacon it was still being shown as "Home" for another three minutes. It was only after reviewing `const.py` did I understand why.

This updates the documentation to make it clear.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
