### PR TITLE
Combine Nibe heatpump models

### DIFF
--- a/source/_integrations/nibe_heatpump.markdown
+++ b/source/_integrations/nibe_heatpump.markdown
@@ -22,22 +22,17 @@ The Nibe Heat Pump integration allows you to control and monitor [Nibe Heat Pump
 
 Supported devices:
 
-- F1145
-- F1155
-- F1245
-- F1255
+- F1145/F1245
+- F1155/F1255
 - F1345
 - F1355
-- F370
-- F470
+- F370/F470
 - F730
 - F750
 - SMO20
 - SMO40
-- VVM225
+- VVM225/VM320/VM325
 - VVM310
-- VVM320
-- VVM325
 - VVM500
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Some Nibe heatpump models share an identifier (in the enum on the Nibe library). This makes it so the UI selection does not show my model (F1245), because F1145 already is in the list. Selecting F1145 does work with my heatpump model.
This change might make it easier for users to distinguish which entry they should select. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
