### PR TITLE
Add configuration option decode_payload

### DIFF
--- a/source/_integrations/imap_email_content.markdown
+++ b/source/_integrations/imap_email_content.markdown
@@ -26,6 +26,7 @@ sensor:
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
     folder: YOUR_FOLDER
+    decode_payload: False
     senders:
       - example@gmail.com
 ```
@@ -57,6 +58,11 @@ folder:
   required: false
   default: INBOX
   type: string
+decode_payload:
+  description: Try to auto decode email body if encoded in *Base64* or *quoted-printable*.
+  required: false
+  default: False
+  type: boolean
 senders:
   description: A list of sender email addresses that are allowed to report state via email. Only emails received from these addresses will be processed.
   required: true


### PR DESCRIPTION
## Proposed change
Add a configuration parameter **decode_payload**, with default to **False**.
Change it to **True** to enable auto decode email body.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase:  [PR #80007 in core](https://github.com/home-assistant/core/pull/80007)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
