### PR TITLE
Fix link to Update category in update.markdown

### DIFF
--- a/source/_integrations/update.markdown
+++ b/source/_integrations/update.markdown
@@ -32,7 +32,7 @@ Update entities are here to be consumed and provided by other integrations and
 are are not designed to be created manually directly.
 
 This page, therefore, does not provide instructions on how to create update
-entities. Please see the ["Updates" category](/integrations/#updates) on the
+entities. Please see the ["Update" category](/integrations/#update) on the
 integrations page to find integration offering update entities.
 
 </div>


### PR DESCRIPTION
## Proposed change
Fix link to Update category in update.markdown by replacing Updates / #updates with Update / #update.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
