### PR TITLE
Changes for "color_temp" selector

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -256,9 +256,9 @@ The output of this selector is `true` when the toggle was on, `false` otherwise.
 
 ## Color temperature selector
 
-The color temperature selector provides a select that allows for selecting
-a color temperature. The selector returns the number of mireds selected and
-allows limiting the range of selectable mireds.
+The color temperature selector provides a slider that allows for selecting
+a color temperature. The selector returns the number of Kelvin or mireds selected and
+allows limiting the range of selectable values.
 
 ![Screenshot of the Color temperature selector](/images/blueprints/selector-color-temp.png)
 
@@ -267,19 +267,24 @@ color_temp:
 ```
 
 {% configuration color_temp %}
-min_mireds:
-  description: The minimum color temperature in mireds.
+unit:
+  description: Unit to use for the selector. Either "Kelvin" or "Mired".
+  type: string
+  defaulr: "Kelvin"
+  required: true
+min:
+  description: The minimum color temperature.
   type: integer
-  default: 153
+  default: 2700 for Kelvin, 153 for Mired
   required: false
-max_mireds:
-  description: The maximum color temperature in mireds.
+max:
+  description: The maximum color temperature.
   type: integer
-  default: 500
+  default: 6000 for Kelvin, 500 for Mired
   required: false
 {% endconfiguration %}
 
-The output of this selector is the number of mired selected, for example, `243`.
+The output of this selector is the number of Kelvin or mired selected, for example, `243`.
 
 ## Config entry selector
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/83016
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
