### PR TITLE
Add examples for splitting the configuration for items without a platform key

### DIFF
--- a/source/_docs/configuration/splitting_configuration.markdown
+++ b/source/_docs/configuration/splitting_configuration.markdown
@@ -184,51 +184,6 @@ This (large) sensor configuration gives us another example:
 
 You'll notice that this example includes a secondary parameter section (under the steam section) as well as a better example of the way comments can be used to break down files into sections.
 
-In the previous examples we combined configuration items for multiple platforms.
-For some integrations, like `mqtt`, the configuration of manual configured MQTT items is done under the integration key. Note that the manual configured `mqtt` items do not have a `platform` key.
-
-You can still split up the configuration using one file per platform key. If for example, wou want to split up the following configuration:
-
-```yaml
-...
-mqtt:
-  sensor:
-    - name: "Sensor_1"
-      state_topic: "state/sensor1"
-    - name: "Sensor_2"
-      state_topic: "state/sensor2"
-  switch:  
-    - name: "Switch_1"
-      command_topic: "cmd/switch1"
-    - name: "Switch_2"
-      command_topic: "cmd/switch2"
-```
-
-After splitting up, your setup in `configuration.yaml` could be as simple as:
-
-```yaml
-...
-mqtt: !include_dir_named mqtt/
-```
-
-Where the `sensor` entries are places in `mqtt/sensor.yaml` ...
-
-```yaml
-- name: "Sensor_1"
-  state_topic: "state/sensor1"
-- name: "Sensor_2"
-  state_topic: "state/sensor2"
-```
-
-and the `switch` entries in `mqtt/switch.yaml` ...
-
-```yaml
-- name: "Switch_1"
-  command_topic: "cmd/switch1"
-- name: "Switch_2"
-  command_topic: "cmd/switch2"
-```
-
 All of the above can be applied when splitting up files using packages. To
 learn more about packages, see the [Packages](/docs/configuration/packages) page.
 

--- a/source/_docs/configuration/splitting_configuration.markdown
+++ b/source/_docs/configuration/splitting_configuration.markdown
@@ -184,6 +184,51 @@ This (large) sensor configuration gives us another example:
 
 You'll notice that this example includes a secondary parameter section (under the steam section) as well as a better example of the way comments can be used to break down files into sections.
 
+In the previous examples we combined configuration items for multiple platforms.
+For some integrations, like `mqtt`, the configuration of manual configured MQTT items is done under the integration key. Note that the manual configured `mqtt` items do not have a `platform` key.
+
+You can still split up the configuration using one file per platform key. If for example, wou want to split up the following configuration:
+
+```yaml
+...
+mqtt:
+  sensor:
+    - name: "Sensor_1"
+      state_topic: "state/sensor1"
+    - name: "Sensor_2"
+      state_topic: "state/sensor2"
+  switch:  
+    - name: "Switch_1"
+      command_topic: "cmd/switch1"
+    - name: "Switch_2"
+      command_topic: "cmd/switch2"
+```
+
+After splitting up, your setup in `configuration.yaml` could be as simple as:
+
+```yaml
+...
+mqtt: !include_dir_named mqtt/
+```
+
+Where the `sensor` entries are places in `mqtt/sensor.yaml` ...
+
+```yaml
+- name: "Sensor_1"
+  state_topic: "state/sensor1"
+- name: "Sensor_2"
+  state_topic: "state/sensor2"
+```
+
+and the `switch` entries in `mqtt/switch.yaml` ...
+
+```yaml
+- name: "Switch_1"
+  command_topic: "cmd/switch1"
+- name: "Switch_2"
+  command_topic: "cmd/switch2"
+```
+
 All of the above can be applied when splitting up files using packages. To
 learn more about packages, see the [Packages](/docs/configuration/packages) page.
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -628,6 +628,8 @@ For most platforms it is also possible to manual set up MQTT items in `configura
 
 {% enddetails %}
 
+If you have a lot of manual configured items you might want to consider [splitting up the configuration](/docs/configuration/splitting_configuration/).
+
 ## Using Templates
 
 The MQTT platform support templating. Read more [about using templates with the MQTT integration](/docs/configuration/templating/#using-templates-with-the-mqtt-integration).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Some integrations like `mqtt` store there manual configered entities under the integration key now. When you want to split up the configuration this works a bit different. This PR's shows how this can be done with manual configured `mqtt` items as an example.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/82431

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
