### PR TITLE
Document AVM Fritz!Box Templates

### DIFF
--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -7,6 +7,7 @@ ha_category:
   - Light
   - Sensor
   - Switch
+  - Button
 ha_release: 0.68
 ha_iot_class: Local Polling
 ha_domain: fritzbox
@@ -20,6 +21,7 @@ ha_platforms:
   - light
   - sensor
   - switch
+  - button
 ha_codeowners:
   - '@mib1185'
   - '@flabbamann'
@@ -36,6 +38,8 @@ There is currently support for the following device types within Home Assistant:
 - Light
 - Sensor
 - Switch
+
+Additionally we also support templates.
 
 #### Tested Devices
 
@@ -115,3 +119,7 @@ The FRITZ!DECT 500 lightbulb supports only 36 colors. When a color is picked in 
 ## Cover
 
 To get AVM FRITZ!DECT compatible covers (e.g., Rademacher RolloTron DECT 1213) follow the [configuration instructions](#configuration) above.
+
+## Template
+
+To get AVM FRITZ! Templates (e.g., for your heating schedule) follow the [configuration instructions](#configuration) above.

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -39,7 +39,7 @@ There is currently support for the following device types within Home Assistant:
 - Sensor
 - Switch
 
-Additionally we also support templates.
+Additionally, we also support to trigger smarthome templates.
 
 #### Tested Devices
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#81885
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
