### PR TITLE
Added OralB documentation

### DIFF
--- a/source/_integrations/oralb.markdown
+++ b/source/_integrations/oralb.markdown
@@ -1,0 +1,20 @@
+---
+title: OralB
+description: Get information about your Bluetooth OralB toothbrush
+ha_category:
+  - Sensor
+ha_bluetooth: true
+ha_release: 2022.11
+ha_iot_class: Local Push
+ha_codeowners:
+  - '@bkbilly'
+ha_domain: oralb
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_integration_type: integration
+ha_supporting_domain: oralb
+ha_supporting_integration: OralB
+---
+
+{% include integrations/supported_brand.md %}

--- a/source/_integrations/oralb.markdown
+++ b/source/_integrations/oralb.markdown
@@ -17,4 +17,6 @@ ha_supporting_domain: oralb
 ha_supporting_integration: OralB
 ---
 
-{% include integrations/supported_brand.md %}
+Integrates [OralB](https://oralb.com/en-us/products/shop-all/) Bluetooth Toothbrushes into Home Assistant.
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Connect with OralB bluetooth toothbrush to get information.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80283
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3784
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
