### PR TITLE
Update Known working Bluetooth adapters with performance data

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -117,6 +117,8 @@ Performance testing used the following hardware:
 - ZEXMTE BT-DG54 (RTL8761BU) 📶
 - ZETSAGE BH451A (RTL8761BU) 📶
 
+📶 Denotes external antenna
+
 ### Unsupported adapters
 
 - Belkin F8T003 ver 2. - Fails to setup and add successfully

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -101,7 +101,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 
 #### Performance
 
-Performance is primarily determined by the chip and the combination of drivers that the adapter uses. Some vendors using the same chip had an unacceptable performance and are listed as unsupported.
+Performance is primarily determined combination of the chip and the Linux drivers that the adapter uses. Some vendors using the same chip had an unacceptable performance and are listed as unsupported.
 
 The following requirements must be met for an adapter to be labeled as High Performance:
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -82,20 +82,22 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 | Device                            | Chip       | High Performance | External Antennae |
 | --------------------------------- | ---------- | ---------------- | ----------------- |
 | ASUS USB-BT400                    | BCM20702A1 |                  |                   |
-| ASUS USB-BT500                    | RTL8761BU  | ⚠️                |                   |
-| Avantree DG45                     | RTL8761BU  | ⚠️                |                   |
-| EDUP LOVE EP-B3536                | RTL8761BU  | ⚠️                | ✅                |
+| ASUS USB-BT500                    | RTL8761BU  |                  |                   |
+| Avantree DG45                     | RTL8761BU  |                  |                   |
+| EDUP LOVE EP-B3536                | RTL8761BU  |                  | ✅                |
 | Feasycom FSC-BP119                | CSR8510A10 | ✅               | ✅                |
 | Kinivo BTD-400                    | BCM20702A1 |                  |                   |
-| Maxuni BT-501                     | RTL8761B   | ⚠️                |                   |
+| Maxuni BT-501                     | RTL8761BU  |                  |                   |
+| MPOW BH45A                        | RTL8761BU  |                  |                   |
 | Raspberry Pi 3B+                  | CYW43455   | ✅               |                   |
 | Raspberry Pi 4B                   | CYW43455   | ✅               |                   |
-| StarTech USBA-BLUETOOTH-V5-C2     | RTL8761BU  | ⚠️                |                   |
-| SUMEE BT501                       | RTL8761B   | ⚠️                |                   |
-| UGREEN CM390                      | RTL8761BU  | ⚠️                |                   |
-| XDO BT802                         | RTL8761BU  | ⚠️                | ✅                |
-| ZEXMTE BT-505                     | RTL8761BU  | ⚠️                | ✅                |
-| ZEXMTE BT-DG54                    | RTL8761BU  | ⚠️                |                   |
+| StarTech USBA-BLUETOOTH-V5-C2     | RTL8761BU  |                  |                   |
+| SUMEE BT501                       | RTL8761BU  |                  |                   |
+| UGREEN CM390                      | RTL8761BU  |                  |                   |
+| XDO BT802                         | RTL8761BU  |                  | ✅                |
+| ZEXMTE BT-505                     | RTL8761BU  |                  | ✅                |
+| ZEXMTE BT-DG54                    | RTL8761BU  |                  |                   |
+| ZETSAGE BH451A                    | RTL8761BU  |                  |                   |
 
 
 #### High performance requirements
@@ -103,6 +105,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - Establish a connection in about 1s or less
 - Process at least one advertisement per second from a device without dropping data
 - Reliable connections
+- Meets the above requirements with Home Assistant Operating System 9.3 or later
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -108,7 +108,7 @@ The following requirements must be met for an adapter to be labeled as High Perf
 - Establish a connection in about 1s or less
 - Process at least one advertisement per second from a device without dropping data
 - 95% of connection attempts are successful within two tries
-- Meets the above requirements with Home Assistant Operating System 9.3 or later
+- Meets the above requirements with Home Assistant Core 2022.11.1 or later and Home Assistant Operating System 9.3 or later
 
 Performance testing used the following hardware:
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -101,7 +101,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 
 #### Performance
 
-Performance is determined by the chip and the combination of drivers that the adapter uses.
+Performance is primarily determined by the chip and the combination of drivers that the adapter uses. Some vendors using the same chip had an unacceptable performance and are listed as unsupported.
 
 The following requirements must be met for an adapter to be labeled as High Performance:
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -82,20 +82,20 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 | Device                            | Chip       | High Performance | External Antennae |
 | --------------------------------- | ---------- | ---------------- | ----------------- |
 | ASUS USB-BT400                    | BCM20702A1 |                  |                   |
-| ASUS USB-BT500                    | RTL8761BU  |                  |                   |
-| Avantree DG45                     | RTL8761BU  |                  |                   |
-| EDUP LOVE EP-B3536                | RTL8761BU  |                  | ✅                |
+| ASUS USB-BT500                    | RTL8761BU  | ⚠️                |                   |
+| Avantree DG45                     | RTL8761BU  | ⚠️                |                   |
+| EDUP LOVE EP-B3536                | RTL8761BU  | ⚠️                | ✅                |
 | Feasycom FSC-BP119                | CSR8510A10 | ✅               | ✅                |
 | Kinivo BTD-400                    | BCM20702A1 |                  |                   |
-| Maxuni BT-501                     | RTL8761B   |                  |                   |
+| Maxuni BT-501                     | RTL8761B   | ⚠️                |                   |
 | Raspberry Pi 3B+                  | CYW43455   | ✅               |                   |
 | Raspberry Pi 4B                   | CYW43455   | ✅               |                   |
-| StarTech USBA-BLUETOOTH-V5-C2     | RTL8761BU  |                  |                   |
-| SUMEE BT501                       | RTL8761B   |                  |                   |
-| UGREEN CM390                      | RTL8761BU  |                  |                   |
-| XDO BT802                         | RTL8761BU  |                  | ✅                |
-| ZEXMTE BT-505                     | RTL8761BU  |                  | ✅                |
-| ZEXMTE BT-DG54                    | RTL8761BU  |                  |                   |
+| StarTech USBA-BLUETOOTH-V5-C2     | RTL8761BU  | ⚠️                |                   |
+| SUMEE BT501                       | RTL8761B   | ⚠️                |                   |
+| UGREEN CM390                      | RTL8761BU  | ⚠️                |                   |
+| XDO BT802                         | RTL8761BU  | ⚠️                | ✅                |
+| ZEXMTE BT-505                     | RTL8761BU  | ⚠️                | ✅                |
+| ZEXMTE BT-DG54                    | RTL8761BU  | ⚠️                |                   |
 
 
 #### High performance requirements

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -79,7 +79,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 
 ### Known working adapters
 
-| Device                            | Chip       | High Performance | External Antennae |
+| Device                            | Chip       | High Performance | External Antenna |
 | --------------------------------- | ---------- | ---------------- | ----------------- |
 | ASUS USB-BT400                    | BCM20702A1 | ✅               |                   |
 | ASUS USB-BT500                    | RTL8761BU  |                  |                   |

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -114,7 +114,7 @@ Performance testing used the following hardware:
 
 - Active connection to Nanoleaf A19 Bulb NL45-0800 after GATT services were cached by BlueZ
 - Advertisements from an Oral-B iO Series 8
-- External Adapters only: Home Assistant Blue running Home Assistant Operating System 9.3
+- External Adapters only: Home Assistant Blue running Home Assistant Operating System 9.3 with a USB extension cable.
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -107,13 +107,13 @@ The following requirements must be met for an adapter to be labeled as High Perf
 
 - Establish a connection in about 1s or less
 - Process at least one advertisement per second from a device without dropping data
-- 95% of connection attempts are successful within 2 tries
+- 95% of connection attempts are successful within two tries
 - Meets the above requirements with Home Assistant Operating System 9.3 or later
 
 Performance testing used the following hardware:
 
 - Active connection to Nanoleaf A19 Bulb NL45-0800 after GATT services were cached by BlueZ
-- Advertisements from a Oral-B iO Series 8
+- Advertisements from an Oral-B iO Series 8
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -81,12 +81,12 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 
 | Device                            | Chip       | High Performance | External Antennae |
 | --------------------------------- | ---------- | ---------------- | ----------------- |
-| ASUS USB-BT400                    | BCM20702A1 |                  |                   |
+| ASUS USB-BT400                    | BCM20702A1 | ✅               |                   |
 | ASUS USB-BT500                    | RTL8761BU  |                  |                   |
 | Avantree DG45                     | RTL8761BU  |                  |                   |
 | EDUP LOVE EP-B3536                | RTL8761BU  |                  | ✅                |
 | Feasycom FSC-BP119                | CSR8510A10 | ✅               | ✅                |
-| Kinivo BTD-400                    | BCM20702A1 |                  |                   |
+| Kinivo BTD-400                    | BCM20702A1 | ✅               |                   |
 | Maxuni BT-501                     | RTL8761BU  |                  |                   |
 | MPOW BH45A                        | RTL8761BU  |                  |                   |
 | Raspberry Pi 3B+                  | CYW43455   | ✅               |                   |
@@ -99,13 +99,21 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 | ZEXMTE BT-DG54                    | RTL8761BU  |                  |                   |
 | ZETSAGE BH451A                    | RTL8761BU  |                  |                   |
 
+#### Performance
 
-#### High performance requirements
+Performance is determined by the chip and the combination of drivers that the adapter uses.
+
+The following requirements must be met for an adapter to be labeled as High Performance:
 
 - Establish a connection in about 1s or less
 - Process at least one advertisement per second from a device without dropping data
-- Reliable connections
+- 95% of connection attempts are successful within 2 tries
 - Meets the above requirements with Home Assistant Operating System 9.3 or later
+
+Performance testing used the following hardware:
+
+- Active connection to Nanoleaf A19 Bulb NL45-0800 after GATT services were cached by BlueZ
+- Advertisements from a Oral-B iO Series 8
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -79,18 +79,29 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 
 ### Known working adapters
 
-- ASUS USB-BT400 [BCM20702A1]
-- ASUS USB-BT500 [RTL8761BU]
-- Avantree DG45 [RTL8761BU]
-- EDUP LOVE EP-B3536 [RTL8761BU] (Long Range)
-- Feasycom FSC-BP119 [CSR8510A10] (Long Range)
-- Kinivo BTD-400 [BCM20702A1]
-- Maxuni BT-501 [RTL8761B]
-- SUMEE BT501 [RTL8761B]
-- UGREEN CM390 [RTL8761BU]
-- XDO BT802 [RTL8761BU] (Long Range)
-- ZEXMTE BT-505 [RTL8761BU] (Long Range)
-- ZEXMTE BT-DG54 [RTL8761BU]
+| Device                            | Chip       | High Performance | External Antennae |
+| --------------------------------- | ---------- | ---------------- | ----------------- |
+| ASUS USB-BT400                    | BCM20702A1 |                  |                   |
+| ASUS USB-BT500                    | RTL8761BU  |                  |                   |
+| Avantree DG45                     | RTL8761BU  |                  |                   |
+| EDUP LOVE EP-B3536                | RTL8761BU  |                  | ✅                |
+| Feasycom FSC-BP119                | CSR8510A10 | ✅               | ✅                |
+| Kinivo BTD-400                    | BCM20702A1 |                  |                   |
+| Maxuni BT-501                     | RTL8761B   |                  |                   |
+| Raspberry Pi 3B+                  | CYW43455   | ✅               |                   |
+| Raspberry Pi 4B                   | CYW43455   | ✅               |                   |
+| SUMEE BT501                       | RTL8761B   |                  |                   |
+| UGREEN CM390                      | RTL8761BU  |                  |                   |
+| XDO BT802                         | RTL8761BU  |                  | ✅                |
+| ZEXMTE BT-505                     | RTL8761BU  |                  | ✅                |
+| ZEXMTE BT-DG54                    | RTL8761BU  |                  |                   |
+
+
+#### High performance requirements
+
+- Establish a connection in about 1s or less
+- Process at least one advertisement per second from a device without dropping data
+- Reliable connections
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -114,6 +114,7 @@ Performance testing used the following hardware:
 
 - Active connection to Nanoleaf A19 Bulb NL45-0800 after GATT services were cached by BlueZ
 - Advertisements from an Oral-B iO Series 8
+- Home Assistant Blue running Home Assistant Operating System 9.3 (excludes Raspberry Pi on-board)
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -79,11 +79,11 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 
 ### Known working high performance adapters
 
-ASUS USB-BT400 (BCM20702A1)
-Feasycom FSC-BP119 (CSR8510A10) 📶
-Kinivo BTD-400 (BCM20702A1)
-Raspberry Pi 3B+ (CYW43455)
-Raspberry Pi 4B (CYW43455)
+- ASUS USB-BT400 (BCM20702A1)
+- Feasycom FSC-BP119 (CSR8510A10) 📶
+- Kinivo BTD-400 (BCM20702A1)
+- Raspberry Pi 3B+ (CYW43455)
+- Raspberry Pi 4B (CYW43455)
 
 📶 Denotes external antenna
 
@@ -104,18 +104,18 @@ Performance testing used the following hardware:
 
 ### Known working adapters
 
-ASUS USB-BT500 (RTL8761BU)
-Avantree DG45 (RTL8761BU)
-EDUP LOVE EP-B3536 (RTL8761BU) 📶
-Maxuni BT-501 (RTL8761BU)
-MPOW BH45A (RTL8761BU)
-StarTech USBA-BLUETOOTH-V5-C2 (RTL8761BU)
-SUMEE BT501 (RTL8761BU)
-UGREEN CM390 (RTL8761BU)
-XDO BT802 (RTL8761BU) 📶
-ZEXMTE BT-505 (RTL8761BU) 📶
-ZEXMTE BT-DG54 (RTL8761BU) 📶
-ZETSAGE BH451A (RTL8761BU) 📶
+- ASUS USB-BT500 (RTL8761BU)
+- Avantree DG45 (RTL8761BU)
+- EDUP LOVE EP-B3536 (RTL8761BU) 📶
+- Maxuni BT-501 (RTL8761BU)
+- MPOW BH45A (RTL8761BU)
+- StarTech USBA-BLUETOOTH-V5-C2 (RTL8761BU)
+- SUMEE BT501 (RTL8761BU)
+- UGREEN CM390 (RTL8761BU)
+- XDO BT802 (RTL8761BU) 📶
+- ZEXMTE BT-505 (RTL8761BU) 📶
+- ZEXMTE BT-DG54 (RTL8761BU) 📶
+- ZETSAGE BH451A (RTL8761BU) 📶
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -122,8 +122,8 @@ Performance testing used the following hardware:
 ### Unsupported adapters
 
 - Belkin F8T003 ver 2. - Fails to setup and add successfully
-- tp-link UB400 [BCM20702A1] - Frequent connection failures with active connections
-- tp-link UB500 [RTL8761BU] - Frequent connection failures with active connections
+- tp-link UB400 (BCM20702A1) - Frequent connection failures with active connections
+- tp-link UB500 (RTL8761BU) - Frequent connection failures with active connections
 
 ## Multiple adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -90,6 +90,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 | Maxuni BT-501                     | RTL8761B   |                  |                   |
 | Raspberry Pi 3B+                  | CYW43455   | ✅               |                   |
 | Raspberry Pi 4B                   | CYW43455   | ✅               |                   |
+| StarTech USBA-BLUETOOTH-V5-C2     | RTL8761BU  |                  |                   |
 | SUMEE BT501                       | RTL8761B   |                  |                   |
 | UGREEN CM390                      | RTL8761BU  |                  |                   |
 | XDO BT802                         | RTL8761BU  |                  | ✅                |

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -101,7 +101,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 
 #### Performance
 
-Performance is primarily determined combination of the chip and the Linux drivers that the adapter uses. Some vendors using the same chip had an unacceptable performance and are listed as unsupported.
+Performance is primarily determined by a combination of the chip and the Linux drivers for the adapter. Some vendors using the same chip had an unacceptable performance and are listed as unsupported.
 
 The following requirements must be met for an adapter to be labeled as High Performance:
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -77,29 +77,15 @@ Some systems may not come with Bluetooth and require a USB adapter. Installing a
 
 If you experience an unreliable Bluetooth connection, installing a short USB extension cable between your Bluetooth adapter and your Home Assistant server may improve reliability.
 
-### Known working adapters
+### Known working high performance adapters
 
-| Device                            | Chip       | High Performance | External Antenna |
-| --------------------------------- | ---------- | ---------------- | ----------------- |
-| ASUS USB-BT400                    | BCM20702A1 | ✅               |                   |
-| ASUS USB-BT500                    | RTL8761BU  |                  |                   |
-| Avantree DG45                     | RTL8761BU  |                  |                   |
-| EDUP LOVE EP-B3536                | RTL8761BU  |                  | ✅                |
-| Feasycom FSC-BP119                | CSR8510A10 | ✅               | ✅                |
-| Kinivo BTD-400                    | BCM20702A1 | ✅               |                   |
-| Maxuni BT-501                     | RTL8761BU  |                  |                   |
-| MPOW BH45A                        | RTL8761BU  |                  |                   |
-| Raspberry Pi 3B+                  | CYW43455   | ✅               |                   |
-| Raspberry Pi 4B                   | CYW43455   | ✅               |                   |
-| StarTech USBA-BLUETOOTH-V5-C2     | RTL8761BU  |                  |                   |
-| SUMEE BT501                       | RTL8761BU  |                  |                   |
-| UGREEN CM390                      | RTL8761BU  |                  |                   |
-| XDO BT802                         | RTL8761BU  |                  | ✅                |
-| ZEXMTE BT-505                     | RTL8761BU  |                  | ✅                |
-| ZEXMTE BT-DG54                    | RTL8761BU  |                  |                   |
-| ZETSAGE BH451A                    | RTL8761BU  |                  |                   |
+ASUS USB-BT400 (BCM20702A1)
+Feasycom FSC-BP119 (CSR8510A10) 📶
+Kinivo BTD-400 (BCM20702A1)
+Raspberry Pi 3B+ (CYW43455)
+Raspberry Pi 4B (CYW43455)
 
-#### Performance
+📶 Denotes external antenna
 
 Performance is primarily determined by a combination of the chip and the Linux drivers for the adapter. Some vendors using the same chip had an unacceptable performance and are listed as unsupported.
 
@@ -115,6 +101,21 @@ Performance testing used the following hardware:
 - Active connection to Nanoleaf A19 Bulb NL45-0800 after GATT services were cached by BlueZ
 - Advertisements from an Oral-B iO Series 8
 - External Adapters only: Home Assistant Blue running Home Assistant Operating System 9.3 with a USB extension cable.
+
+### Known working adapters
+
+ASUS USB-BT500 (RTL8761BU)
+Avantree DG45 (RTL8761BU)
+EDUP LOVE EP-B3536 (RTL8761BU) 📶
+Maxuni BT-501 (RTL8761BU)
+MPOW BH45A (RTL8761BU)
+StarTech USBA-BLUETOOTH-V5-C2 (RTL8761BU)
+SUMEE BT501 (RTL8761BU)
+UGREEN CM390 (RTL8761BU)
+XDO BT802 (RTL8761BU) 📶
+ZEXMTE BT-505 (RTL8761BU) 📶
+ZEXMTE BT-DG54 (RTL8761BU) 📶
+ZETSAGE BH451A (RTL8761BU) 📶
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -114,7 +114,7 @@ Performance testing used the following hardware:
 
 - Active connection to Nanoleaf A19 Bulb NL45-0800 after GATT services were cached by BlueZ
 - Advertisements from an Oral-B iO Series 8
-- Home Assistant Blue running Home Assistant Operating System 9.3 (excludes Raspberry Pi on-board)
+- External Adapters only: Home Assistant Blue running Home Assistant Operating System 9.3
 
 ### Unsupported adapters
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update Known working Bluetooth adapters

I dropped the `Long Range` language as that didn't really stand up in testing and replaced it with External Antenna which is a clear differentiator but did not always improve range vs some of the better performing adapters.  Range is not considered in the data since its hard to come up with a way to accurately estimate it due to interference/repeatable testing.

The following requirements must be met for an adapter to be labeled as High Performance:

- Establish a connection in about 1s or less
- Process at least one advertisement per second from a device without dropping data
- 95% of connection attempts are successful within two tries
- Meets the above requirements with Home Assistant Core 2022.11.1 or later and Home Assistant Operating System 9.3 or later

Performance testing used the following hardware:

- Active connection to Nanoleaf A19 Bulb NL45-0800 after GATT services were cached by BlueZ
- Advertisements from an Oral-B iO Series 8

I purchased and tested all the current adapters on the list to see which ones performed the best. (More to come but not all have arrived yet)

![IMG_0035](https://user-images.githubusercontent.com/663432/200218763-7054af53-2e93-4cd2-afd7-c41e478c0c61.jpg)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
