### PR TITLE
Add instructions to get the flap_id

### DIFF
--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -32,7 +32,7 @@ This service lets you change the locking state of a flap.
 
 | Service data attribute | Required | Type | Description |
 | ---------------------- | -------- | -------- | ----------- |
-| `flap_id` | `True` | integer | Flap ID to change - see below for instructions on finding device IDs
+| `flap_id` | `True` | integer | Flap ID to change - Log into [surepetcare.io](https://surepetcare.io/), open the side bar, click you flap and the flap_id will be at the end of the url (i.e. https://surepetcare.io/control/device/DEVICE-ID)
 | `lock_state` | `True` | string | New state to change the flap to
 
 `lock_state` should be one of:

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -32,7 +32,7 @@ This service lets you change the locking state of a flap.
 
 | Service data attribute | Required | Type | Description |
 | ---------------------- | -------- | -------- | ----------- |
-| `flap_id` | `True` | integer | Flap ID to change - Log into [surepetcare.io](https://surepetcare.io/), open the side bar, click you flap and the flap_id will be at the end of the url (i.e. https://surepetcare.io/control/device/DEVICE-ID)
+| `flap_id` | `True` | integer | Flap ID to change - Log into [surepetcare.io](https://surepetcare.io/), open the side bar, click you flap and the flap_id will be at the end of the URL (i.e. https://surepetcare.io/control/device/DEVICE-ID)
 | `lock_state` | `True` | string | New state to change the flap to
 
 `lock_state` should be one of:

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -35,7 +35,11 @@ This service lets you change the locking state of a flap.
 | `flap_id` | `True` | integer | Flap ID to change - see below for instructions on finding device ID
 | `lock_state` | `True` | string | New state to change the flap to
 
-`flap_id` can be found following this instructions: Log into [surepetcare.io](https://surepetcare.io/), open the side bar, click your flap and the flap_id will be at the end of the URL (i.e. https://surepetcare.io/control/device/DEVICE-ID)
+The `flap_id` can be found following these instructions:
+
+- Log into [surepetcare.io](https://surepetcare.io/).
+- Open the sidebar and click your flap.
+- The `flap_id` will be at the end of the URL (i.e., `https://surepetcare.io/control/device/FLAP-ID`)
 
 `lock_state` should be one of:
 

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -32,8 +32,10 @@ This service lets you change the locking state of a flap.
 
 | Service data attribute | Required | Type | Description |
 | ---------------------- | -------- | -------- | ----------- |
-| `flap_id` | `True` | integer | Flap ID to change - Log into [surepetcare.io](https://surepetcare.io/), open the side bar, click you flap and the flap_id will be at the end of the URL (i.e. https://surepetcare.io/control/device/DEVICE-ID)
+| `flap_id` | `True` | integer | Flap ID to change - see below for instructions on finding device ID
 | `lock_state` | `True` | string | New state to change the flap to
+
+`flap_id` can be found following this instructions: Log into [surepetcare.io](https://surepetcare.io/), open the side bar, click your flap and the flap_id will be at the end of the URL (i.e. https://surepetcare.io/control/device/DEVICE-ID)
 
 `lock_state` should be one of:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
