### PR TITLE
Small grammar fix for skyconnect

### DIFF
--- a/source/skyconnect/index.html
+++ b/source/skyconnect/index.html
@@ -160,9 +160,11 @@ frontpage_image: /images/skyconnect/skyconnect-cover.png
   for us to do this is using Home Assistant add-ons in a known host environment,
   which is Home Assistant OS. {% enddetails %} {% details "Why include a USB
   extension cable?" %} USB 3.0 ports (the ones with blue on the inside)
-  interfere with any radio at 2.4Ghz frequency. This includes Zigbee and Thread.
-  If you don't use the extension cable it might not work at all, or flaky at
-  best. {% enddetails %}
+  are known to cause significant noise and radio interference to any 2.4Ghz
+  wireless devices. This includes Zigbee and Thread. If you do not use the
+  extension cable, it may not work at all, and if it does, it could be flaky at
+  best with intermittent problems (issues with pairing, device dropouts, unreachable
+  devices, timeout errors, etc). {% enddetails %}
 </div>
 
 <div id="buy-dialog" class="dialog">


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I know this documentation is very preliminary and fresh, but the final sentence here didn't read right to me, so I added a little bit of info on top of just the grammar correction

I am excited to get my hands on one! Thanks!

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
