### PR TITLE
add Signal Messenger JSONRPC

### DIFF
--- a/source/_integrations/signal_messenger_jsonrpc.markdown
+++ b/source/_integrations/signal_messenger_jsonrpc.markdown
@@ -1,0 +1,123 @@
+---
+title: Signal Messenger JSONRPC
+description: Instructions on how to integrate Signal Messenger JSONRPC within Home Assistant.
+ha_category:
+  - Notifications
+ha_iot_class: Cloud Push
+ha_codeowners:
+  - '@morph027'
+ha_domain: signal_messenger_jsonrpc
+ha_platforms:
+  - notify
+ha_integration_type: integration
+---
+
+The `signal_messenger_jsonrpc` integration uses the native JSON-RPC HTTP endpoint of [signal-cli](https://github.com/AsamK/signal-cli/) to deliver notifications from Home Assistant to your Android, iOS or other Signal client devices.
+
+## Setup
+ 
+The requirements are:
+
+- You need to set up the signal-cli w/ http endpoint. 
+- You need a spare phone number to register with the signal-cli service. 
+
+Please follow the signal-cli [instructions](https://github.com/AsamK/signal-cli/#installation) to set up the requirements.
+
+
+## Configuration
+
+To send Signal Messenger notifications with Home Assistant, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry for Signal Messenger JSONRPC
+notify:
+  - name: signal
+    platform: signal_messenger_jsonrpc
+    endpoint: "http://127.0.0.1:3000/api/v1/rpc" # the URL where the signal-cli JSON-RPC API is listening 
+    user: username # optional basic auth username
+    password: password # optional basic auth password
+    account: "YOUR_SIGNAL_CLI_ACCOUNT" # the sender account
+    recipients: # one or more recipients
+      - "RECIPIENT1"
+```
+
+Both phone numbers and Signal Messenger groups can be added to the `recipients` list. However, it's not possible to mix phone numbers and Signal Messenger groups in a single notifier. If you would like to send messages to individual phone numbers and Signal Messenger groups, separate notifiers need to be created.
+
+You can obtain Signal Messenger group ids using this api call:
+
+```
+curl -s -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "method": "listGroups", "id": "42", "params": {"account": "YOUR_SIGNAL_CLI_ACCOUNT"}}' http://127.0.0.1:3000/api/v1/rpc # the URL where the signal-cli JSON-RPC API is listening
+```
+
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  type: string
+  default: notify
+endpoint:
+  description: the URL where the signal-cli JSON-RPC API is listening.
+  required: true
+  type: string
+username:
+  description: Optional basic auth username.
+  required: false
+  type: string
+password:
+  description: Optional basic auth password.
+  required: false
+  type: string
+account:
+  description: The sender account.
+  required: true
+  type: string
+recipients:
+  description: A list of recipients (either phone numbers or Signal Messenger group ids).
+  required: true
+  type: string
+{% endconfiguration %}
+
+## Examples
+
+A few examples on how to use this integration as actions in automations.
+
+### Text message
+
+```yaml
+...
+action:
+  service: notify.NOTIFIER_NAME
+  data:
+    message: "That's an example that sends a simple text message to the recipients specified in the configuration.yaml"
+```
+
+### Text message with an attachment
+
+```yaml
+...
+action:
+  service: notify.NOTIFIER_NAME
+  data:
+    message: "Alarm in the living room!"
+    data:
+      attachments:
+        - "/tmp/surveillance_camera.jpg"
+```
+
+### Text message with an attachment from a URL
+
+To attach files from outside of Home Assistant, the URLs must be added to the [`allowlist_external_urls`](/docs/configuration/basic/#allowlist_external_urls) list.
+
+Note there is a 50MB size limit for attachments retrieved via URLs. You can also set `verify_ssl` to `false` to ignore SSL errors (default `true`).
+
+```yaml
+...
+action:
+  service: notify.NOTIFIER_NAME
+  data:
+    message: "Person detected on Front Camera!"
+    data:
+      verify_ssl: false
+      urls:
+        - "http://homeassistant.local/api/frigate/notifications/<event-id>/thumbnail.jpg"
+```

--- a/source/_integrations/signal_messenger_jsonrpc.markdown
+++ b/source/_integrations/signal_messenger_jsonrpc.markdown
@@ -18,7 +18,7 @@ The `signal_messenger_jsonrpc` integration uses the native JSON-RPC HTTP endpoin
  
 The requirements are:
 
-- You need to set up the signal-cli w/ http endpoint. 
+- You need to set up the signal-cli w/ HTTP endpoint. 
 - You need a spare phone number to register with the signal-cli service. 
 
 Please follow the signal-cli [instructions](https://github.com/AsamK/signal-cli/#installation) to set up the requirements.
@@ -45,7 +45,7 @@ Both phone numbers and Signal Messenger groups can be added to the `recipients` 
 
 You can obtain Signal Messenger group ids using this api call:
 
-```
+```bash
 curl -s -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "method": "listGroups", "id": "42", "params": {"account": "YOUR_SIGNAL_CLI_ACCOUNT"}}' http://127.0.0.1:3000/api/v1/rpc # the URL where the signal-cli JSON-RPC API is listening
 ```
 


### PR DESCRIPTION
Signed-off-by: morph027 <morph+github@morph027.de>

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

PR for new component `signal_messenger_jsonrpc`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/81855
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
