### PR TITLE
edl21: make scan interval configurable

### DIFF
--- a/source/_integrations/edl21.markdown
+++ b/source/_integrations/edl21.markdown
@@ -37,6 +37,7 @@ To set it up, add the following information to your `configuration.yaml` file:
 sensor:
   - platform: edl21
     serial_port: /dev/ttyUSB0
+    scan_interval_seconds: 5
 ```
 
 {% configuration %}
@@ -48,6 +49,10 @@ serial_port:
   description: The device to communicate with. When using ser2net, use socket://host:port.
   required: true
   type: string
+scan_interval_seconds:
+  description: Number of seconds which have to pass before accepting another value from the reader. Minimum is 1. Default is 60
+  required: false
+  type: integer
 {% endconfiguration %}
 
 ## InF Mode


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds documentation for new config item being introduced to edl21 integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/82332
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
