### PR TITLE
Update Bluetooth adapters

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -82,8 +82,10 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - ASUS USB-BT400 (BCM20702A1)
 - Feasycom FSC-BP119 (CSR8510A10) 📶
 - Kinivo BTD-400 (BCM20702A1)
+- Panda Wireless PBU40 (CSR8510A10)
 - Raspberry Pi 3B+ (CYW43455)
 - Raspberry Pi 4B (CYW43455)
+- SABRENT BT-UB40 (CSR8510A10)
 
 📶 Denotes external antenna
 
@@ -122,6 +124,8 @@ Performance testing used the following hardware:
 ### Unsupported adapters
 
 - Belkin F8T003 ver 2. - Fails to setup and add successfully
+- Pluggable USB-BT4LE (BCM20702A1) - No working driver
+- QUMOX Bluetooth 5.0 (Barrot 8041A02) - No working driver
 - tp-link UB400 (BCM20702A1) - Frequent connection failures with active connections
 - tp-link UB500 (RTL8761BU) - Frequent connection failures with active connections
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -141,7 +141,9 @@ The BCM20702 based adapters may take an additional 120 seconds to initialize aft
 ### Unsupported adapters
 
 - Belkin F8T003 ver 2. - Fails to setup and add successfully
+- eppfun AK3040G (ATS2851) - No driver available yet for USB id 10d7:b012
 - QUMOX Bluetooth 5.0 (Barrot 8041A02) - No working driver
+- UGREEEN CM591 (ATS2851) - No driver available yet for USB id 10d7:b012
 - tp-link UB400 (CSR4) - Frequent connection failures with active connections
 - tp-link UB500 (RTL8761BU) - Frequent connection failures with active connections
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -88,6 +88,7 @@ Some adapters, mainly the Cambridge Silicon Radio (CSR) and Broadcom (BCM) adapt
 - Raspberry Pi 3B+ (CYW43455)
 - Raspberry Pi 4B (CYW43455)
 - SABRENT BT-UB40 (CSR8510A10)
+- Techkey PBT06H (CSR8510A10)
 
 📶 Denotes external antenna
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -81,6 +81,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 
 - ASUS USB-BT400 (BCM20702A0)
 - Cable Matters 604002-BLK (BCM20702A0)
+- Enbiawit BT403 (CSR8510A10)
 - Feasycom FSC-BP119 (CSR8510A10) 📶
 - GMYLE 3340 (BCM20702A0)
 - HIDEEZ BT0015-01 (CSR8510A10)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -86,6 +86,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - GMYLE 3340 (BCM20702A0)
 - HIDEEZ BT0015-01 (CSR8510A10)
 - Kinivo BTD-400 (BCM20702A0)
+- Nuu You BT40 (CSR8510A10)
 - Panda Wireless PBU40 (CSR8510A10)
 - Pluggable USB-BT4LE (BCM20702A0)
 - QGOO BT-06A (CSR8510A10)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -144,6 +144,7 @@ The BCM20702 based adapters may take an additional 120 seconds to initialize aft
 ### Unsupported adapters
 
 - Belkin F8T003 ver 2. - Fails to setup and add successfully
+- EDIMAX EW-7611ULB (RTL8723BU) - Frequent connection failures and drop outs
 - eppfun AK3040G (ATS2851) - No driver available yet for USB id 10d7:b012
 - QUMOX Bluetooth 5.0 (Barrot 8041A02) - No working driver
 - UGREEEN CM591 (ATS2851) - No driver available yet for USB id 10d7:b012

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -112,9 +112,9 @@ Performance testing used the following hardware:
 - Advertisements from an Oral-B iO Series 8
 - External Adapters only: Home Assistant Blue running Home Assistant Operating System 9.3 with a USB extension cable.
 
-### Slow startup on the ODRIOD N2+ platform
+### Slow startup of Broadcom adapters on the ODROID N2+ platform
 
-These adapter take an additional 120 seconds to initialize after boot with Home Assistant Operating System 9.3 when using an ODROID N2+; eventually, they come online.
+The BCM20702 based adapters take an additional 120 seconds to initialize after boot with Home Assistant Operating System 9.3 when using an ODROID N2+; eventually, they come online.
 
 ### Known working adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -88,7 +88,6 @@ Some adapters, mainly the Cambridge Silicon Radio (CSR) and Broadcom (BCM) adapt
 - Raspberry Pi 3B+ (CYW43455)
 - Raspberry Pi 4B (CYW43455)
 - SABRENT BT-UB40 (CSR8510A10)
-- StarTech USBBT1EDR4 (BCM20702A1)
 - Techkey PBT06H (CSR8510A10)
 
 📶 Denotes external antenna
@@ -117,6 +116,7 @@ Performance testing used the following hardware:
 - Maxuni BT-501 (RTL8761BU)
 - MPOW BH45A (RTL8761BU)
 - StarTech USBA-BLUETOOTH-V5-C2 (RTL8761BU)
+- StarTech USBBT1EDR4 (BCM20702A1)
 - SUMEE BT501 (RTL8761BU)
 - UGREEN CM390 (RTL8761BU)
 - XDO BT802 (RTL8761BU) 📶

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -122,6 +122,7 @@ While the Broadcom chips and drivers are generally performant, the experience ma
 
 - ASUS USB-BT500 (RTL8761BU)
 - Avantree DG45 (RTL8761BU)
+- COMCAST CF-B05 (RTL8761BU) 📶
 - EDUP LOVE EP-B3536 (RTL8761BU) 📶
 - Maxuni BT-501 (RTL8761BU)
 - MPOW BH45A (RTL8761BU)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -83,6 +83,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - Cable Matters 604002-BLK (BCM20702A0)
 - Feasycom FSC-BP119 (CSR8510A10) 📶
 - GMYLE 3340 (BCM20702A0)
+- HIDEEZ BT0015-01 (CSR8510A10)
 - Kinivo BTD-400 (BCM20702A0)
 - Panda Wireless PBU40 (CSR8510A10)
 - Pluggable USB-BT4LE (BCM20702A0)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -82,6 +82,7 @@ Some adapters, mainly the Cambridge Silicon Radio (CSR) and Broadcom (BCM) adapt
 ### Known working high performance adapters
 
 - ASUS USB-BT400 (BCM20702A1)
+- Cable Matters 604002-BLK (BCM20702A1)
 - Feasycom FSC-BP119 (CSR8510A10) 📶
 - Kinivo BTD-400 (BCM20702A1)
 - Panda Wireless PBU40 (CSR8510A10)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -112,11 +112,11 @@ These adapters do not currently have patch files with Home Assistant Operating S
 While the Broadcom chips and drivers are generally performant, the experience may be sub-optimal until patch files are added.
 
 - ASUS USB-BT400 (BCM20702A1) - USB id 0b05:17cb
-- Cable Matters 604002-BLK (BCM20702A1) - USB id 0a5c:21e8
+- Cable Matters 604002-BLK (BCM20702A0) - USB id 0a5c:21e8
 - Kinivo BTD-400 (BCM20702A0) - USB id 0a5c:21e8
-- Pluggable USB-BT4LE (BCM20702A1) - USB id 0a5c:21e8
+- Pluggable USB-BT4LE (BCM20702A0) - USB id 0a5c:21e8
 - SoundBot SB342 (BCM20702A1) - USB id 0a5c:21ec
-- StarTech USBBT2EDR4 (BCM20702A1) - USB id 0a5c:21e8
+- StarTech USBBT2EDR4 (BCM20702A0) - USB id 0a5c:21e8
   
 ### Known working adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -111,7 +111,7 @@ These adapters do not currently have patch files with Home Assistant Operating S
 
 While the Broadcom chips and drivers are generally performant, the experience may be sub-optimal until patch files are added.
 
-- ASUS USB-BT400 (BCM20702A1) - USB id 0b05:17cb
+- ASUS USB-BT400 (BCM20702A0) - USB id 0b05:17cb
 - Cable Matters 604002-BLK (BCM20702A0) - USB id 0a5c:21e8
 - Kinivo BTD-400 (BCM20702A0) - USB id 0a5c:21e8
 - Pluggable USB-BT4LE (BCM20702A0) - USB id 0a5c:21e8

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -113,7 +113,7 @@ Performance testing used the following hardware:
 
 ### Slow startup of Broadcom adapters on the ODROID N2+ platform
 
-The BCM20702 based adapters take an additional 120 seconds to initialize after boot with Home Assistant Operating System 9.3 when using an ODROID N2+; eventually, they come online.
+The BCM20702 based adapters may take an additional 120 seconds to initialize after boot with Home Assistant Operating System 9.3 when using an ODROID N2+; eventually, they come online.
 
 ### Known working adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -82,6 +82,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - ASUS USB-BT400 (BCM20702A0)
 - Cable Matters 604002-BLK (BCM20702A0)
 - Feasycom FSC-BP119 (CSR8510A10) 📶
+- GMYLE 3340 (BCM20702A0)
 - Kinivo BTD-400 (BCM20702A0)
 - Panda Wireless PBU40 (CSR8510A10)
 - Pluggable USB-BT4LE (BCM20702A0)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -112,7 +112,7 @@ Performance testing used the following hardware:
 
 - ASUS USB-BT500 (RTL8761BU)
 - Avantree DG45 (RTL8761BU)
-- Cable Matters 604002-BLK (BCM20702A1) - Good performance, but takes 2-3 minutes to initialize after boot
+- Cable Matters 604002-BLK (BCM20702A1) - Performant, but takes 2-3 minutes to initialize after boot
 - EDUP LOVE EP-B3536 (RTL8761BU) 📶
 - Maxuni BT-501 (RTL8761BU)
 - MPOW BH45A (RTL8761BU)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -77,8 +77,6 @@ Some systems may not come with Bluetooth and require a USB adapter. Installing a
 
 If you experience an unreliable Bluetooth connection, installing a short USB extension cable between your Bluetooth adapter and your Home Assistant server may improve reliability.
 
-Some adapters, mainly the Cambridge Silicon Radio (CSR) and Broadcom (BCM) adapters, require a reboot to be discovered.
-
 ### Known working high performance adapters
 
 - Feasycom FSC-BP119 (CSR8510A10) 📶
@@ -108,7 +106,9 @@ Performance testing used the following hardware:
 
 ### Adapters with missing firmware patch files
 
-These adapters do not currently have patch files with Home Assistant Operating System 9.3. The adapter may take multiple minutes to initialize after boot; eventually, they come online. While the Broadcom chips and drivers are generally performant, the experience may be sub-optimal until patch files are added.
+These adapters do not currently have patch files with Home Assistant Operating System 9.3. The adapter may take multiple minutes to initialize after boot; eventually, they come online.
+
+While the Broadcom chips and drivers are generally performant, the experience may be sub-optimal until patch files are added.
 
 - ASUS USB-BT400 (BCM20702A1) - USB id 0b05:17cb
 - Cable Matters 604002-BLK (BCM20702A1) - USB id 0a5c:21e8

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -112,7 +112,7 @@ While the Broadcom chips and drivers are generally performant, the experience ma
 
 - ASUS USB-BT400 (BCM20702A1) - USB id 0b05:17cb
 - Cable Matters 604002-BLK (BCM20702A1) - USB id 0a5c:21e8
-- Kinivo BTD-400 (BCM20702A1) - USB id 0a5c:21e8
+- Kinivo BTD-400 (BCM20702A0) - USB id 0a5c:21e8
 - Pluggable USB-BT4LE (BCM20702A1) - USB id 0a5c:21e8
 - SoundBot SB342 (BCM20702A1) - USB id 0a5c:21ec
 - StarTech USBBT2EDR4 (BCM20702A1) - USB id 0a5c:21e8

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -96,6 +96,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - StarTech USBBT2EDR4 (BCM20702A0)
 - Techkey PBT06H (CSR8510A10)
 - TRENDnet TBW-107UB (CSR8510A10)
+- UGREEN CM109 (CSR8510A10)
 - Warmstor WBT-AD01 (CSR8510A10)
 
 📶 Denotes external antenna

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -112,11 +112,11 @@ Performance testing used the following hardware:
 
 - ASUS USB-BT500 (RTL8761BU)
 - Avantree DG45 (RTL8761BU)
-- Cable Matters 604002-BLK (BCM20702A1) - Performant, but takes multiple minutes to initialize after boot because firmware patch files are missing for 0a5c-21e8
+- Cable Matters 604002-BLK (BCM20702A1) - Performant, but takes multiple minutes to initialize after boot; firmware patch files are missing for 0a5c-21e8
 - EDUP LOVE EP-B3536 (RTL8761BU) 📶
 - Maxuni BT-501 (RTL8761BU)
 - MPOW BH45A (RTL8761BU)
-- Pluggable USB-BT4LE (BCM20702A1) - Performant, but takes multiple minutes to initialize after boot because firmware patch files are missing for 0a5c-21e8
+- Pluggable USB-BT4LE (BCM20702A1) - Performant, but takes multiple minutes to initialize after boot; firmware patch files are missing for 0a5c-21e8
 - StarTech USBA-BLUETOOTH-V5-C2 (RTL8761BU)
 - SUMEE BT501 (RTL8761BU)
 - UGREEN CM390 (RTL8761BU)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -106,6 +106,7 @@ The following requirements must be met for an adapter to be labeled as High Perf
 - Process at least one advertisement per second from a device without dropping data
 - 95% of connection attempts are successful within two tries
 - Meets the above requirements with Home Assistant Core 2022.11.1 or later and Home Assistant Operating System 9.3 or later
+- Must be able to hold five (5) connections at the same time
 
 Performance testing used the following hardware:
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -85,6 +85,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - Kinivo BTD-400 (BCM20702A0)
 - Panda Wireless PBU40 (CSR8510A10)
 - Pluggable USB-BT4LE (BCM20702A0)
+- QGOO BT-06A (CSR8510A10)
 - Raspberry Pi 3B+ (CYW43455)
 - Raspberry Pi 4B (CYW43455)
 - SABRENT BT-UB40 (CSR8510A10)
@@ -93,6 +94,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - StarTech USBBT2EDR4 (BCM20702A0)
 - Techkey PBT06H (CSR8510A10)
 - TRENDnet TBW-107UB (CSR8510A10)
+- Warmstor WBT-AD01 (CSR8510A10)
 
 📶 Denotes external antenna
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -104,7 +104,7 @@ Performance testing used the following hardware:
 - Advertisements from an Oral-B iO Series 8
 - External Adapters only: Home Assistant Blue running Home Assistant Operating System 9.3 with a USB extension cable.
 
-### Adapters with missing firmware patch files
+### Known working adapters with missing firmware patch files
 
 These adapters do not currently have patch files with Home Assistant Operating System 9.3. The adapter may take multiple minutes to initialize after boot; eventually, they come online.
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -88,6 +88,7 @@ Some adapters, mainly the Cambridge Silicon Radio (CSR) and Broadcom (BCM) adapt
 - Raspberry Pi 3B+ (CYW43455)
 - Raspberry Pi 4B (CYW43455)
 - SABRENT BT-UB40 (CSR8510A10)
+- StarTech USBBT1EDR4 (BCM20702A1)
 - Techkey PBT06H (CSR8510A10)
 
 📶 Denotes external antenna
@@ -112,11 +113,9 @@ Performance testing used the following hardware:
 
 - ASUS USB-BT500 (RTL8761BU)
 - Avantree DG45 (RTL8761BU)
-- Cable Matters 604002-BLK (BCM20702A1) - Performant, but takes multiple minutes to initialize after boot; firmware patch files are missing for 0a5c-21e8
 - EDUP LOVE EP-B3536 (RTL8761BU) 📶
 - Maxuni BT-501 (RTL8761BU)
 - MPOW BH45A (RTL8761BU)
-- Pluggable USB-BT4LE (BCM20702A1) - Performant, but takes multiple minutes to initialize after boot; firmware patch files are missing for 0a5c-21e8
 - StarTech USBA-BLUETOOTH-V5-C2 (RTL8761BU)
 - SUMEE BT501 (RTL8761BU)
 - UGREEN CM390 (RTL8761BU)
@@ -126,6 +125,15 @@ Performance testing used the following hardware:
 - ZETSAGE BH451A (RTL8761BU) 📶
 
 📶 Denotes external antenna
+
+### Adapters with missing firmware patch files
+
+These adapters do not currently have patch files with Home Assistant Operating System 9.3. They take multiple minutes to initialize after boot but do eventually come online and may not be reliable.
+
+- Cable Matters 604002-BLK (BCM20702A1) - usb id 0a5c-21e8
+- Pluggable USB-BT4LE (BCM20702A1) - usb id 0a5c-21e8
+- SoundBot SB342 (BCM20702A1) - usb id 0a5c-21ec
+- StarTech USBBT2EDR4 (BCM20702A1) - usb id 0a5c-21e8
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -142,6 +142,10 @@ The BCM20702 based adapters may take an additional 120 seconds to initialize aft
 
 📶 Denotes external antenna
 
+#### Realtek RTL8761BU adapters
+
+These adapters do not have a reset pin. If they stop responding, there is currently no way for the kernel to reset them automatically. A generic USB reset for these adapters has been introduced in Linux kernel 6.1 and later.
+
 ### Unsupported adapters
 
 - Belkin F8T003 ver 2. - Fails to setup and add successfully

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -112,7 +112,7 @@ Performance testing used the following hardware:
 
 - ASUS USB-BT500 (RTL8761BU)
 - Avantree DG45 (RTL8761BU)
-- Cable Matters 604002-BLK (BCM20702A1) - Takes 2-3 minutes to initialize after boot
+- Cable Matters 604002-BLK (BCM20702A1) - Good performance, but takes 2-3 minutes to initialize after boot
 - EDUP LOVE EP-B3536 (RTL8761BU) 📶
 - Maxuni BT-501 (RTL8761BU)
 - MPOW BH45A (RTL8761BU)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -82,7 +82,6 @@ Some adapters, mainly the Cambridge Silicon Radio (CSR) and Broadcom (BCM) adapt
 ### Known working high performance adapters
 
 - Feasycom FSC-BP119 (CSR8510A10) 📶
-- Kinivo BTD-400 (BCM20702A1)
 - Panda Wireless PBU40 (CSR8510A10)
 - Raspberry Pi 3B+ (CYW43455)
 - Raspberry Pi 4B (CYW43455)
@@ -113,6 +112,7 @@ These adapters do not currently have patch files with Home Assistant Operating S
 
 - ASUS USB-BT400 (BCM20702A1) - USB id 0b05:17cb
 - Cable Matters 604002-BLK (BCM20702A1) - USB id 0a5c:21e8
+- Kinivo BTD-400 (BCM20702A1)
 - Pluggable USB-BT4LE (BCM20702A1) - USB id 0a5c:21e8
 - SoundBot SB342 (BCM20702A1) - USB id 0a5c:21ec
 - StarTech USBBT2EDR4 (BCM20702A1) - USB id 0a5c:21e8

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -81,7 +81,6 @@ Some adapters, mainly the Cambridge Silicon Radio (CSR) and Broadcom (BCM) adapt
 
 ### Known working high performance adapters
 
-- ASUS USB-BT400 (BCM20702A1)
 - Feasycom FSC-BP119 (CSR8510A10) 📶
 - Kinivo BTD-400 (BCM20702A1)
 - Panda Wireless PBU40 (CSR8510A10)
@@ -108,6 +107,16 @@ Performance testing used the following hardware:
 - Advertisements from an Oral-B iO Series 8
 - External Adapters only: Home Assistant Blue running Home Assistant Operating System 9.3 with a USB extension cable.
 
+### Adapters with missing firmware patch files
+
+These adapters do not currently have patch files with Home Assistant Operating System 9.3. The adapter may take multiple minutes to initialize after boot; eventually, they come online. While the Broadcom chips and drivers are generally performant, the experience may be sub-optimal until patch files are added.
+
+- ASUS USB-BT400 (BCM20702A1) - USB id 0b05:17cb
+- Cable Matters 604002-BLK (BCM20702A1) - USB id 0a5c:21e8
+- Pluggable USB-BT4LE (BCM20702A1) - USB id 0a5c:21e8
+- SoundBot SB342 (BCM20702A1) - USB id 0a5c:21ec
+- StarTech USBBT2EDR4 (BCM20702A1) - USB id 0a5c:21e8
+  
 ### Known working adapters
 
 - ASUS USB-BT500 (RTL8761BU)
@@ -125,15 +134,6 @@ Performance testing used the following hardware:
 - ZETSAGE BH451A (RTL8761BU) 📶
 
 📶 Denotes external antenna
-
-### Adapters with missing firmware patch files
-
-These adapters do not currently have patch files with Home Assistant Operating System 9.3. They take multiple minutes to initialize after boot but do eventually come online and may not be reliable.
-
-- Cable Matters 604002-BLK (BCM20702A1) - USB id 0a5c:21e8
-- Pluggable USB-BT4LE (BCM20702A1) - USB id 0a5c:21e8
-- SoundBot SB342 (BCM20702A1) - USB id 0a5c:21ec
-- StarTech USBBT2EDR4 (BCM20702A1) - USB id 0a5c:21e8
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -77,6 +77,8 @@ Some systems may not come with Bluetooth and require a USB adapter. Installing a
 
 If you experience an unreliable Bluetooth connection, installing a short USB extension cable between your Bluetooth adapter and your Home Assistant server may improve reliability.
 
+Some adapters, mainly the Cambridge Silicon Radio (CSR) and Broadcom (BCM) adapters, require a reboot to be discovered.
+
 ### Known working high performance adapters
 
 - ASUS USB-BT400 (BCM20702A1)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -111,7 +111,7 @@ Performance testing used the following hardware:
 - Advertisements from an Oral-B iO Series 8
 - External Adapters only: Home Assistant Blue running Home Assistant Operating System 9.3 with a USB extension cable.
 
-### Slow startup of Broadcom adapters on the ODROID N2+ platform
+#### Slow startup of Broadcom adapters on the ODROID N2+ platform
 
 The BCM20702 based adapters may take an additional 120 seconds to initialize after boot with Home Assistant Operating System 9.3 when using an ODROID N2+; eventually, they come online.
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -84,6 +84,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - Raspberry Pi 3B+ (CYW43455)
 - Raspberry Pi 4B (CYW43455)
 - SABRENT BT-UB40 (CSR8510A10)
+- StarTech USBBT1EDR4 (CSR8510A10)
 - Techkey PBT06H (CSR8510A10)
 
 📶 Denotes external antenna
@@ -125,7 +126,6 @@ While the Broadcom chips and drivers are generally performant, the experience ma
 - Maxuni BT-501 (RTL8761BU)
 - MPOW BH45A (RTL8761BU)
 - StarTech USBA-BLUETOOTH-V5-C2 (RTL8761BU)
-- StarTech USBBT1EDR4 (BCM20702A1)
 - SUMEE BT501 (RTL8761BU)
 - UGREEN CM390 (RTL8761BU)
 - XDO BT802 (RTL8761BU) 📶

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -151,6 +151,7 @@ The BCM20702 based adapters may take an additional 120 seconds to initialize aft
 - UGREEEN CM591 (ATS2851) - No driver available yet for USB id 10d7:b012
 - tp-link UB400 (CSR4) - Frequent connection failures with active connections
 - tp-link UB500 (RTL8761BU) - Frequent connection failures with active connections
+- Unbranded CSR 4.0 clones with USB id 0a12:0001 - Unrecoverable driver failure
 
 ## Multiple adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -85,6 +85,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - Feasycom FSC-BP119 (CSR8510A10) 📶
 - GMYLE 3340 (BCM20702A0)
 - HIDEEZ BT0015-01 (CSR8510A10)
+- IOGEAR GBU521W6 (BCM20702A0)
 - Kinivo BTD-400 (BCM20702A0)
 - Nuu You BT40 (CSR8510A10)
 - Panda Wireless PBU40 (CSR8510A10)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -79,12 +79,18 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 
 ### Known working high performance adapters
 
+- ASUS USB-BT400 (BCM20702A0)
+- Cable Matters 604002-BLK (BCM20702A0)
 - Feasycom FSC-BP119 (CSR8510A10) 📶
+- Kinivo BTD-400 (BCM20702A0)
 - Panda Wireless PBU40 (CSR8510A10)
+- Pluggable USB-BT4LE (BCM20702A0)
 - Raspberry Pi 3B+ (CYW43455)
 - Raspberry Pi 4B (CYW43455)
 - SABRENT BT-UB40 (CSR8510A10)
+- SoundBot SB342 (BCM20702A0)
 - StarTech USBBT1EDR4 (CSR8510A10)
+- StarTech USBBT2EDR4 (BCM20702A0)
 - Techkey PBT06H (CSR8510A10)
 - TRENDnet TBW-107UB (CSR8510A10)
 
@@ -106,19 +112,10 @@ Performance testing used the following hardware:
 - Advertisements from an Oral-B iO Series 8
 - External Adapters only: Home Assistant Blue running Home Assistant Operating System 9.3 with a USB extension cable.
 
-### Known working adapters with missing firmware patch files
+### Slow startup on the ODRIOD N2+ platform
 
-These adapters do not currently have patch files with Home Assistant Operating System 9.3. The adapter may take multiple minutes to initialize after boot; eventually, they come online.
+These adapter take an additional 120 seconds to initialize after boot with Home Assistant Operating System 9.3 when using an ODROID N2+; eventually, they come online.
 
-While the Broadcom chips and drivers are generally performant, the experience may be sub-optimal until patch files are added.
-
-- ASUS USB-BT400 (BCM20702A0) - USB id 0b05:17cb
-- Cable Matters 604002-BLK (BCM20702A0) - USB id 0a5c:21e8
-- Kinivo BTD-400 (BCM20702A0) - USB id 0a5c:21e8
-- Pluggable USB-BT4LE (BCM20702A0) - USB id 0a5c:21e8
-- SoundBot SB342 (BCM20702A0) - USB id 0a5c:21ec
-- StarTech USBBT2EDR4 (BCM20702A0) - USB id 0a5c:21e8
-  
 ### Known working adapters
 
 - ASUS USB-BT500 (RTL8761BU)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -139,7 +139,7 @@ While the Broadcom chips and drivers are generally performant, the experience ma
 
 - Belkin F8T003 ver 2. - Fails to setup and add successfully
 - QUMOX Bluetooth 5.0 (Barrot 8041A02) - No working driver
-- tp-link UB400 (BCM20702A1) - Frequent connection failures with active connections
+- tp-link UB400 (CSR4) - Frequent connection failures with active connections
 - tp-link UB500 (RTL8761BU) - Frequent connection failures with active connections
 
 ## Multiple adapters

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -112,7 +112,7 @@ While the Broadcom chips and drivers are generally performant, the experience ma
 
 - ASUS USB-BT400 (BCM20702A1) - USB id 0b05:17cb
 - Cable Matters 604002-BLK (BCM20702A1) - USB id 0a5c:21e8
-- Kinivo BTD-400 (BCM20702A1)
+- Kinivo BTD-400 (BCM20702A1) - USB id 0a5c:21e8
 - Pluggable USB-BT4LE (BCM20702A1) - USB id 0a5c:21e8
 - SoundBot SB342 (BCM20702A1) - USB id 0a5c:21ec
 - StarTech USBBT2EDR4 (BCM20702A1) - USB id 0a5c:21e8

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -115,7 +115,7 @@ While the Broadcom chips and drivers are generally performant, the experience ma
 - Cable Matters 604002-BLK (BCM20702A0) - USB id 0a5c:21e8
 - Kinivo BTD-400 (BCM20702A0) - USB id 0a5c:21e8
 - Pluggable USB-BT4LE (BCM20702A0) - USB id 0a5c:21e8
-- SoundBot SB342 (BCM20702A1) - USB id 0a5c:21ec
+- SoundBot SB342 (BCM20702A0) - USB id 0a5c:21ec
 - StarTech USBBT2EDR4 (BCM20702A0) - USB id 0a5c:21e8
   
 ### Known working adapters

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -86,6 +86,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - SABRENT BT-UB40 (CSR8510A10)
 - StarTech USBBT1EDR4 (CSR8510A10)
 - Techkey PBT06H (CSR8510A10)
+- TRENDnet TBW-107UB (CSR8510A10)
 
 📶 Denotes external antenna
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -130,10 +130,10 @@ Performance testing used the following hardware:
 
 These adapters do not currently have patch files with Home Assistant Operating System 9.3. They take multiple minutes to initialize after boot but do eventually come online and may not be reliable.
 
-- Cable Matters 604002-BLK (BCM20702A1) - usb id 0a5c-21e8
-- Pluggable USB-BT4LE (BCM20702A1) - usb id 0a5c-21e8
-- SoundBot SB342 (BCM20702A1) - usb id 0a5c-21ec
-- StarTech USBBT2EDR4 (BCM20702A1) - usb id 0a5c-21e8
+- Cable Matters 604002-BLK (BCM20702A1) - USB id 0a5c:21e8
+- Pluggable USB-BT4LE (BCM20702A1) - USB id 0a5c:21e8
+- SoundBot SB342 (BCM20702A1) - USB id 0a5c:21ec
+- StarTech USBBT2EDR4 (BCM20702A1) - USB id 0a5c:21e8
 
 ### Unsupported adapters
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -82,7 +82,6 @@ Some adapters, mainly the Cambridge Silicon Radio (CSR) and Broadcom (BCM) adapt
 ### Known working high performance adapters
 
 - ASUS USB-BT400 (BCM20702A1)
-- Cable Matters 604002-BLK (BCM20702A1)
 - Feasycom FSC-BP119 (CSR8510A10) 📶
 - Kinivo BTD-400 (BCM20702A1)
 - Panda Wireless PBU40 (CSR8510A10)
@@ -97,6 +96,7 @@ Performance is primarily determined by a combination of the chip and the Linux d
 
 The following requirements must be met for an adapter to be labeled as High Performance:
 
+- Up by the time the Home Assistant Core container is started when using Home Assistant Operating System
 - Establish a connection in about 1s or less
 - Process at least one advertisement per second from a device without dropping data
 - 95% of connection attempts are successful within two tries
@@ -112,6 +112,7 @@ Performance testing used the following hardware:
 
 - ASUS USB-BT500 (RTL8761BU)
 - Avantree DG45 (RTL8761BU)
+- Cable Matters 604002-BLK (BCM20702A1) - Takes 2-3 minutes to initialize after boot
 - EDUP LOVE EP-B3536 (RTL8761BU) 📶
 - Maxuni BT-501 (RTL8761BU)
 - MPOW BH45A (RTL8761BU)

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -112,10 +112,11 @@ Performance testing used the following hardware:
 
 - ASUS USB-BT500 (RTL8761BU)
 - Avantree DG45 (RTL8761BU)
-- Cable Matters 604002-BLK (BCM20702A1) - Performant, but takes 2-3 minutes to initialize after boot
+- Cable Matters 604002-BLK (BCM20702A1) - Performant, but takes multiple minutes to initialize after boot because firmware patch files are missing for 0a5c-21e8
 - EDUP LOVE EP-B3536 (RTL8761BU) 📶
 - Maxuni BT-501 (RTL8761BU)
 - MPOW BH45A (RTL8761BU)
+- Pluggable USB-BT4LE (BCM20702A1) - Performant, but takes multiple minutes to initialize after boot because firmware patch files are missing for 0a5c-21e8
 - StarTech USBA-BLUETOOTH-V5-C2 (RTL8761BU)
 - SUMEE BT501 (RTL8761BU)
 - UGREEN CM390 (RTL8761BU)
@@ -129,7 +130,6 @@ Performance testing used the following hardware:
 ### Unsupported adapters
 
 - Belkin F8T003 ver 2. - Fails to setup and add successfully
-- Pluggable USB-BT4LE (BCM20702A1) - No working driver
 - QUMOX Bluetooth 5.0 (Barrot 8041A02) - No working driver
 - tp-link UB400 (BCM20702A1) - Frequent connection failures with active connections
 - tp-link UB500 (RTL8761BU) - Frequent connection failures with active connections

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -100,7 +100,6 @@ Performance is primarily determined by a combination of the chip and the Linux d
 
 The following requirements must be met for an adapter to be labeled as High Performance:
 
-- Up by the time the Home Assistant Core container is started when using Home Assistant Operating System
 - Establish a connection in about 1s or less
 - Process at least one advertisement per second from a device without dropping data
 - 95% of connection attempts are successful within two tries


### PR DESCRIPTION
## Proposed change

Now that I know what to look for when ordering these, I found
quite a few more of the better performing ones as the quality
of the Linux driver seems to be the most important factor.

Another pile of adapters arrived today so I'm updating
the docs again.

Document the slow startup of the Broadcom adapters
on the Odroid n2+

Document the lack of reset pin on the RTLs

The test box has grown to two test boxes:
![IMG_0068](https://user-images.githubusercontent.com/663432/201812110-86c3c407-6668-445c-9277-81c2cd3b2954.jpg)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
