### PR TITLE
Fix ring download with date and time extensions documentation

### DIFF
--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -88,8 +88,8 @@ You may consider some modifications in the subdirectory and the filename to suit
 ```yaml
     data:
       url: "{{ state_attr('camera.front_door', 'video_url') }}"
-      subdir: "{{ state_attr('camera.front_door', 'friendly_name') }}/{{ now().strftime("%m.%Y") }}"
-      filename: "{{ now().strftime("%Y-%m-%d-at-%H-%M-%S") }}.mp4"
+      subdir: "{{ state_attr('camera.front_door', 'friendly_name') }}/{{ now().strftime('%m.%Y') }}"
+      filename: "{{ now().strftime('%Y-%m-%d-at-%H-%M-%S') }}.mp4"
 ```
 {% endraw %}
 


### PR DESCRIPTION
## Proposed change
When setting up the ring extension, i noticed that i couldn't access my HA. Looking at the logs, i noticed there was an error: `Failed to parse configuration.yaml: while scanning for the next token found character '%' that cannot start any token`

It seems that there were double quotes in a double quoted config example. Changing them to single quotes worked and this is also tested.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
