### PR TITLE
Add RainMachine config option to use default run times from app

### DIFF
--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -44,7 +44,7 @@ Note that some entities are disabled by default. If you are missing a sensor or 
 The integration has two configuration options: 
 
 1. "Default Zone Run Time": sets a default duration when turning on a zone switch (default: 600 seconds). This can be overriden with a service call (see below). 
-2. "Use Run Times from App": if enabled, will use the zone-specific run times from the last time the zone was turned on manually in the RainMachine App--this allows you to set per-zone default times using the RainMachine app instead of the same default time for all zones.
+2. "Use Run Times from App": if enabled, will use the zone-specific run times from the last time the zone was turned on manually in the RainMachine App – this allows you to set per-zone default times using the RainMachine app instead of the same default time for all zones.
 
 ## Services
 

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -39,6 +39,13 @@ Note that some entities are disabled by default. If you are missing a sensor or 
 
 {% include integrations/config_flow.md %}
 
+## Configuaration Options
+
+The integration has two configuration options: 
+
+1. "Default Zone Run Time": sets a default duration when turning on a zone switch (default: 600 seconds). This can be overriden with a service call (see below). 
+2. "Use Run Times from App": if enabled, will use the zone-specific run times from the last time the zone was turned on manually in the RainMachine App--this allows you to set per-zone default times using the RainMachine app instead of the same default time for all zones.
+
 ## Services
 
 Services accept either device IDs or entity IDs, depending on the nature of the service:
@@ -116,9 +123,9 @@ Start a RainnMachine program.
 
 Start a RainMachine zone for a set number of seconds.
 
-| Service Data Attribute | Optional | Description                                          |
-| ---------------------- | -------- | ---------------------------------------------------- |
-| `zone_run_time`        | yes      | The number of seconds to run; defaults to 60 seconds |
+| Service Data Attribute | Optional | Description                                           |
+| ---------------------- | -------- | ----------------------------------------------------- |
+| `zone_run_time`        | yes      | The number of seconds to run; defaults to 600 seconds |
 
 ### `rainmachine.stop_all`
 
@@ -145,7 +152,7 @@ Remove all watering restrictions enforced by `rainmachine.restrict_watering`.
 After Home Assistant loads, new switches will be added for every enabled program and zone. These work as expected:
 
 - Program On/Off: starts/stops a program
-- Zone On/Off: starts/stops a zone (using the `zone_run_time` parameter to determine how long to run for)
+- Zone On/Off: starts/stops a zone (using the configuration options described above to determine how long to run for)
 
 Programs and zones are linked. While a program is running, you will see both the program and zone switches turned on; turning either one off will turn the other one off (just like in the web app).
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds an option to RainMachine for the integration to use the default per-zone run times a user has set in the RainMachine app when turning on a zone from Home Assistant.

Currently, the user can specify a default run time that all zones share when toggling the switch from the front end. If the new option is enabled, the integration uses the last manual watering time for each zone from the app.

Defaults to False to prevent breaking changes.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#80984
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: fixes #n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
