### PR TITLE
Document trusted_networks/trusted_proxies clash

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -61,6 +61,12 @@ The [multi-factor authentication module](/docs/authentication/multi-factor-auth/
 
 </div>
 
+<div class='note info'>
+
+You cannot trust a network that you are using in any [trusted_proxies](/integrations/http/#reverse-proxies). The `trusted_networks` authentication will fail with the message: Your computer is not allowed
+
+</div>
+
 Here is an example in `configuration.yaml` to set up Trusted Networks:
 
 ```yaml


### PR DESCRIPTION
## Proposed change
I spent about a month trying to find why my `trusted_networks` config wasn't working until I stumbled upon
https://github.com/home-assistant/core/issues/77418. This documentation should probably have gone in with
https://github.com/home-assistant/core/pull/52388.


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
This PR fixes missing information about trusted_networks/trusted_proxies clash.
https://github.com/home-assistant/core/issues/77418
https://github.com/home-assistant/core/pull/52388

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
