### PR TITLE
Update google_translate to include dialects

### DIFF
--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -37,11 +37,12 @@ tld:
 {% endconfiguration %}
 
 Check the [complete list of supported languages](https://translate.google.com/intl/en_ALL/about/languages/) (languages where "Talk" feature is enabled in Google Translate) for allowed values.
-Use the 2 digit language code which you can find at the end of URL when you click on Language name. 
+Use the 2-digit language code which you can find at the end of the URL when you click on the language name. 
 
-Check the [complete list of supported tld](https://www.google.com/supported_domains) for allowed TLD values. This is used to force the dialect used when multiple fall into the same 2 digit language code(ie, *US, UK, AU*)
+Check the [complete list of supported tld](https://www.google.com/supported_domains) for allowed TLD values. This is used to force the dialect used when multiple fall into the same 2-digit language code(i.e., *US, UK, AU*)
 
 You can also use supported BCP 47 tags like the below or the 2-2 digit format for your supported dialect(`en-gb` or `en-us`). Below is a list of the currently implemented mappings:
+
 | Dialect | Language | TLD |
 |---------|----------|-----|
 |en-us|en|com|
@@ -74,7 +75,7 @@ tts:
 
 ## Service say
 
-The `google_translate_say` service support `language` and also `options` for set, `tld`. The text for speech is set with `message`. Since release 0.92, service name can be defined in configuration `service_name` option.
+The `google_translate_say` service supports `language` and also `options` for setting `tld`. The text for speech is set with `message`. Since release 0.92, the service name can be defined in the configuration `service_name` option.
 
 Say to all `media_player` device entities:
 

--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -29,12 +29,36 @@ language:
   required: false
   type: string
   default: "`en`"
+tld:
+  description: "The default Google domain you want to use to choose dialect."
+  required: false
+  type: string
+  default: "`com`"
 {% endconfiguration %}
 
 Check the [complete list of supported languages](https://translate.google.com/intl/en_ALL/about/languages/) (languages where "Talk" feature is enabled in Google Translate) for allowed values.
-Use the 2 digit language code which you can find at the end of URL when you click on Language name.
+Use the 2 digit language code which you can find at the end of URL when you click on Language name. 
 
-For more information about using text-to-speech with Home Assistant and more details on all the options it provides, see the [TTS documentation](/integrations/tts/).
+Check the [complete list of supported tld](https://www.google.com/supported_domains) for allowed TLD values. This is used to force the dialect used when multiple fall into the same 2 digit language code(ie, *US, UK, AU*)
+
+You can also use supported BCP 47 tags like the below or the 2-2 digit format for your supported dialect(`en-gb` or `en-us`). Below is a list of the currently implemented mappings:
+| Dialect | Language | TLD |
+|---------|----------|-----|
+|en-us|en|com|
+|en-gb|en|co.uk|
+|en-uk|en|co.uk|
+|en-au|en|com.au|
+|en-ca|en|ca|
+|en-in|en|co.in|
+|en-ie|en|ie|
+|en-za|en|co.za|
+|fr-ca|fr|ca|
+|fr-fr|fr|fr|
+|pt-br|pt|com.br|
+|pt-pt|pt|pt|
+|es-es|es|es|
+|es-us|es|com|
+
 
 ## Full configuration example
 
@@ -45,4 +69,73 @@ A full configuration sample including optional variables:
 tts:
   - platform: google_translate
     language: "de"
+    tld: com
 ```
+
+## Service say
+
+The `google_translate_say` service support `language` and also `options` for set, `tld`. The text for speech is set with `message`. Since release 0.92, service name can be defined in configuration `service_name` option.
+
+Say to all `media_player` device entities:
+
+```yaml
+# Replace google_translate_say with <platform>_say when you use a different platform.
+service: tts.google_translate_say
+data:
+  entity_id: all
+  message: "May the force be with you."
+```
+
+Say to the `media_player.floor` device entity:
+
+```yaml
+service: tts.google_translate_say
+data:
+  entity_id: media_player.floor
+  message: "May the force be with you."
+```
+
+Say to the `media_player.floor` device entity in French:
+
+```yaml
+service: tts.google_translate_say
+data:
+  entity_id: media_player.floor
+  message: "Que la force soit avec toi."
+  language: "fr"
+```
+
+Say to the `media_player.floor` device entity in UK English:
+
+```yaml
+service: tts.google_translate_say
+data:
+  entity_id: media_player.floor
+  message: "May the force be with you."
+  language: "en-uk"
+```
+
+```yaml
+service: tts.google_translate_say
+data:
+  entity_id: media_player.floor
+  message: "May the force be with you."
+  language: "en"
+  options:
+    tld: co.uk  
+```
+
+With a template:
+
+{% raw %}
+
+```yaml
+service: tts.google_translate_say
+data:
+  message: "Temperature is {{states('sensor.temperature')}}."
+  cache: false
+```
+
+{% endraw %}
+
+For more information about using text-to-speech with Home Assistant and more details on all the options it provides, see the [TTS documentation](/integrations/tts/).


### PR DESCRIPTION
## Proposed change
I'm extending the google_translate in home-assistant/core#81768 to support dialects either through TLD option or BCP 47 mapping shortcut(`en-gb`,`en-us`)
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#81768
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
