### PR TITLE
Document support for EnOcean A5-14-09 and A5-14-0A

### DIFF
--- a/source/_integrations/enocean.markdown
+++ b/source/_integrations/enocean.markdown
@@ -43,6 +43,7 @@ The following devices have been confirmed to work out of the box:
 - Permundo PSC234 (switch and power monitor)
 - EnOcean STM-330 temperature sensor
 - Hoppe SecuSignal window handle from Somfy
+- Roto Com-Tec Comfort sensor (as window handle)
 
 If you own a device not listed here, please check whether your device can talk in one of the listed [EnOcean Equipment Profiles](https://www.enocean-alliance.org/what-is-enocean/specifications/) (EEP). If it does, it will most likely work. The available profiles are usually listed somewhere in the device manual.
 
@@ -301,6 +302,8 @@ sensor:
 ### Window handle
 
 As of now, the Hoppe SecuSignal window handle from Somfy has been successfully tested. However, any mechanical window handle that follows the EnOcean RPS telegram spec F6 10 00 (Hoppe AG) is supported.
+
+Sensors that support the states open/closed/tilt like the [EnOcean Equipment Profiles](https://www.enocean-alliance.org/what-is-enocean/specifications/) **A5-14-09** (e.g. Roto Com-Tec Comfort) and **A5-14-0A** (e.g. Roto Com-Tec Comfort S) can be configured as window handle.
 
 To configure a window handle, add the following code to your `configuration.yaml`:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds  the documentation for the PR https://github.com/home-assistant/core/pull/79108 which adds support for an EnOcean window/door contact.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/79108/files
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
