### PR TITLE
Update enphase_envoy.markdown

### DIFF
--- a/source/_integrations/enphase_envoy.markdown
+++ b/source/_integrations/enphase_envoy.markdown
@@ -15,6 +15,11 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
+<div class='note warning'>
+
+  Enphase Envoys with Software Version D7.0.155 and above are no longer able to [use this integration](https://github.com/home-assistant/core/issues/79382) 
+  
+</div>
 A sensor platform for the [Enphase Envoy](https://enphase.com/en-us/products-and-services/envoy-and-combiner) solar energy gateway. Works with older models that only have production metrics (ie. Envoy-C) and newer models that offer both production and consumption metrics (ie. Envoy-S).
 
 {% include integrations/config_flow.md %}
@@ -24,3 +29,4 @@ A sensor platform for the [Enphase Envoy](https://enphase.com/en-us/products-and
 For newer models, the username `envoy` without a password will grant access to the device. For older models, the password for the `installer` user can be obtained with this: [tool](https://thecomputerperson.wordpress.com/2016/08/28/reverse-engineering-the-enphase-installer-toolkit/).
 
 In some cases, you need to use the username `envoy` with the last 6 digits of the unit's serial number as password. See [the enphase documentation](https://www4.enphase.com/en-us/support/faq/what-username-and-password-administration-page-envoy-local-interface) for more details on other units.
+


### PR DESCRIPTION
Software Version D7.0.155 is breaking this current integration as listed https://github.com/home-assistant/core/issues/79382, the experimental version in https://github.com/jrutski/home_assistant_envoy_d7_fw is working. This took me a while to diagnose, so adding this explicitly in the documentation may help people discover alternatives faster.

## Proposed change
Add a warning message to the main page of this integration to help people identify the breakage faster instead of spending a lot of time trying to diagnose the issue



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
