### PR TITLE
Remove bluesound specific join and unjoin services

### DIFF
--- a/source/_integrations/bluesound.markdown
+++ b/source/_integrations/bluesound.markdown
@@ -59,23 +59,6 @@ media_player:
       - host: 192.168.1.131
 ```
 
-### Service `bluesound.join`
-
-Group players together under a single master speaker. That will make a new group or join an existing group.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `master` | no | A single `entity_id` that will become/hold the master speaker.
-| `entity_id` | no | String or list of a single `entity_id` that will group to master speaker.
-
-### Service `bluesound.unjoin`
-
-Remove one or more speakers from a group of speakers. If no `entity_id` is provided, all speakers are unjoined.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of `entity_id`s that will be separated from their master speaker.
-
 ### Service `bluesound.set_sleep_timer`
 
 Sets a timer that will turn off the speaker. For each time you call this it will increase the time by one step. The steps are (in minutes): 15, 30, 45, 60, 90, 0.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Remove bluesound specific join and unjoin services



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80719
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
