### PR TITLE
Improve accessibility for expandable details

### DIFF
--- a/plugins/details.rb
+++ b/plugins/details.rb
@@ -4,6 +4,7 @@ module Jekyll
     def initialize(tag_name, title, tokens)
       super
       @title = title
+      @details_idx = 1
     end
 
     def render(context)
@@ -15,25 +16,35 @@ module Jekyll
       end
       title = title.to_s.delete("\"")
 
+      idx = context["details_idx"]
+      if idx.nil? then
+        idx = 0
+      end
+      context["details_idx"] = idx + 1
+
       <<~MARKUP
         <script>
         function showDetails(el) {
           const content = el.parentElement.querySelector(".details-block-content");
           const up = el.querySelector("svg#up");
           const down = el.querySelector("svg#down");
-          up.style.display = up.style.display === "none" ? "block" : "none";
-          down.style.display = down.style.display === "none" ? "block" : "none";
-          content.hidden = !content.hidden;
+          const shouldExpand = down.style.display === "block";
+          up.style.display = shouldExpand ? "block" : "none";
+          down.style.display = !shouldExpand ? "block" : "none";
+          content.hidden = !shouldExpand;
+          el.ariaExpanded = shouldExpand;
         }
         </script>
         <div class="details-block">
           <div class='details-block-item'>
-            <div class='details-block-title' onclick='showDetails(this)'>
+            <button class='details-block-title' onclick='showDetails(this)' aria-controls="content_#{idx}" aria-expanded="false">
               #{title}
+              <div class='details-block-arrow'>
               <svg id="down" style="display: block;" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>
               <svg id="up" style="display: none;" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" /></svg>
-            </div>
-            <div class='details-block-content' hidden>#{contents}</div>
+              </div>
+            </button>
+            <div class='details-block-content' id="content_#{idx}" hidden>#{contents}</div>
           </div>
         </div>
       MARKUP

--- a/sass/custom/_details.scss
+++ b/sass/custom/_details.scss
@@ -18,6 +18,9 @@ div.details-block {
       justify-content: space-between;
       display: flex;
       align-items: center;
+      background-color: white;
+      border: 0px;
+      width: 100%;
     }
     .details-block-content {
       margin: 4px 32px 12px 0;


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Improve accessibility of the expandable details items by converting to a button and tagging with `aria-expanded` so that screen readers can understand the semantics of these collapsable/expandable units.

A screen reader will now identify the heading, and add "collapsed button" or "expanded button" depending on the state of the collapsed area. The styling has been updated so that these buttons look like they did before.




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue:
- Related issue #24496


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
