### PR TITLE
Add password param to linksys_smart integration

### DIFF
--- a/source/_integrations/linksys_smart.markdown
+++ b/source/_integrations/linksys_smart.markdown
@@ -33,12 +33,22 @@ To use a Linksys Smart Wi-Fi Router in your Home Assistant installation, add the
 device_tracker:
   - platform: linksys_smart
     host: 192.168.1.1
+    username: admin
+    password: admin
 ```
 
 {% configuration %}
 host:
   description: The hostname or IP address of your router, e.g., `192.168.1.1`.
   required: true
+  type: string
+host:
+  description: The admin username of your router. Default "admin"
+  required: false
+  type: string
+host:
+  description: The admin password of your router. Can be exluded for older firmware versions that don't require authentication.
+  required: false
   type: string
 {% endconfiguration %}
 


### PR DESCRIPTION
## Proposed change
I added username and password params to the linksys_smart integration and am updating the documentation to include them

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/81987
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
