### PR TITLE
Add message service to LaMetric

### DIFF
--- a/source/_integrations/lametric.markdown
+++ b/source/_integrations/lametric.markdown
@@ -33,21 +33,21 @@ ha_ssdp: true
 The LaMetric integration provides services to interact with your LaMetric
 device(s). Those service can be called in, for example, automations.
 
-### Service `lametric.text`
+### Service `lametric.message`
 
-The {% my developer_call_service service="lametric.text" title="`lametric.text`" %}
-service allows you to send a text message to your LaMetric. These
+The {% my developer_call_service service="lametric.message" title="`lametric.message`" %}
+service allows you to send a message to your LaMetric. These
 messages can be enrichted with icons and sounds.
 
-{% my developer_call_service badge service="lametric.text" %}
+{% my developer_call_service badge service="lametric.message" %}
 
-{% configuration "lametric.text" %}
+{% configuration "lametric.message" %}
 device_id:
-  description: The ID of the device to send the text message to.
+  description: The ID of the device to send the message to.
   required: true
   type: string
-text:
-  description: The text to send to the LaMetric device.
+message:
+  description: The message to send to the LaMetric device.
   required: true
   type: string
 icon:

--- a/source/_integrations/lametric.markdown
+++ b/source/_integrations/lametric.markdown
@@ -28,6 +28,53 @@ ha_ssdp: true
 
 {% include integrations/config_flow.md %}
 
+## Services
+
+The LaMetric integration provides services to interact with your LaMetric
+device(s). Those service can be called in, for example, automations.
+
+### Service `lametric.text`
+
+The {% my developer_call_service service="lametric.text" title="`lametric.text`" %}
+service allows you to send a text message to your LaMetric. These
+messages can be enrichted with icons and sounds.
+
+{% my developer_call_service badge service="lametric.text" %}
+
+{% configuration "lametric.text" %}
+device_id:
+  description: The ID of the device to send the text message to.
+  required: true
+  type: string
+text:
+  description: The text to send to the LaMetric device.
+  required: true
+  type: string
+icon:
+  description: "An icon or animation. List of all icons available at [https://developer.lametric.com/icons](https://developer.lametric.com/icons)."
+  required: false
+  type: string
+cycles:
+  description: "Defines how long the notification will be displayed. Set to `0` to require manual dismissal."
+  required: false
+  type: integer
+  default: 1
+priority:
+  description: "Defines the priority of the notification. Allowed values are `info`, `warning`, and `critical`."
+  required: false
+  type: string
+  default: info
+icon_type:
+  description: "Defines the nature of notification. Allowed values are `none`, `info`, and `alert`."
+  required: false
+  type: string
+  default: none
+sound:
+  description: "Defines the sound of the notification. Allowed are listed [below](#list-of-notification-sounds)."
+  required: false
+  type: string
+{% endconfiguration %}
+
 ## Notifications
 
 You can send notifications to your LaMetric device using
@@ -41,7 +88,7 @@ called "My LaMetric", the service would become `notify.my_lametric`.
 The notification service call against an LaMetric device can take the
 following, additional, optional parameters:
 
-{% configuration %}
+{% configuration "notification" %}
 icon:
   description: "An icon or animation. List of all icons available at [https://developer.lametric.com/icons](https://developer.lametric.com/icons)."
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds documentation for the `lametric.message` service.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80448
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
