### PR TITLE
Add description about HomeWizard Energy Socket "Light level" control

### DIFF
--- a/source/_integrations/homewizard.markdown
+++ b/source/_integrations/homewizard.markdown
@@ -65,9 +65,11 @@ The HomeWizard Energy API only exposes properties that are used within the HomeW
 | Active water usage | liter per minute | HWE-WTR | The current usage of water. |
 | Total water usage | m3 | HWE-WTR | Total of water measured since installation. |
 
-## Switches
+## Energy Socket
 
-The Wifi Energy Socket (`HWE-SKT`) outlet state can be controlled the switch platform. There are two switches:
+The Wifi Energy Socket (`HWE-SKT`) outlet state and status light can be controlled. There are two switches:
 
 - **Switch**: Controls the outlet state of the Energy Socket. This switch is locked out when `Switch Lock` is turned on. 
 - **Switch lock**: Forces the outlet state in the `on` position and disables the physical button. This option is useful when the socket is used for a device that must not be turned off, such as a refrigerator.
+
+You can also control the green status light level percentage with **Light level**. This light turns on when the `Switch` is on.

--- a/source/_integrations/homewizard.markdown
+++ b/source/_integrations/homewizard.markdown
@@ -72,4 +72,4 @@ The Wifi Energy Socket (`HWE-SKT`) outlet state and status light can be controll
 - **Switch**: Controls the outlet state of the Energy Socket. This switch is locked out when `Switch Lock` is turned on. 
 - **Switch lock**: Forces the outlet state in the `on` position and disables the physical button. This option is useful when the socket is used for a device that must not be turned off, such as a refrigerator.
 
-You can also control the green status light level percentage with **Light level**. This light turns on when the `Switch` is on.
+You can also control the green status light brightness with **Status light brightness**. This light turns on when the `Switch` is on.

--- a/source/_integrations/homewizard.markdown
+++ b/source/_integrations/homewizard.markdown
@@ -72,4 +72,4 @@ The Wifi Energy Socket (`HWE-SKT`) outlet state and status light can be controll
 - **Switch**: Controls the outlet state of the Energy Socket. This switch is locked out when `Switch Lock` is turned on. 
 - **Switch lock**: Forces the outlet state in the `on` position and disables the physical button. This option is useful when the socket is used for a device that must not be turned off, such as a refrigerator.
 
-You can also control the green status light brightness with **Status light brightness**. This light turns on when the `Switch` is on.
+You can also control the green status light brightness with **Status light brightness**. This light turns on when the switch is on.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add info about "Light level" for the HomeWizard Energy Socket


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/82378
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
