### PR TITLE
Clarify authentication to Deluge

### DIFF
--- a/source/_integrations/deluge.markdown
+++ b/source/_integrations/deluge.markdown
@@ -22,7 +22,10 @@ There is currently support for the following device types within Home Assistant:
 - [Sensor](#sensor)
 - [Switch](#switch)
 
-To be able to use this integration, you have to enable the following option in deluge settings: Daemon > Allow Remote Connections
+To be able to use this integration, you need to do the following:
+
+1. Enable the following option in deluge settings: Daemon > Allow Remote Connections
+2. Refer [here](https://dev.deluge-torrent.org/wiki/UserGuide/Authentication) to set daemon credentials. Use the username and password you put there to authenticate the integration with the daemon.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/deluge.markdown
+++ b/source/_integrations/deluge.markdown
@@ -25,7 +25,7 @@ There is currently support for the following device types within Home Assistant:
 To be able to use this integration, you need to do the following:
 
 1. Enable the following option in deluge settings: Daemon > Allow Remote Connections
-2. Refer [here](https://dev.deluge-torrent.org/wiki/UserGuide/Authentication) to set daemon credentials. Use the username and password you put there to authenticate the integration with the daemon.
+2. When set up, the daemon has an account called localclient. Refer [here](https://dev.deluge-torrent.org/wiki/UserGuide/Authentication) to get the password for the local client or add a line in the auth file with your own username and password. Use one of those credentials from there to authenticate the integration with the daemon.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/deluge.markdown
+++ b/source/_integrations/deluge.markdown
@@ -22,6 +22,8 @@ There is currently support for the following device types within Home Assistant:
 - [Sensor](#sensor)
 - [Switch](#switch)
 
+## Prerequisites
+
 To be able to use this integration, you need to do the following:
 
 1. Enable the following option in deluge settings: Daemon > Allow Remote Connections


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The Deluge integration docs do not do enough of a job of helping the user to get set up. This PR attempts to do that better.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/83159

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
