### PR TITLE
Add unique_id to `mqtt_room` integration

### DIFF
--- a/source/_integrations/mqtt_room.markdown
+++ b/source/_integrations/mqtt_room.markdown
@@ -26,6 +26,11 @@ sensor:
 ```
 
 {% configuration %}
+away_timeout:
+  description: The time in seconds after which the state should be set to `not_home` if there were no updates. `0` disables the check.
+  required: false
+  default: 0
+  type: integer
 device_id:
   description: The device id to track for this sensor.
   required: true
@@ -44,11 +49,10 @@ timeout:
   required: false
   default: 5
   type: integer
-away_timeout:
-  description: The time in seconds after which the state should be set to `not_home` if there were no updates. `0` disables the check.
+unique_id:
+  description: "An ID that uniquely identifies this room sensor. If two sensors have the same unique ID, Home Assistant will raise an exception."
   required: false
-  default: 0
-  type: integer
+  type: string
 {% endconfiguration %}
 
 ## Usage


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add unique_id to `mqtt_room` integration.
Sort config options.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/82521
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
