### PR TITLE
Make the description into something a bit nicer for the chat bots

### DIFF
--- a/source/integrations.json
+++ b/source/integrations.json
@@ -5,7 +5,7 @@ layout: none
 {%- for integration in site.integrations %}
 {%- assign target = integration.ha_domain | append: ".markdown" | prepend: "_integrations/" -%}
 {%- if integration.ha_supporting_integration -%}
-  {%- assign description = "Support for devices by " ~ {{ integration.title }} ~ "in Home Assistant is provided by the " ~ {{ integration.ha_supporting_integration }} ~ " integration." -%}
+  {%- assign description = "Support for devices by " | append: {{ integration.title }} | append: " in Home Assistant is provided by the " | append: {{ integration.ha_supporting_integration }} | append: " integration." -%}
 {%- else -%}
   {%- assign content = integration.content | markdownify -%}
   {%- assign content = content | split: "</p>" | first -%}
@@ -24,4 +24,3 @@ layout: none
 {%- endif -%}
 {%- endfor %}
 }
-

--- a/source/integrations.json
+++ b/source/integrations.json
@@ -4,14 +4,23 @@ layout: none
 {
 {%- for integration in site.integrations %}
 {%- assign target = integration.ha_domain | append: ".markdown" | prepend: "_integrations/" -%}
+{%- if integration.ha_supporting_integration -%}
+  {%- assign description = "Support for devices by " ~ {{ integration.title }} ~ "in Home Assistant is provided by the " ~ {{ integration.ha_supporting_integration }} ~ " integration." -%}
+{%- else -%}
+  {%- assign content = integration.content | markdownify -%}
+  {%- assign content = content | split: "</p>" | first -%}
+  {%- assign content = content | append: "</p>" | strip_html -%}
+  {%- assign description = content | replace: "\n", " " | remove: '"' -%}
+{%- endif -%}
 {%- if integration.path == target %}
+  "integrations"
   "{{integration.ha_domain}}": {
     "title": "{{integration.title}}",
-    "description": "{{ integration.description }}",
+    "description": "{{ description }}",
     "quality_scale": "{{integration.ha_quality_scale}}",
     "iot_class": "{{integration.ha_iot_class}}",
     "integration_type": "{{integration.ha_integration_type}}"
-  }{%- if forloop.last -%}{%- else -%},{%- endif -%}
+  }{%- unless forloop.last -%},{%- endunless -%}
 {%- endif -%}
 {%- endfor %}
 }

--- a/source/integrations.json
+++ b/source/integrations.json
@@ -9,8 +9,8 @@ layout: none
 {%- else -%}
   {%- assign content = integration.content | markdownify -%}
   {%- assign content = content | split: "</p>" | first -%}
-  {%- assign content = content | append: "</p>" | strip_html -%}
-  {%- assign description = content | replace: "\n", " " | remove: '"' -%}
+  {%- assign content = content | strip_html -%}
+  {%- assign description = content | replace: "\n", " " | replace: '"', "'" -%}
 {%- endif -%}
 {%- if integration.path == target %}
   "integrations"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This is now getting the first line of the description if there is one for the chat. If it is a virtual integration, it borrows from the supported brands and tells you which brand supports this.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

None of the above really.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
Because of the way the pages are written and formatted this was more work than you might expect. There's special casing for virtual integrations, but in addition, some integrations have single line breaks to make their text lines shorter which do not appear in the Markdown output (Adguard is the first alphabetical instance of this).

Rather than trying to fix all of those and write some kind of test to make sure everything from now on adheres to that, I have instead handled both "using line breaks for styling of the Markdown file" and paragraph breaks—this necessitated the `markdownify`, as well as splitting on a closing paragraph tag (`</p>`) that before stripping HTML. I added some safety by replacing any double quotes with single quotes—otherwise the produced JSON will be invalid.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
