### PR TITLE
Updated template shorthand

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -436,7 +436,7 @@ Within an automation, template conditions also have access to the `trigger` vari
 ### Template condition shorthand notation
 
 The template condition has a shorthand notation that can be used to make your scripts and automations shorter. <br>
-It needs to be wrapped in quotation marks (```""```) unless using folding (```>```) where it must not use quotation marks. <br>
+It needs to be wrapped in quotation marks (```""```) unless using folding (```>```) where it must not use quotation marks. When wrapping in outside double quotation marks ensure any inner quotation marks are of the single (```'```) variant. <br>
 Note: use ```condition``` in contrast with ```conditions``` when using [choose](https://www.home-assistant.io/docs/scripts/#choose-a-group-of-actions).
 
 For example:

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -435,14 +435,16 @@ Within an automation, template conditions also have access to the `trigger` vari
 
 ### Template condition shorthand notation
 
-The template condition has a shorthand notation that can be used to make your scripts and automations shorter.
+The template condition has a shorthand notation that can be used to make your scripts and automations shorter. <br>
+It needs to be wrapped in quotation marks (```""```) unless using folding (```>```) where it must not use quotation marks. <br>
+Note: use ```condition``` in contrast with ```conditions``` when using [choose](https://www.home-assistant.io/docs/scripts/#choose-a-group-of-actions).
 
 For example:
 
 {% raw %}
 
 ```yaml
-conditions: "{{ (state_attr('device_tracker.iphone', 'battery_level')|int) > 50 }}"
+condition: "{{ (state_attr('device_tracker.iphone', 'battery_level')|int) > 50 }}"
 ```
 
 {% endraw %}
@@ -453,7 +455,7 @@ chapter and one or more shorthand template conditions
 {% raw %}
 
 ```yaml
-conditions:
+condition:
   - "{{ (state_attr('device_tracker.iphone', 'battery_level')|int) > 50 }}"
   - condition: state
     entity_id: alarm_control_panel.home


### PR DESCRIPTION
Changed "conditions" to "condition" (tested against 2022.11). Added link to choose. Added note about quotation marks and folding. This might be general yaml knowledge but due to all the different example I find it useful here.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
