### PR TITLE
Fix hvac mode keys

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -414,13 +414,19 @@ modbus:
         hvac_mode_register:
           address: 11
           values:
-            auto: 0
-            cool: 1
-            heat: 2
-            fan_only: 3
-            dry: 4
+            state_auto: 0
+            state_cool: 1
+            state_heat: 2
+            state_fan_only: 3
+            state_dry: 4
         hvac_onoff_register: 11
 ```
+
+{% details "Previous configuration format" %}
+
+The configuration format of `hvac_mode_register` has changed. The old format uses keys such as `off`, `auto`, `cool` instead of `state_off`, `state_auto` and `state_cool` that is currently used. The old keys should no longer be used and is deprecated.
+
+{% enddetails %}
 
 {% configuration %}
 climates:
@@ -480,31 +486,31 @@ climates:
           required: true
           type: [map]
           keys:
-            "off":
+            state_off:
               description: The register value corresponding to HVAC Off mode.
               required: false
               type: integer
-            heat:
+            state_heat:
               description: The register value corresponding to HVAC Heat mode.
               required: false
               type: integer
-            cool:
+            state_cool:
               description: The register value corresponding to HVAC Cool mode.
               required: false
               type: integer
-            auto:
+            state_auto:
               description: The register value corresponding to HVAC Auto mode.
               required: false
               type: integer
-            dry:
+            state_dry:
               description: The register value corresponding to HVAC Dry mode.
               required: false
               type: integer
-            fan_only:
+            state_fan_only:
               description: The register value corresponding to HVAC Fan only mode.
               required: false
               type: integer
-            heat_cool:
+            state_heat_cool:
               description: The register value corresponding to HVAC Heat/Cool mode.
               required: false
               type: integer

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -419,6 +419,7 @@ modbus:
             state_heat: 2
             state_fan_only: 3
             state_dry: 4
+            state_off: 5
         hvac_onoff_register: 11
 ```
 


### PR DESCRIPTION
The keys used in the configuration under modbus -> climate -> hvac_mode_register have changed.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Change the names of the keys used for the configuration of climate mode in Modbus integration. The existing keys use the word "off" which gets parsed as a boolean False instead of a string.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
