### PR TITLE
Add template for the still image URL for Blue Iris

### DIFF
--- a/source/_integrations/mjpeg.markdown
+++ b/source/_integrations/mjpeg.markdown
@@ -43,7 +43,7 @@ use is automatically detected when using a username and password.
 
 - Blue Iris Cameras / Blue Iris Server:
   - MJPEG URL: `http://IP:PORT/mjpg/CAMERASHORTNAME/video.mjpeg`
-  - Still Image URL: n/a
+  - Still Image URL: `http://IP:PORT/image/CAMERASHORTNAME`
 
 - DCS-930L Wireless N Network Camera from D-Link:
   - MJPEG URL: `http://IP/video/mjpg.cgi`


### PR DESCRIPTION
Add a missing template for Blue Iris Still Image URL. This is based on the Blue Iris .chm help file and works in my setup.

## Proposed change
Just minor update doc to add a missing info about pulling static images from Blue Iris cameras.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
