### PR TITLE
Add ikea symfonisk

### DIFF
--- a/source/_integrations/symfonisk.markdown
+++ b/source/_integrations/symfonisk.markdown
@@ -1,0 +1,29 @@
+---
+title: IKEA SYMFONISK
+description: Connect and control your IKEA SYMFONISK devices using the Sonos integration
+ha_category:
+  - Media Player
+  - Sensor
+ha_domain: symfonisk
+ha_release: 0.7.3
+ha_iot_class: Local Push
+ha_config_flow: true
+ha_domain: sonos
+ha_codeowners:
+  - '@cgtobi'
+  - '@jjlawren'
+ha_ssdp: true
+ha_platforms:
+  - binary_sensor
+  - diagnostics
+  - media_player
+  - number
+  - sensor
+  - switch
+ha_zeroconf: true
+ha_integration_type: integration
+ha_supporting_domain: sonos
+ha_supporting_integration: Sonos
+---
+
+{% include integrations/supported_brand.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds the IKEA SYMFONISK virtual integration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80833
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3814
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
