### PR TITLE
Update services keys in Transmission

### DIFF
--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -86,7 +86,7 @@ Adds a new torrent to download. It can either be a URL (HTTP, HTTPS or FTP), mag
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `name`    | yes | Name of the configured instance (Default: "Transmission")
+| `entry_id`    | no | The integration entry_id
 | `torrent` | no | Torrent to download
 
 ### Service `remove_torrent`
@@ -95,7 +95,7 @@ Removes a torrent from the client.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `name`    | no | Name of the configured instance (Default: "Transmission")
+| `entry_id`    | no | The integration entry_id
 | `id` | no | ID of the torrent, can be found in the `torrent_info` attribute of the `*_torrents` sensors
 | `delete_data` | yes | Delete torrent data (Default: false)
 
@@ -105,7 +105,7 @@ Starts a torrent.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `name`    | no | Name of the configured instance (Default: "Transmission")
+| `entry_id`    | no | The integration entry_id
 | `id` | no | ID of the torrent, can be found in the `torrent_info` attribute of the `*_torrents` sensors
 
 ### Service `stop_torrent`
@@ -114,7 +114,7 @@ Stops a torrent.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `name`    | no | Name of the configured instance (Default: "Transmission")
+| `entry_id`    | no | The integration entry_id
 | `id` | no | ID of the torrent, can be found in the `torrent_info` attribute of the `*_torrents` sensors
 
 ## Templating


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update services keys in Transmission. `name` key has been replaced by `entry_id` key.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/78577
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
