### PR TITLE
Fixed Magic Home dead links to product pages

### DIFF
--- a/source/_integrations/flux_led.markdown
+++ b/source/_integrations/flux_led.markdown
@@ -36,7 +36,6 @@ Example of bulbs:
 
 - [MagicLight Smart Bulbs](https://www.magiclightbulbs.com/lightbulbs) or [Amazon](https://www.amazon.com/gp/product/B081YJHHB1/)
 - [RGBCW Downlights](https://www.amazon.com/gp/product/B093Q83G7S/)
-- [RGBCW Floodlights](https://www.amazon.com/gp/product/B09J38NKPN)
 
 Examples of controllers with strips:
 
@@ -47,7 +46,6 @@ Examples of controllers:
 - [Single color](https://www.amazon.com/gp/product/B07J5B3R5L/)
 - [RGB](https://www.amazon.com/gp/product/B07C1LN7FZ/)
 - [RGBW](https://www.amazon.com/gp/product/B07J9QCQNN/)
-- [RGBCW](https://www.amazon.com/gp/product/B09BMC4JNJ/)
 - [RGB/W/CW](https://www.amazon.com/gp/product/B01DY56N8U/)
 
 Examples of addressable controllers:

--- a/source/_integrations/flux_led.markdown
+++ b/source/_integrations/flux_led.markdown
@@ -36,6 +36,7 @@ Example of bulbs:
 
 - [MagicLight Smart Bulbs](https://www.magiclightbulbs.com/lightbulbs) or [Amazon](https://www.amazon.com/gp/product/B081YJHHB1/)
 - [RGBCW Downlights](https://www.amazon.com/gp/product/B093Q83G7S/)
+- [RGBCW Floodlights](https://www.amazon.com/dp/product/B08CDS3N6H)
 
 Examples of controllers with strips:
 
@@ -46,6 +47,7 @@ Examples of controllers:
 - [Single color](https://www.amazon.com/gp/product/B07J5B3R5L/)
 - [RGB](https://www.amazon.com/gp/product/B07C1LN7FZ/)
 - [RGBW](https://www.amazon.com/gp/product/B07J9QCQNN/)
+- [RGBCW](https://www.amazon.co.uk/gp/product/B09BMC4JNJ/)
 - [RGB/W/CW](https://www.amazon.com/gp/product/B01DY56N8U/)
 
 Examples of addressable controllers:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Two of the products linked no longer exist on Amazon's website and produce a 404 error. Consequentially, I have removed them from the documentation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
