### PR TITLE
Add warning about bridged adapter

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -230,6 +230,10 @@ _All these can be extended if your usage calls for more resources._
     3. Select “Use an existing virtual hard disk file”, select the unzipped VDI file from above
     4. Edit the “Settings” of the VM and go “System” then “Motherboard” and select “Enable EFI”
     5. Then go to “Network” “Adapter 1” choose “Bridged Adapter” and choose your Network adapter
+    <div class="note warning">
+    Please keep in mind that the bridged adapter only fuctions over a hardwared ethernet connection
+    using Wi-Fi on your VirtualBox host is unsupported
+    </div>
     6. Then go to “Audio” and choose “Intel HD Audio” as Audio Controller.
     <div class="note info">
 

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -231,8 +231,8 @@ _All these can be extended if your usage calls for more resources._
     4. Edit the “Settings” of the VM and go “System” then “Motherboard” and select “Enable EFI”
     5. Then go to “Network” “Adapter 1” choose “Bridged Adapter” and choose your Network adapter
     <div class="note warning">
-    Please keep in mind that the bridged adapter only fuctions over a hardwared ethernet connection
-    using Wi-Fi on your VirtualBox host is unsupported
+    Please keep in mind that the bridged adapter only functions over a hardwired ethernet connection. 
+    Using Wi-Fi on your VirtualBox host is unsupported.
     </div>
     6. Then go to “Audio” and choose “Intel HD Audio” as Audio Controller.
     <div class="note info">


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Running a bridged adapter in VirtualBox over Wi-Fi does not work on most systems and it has confused many I have tried to help install Home Assistant therefore I think a warning is necessary 



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
