### PR TITLE
qBittorrent: add 'verify_ssl' option

### DIFF
--- a/source/_integrations/qbittorrent.markdown
+++ b/source/_integrations/qbittorrent.markdown
@@ -49,6 +49,11 @@ password:
   description: The password of the Web UI of qBittorrent.
   required: true
   type: string
+verify_ssl:
+  description: Verify the SSL certificate of the Web UI of qBittorrent.
+  required: false
+  type: boolean
+  default: true
 {% endconfiguration %}
 
 ## Sensors


### PR DESCRIPTION
## Proposed change

- Add optional `verify_ssl` config option to `qbittorrent` integration.
- When `verify_ssl: false`, SSL certificate verification will be disabled.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/82506
- Link to parent pull request in the Brands repository: None
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/79501

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
