### PR TITLE
Fixed torque webserver url

### DIFF
--- a/source/_integrations/torque.markdown
+++ b/source/_integrations/torque.markdown
@@ -29,7 +29,7 @@ Under the **Logging Preferences** header:
 Under the **Realtime Web Upload** header:
 
 - Check **Upload to web-server**.
-- Enter `https://HOST:PORT/api/torque` as the **Web-server URL**, where `HOST` and `PORT` are your externally accessible Home Assistant HTTP host. To use a Bearer Token, this has to be [SSL/TSL](/docs/ecosystem/certificates/).
+- Enter `https://HOST/api/torque` or `https://@/HOST:PORT/api/torque` as the **Web-server URL**, where `HOST` and `PORT` are your externally accessible Home Assistant HTTP host. To use a Bearer Token, this has to be [SSL/TSL](/docs/ecosystem/certificates/).
 - Enable **Send https: Bearer Token**  (available since Torque Pro 1.12.46)
 - Paste a Long-Lived Access Token from any Home Assistant user in **Set Bearer Token** field.
 - Enter an email address in **User Email Address** (this can be any non empty string you like). 


### PR DESCRIPTION
## Proposed change
Fix misleading documentation



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
If using a port, the `@/` is needed in order to fool the torque app and keep the port, otherwise the port gets ignored

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #75012, #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
