### PR TITLE
Update lutron_caseta docs - Add button section

### DIFF
--- a/source/_integrations/lutron_caseta.markdown
+++ b/source/_integrations/lutron_caseta.markdown
@@ -10,6 +10,7 @@ ha_category:
   - Light
   - Scene
   - Switch
+  - Button
 ha_release: 0.41
 ha_iot_class: Local Push
 ha_domain: lutron_caseta
@@ -28,6 +29,7 @@ ha_platforms:
   - light
   - scene
   - switch
+  - button
 ha_integration_type: integration
 ---
 
@@ -173,6 +175,14 @@ Lutron Caseta occupancy sensors support 4 different timeouts and 3 different sen
 Because Lutron Caseta devices automatically report state to Home Assistant (rather than relying on polling), occupancy status updates occur almost instantaneously.
 
 For more information on working with binary sensors in Home Assistant, see the [Binary Sensors Component](/components/binary_sensor/)
+
+## Button
+
+After setup, buttons will appear in Home Assistant using an `entity_id` based on the name used in the Lutron mobile app. For example, a button 'Button 1' on a keypad called 'Front Entrance Keypad' will appear in Home Assistant as `button.front_entrance_keypad_button_1`.
+
+For more information on working with buttons in Home Assistant, see the [Buttons component](/integrations/button/).
+
+Available services: `button.press`
 
 ## Pico and Shade Remotes
 


### PR DESCRIPTION
## Proposed change
Adding a button section to the lutron_caseta integration
Based on HA core PR# 79963

https://github.com/home-assistant/core/pull/79963

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/79963
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
