### PR TITLE
Add the velbus cache service

### DIFF
--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -7,6 +7,7 @@ ha_category:
   - Hub
   - Light
   - Sensor
+  - Button
   - Switch
 ha_iot_class: Local Push
 ha_release: '0.50'
@@ -53,6 +54,7 @@ The port string used in the user interface or the configuration file can have 2 
 - `velbus.sync clock`: Synchronize Velbus time to local clock.
 - `velbus.scan`: Scan the bus for new devices.
 - `velbus.set_memo_text`: Show memo text on Velbus display modules.
+- `velbus.clear_cache`: Clear the full velbuscache or the cache for one module only.
 
 ### Service `velbus.sync_clock`
 
@@ -94,6 +96,16 @@ script:
         interface: "tls://192.168.1.9:27015"
       service: velbus.set_memo_text
 ```
+
+### Service `velbus.clear_cache`
+
+You can use the service `velbus.clear_cache` to clear the cache of one module or the full cache. Once the clear happend the integration will start a new scan.
+Use this service when you make changes to your configuration via velbuslink.
+
+| Service data attribute | Optional | Description                              |
+| ---------------------- | -------- | ---------------------------------------- |
+| `interface`            | no       | The port used to connect to the bus (the same one as used during configuration). |
+| `address`              | no       | The module address in decimal format, which is displayed at the device list at the integration page, if provided the service will only clear the cache for this moduel, without an address the full velbuscache will be cleared.. |
 
 ## Example automation
 

--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -99,13 +99,13 @@ script:
 
 ### Service `velbus.clear_cache`
 
-You can use the service `velbus.clear_cache` to clear the cache of one module or the full cache. Once the clear happend the integration will start a new scan.
+You can use the service `velbus.clear_cache` to clear the cache of one module or the full cache. Once the clear happens, the integration will start a new scan.
 Use this service when you make changes to your configuration via velbuslink.
 
 | Service data attribute | Optional | Description                              |
 | ---------------------- | -------- | ---------------------------------------- |
-| `interface`            | no       | The port used to connect to the bus (the same one as used during configuration). |
-| `address`              | no       | The module address in decimal format, which is displayed at the device list at the integration page, if provided the service will only clear the cache for this moduel, without an address the full velbuscache will be cleared.. |
+| `interface`            | no       | The port used to connect to the bus (the same one used during configuration). |
+| `address`              | no       | The module address in decimal format, which is displayed on the device list on the integration page, if provided the service will only clear the cache for this model, without an address, the full velbuscache will be cleared. |
 
 ## Example automation
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
add documentation for home-assistant/core#79995

add documentation for the velbus clear cache service

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#79995
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
