### PR TITLE
Add "Push Flow Meter Data" service to RainMachine

### DIFF
--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -69,10 +69,10 @@ Pause all watering activities for a number of seconds. After the pause is comple
 
 Push Flow Meter data from Home Assistant to the RainMachine device.
 
-| Service Data Attribute | Optional | Description                                                                                                       |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| `value`                | no       | The flow meter value to send. May be any positive number.                                                         |
-| `unit_of_measurement`  | yes      | The flow meter units to send. String must be one of "clicks", "gal", "m3", or "litre" (default, if not provided). |
+| Service Data Attribute | Optional | Description                                                                                                |
+| ---------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `value`                | no       | The flow meter value to send. May be any positive number.                                                  |
+| `unit_of_measurement`  | yes      | The flow meter units to send. String must be one of "clicks", "gal", "litre", or "m3"  (default: "litre"). |
 
 ### `rainmachine.push_weather_data`
 

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -45,6 +45,7 @@ Services accept either device IDs or entity IDs, depending on the nature of the 
 
 - Services that require a device ID as a target:
   - `rainmachine.pause_watering`
+  - `rainmachine.push_flow_meter_data`
   - `rainmachine.push_weather_data`
   - `rainmachine.restrict_watering`
   - `rainmachine.stop_all`
@@ -64,13 +65,22 @@ Pause all watering activities for a number of seconds. After the pause is comple
 | ---------------------- | -------- | ------------------------------ |
 | `seconds`              | no       | The number of seconds to pause |
 
+### `rainmachine.push_flow_meter_data`
+
+Push Flow Meter data from Home Assistant to the RainMachine device.
+
+| Service Data Attribute | Optional | Description                                                                                                       |
+| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `value`                | no       | The flow meter value to send. May be any positive number.                                                         |
+| `unit_of_measurement`  | yes      | The flow meter units to send. String must be one of "clicks", "gal", "m3", or "litre" (default, if not provided). |
+
 ### `rainmachine.push_weather_data`
 
 Push Weather Data from Home Assistant to the RainMachine device.
 
 Local Weather Push service should be enabled from Settings > Weather > Developer tab for RainMachine to consider the values being sent. Units must be sent in metric; no conversions are performed by the integration. Note: RAIN and QPF values shouldn't be sent as cumulative values but the measured/forecasted values for each hour or day. The RainMachine Mixer will sum all RAIN or QPF values in the current day to have the day total RAIN or QPF.
 
-See details of RainMachine API here: 
+See details of RainMachine API here:
 <https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post>
 
 | Service Data Attribute | Optional | Description                                                                                                           |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add new service to RainMachine to push flow meter data from an external device to the RainMachine controller.

This functionality was added in RainMachine API 4.6.1


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/80890
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: fixes # n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
