### PR TITLE
Fix attributes topic

### DIFF
--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -276,7 +276,7 @@ mosquitto_pub -h 127.0.0.1 -t homeassistant/device_tracker/a4567d663eaf/config -
 To set the state of the device tracker to specific coordinates:
 
 ```bash
-mosquitto_pub -h 127.0.0.1 -t a4567d663eaf/state -m '{"latitude": 32.87336, "longitude": -117.22743, "gps_accuracy": 1.2}'
+mosquitto_pub -h 127.0.0.1 -t a4567d663eaf/attributes -m '{"latitude": 32.87336, "longitude": -117.22743, "gps_accuracy": 1.2}'
 ```
 
 


### PR DESCRIPTION
## Proposed change

I believe that updates on attributes must be published to the previously defined `json_attributes_topic`. At least that's what works in my Home Assistant 2022.10.4.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].
