### PR TITLE
Add chart service to LaMetric

### DIFF
--- a/source/_integrations/lametric.markdown
+++ b/source/_integrations/lametric.markdown
@@ -33,6 +33,43 @@ ha_ssdp: true
 The LaMetric integration provides services to interact with your LaMetric
 device(s). Those service can be called in, for example, automations.
 
+### Service `lametric.chart`
+
+The {% my developer_call_service service="lametric.chart" title="`lametric.chart`" %}
+service allows you to display a little chart to your LaMetric.
+
+{% my developer_call_service badge service="lametric.chart" %}
+
+{% configuration "lametric.chart" %}
+device_id:
+  description: The ID of the device to send the message to.
+  required: true
+  type: string
+data:
+  description: The data points in the chart, as a list of numbers. For example `[1, 2, 3, 2, 1]`.
+  required: true
+  type: list
+cycles:
+  description: "Defines how long the notification will be displayed. Set to `0` to require manual dismissal."
+  required: false
+  type: integer
+  default: 1
+priority:
+  description: "Defines the priority of the notification. Allowed values are `info`, `warning`, and `critical`."
+  required: false
+  type: string
+  default: info
+icon_type:
+  description: "Defines the nature of notification. Allowed values are `none`, `info`, and `alert`."
+  required: false
+  type: string
+  default: none
+sound:
+  description: "Defines the sound of the notification. Allowed are listed [below](#list-of-notification-sounds)."
+  required: false
+  type: string
+{% endconfiguration %}
+
 ### Service `lametric.message`
 
 The {% my developer_call_service service="lametric.message" title="`lametric.message`" %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the `lametric.chart` service

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80554
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
