### PR TITLE
Add device actions to NUT integration doc

### DIFF
--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -75,4 +75,4 @@ human-readable version.
 
 ## Device Actions
 
-A device action is available for each of the parameterless NUT [commands](https://networkupstools.org/docs/user-manual.chunked/apcs03.html) supported by the device.
+A device action is available for each parameterless NUT [command](https://networkupstools.org/docs/user-manual.chunked/apcs03.html) supported by the device.

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -95,7 +95,7 @@ No actions will be available if no user credentials are specified for a given de
 
 Ensure the user you specify has the required permissions to execute the desired commands. Here's an example of a user with command permissions in the `upsd.users` file:
 
-```css
+```text
 [my_user]
     password = my_password
     actions = SET

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -72,3 +72,7 @@ values with `ups`, `battery`, `input` and `output` prefixes.
 An additional virtual sensor type `ups.status.display` is available
 translating the UPS status value retrieved from `ups.status` into a
 human-readable version.
+
+## Device Actions
+
+A device action is available for each of the parameterless NUT [commands](https://networkupstools.org/docs/user-manual.chunked/apcs03.html) supported by the device.

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -76,8 +76,11 @@ human-readable version.
 
 ## Device Actions
 
-A device action is available for each parameterless NUT [command](https://networkupstools.org/docs/user-manual.chunked/apcs03.html) supported by the device. To find the list of supported commands for your specific 
-UPS device, you can use the upscmd -l command followed by the UPS name:
+A device action is available for each parameterless NUT 
+[command](https://networkupstools.org/docs/user-manual.chunked/apcs03.html) 
+supported by the device. To find the list of supported commands for 
+your specific UPS device, you can use the `upscmd -l` command followed 
+by the UPS name:
 
 ```yaml
 $ upscmd -l my_ups

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -17,10 +17,7 @@ ha_platforms:
 ha_integration_type: device
 ---
 
-The Network UPS Tools (NUT) integration allows you to monitor and manage a UPS
-(battery backup) using a [NUT](https://networkupstools.org/)
-server. It enables you to view their status, receive notifications about important 
-events, and execute commands as device actions.
+The Network UPS Tools (NUT) integration allows you to monitor and manage a UPS (battery backup) using a [NUT] https://networkupstools.org/) server. It lets you view their status, receives notifications about important events, and execute commands as device actions.
 
 {% include integrations/config_flow.md %}
 
@@ -76,13 +73,10 @@ human-readable version.
 
 ## Device Actions
 
-A device action is available for each parameterless NUT 
-[command](https://networkupstools.org/docs/user-manual.chunked/apcs03.html) 
-supported by the device. To find the list of supported commands for 
-your specific UPS device, you can use the `upscmd -l` command followed 
-by the UPS name:
+A device action is available for each parameterless NUT [command](https://networkupstools.org/docs/user-manual.chunked/apcs03.html) supported by the device. To find the list of supported commands for 
+your specific UPS device, you can use the `upscmd -l` command followed by the UPS name:
 
-```yaml
+```bash
 $ upscmd -l my_ups
 Instant commands supported on UPS [my_ups]:
 beeper.disable - Disable the UPS beeper
@@ -91,23 +85,15 @@ test.battery.start.quick - Start a quick battery test
 test.battery.stop - Stop the battery test
 ```
 
-These commands will be available as device actions in Home Assistant,
-allowing you to interact with your UPS.
+These commands will be available as device actions in Home Assistant, allowing you to interact with your UPS.
 
 ### User Credentials and Permissions
 
-To execute device actions through the NUT integration, you need to 
-specify user credentials in the configuration. These credentials are 
-based on the `upsd.users` file, which is part of the NUT server 
-configuration. This file defines the usernames, passwords, and 
-permissions for users accessing the UPS devices.
+To execute device actions through the NUT integration, you must specify user credentials in the configuration. These credentials are stored in the `upsd.users` file, part of the NUT server configuration. This file defines the usernames, passwords, and permissions for users accessing the UPS devices.
 
-If no user credentials are specified for a given device, then no 
-actions will be available for it.
+No actions will be available if no user credentials are specified for a given device.
 
-Make sure that the user you specify has the required permissions to 
-execute the desired commands. Here's an example of a user with 
-command permissions in the `upsd.users` file:
+Ensure the user you specify has the required permissions to execute the desired commands. Here's an example of a user with command permissions in the `upsd.users` file:
 
 ```css
 [my_user]
@@ -116,10 +102,6 @@ command permissions in the `upsd.users` file:
     instcmds = ALL
 ```
 
-In this example, the user my_user has the permissions to execute all 
-commands (instcmds = ALL).
+In this example, the user `my_user` has permission to execute all commands (`instcmds = ALL`).
 
-Please note that Home Assistant cannot determine whether a given user 
-has access to a specific action without executing it. If you attempt 
-to execute an action for which the user does not have permissions, 
-an exception will be thrown at runtime.
+Please note that Home Assistant cannot determine whether a user can access a specific action without executing it. If you attempt to perform an action for which the user does not have permission, an exception will be thrown at runtime.

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -17,9 +17,10 @@ ha_platforms:
 ha_integration_type: device
 ---
 
-The Network UPS Tools (NUT) integration allows you to monitor a UPS
-(battery backup) by using data from a [NUT](https://networkupstools.org/)
-server.
+The Network UPS Tools (NUT) integration allows you to monitor and manage a UPS
+(battery backup) using a [NUT](https://networkupstools.org/)
+server. It enables you to view their status, receive notifications about important 
+events, and execute commands as device actions.
 
 {% include integrations/config_flow.md %}
 
@@ -75,4 +76,47 @@ human-readable version.
 
 ## Device Actions
 
-A device action is available for each parameterless NUT [command](https://networkupstools.org/docs/user-manual.chunked/apcs03.html) supported by the device.
+A device action is available for each parameterless NUT [command](https://networkupstools.org/docs/user-manual.chunked/apcs03.html) supported by the device. To find the list of supported commands for your specific 
+UPS device, you can use the upscmd -l command followed by the UPS name:
+
+```yaml
+$ upscmd -l my_ups
+Instant commands supported on UPS [my_ups]:
+beeper.disable - Disable the UPS beeper
+beeper.enable - Enable the UPS beeper
+test.battery.start.quick - Start a quick battery test
+test.battery.stop - Stop the battery test
+```
+
+These commands will be available as device actions in Home Assistant,
+allowing you to interact with your UPS.
+
+### User Credentials and Permissions
+
+To execute device actions through the NUT integration, you need to 
+specify user credentials in the configuration. These credentials are 
+based on the `upsd.users` file, which is part of the NUT server 
+configuration. This file defines the usernames, passwords, and 
+permissions for users accessing the UPS devices.
+
+If no user credentials are specified for a given device, then no 
+actions will be available for it.
+
+Make sure that the user you specify has the required permissions to 
+execute the desired commands. Here's an example of a user with 
+command permissions in the `upsd.users` file:
+
+```css
+[my_user]
+    password = my_password
+    actions = SET
+    instcmds = ALL
+```
+
+In this example, the user my_user has the permissions to execute all 
+commands (instcmds = ALL).
+
+Please note that Home Assistant cannot determine whether a given user 
+has access to a specific action without executing it. If you attempt 
+to execute an action for which the user does not have permissions, 
+an exception will be thrown at runtime.


### PR DESCRIPTION
Documentation change for the following PR: https://github.com/home-assistant/core/pull/80986

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR updates the [NUT integration](https://www.home-assistant.io/integrations/nut/) documentation page to include a section covering the available device actions.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/80986
- This PR is related to this feature request: [Nut Commands (upscmd)](https://community.home-assistant.io/t/nut-commands-upscmd/401107).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
