### PR TITLE
Add mandatory `expires:` field to security.txt

### DIFF
--- a/source/.well-known/security.txt
+++ b/source/.well-known/security.txt
@@ -2,3 +2,4 @@ Contact: mailto:security@home-assistant.io
 Preferred-Languages: en
 Canonical: https://www.home-assistant.io/.well-known/security.txt
 Policy: https://www.home-assistant.io/security/
+Expires: 2032-12-31T22:59:00.000Z


### PR DESCRIPTION
## Proposed change
SSIA.

`Expires:` field is a mandatory field for `security.txt`
See https://datatracker.ietf.org/doc/html/draft-foudil-securitytxt-12#section-3.5.5
I've chosen a date far, far away as I don't think this will actually expire in the HA organisation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
