### PR TITLE
Added action_name config value for button card

### DIFF
--- a/source/_dashboards/button.markdown
+++ b/source/_dashboards/button.markdown
@@ -101,6 +101,11 @@ theme:
   required: false
   description: Override the used theme for this card with any loaded theme. For more information about themes, see the [frontend documentation](/integrations/frontend/).
   type: string
+action_name:
+  required: false
+  description: Override the default action name for a button row.
+  type: string
+  default: Run
 {% endconfiguration %}
 
 Example:


### PR DESCRIPTION
## Proposed change
The `action_name` configuration variable was missing from the documentation, but was present in the [card](https://github.com/home-assistant/frontend/blob/1f9763d6c8de0454f9bfa03e2cc2c96d17f16c09/src/panels/lovelace/special-rows/hui-button-row.ts#L66). This is specifically for a `hui-button-row`.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
