### PR TITLE
Fix "Developer Tools -> Services" link

### DIFF
--- a/source/_docs/automation/basics.markdown
+++ b/source/_docs/automation/basics.markdown
@@ -37,7 +37,7 @@ Automation rules interact directly with the internal state of Home Assistant, so
 
 State changes can be used as the source of triggers and the current state can be used in conditions.
 
-Actions are all about calling *services*. To explore the available *services* open the **{% my developer_states title="Developer Tools -> Services" %}**. *Services* allow changing anything. For example turn on a light, run a script or enable a scene. Each *service* has a domain and a name. For example the *service* {% my developer_call_service service="light.turn_on" %} is capable of turning on any light in your system. Parameters can be passed to a *service* to indicate, for example, which device to activate or which color to use.
+Actions are all about calling *services*. To explore the available *services* open the **{% my developer_services title="Developer Tools -> Services" %}**. *Services* allow changing anything. For example turn on a light, run a script or enable a scene. Each *service* has a domain and a name. For example the *service* {% my developer_call_service service="light.turn_on" %} is capable of turning on any light in your system. Parameters can be passed to a *service* to indicate, for example, which device to activate or which color to use.
 
 ## Creating automations
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fixes the "My Home Assistant" link to "Developer Tools -> Services" (it was previously linking to "Developer Tools -> States").


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
