### PR TITLE
Update documentation 'Gauge Card' - built-in CSS variables usage

### DIFF
--- a/source/_dashboards/gauge.markdown
+++ b/source/_dashboards/gauge.markdown
@@ -154,3 +154,31 @@ segments:
   - from: 65
     color: '#db4437'
 ```
+
+CSS variables can be used (instead of CSS '#rrggbb') for default gauge segment colors:
+
+- `var(--success-color)` for green color
+- `var(--warning-color)` for yellow color
+- `var(--error-color)` for red color
+- `var(--info-color)` for blue color
+
+Therefore, the previous example can be defined also as:
+
+```yaml
+type: gauge
+entity: sensor.kitchen_humidity
+needle: true
+min: 20
+max: 80
+segments:
+  - from: 0
+    color: var(--error-color)
+  - from: 35
+    color: var(--warning-color)
+  - from: 40
+    color: var(--success-color)
+  - from: 60
+    color: var(--warning-color)
+  - from: 65
+    color: var(--error-color)
+```


### PR DESCRIPTION
## Proposed change

Gauge card segments can use Home-Assistant's built-in CSS variables as alternative to RGB colors. It can be useful for users, therefore I am proposing to add it into documentation page `Gauge Card`.

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
