### PR TITLE
Vicare switch onetimechg

### DIFF
--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -15,6 +15,7 @@ ha_platforms:
   - climate
   - diagnostics
   - sensor
+  - switch
   - water_heater
 ha_dhcp: true
 ha_integration_type: integration
@@ -29,6 +30,7 @@ There is currently support for the following device types within Home Assistant:
 - [Water Heater](#water-heater) (Domestic Hot Water)
 - [Sensor](#sensor) (Sensor)
 - [Button](#button) (Button)
+- [Switch](#switch) (Switch)
 
 {% include integrations/config_flow.md %}
 
@@ -132,6 +134,10 @@ Sets the target temperature of domestic hot water to the given temperature.
 
 Additional data from ViCare is available as separate sensors. The sensors are automatically discovered based on the available API data points.
 
+## Switch
+
+A switch entity is created to enable or cancel one-time charging the domestic hot water (DHW), if your device supports this.
+
 ## Button
 
-Button entities are available for triggering like a one-time charge of the water heater.
+Previously, the DHW one-time-charging was only available as a button which should no longer be used in your setup. Prefer the switch entity (see above).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The vicare integration currently exposes a fire-and-forget style button to heat the Domestic Hot Water (DHW) once to a certain level. Since the API offers to deactivate the one-time-charge, and to read its status, I have now enhanced this to offering a switch entity. This will make the status of DHW heating more transparent to vicare users, and allows further use cases.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80045
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
