### PR TITLE
Fixing messed up configuration documentation

### DIFF
--- a/source/_integrations/folder_watcher.markdown
+++ b/source/_integrations/folder_watcher.markdown
@@ -37,7 +37,7 @@ folder:
 patterns:
   description: Pattern matching to apply
   required: false
-  default: "*"
+  default: "\*"
   type: string
 {% endconfiguration %}
 

--- a/source/_integrations/folder_watcher.markdown
+++ b/source/_integrations/folder_watcher.markdown
@@ -37,7 +37,7 @@ folder:
 patterns:
   description: Pattern matching to apply
   required: false
-  default: "\u002a"
+  default: ' * '
   type: string
 {% endconfiguration %}
 

--- a/source/_integrations/folder_watcher.markdown
+++ b/source/_integrations/folder_watcher.markdown
@@ -37,7 +37,7 @@ folder:
 patterns:
   description: Pattern matching to apply
   required: false
-  default: "\*"
+  default: '*'
   type: string
 {% endconfiguration %}
 

--- a/source/_integrations/folder_watcher.markdown
+++ b/source/_integrations/folder_watcher.markdown
@@ -37,7 +37,7 @@ folder:
 patterns:
   description: Pattern matching to apply
   required: false
-  default: '*'
+  default: "\u002a"
   type: string
 {% endconfiguration %}
 


### PR DESCRIPTION
The configuration documentation is currently messed up as the asterisk is interpreted as a bullet point, resulting in an ugly piece of documentation page. Escaping is needed to avoid the asterisk from being interpreted as a bullet point.

<img width="1065" alt="Screenshot 2022-10-17 at 10 46 22" src="https://user-images.githubusercontent.com/25389602/196136147-d3e39e1e-28b6-4d0f-ac61-b6aa5fa249b4.png">


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Escaping asterisk to prevent it from being interpreted as a bullet point.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
