### PR TITLE
Add heiwa integration

### DIFF
--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -19,7 +19,6 @@ The Gree integration allows you to control a [Gree Smart HVAC](http://global.gre
 
 There is currently support for the following device types within Home Assistant:
 
-- [Supported models](#supported-models)
 - [Climate](#climate)
 - [Switch](#switch)
 

--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -19,6 +19,7 @@ The Gree integration allows you to control a [Gree Smart HVAC](http://global.gre
 
 There is currently support for the following device types within Home Assistant:
 
+- [Supported models](#supported-models)
 - [Climate](#climate)
 - [Switch](#switch)
 
@@ -37,6 +38,7 @@ Any Gree Smart device working with the Gree+ app should be supported, including 
 - Cooper & Hunter
 - Proklima
 - Tadiran
+- Heiwa
 
 ## Climate
 

--- a/source/_integrations/heiwa.markdown
+++ b/source/_integrations/heiwa.markdown
@@ -1,0 +1,20 @@
+---
+title: Heiwa
+description: Connect and control your Heiwa devices using the Gree Climate integration
+ha_category:
+  - Climate
+ha_release: 2022.11.0
+ha_iot_class: Local Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@renaiku'
+ha_domain: heiwa
+ha_platforms:
+  - climate
+  - switch
+ha_integration_type: integration
+ha_supporting_domain: gree
+ha_supporting_integration: Gree Climate
+---
+
+{% include integrations/supported_brand.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Heiwa integration documentation


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80242
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3770
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
