### PR TITLE
Rewrite Wake-on-LAN Linux example.

### DIFF
--- a/source/_integrations/wake_on_lan.markdown
+++ b/source/_integrations/wake_on_lan.markdown
@@ -117,14 +117,14 @@ Recipe for the `turn_off` action to suspend a Linux **target** from Home Assista
 1. If needed, install OpenSSH server with package manager. For example, on Ubuntu:
 
 ```sh
-$ sudo apt install openssh-server
+sudo apt install openssh-server
 ```
 
 2. Create a new system user and set password.
 
 ```sh
-$ sudo adduser --system hass --home /var/hass --shell /bin/sh
-$ sudo passwd hass
+sudo adduser --system hass --home /var/hass --shell /bin/sh
+sudo passwd hass
 ```
 
 3. Allow the user to suspend without password.
@@ -132,7 +132,7 @@ $ sudo passwd hass
 **Note**: Most Linux operating systems (Ubuntu, Fedora, Arch, etc.) utilize systemd and can use the builtin `systemctl` command to manage power states. For other operating systems (Gqentoo, Void, etc.), you will need alternative methods such as `elogind` or `pm-utils`.
 
 ```sh
-$ echo "hass ALL= NOPASSWD: /usr/bin/systemctl suspend" | sudo tee /etc/sudoers.d/hass-suspend
+echo "hass ALL= NOPASSWD: /usr/bin/systemctl suspend" | sudo tee /etc/sudoers.d/hass-suspend
 ```
 
 ##### On the Server
@@ -140,20 +140,20 @@ $ echo "hass ALL= NOPASSWD: /usr/bin/systemctl suspend" | sudo tee /etc/sudoers.
 1. If needed, install OpenSSH client with package manager. For example, on Ubuntu:
 
 ```sh
-$ sudo apt install openssh-client
+sudo apt install openssh-client
 ```
 
 2. Create a new passwordless SSH key and copy it to the target. If a key already exists, choose a different place to store the key when prompted. If using `docker`, ensure the container has access to the SSH directory by mounting it in.
 
 ```sh
-$ ssh-keygen -N ""
-$ ssh-copy-id hass@TARGET-IP
+ssh-keygen -N ""
+ssh-copy-id hass@TARGET-IP
 ```
 
 3. Optionally manually verify that the **server** can suspend the **target**.
 
 ```sh
-$ ssh hass@TARGET-IP sudo /usr/bin/systemctl suspend
+ssh hass@TARGET-IP sudo /usr/bin/systemctl suspend
 ```
 
 4. Add the suspend command to `configuration.yaml`.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I found the Linux WoL example to be dense and tough to read as well as having some staleness so I wanted to rework it. My changes:

* Split into respective target/server sections instead of being interspersed
* Switched to recommend `systemctl` which is native to most operating systems now
* Added clarifications and removed some unnecessary verbosity

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
-->

N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
