### PR TITLE
Add note about improved UniFi PoE control

### DIFF
--- a/source/_posts/2022-11-02-release-202211.markdown
+++ b/source/_posts/2022-11-02-release-202211.markdown
@@ -310,6 +310,9 @@ noteworthy changes this release:
   - [Bayesian], added by [@HarvsG]
   - [Min/Max], added by [@gjohansson-ST]
   - [Scrape], added by [@epenet]
+- The [UniFi] integration now provides individual PoE control. Exposed per port
+  (disabled by default), it is now possible to control both client and device PoE.
+  The Old implementation will be removed with next release. Thanks, [@Kane610]!
 
 [@alexdrl]: https://github.com/alexdrl
 [@bieniu]: https://github.com/bieniu


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
As generic PoE control has been requested many times and the entities are disabled I think its a good idea to point it out in the release notes that the new implementation actually exist.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
