### PR TITLE
Add docs for fully_kiosk.load_url service

### DIFF
--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -72,7 +72,7 @@ The following controls are available:
 
 **Service `load_url`**
 
-You can use the service `fully_kiosk/load_url` to have the tablet open the specified URL.
+You can use the service `fully_kiosk.load_url` to have the tablet open the specified URL.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |

--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -84,7 +84,7 @@ Example:
 ```yaml
 service: fully_kiosk.load_url
 data:
-  url: https://home-assistant.io
+  url: "https://home-assistant.io"
 target:
   device_id: a674c90eca95eca91f6020415de07713
 ```

--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -67,3 +67,24 @@ The following controls are available:
 <div class='note warning'>
   The Fully Kiosk Browser app does not provide feedback on the device volume or media playback status, so we are unable to display the current volume level or playback status.
 </div>
+
+## Services
+
+**Service `load_url`**
+
+You can use the service `fully_kiosk/load_url` to have the tablet open the specified URL.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `device_id` | yes | Device ID (or list of device IDs) to load the URL on.
+| `url` | yes | The URL to load.
+
+Example:
+
+```yaml
+service: fully_kiosk.load_url
+data:
+  url: https://home-assistant.io
+target:
+  device_id: a674c90eca95eca91f6020415de07713
+```


### PR DESCRIPTION
## Proposed change
Adds documentation for the `fully_kiosk.load_url` service.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/79969
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
