### PR TITLE
Nobø Hub - Support week profiles and global override

### DIFF
--- a/source/_integrations/nobo_hub.markdown
+++ b/source/_integrations/nobo_hub.markdown
@@ -53,12 +53,12 @@ This can be utilized the following ways:
 ### Preset override duration
 
 By default, all overrides (when operation is not in "Auto" mode) are constant. It is possible to change this
-to  let overrides end when the week profile changes next (same as duration "Now" in the Nobø Energy mobile app)
+to let overrides end when the week profile changes next (same as duration "Now" in the Nobø Energy mobile app)
 in the integration configuration.
 
 ### Week profiles
 
-The week profiles are retrieved from the hub, and it is possible to change current week profile for a zone
+The week profiles are retrieved from the hub. It is possible to change the current week profile for a zone
 using a selector. Week profiles must be created and edited using the Nobø Energy mobile app.
 
 ### No preset "Off"
@@ -67,9 +67,11 @@ Nobø heaters do not support preset "Off". This is not a limitation of the integ
 Nobø system (perhaps related to frozen pipes due to frost in Nordic regions). 
 "Away" temperature is fixed to 7°C and cannot be altered. On/off receivers will be off when the zone is in "Away" status.
 
-A possible workaround to turn heaters completely off, is to create a week profile (in the Nobø Energy mobile app) where
-all days are set to state off. To turn a zone off, select this week profile for the zone. To turn a zone on again,
-switch to the normal week profile for the zone.
+To turn heaters completely off, follow these steps (this is a workaround solution): 
+1. In the Nobø Energy mobile app, create a week profile.
+    - In this profile, set all days to state off. 
+2. To turn a zone off, select this week profile for the zone. 
+3. To turn a zone on again, switch to the normal week profile for the zone.
 
 For more information, see the [Nobø Ecohub manual](https://help.nobo.no/en/user-manual/before-you-start/what-is-a-weekly-program/).
 

--- a/source/_integrations/nobo_hub.markdown
+++ b/source/_integrations/nobo_hub.markdown
@@ -52,14 +52,14 @@ This can be utilized the following ways:
 
 ### Preset override duration
 
-By default, all overrides (when operation is not "Auto" mode) are constant. It is possible to change this to let
-overrides end when the week profile changes next (same as duration "Now" in the Nobø Energy mobile app) in
-the integration configuration.
+By default, all overrides (when operation is not in "Auto" mode) are constant. It is possible to change this
+to  let overrides end when the week profile changes next (same as duration "Now" in the Nobø Energy mobile app)
+in the integration configuration.
 
 ### Week profiles
 
 The week profiles are retrieved from the hub, and it is possible to change current week profile for a zone
-using a selector. Week profiles must be created and adjusted using the Nobø Energy mobile app.
+using a selector. Week profiles must be created and edited using the Nobø Energy mobile app.
 
 ### No preset "Off"
 

--- a/source/_integrations/nobo_hub.markdown
+++ b/source/_integrations/nobo_hub.markdown
@@ -63,7 +63,7 @@ using a selector. Week profiles must be created and edited using the Nobø Energ
 
 ### No preset "Off"
 
-Nobø heaters does not support preset "Off". This is not a limitation of the integration, but a safety mechanism in the
+Nobø heaters do not support preset "Off". This is not a limitation of the integration, but a safety mechanism in the
 Nobø system (perhaps related to frozen pipes due to frost in Nordic regions). 
 "Away" temperature is fixed to 7°C and cannot be altered. On/off receivers will be off when the zone is in "Away" status.
 

--- a/source/_integrations/nobo_hub.markdown
+++ b/source/_integrations/nobo_hub.markdown
@@ -12,6 +12,7 @@ ha_codeowners:
 ha_domain: nobo_hub
 ha_platforms:
   - climate
+  - select
   - sensor
 ha_integration_type: integration
 ---
@@ -27,12 +28,13 @@ on the back of the hub. If the hub is on a different network than Home Assistant
 
 # Heaters
 
-Each zone containing floor or wall mounted heaters is represented as an HVAC entity.
+Each zone containing floor or wall mounted heaters is represented as an HVAC entity. Adding and removing zones
+and heaters must be done using the Nobø Energy mobile app. 
 
 ## Operation modes
 
 Currently, you can see and change operation and preset for zones and set eco/comfort temperatures if you have
-a supported thermostat.
+a thermostat that supports remote control of the temperature settings.
 
 The possible operation modes are as follows:
 
@@ -48,13 +50,33 @@ This can be utilized the following ways:
 - Changing operation to "Auto" will automatically update preset.
 - Changing operation to "Heat" will set preset to "Comfort".
 
+### Preset override duration
+
+By default, all overrides (when operation is not "Auto" mode) are constant. It is possible to change this to let
+overrides end when the week profile changes next (same as duration "Now" in the Nobø Energy mobile app) in
+the integration configuration.
+
+### Week profiles
+
+The week profiles are retrieved from the hub, and it is possible to change current week profile for a zone
+using a selector. Week profiles must be created and adjusted using the Nobø Energy mobile app.
+
 ### No preset "Off"
 
 Nobø heaters does not support preset "Off". This is not a limitation of the integration, but a safety mechanism in the
 Nobø system (perhaps related to frozen pipes due to frost in Nordic regions). 
 "Away" temperature is fixed to 7°C and cannot be altered. On/off receivers will be off when the zone is in "Away" status.
 
+A possible workaround to turn heaters completely off, is to create a week profile (in the Nobø Energy mobile app) where
+all days are set to state off. To turn a zone off, select this week profile for the zone. To turn a zone on again,
+switch to the normal week profile for the zone.
+
 For more information, see the [Nobø Ecohub manual](https://help.nobo.no/en/user-manual/before-you-start/what-is-a-weekly-program/).
+
+## Global override
+
+To override all zones to a given preset (except the zones configured to not respect global override), use the global
+override selector. Global override duration respects the same configuration as preset override duration.  
 
 # Nobø Switch
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Implemented select entities for:
- Selecting week profile for a zone.
- Overriding preset for all zones (global override).

Selecting week profile is useful for a workaround to turn all heaters in a zone to off, which can only be done via a week profile (auto mode). It may also be useful to have automations that switch week profiles based on events, e.g. have a different week profile for staying at home on a weekday, but still lower temperature at night.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80866
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
