### PR TITLE
Fix errant references to "Solar.Forecast" in "Forecast.Solar" documentation

### DIFF
--- a/source/_integrations/forecast_solar.markdown
+++ b/source/_integrations/forecast_solar.markdown
@@ -87,7 +87,7 @@ default. Enable those entities in the user interface if you like to use these:
 - Estimated Power Production - Next 12 Hours (in Watt)
 - Estimated Power Production - Next 24 Hours (in Watt)
 
-## Using your Solar.Forecast account
+## Using your Forecast.Solar account
 
 The [Forecast.Solar](https://forecast.solar/) can be used for free, but
 the resolution of the data used is more limited and thus, there are less
@@ -125,7 +125,7 @@ a more realistic forecast graph.
 
 [Read more about the damping factor in the Forecast.Solar documentation](https://doc.forecast.solar/doku.php?id=damping&s[]=damping).
 
-To adjust the configuration settings for your Solar.Forecast integration
+To adjust the configuration settings for your Forecast.Solar integration
 instance:
 
 - Browse to your Home Assistant instance.


### PR DESCRIPTION
## Proposed change

Docs referred in a couple of spots to "Solar.Forecast".  Those references have been corrected to "Forecast.Solar".

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
