### PR TITLE
Add note about Ubuntu fuse dependency for Etcher

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -93,7 +93,7 @@ To use this method, follow the steps described in the procedure below: [Write th
 
 <details>
 
-<summary> Ubuntu dependency's for Etcher </summary>
+<summary>Click to see Ubuntu dependency's for Etcher</summary>
 
 When installing Etcher on an Ubuntu system you may need to install the fuse
 dependency, you can do so with the following commands:

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -91,6 +91,18 @@ To use this method, follow the steps described in the procedure below: [Write th
 
 - To use this method, follow the instructions of your Live distribution (e.g., [this Ubuntu guide](https://ubuntu.com/tutorials/try-ubuntu-before-you-install)). Once you booted the live operating system, follow the steps described in the procedure below: [Write the image to your boot media](#write-the-image-to-your-boot-media).
 
+<div class='note'>
+When installing Etcher on an Ubuntu system you may need to install the fuse
+dependency, you can do so with the following commands:
+
+```bash
+sudo add-apt-repository universe
+sudo apt update
+sudo apt install libfuse2
+```
+
+</div>
+
 {% endif %}
 
 ### Write the image to your boot media

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -91,9 +91,7 @@ To use this method, follow the steps described in the procedure below: [Write th
 
 - To use this method, follow the instructions of your Live distribution (e.g., [this Ubuntu guide](https://ubuntu.com/tutorials/try-ubuntu-before-you-install)). Once you booted the live operating system, follow the steps described in the procedure below: [Write the image to your boot media](#write-the-image-to-your-boot-media).
 
-<details>
-
-<summary>Click to see Ubuntu dependency's for Etcher</summary>
+{% details "Ubuntu dependency's for Etcher" %}
 
 When installing Etcher on an Ubuntu system you may need to install the fuse
 dependency, you can do so with the following commands:
@@ -104,7 +102,7 @@ sudo apt update
 sudo apt install libfuse2
 ```
 
-</details>
+{% enddetails %}
 
 {% endif %}
 

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -91,7 +91,8 @@ To use this method, follow the steps described in the procedure below: [Write th
 
 - To use this method, follow the instructions of your Live distribution (e.g., [this Ubuntu guide](https://ubuntu.com/tutorials/try-ubuntu-before-you-install)). Once you booted the live operating system, follow the steps described in the procedure below: [Write the image to your boot media](#write-the-image-to-your-boot-media).
 
-<div class='note'>
+<details>
+<summary> Ubuntu dependency's for Etcher </summary>
 When installing Etcher on an Ubuntu system you may need to install the fuse
 dependency, you can do so with the following commands:
 
@@ -101,7 +102,7 @@ sudo apt update
 sudo apt install libfuse2
 ```
 
-</div>
+</details>
 
 {% endif %}
 

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -92,7 +92,9 @@ To use this method, follow the steps described in the procedure below: [Write th
 - To use this method, follow the instructions of your Live distribution (e.g., [this Ubuntu guide](https://ubuntu.com/tutorials/try-ubuntu-before-you-install)). Once you booted the live operating system, follow the steps described in the procedure below: [Write the image to your boot media](#write-the-image-to-your-boot-media).
 
 <details>
+
 <summary> Ubuntu dependency's for Etcher </summary>
+
 When installing Etcher on an Ubuntu system you may need to install the fuse
 dependency, you can do so with the following commands:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added note about Ubuntu fuse dependency for Etcher to make it clearer for beginners 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #24351

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
