### PR TITLE
Align manual_mqtt alarm control panel with manual

### DIFF
--- a/source/_integrations/manual_mqtt.markdown
+++ b/source/_integrations/manual_mqtt.markdown
@@ -22,6 +22,7 @@ The integration will accept the following commands from your Alarm Panel via the
 - `ARM_AWAY`
 - `ARM_NIGHT`
 - `ARM_VACATION`
+- `ARM_CUSTOM_BYPASS`
 
 When the state of the manual alarm changes, Home Assistant will publish one of the following states to the `state_topic`:
 
@@ -30,6 +31,7 @@ When the state of the manual alarm changes, Home Assistant will publish one of t
 - 'armed_away'
 - 'armed_night'
 - 'armed_vacation'
+- 'armed_custom_bypass'
 - 'pending'
 - 'triggered'
 
@@ -93,7 +95,7 @@ disarm_after_trigger:
   required: false
   type: boolean
   default: false
-armed_home/armed_away/armed_night/armed_vacation/disarmed/triggered:
+armed_home/armed_away/armed_night/armed_vacation/armed_custom_bypass/disarmed/triggered:
   description: State specific settings
   required: false
   type: list
@@ -155,6 +157,11 @@ payload_arm_vacation:
   required: false
   type: string
   default: ARM_VACATION
+payload_arm_custom_bypass:
+  description: The payload to set armed-custom bypass mode on this Alarm Panel.
+  required: false
+  type: string
+  default: ARM_CUSTOM_BYPASS
 {% endconfiguration %}
 
 ## Examples
@@ -197,6 +204,7 @@ To change the state of the alarm, publish one of the following messages to the `
  - `ARM_AWAY`
  - `ARM_NIGHT`
  - `ARM_VACATION`
+ - `ARM_CUSTOM_BYPASS`
 
 To receive state updates from HA, subscribe to the `state_topic`. Home Assistant will publish a new message whenever the state changes:
 
@@ -205,5 +213,6 @@ To receive state updates from HA, subscribe to the `state_topic`. Home Assistant
  - `armed_away`
  - `armed_night`
  - `armed_vacation`
+ - `armed_custom_bypass`
  - `pending`
  - `triggered`

--- a/source/_integrations/manual_mqtt.markdown
+++ b/source/_integrations/manual_mqtt.markdown
@@ -74,17 +74,17 @@ code_arm_required:
   type: boolean
   default: true
 delay_time:
-  description: The time in seconds of delay added to the triggered state's **pending_time** before triggering the alarm.
+  description: The time in seconds of the 'pending' state before triggering the alarm.
   required: false
   type: integer
-  default: 0
-pending_time:
-  description: The time in seconds of the pending time before effecting a state change.
+  default: 60
+arming_time:
+  description: The time in seconds of the 'arming' state before effecting a state change.
   required: false
   type: integer
   default: 60
 trigger_time:
-  description: The time in seconds of the trigger time in which the alarm is firing.
+  description: The time in seconds of the 'triggered' state in which the alarm is firing.
   required: false
   type: integer
   default: 120
@@ -102,8 +102,8 @@ armed_home/armed_away/armed_night/armed_vacation/disarmed/triggered:
       description: State specific setting for **delay_time** (all states except **triggered**).
       required: false
       type: integer
-    pending_time:
-      description: State specific setting for **pending_time** (all states except **disarmed**).
+    arming_time:
+      description: State specific setting for **arming_time** (all states except **disarmed**)
       required: false
       type: integer
     trigger_time:
@@ -172,13 +172,13 @@ alarm_control_panel:
   - platform: manual_mqtt
     state_topic: home/alarm
     command_topic: home/alarm/set
-    pending_time: 30
+    arming_time: 30
     delay_time: 20
     trigger_time: 4
     disarmed:
       trigger_time: 0
     armed_home:
-      pending_time: 0
+      arming_time: 0
       delay_time: 0
     triggered:
       pending_time: 0


### PR DESCRIPTION
## Proposed change
The manual_mqtt and manual alarm control panel integrations have diverged. The intention of the two is to be as similar as possible, in fact manual_mqtt documentation leaves most of the detail to manual.

In addition the "vacation" mode was in the documentation but not in the code.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/82368
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
