### PR TITLE
Add RuuviTag BLE docs

### DIFF
--- a/source/_integrations/ruuvitag_ble.markdown
+++ b/source/_integrations/ruuvitag_ble.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate RuuviTag BLE devices into Home Ass
 ha_category:
   - Sensor
 ha_bluetooth: true
-ha_release: '2022.11'
+ha_release: '2022.12'
 ha_iot_class: Local Push
 ha_codeowners:
   - '@akx'

--- a/source/_integrations/ruuvitag_ble.markdown
+++ b/source/_integrations/ruuvitag_ble.markdown
@@ -1,0 +1,26 @@
+---
+title: RuuviTag BLE
+description: Instructions on how to integrate RuuviTag BLE devices into Home Assistant.
+ha_category:
+  - Sensor
+ha_bluetooth: true
+ha_release: '2022.11'
+ha_iot_class: Local Push
+ha_codeowners:
+  - '@akx'
+ha_domain: ruuvitag_ble
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_integration_type: integration
+---
+
+Integrates [Ruuvi](https://ruuvi.com/)'s RuuviTag BLE devices into Home Assistant.
+
+{% include integrations/config_flow.md %}
+
+The RuuviTag BLE integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
+
+## Supported devices
+
+- [RuuviTag](https://ruuvi.com/ruuvitag/)


### PR DESCRIPTION
## Proposed change

Documentation PR for `ruuvitag_ble`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/81327
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/3827

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].
  - Quite like the parent PR in core, this was mostly copy-pasted from `tilt_ble`. 

[standards]: https://developers.home-assistant.io/docs/documenting/standards
