### PR TITLE
Update changes in light entity and remove priority light documentation

### DIFF
--- a/source/_integrations/hyperion.markdown
+++ b/source/_integrations/hyperion.markdown
@@ -34,14 +34,27 @@ All configuration options are offered from the frontend. Choose `Options` under 
 relevant entry on the `Integrations` page.
 
 Options supported:
-- **Priority**: The priority for color and effects, make sure this is lower then the streaming sources priority in hyperion itself (typically lower than 200 is appropriate).
+- **Priority**: The priority for color and effects. Hyperion will choose the source 
+  with the lowest priority number as active input. If you have other sources (not 
+  originating from Home Assistant) configured, make sure this option is lower than 
+  those sources priority in Hyperion itself (typically lower than 200 is appropriate).
 - **Effects to hide**: An optional selection of effects to hide from the light effects
   list. New effects added to the Hyperion server will be shown by default.
+
 ## Hyperion Instances
 
 This integration supports multiple Hyperion instances running on a single Hyperion
 server. As instances are added/removed on the Hyperion UI, they will automatically be
 added/removed from Home Assistant.
+
+## Light Entity
+
+The default light entity will send data to Hyperion on the priority you have configured 
+during integration setup. When turned off, it will clear the configured priority again. 
+Other light sources independent of Home Assistant configured in Hyperion might still be 
+active and cause light to be emitted. In order to turn the light output off entirely 
+regardless of active light sources, you can enable the LED device entity that acts as 
+a global switch (see Advanced Entities).
 
 ## Effects
 
@@ -74,8 +87,8 @@ Provided advanced entities:
 
 - `switch.[instance]_component_[component]`: A switch to turn on/off the relevant
   underlying Hyperion component as shown on the Hyperion server `Remote Control` page
-  under `Component Control`. This allows fine grained control over sources (e.g. `USB Capture`) and
-  Hyperion functionality (e.g. `Blackbar Detection`).
+  under `Component Control`. This allows fine grained control over sources (e.g. `USB Capture`),
+  Hyperion functionality (e.g. `Blackbar Detection`) or overall device state (e.g. `LED Device`).
 
 These entities may be enabled by visiting the `Integrations` page, choosing the relevant
 entity and toggling `Enable entity`, followed by `Update`.
@@ -136,4 +149,24 @@ To capture the screen on a USB capture device, when playing something on a media
         entity_id: light.hyperion
       data:
         effect: "USB Capture"
+```
+
+To toggle the LED device together with the light entity in order to turn light output on or off for all sources. In this example both entities are turned on together, create another automation with the values reversed for turning both off:
+
+```yaml
+- alias: "Turn LED device on when Hyperion light is activated"
+  trigger:
+    - platform: state
+      entity_id:
+        - light.ambilight
+      from: "off"
+      to: "on"
+  condition:
+    - condition: state
+      entity_id: switch.[instance]_component_led_device
+      state: "off"
+  action:
+    - service: switch.turn_on
+      target:
+        entity_id: switch.[instance]_component_led_device
 ```

--- a/source/_integrations/hyperion.markdown
+++ b/source/_integrations/hyperion.markdown
@@ -151,11 +151,9 @@ To capture the screen on a USB capture device, when playing something on a media
       entity_id: media_player.plex
       to: "playing"
   action:
-    - service: light.turn_on
+    - service: switch.turn_on
       target:
-        entity_id: light.hyperion
-      data:
-        effect: "USB Capture"
+        entity_id: switch.[instance]_component_usb_capture
 ```
 
 To toggle the LED device together with the light entity in order to turn light output on or off for all sources. In this example both entities are turned on together, create another automation with the values reversed for turning both off:

--- a/source/_integrations/hyperion.markdown
+++ b/source/_integrations/hyperion.markdown
@@ -163,7 +163,7 @@ To toggle the LED device together with the light entity in order to turn light o
   trigger:
     - platform: state
       entity_id:
-        - light.ambilight
+        - light.hyperion
       from: "off"
       to: "on"
   condition:

--- a/source/_integrations/hyperion.markdown
+++ b/source/_integrations/hyperion.markdown
@@ -58,13 +58,8 @@ a global switch (see Advanced Entities).
 
 ## Effects
 
-The effect list is dynamically pulled from the Hyperion server. The following
-extra effects will be available:
-
-- 'Boblight Server': Use a 'Boblight Server' configured in Hyperion.
-- 'Platform Capture': Use a 'Platform Capture' grabber that is configured in Hyperion.
-- 'USB Capture': Use a 'USB Capture' device that is configured in Hyperion.
-- 'Solid': Use a solid color only.
+The effect list is dynamically pulled from the Hyperion server. Additionally, there
+will be a 'Solid' effect to switch (back) to showing a solid color only.
 
 ## Hyperion Camera
 

--- a/source/_integrations/hyperion.markdown
+++ b/source/_integrations/hyperion.markdown
@@ -72,10 +72,6 @@ there are multiple Hyperion server clients (of which Home Assistant is one).
 
 Provided advanced entities:
 
-- `light.[instance]_priority`: A "priority" light that acts exclusively on a given
-  Hyperion priority. Only color/effects (and not components) are available in this light.
-  Turning this light off will set a black color at this given priority rather than
-  turning the light off in absolute terms.
 - `switch.[instance]_component_[component]`: A switch to turn on/off the relevant
   underlying Hyperion component as shown on the Hyperion server `Remote Control` page
   under `Component Control`. This allows fine grained control over sources (e.g. `USB Capture`) and

--- a/source/_integrations/hyperion.markdown
+++ b/source/_integrations/hyperion.markdown
@@ -83,15 +83,27 @@ advanced usecases. These entities expose 'raw' underlying Hyperion API component
 improved extensibility and interoperability which are particularly useful in cases where
 there are multiple Hyperion server clients (of which Home Assistant is one).
 
-Provided advanced entities:
-
-- `switch.[instance]_component_[component]`: A switch to turn on/off the relevant
-  underlying Hyperion component as shown on the Hyperion server `Remote Control` page
-  under `Component Control`. This allows fine grained control over sources (e.g. `USB Capture`),
-  Hyperion functionality (e.g. `Blackbar Detection`) or overall device state (e.g. `LED Device`).
-
 These entities may be enabled by visiting the `Integrations` page, choosing the relevant
 entity and toggling `Enable entity`, followed by `Update`.
+
+### Control over external sources: Screen capture and USB capture
+
+Provided entities for controlling external sources:
+
+- `switch.[instance]_component_platform_capture`: Toggles the `Screen Capture` source
+- `switch.[instance]_component_usb_capture`: Toggles the `USB Capture` source
+
+### Control over Hyperion functionality
+
+Further advanced entities to control Hyperion functionality:
+
+- There will be additional `switch.[instance]_component_[component]` entities that can
+  be used to toggle the relevant underlying Hyperion component as shown on the Hyperion
+  server `Remote Control` page under `Components Control`. This allows fine grained 
+  control over Hyperion functionality (e.g. `Blackbar Detection`) or device
+  state (`LED Device`).
+- `switch.[instance]_component_all`: refers to the entire Hyperion instance state that
+  controls the toggle on the Hyperion server `Dashboard` page.
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Change goes together with HA core PR where (among other changes) priority light entity is removed as obsolete.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80478
- Link to parent pull request in the Brands repository: (not applicable)
- This PR fixes or closes issue: fixes (see parent pull request above)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
