### PR TITLE
Add Adguard Home list_type to add/remove url services

### DIFF
--- a/source/_integrations/adguard.markdown
+++ b/source/_integrations/adguard.markdown
@@ -101,7 +101,6 @@ Removes a block filter subscription from AdGuard Home.
 | ---------------------- | -------- | -------------------------------------- |
 | `url`                  | No       | The filter subscription URL to remove. |
 
-
 ### Service `enable_url`
 
 Enables a filter subscription in AdGuard Home.

--- a/source/_integrations/adguard.markdown
+++ b/source/_integrations/adguard.markdown
@@ -75,9 +75,9 @@ Add a new allow/block filter subscription to AdGuard Home.
 | ---------------------- | -------- | ------------------------------------------------------------ |
 | `name`                 | No       | The name of the filter subscription.                         |
 | `url`                  | No       | The filter URL to subscribe to, containing the filter rules. |
-| `allow`                | Yes      | The filter you are adding is an allowlist filter.            |
+| `list_type`            | Yes      | The list type of the filter you are adding.                  |
 
-By default, `allow` is set to `false`.
+By default, `list_type` is set to `blocklist`.
 
 ### Service `remove_url`
 
@@ -86,9 +86,9 @@ Removes an allow/block filter subscription from AdGuard Home.
 | Service data attribute | Optional | Description                                         |
 | ---------------------- | -------- | --------------------------------------------------- |
 | `url`                  | No       | The filter subscription URL to remove.              |
-| `allow`                | Yes      | The filter you are removing is an allowlist filter. |
+| `list_type`            | Yes      | The list type of the filter you are removing.       |
 
-By default, `allow` is set to `false`.
+By default, `list_type` is set to `blocklist`.
 
 ### Service `enable_url`
 

--- a/source/_integrations/adguard.markdown
+++ b/source/_integrations/adguard.markdown
@@ -61,28 +61,46 @@ AdGuard relies on Query Log to provide stats.
 ## Services
 
 These services allow one to manage filter subscriptions in AdGuard Home.
-Using these services in automations could be helpful to block certain
+Using these services in automations could be helpful to block/unblock certain
 sites/domains at certain times.
 
 For example, you could create a custom filter list that blocks social media sites
 during the day and releases them during the evening.
 
-### Service `add_url`
+### Service `add_allow_url`
 
-Add a new filter subscription to AdGuard Home.
+Add a new allow filter subscription to AdGuard Home.
 
 | Service data attribute | Optional | Description                                                  |
 | ---------------------- | -------- | ------------------------------------------------------------ |
 | `name`                 | No       | The name of the filter subscription.                         |
 | `url`                  | No       | The filter URL to subscribe to, containing the filter rules. |
 
-### Service `remove_url`
+### Service `remove_allow_url`
 
-Removes a filter subscription from AdGuard Home.
+Removes an allow filter subscription from AdGuard Home.
 
 | Service data attribute | Optional | Description                            |
 | ---------------------- | -------- | -------------------------------------- |
 | `url`                  | No       | The filter subscription URL to remove. |
+
+### Service `add_block_url`
+
+Add a new block filter subscription to AdGuard Home.
+
+| Service data attribute | Optional | Description                                                  |
+| ---------------------- | -------- | ------------------------------------------------------------ |
+| `name`                 | No       | The name of the filter subscription.                         |
+| `url`                  | No       | The filter URL to subscribe to, containing the filter rules. |
+
+### Service `remove_block_url`
+
+Removes a block filter subscription from AdGuard Home.
+
+| Service data attribute | Optional | Description                            |
+| ---------------------- | -------- | -------------------------------------- |
+| `url`                  | No       | The filter subscription URL to remove. |
+
 
 ### Service `enable_url`
 

--- a/source/_integrations/adguard.markdown
+++ b/source/_integrations/adguard.markdown
@@ -67,39 +67,28 @@ sites/domains at certain times.
 For example, you could create a custom filter list that blocks social media sites
 during the day and releases them during the evening.
 
-### Service `add_allow_url`
+### Service `add_url`
 
-Add a new allow filter subscription to AdGuard Home.
-
-| Service data attribute | Optional | Description                                                  |
-| ---------------------- | -------- | ------------------------------------------------------------ |
-| `name`                 | No       | The name of the filter subscription.                         |
-| `url`                  | No       | The filter URL to subscribe to, containing the filter rules. |
-
-### Service `remove_allow_url`
-
-Removes an allow filter subscription from AdGuard Home.
-
-| Service data attribute | Optional | Description                            |
-| ---------------------- | -------- | -------------------------------------- |
-| `url`                  | No       | The filter subscription URL to remove. |
-
-### Service `add_block_url`
-
-Add a new block filter subscription to AdGuard Home.
+Add a new allow/block filter subscription to AdGuard Home.
 
 | Service data attribute | Optional | Description                                                  |
 | ---------------------- | -------- | ------------------------------------------------------------ |
 | `name`                 | No       | The name of the filter subscription.                         |
 | `url`                  | No       | The filter URL to subscribe to, containing the filter rules. |
+| `allow`                | Yes      | The filter you are adding is an allowlist filter.            |
 
-### Service `remove_block_url`
+By default, `allow` is set to `false`.
 
-Removes a block filter subscription from AdGuard Home.
+### Service `remove_url`
 
-| Service data attribute | Optional | Description                            |
-| ---------------------- | -------- | -------------------------------------- |
-| `url`                  | No       | The filter subscription URL to remove. |
+Removes an allow/block filter subscription from AdGuard Home.
+
+| Service data attribute | Optional | Description                                         |
+| ---------------------- | -------- | --------------------------------------------------- |
+| `url`                  | No       | The filter subscription URL to remove.              |
+| `allow`                | Yes      | The filter you are removing is an allowlist filter. |
+
+By default, `allow` is set to `false`.
 
 ### Service `enable_url`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I have added a service to adguard home to add and remove allow urls, because the services that where available called add/remove url I had to rename them to `add_block_url` and `remove_block_url` so I could make the new services `add_allow_url` and `remove_allow_url`


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80060
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
