### PR TITLE
Update core.md: Refine requirements for Linux/Rasperry Pi "Core" installation

### DIFF
--- a/source/_includes/installation/core.md
+++ b/source/_includes/installation/core.md
@@ -33,10 +33,10 @@ sudo apt-get upgrade -y
 Install the dependencies:
 
 ```bash
-sudo apt-get install -y python3 python3-dev python3-venv python3-pip bluez libffi-dev libssl-dev libjpeg-dev zlib1g-dev autoconf build-essential libopenjp2-7 libtiff5 libturbojpeg0-dev tzdata
+sudo apt-get install -y python3 python3-dev python3-venv python3-pip bluez libffi-dev libssl-dev libjpeg-dev zlib1g-dev autoconf build-essential libopenjp2-7 libtiff5 libturbojpeg0-dev tzdata libatlas-base-dev
 ```
 
-The above-listed dependencies might differ or missing, depending on your system or personal use of Home Assistant.
+The above-listed dependencies might differ or missing, depending on your system or personal use of Home Assistant. I.e. on Raspberry Pi/Debian devices, you'll have to [install Rust/Cargo](https://www.rust-lang.org/tools/install) as well.
 
 ### Create an account
 


### PR DESCRIPTION
## Proposed change

I'd like to propose adding these two notes to the installation documentation page. 

Today I installed HomeAssistant on a Raspberry Pi Zero W which ran the current default headless Raspberry Pi OS (Debian Bullseye) and had to install two more dependencies: The apt package `libatlas-base-dev` and Rust. Only then I was able to successfully start HomeAssistant with all it's modules (the sub-services `mobile` and `cloud` would fail to start for various reasons otherwise).

As I assume this is quite a common setup, I think it would be helpful to add those dependencies to the documentation.


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
