### PR TITLE
Add an example to detect doorbell button presses

### DIFF
--- a/source/_integrations/amcrest.markdown
+++ b/source/_integrations/amcrest.markdown
@@ -435,18 +435,14 @@ description: "Trigger when Amcrest Button Press Event Fires"
 trigger:
   - platform: event
     event_type: amcrest
-    id: doorbell
     event_data:
-      event: CallNoAnswered
+      event: "CallNoAnswered"
       payload:
-        action: Start
-condition: []
+        action: "Start"
 action:
   - type: flash
     entity_id: light.living_room
     domain: light
-
-
 ```
 
 To check if your Amcrest camera is supported/tested, visit the [supportability matrix](https://github.com/tchellomello/python-amcrest#supportability-matrix) link from the `python-amcrest` project.

--- a/source/_integrations/amcrest.markdown
+++ b/source/_integrations/amcrest.markdown
@@ -424,4 +424,29 @@ amcrest:
       - ptz_preset
 ```
 
+## Example Automation to Detect Button Presses on AD110 and AD410 Doorbells
+
+Using this trigger in an automation will allow you to detect the press of the doorbell call button and create automations based upon it. 
+
+```yaml
+# Example automations.yaml entry
+alias: Doorbell Pressed
+description: "Trigger when Amcrest Button Press Event Fires"
+trigger:
+  - platform: event
+    event_type: amcrest
+    id: doorbell
+    event_data:
+      event: CallNoAnswered
+      payload:
+        action: Start
+condition: []
+action:
+  - type: flash
+    entity_id: light.living_room
+    domain: light
+
+
+```
+
 To check if your Amcrest camera is supported/tested, visit the [supportability matrix](https://github.com/tchellomello/python-amcrest#supportability-matrix) link from the `python-amcrest` project.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The ability to detect button presses on AD410 and AD110 doorbells is commonly discussed on forums with conflicting information given. Proposing adding this example to clear confusion. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
