### PR TITLE
Include instructions to install gateway service

### DIFF
--- a/source/more-info/unsupported/systemd_journal.markdown
+++ b/source/more-info/unsupported/systemd_journal.markdown
@@ -17,8 +17,10 @@ and exposed to supervisor via unix socket.
 If using Home Assistant OS, update to version 7 or later.
 
 If using Home Assistant Supervised, run the following on the host:
-```
+
+```sh
 sudo apt install systemd-journal-remote -y
 ```
-and then reboot. If you still see this error then run the [supervised installer](https://github.com/home-assistant/supervised-installer)
+
+and then reboot. If you still see this issue then run the [supervised installer](https://github.com/home-assistant/supervised-installer)
 on the host as the supervisor service may need an update as well.

--- a/source/more-info/unsupported/systemd_journal.markdown
+++ b/source/more-info/unsupported/systemd_journal.markdown
@@ -16,5 +16,9 @@ and exposed to supervisor via unix socket.
 
 If using Home Assistant OS, update to version 7 or later.
 
-If using Home Assistant Supervised, re-run the [supervised installer](https://github.com/home-assistant/supervised-installer)
-on the host to set up this service and reboot.
+If using Home Assistant Supervised, run the following on the host:
+```
+sudo apt install systemd-journal-remote -y
+```
+and then reboot. If you still see this error then run the [supervised installer](https://github.com/home-assistant/supervised-installer)
+on the host as the supervisor service may need an update as well.


### PR DESCRIPTION
## Proposed change

Supervised installer requires `systemd-journal-remote` service be installed before running the installer, it does not do that for you. Therefore this needs to direct supervised users to install the service first as well.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
