### PR TITLE
Fix YouTube example in Google Cast documentation

### DIFF
--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -332,7 +332,7 @@ Optional:
 #### Example
 
 ```yaml
-alias: "Cast YouTube vid0e to My Chromecast"
+alias: "Cast YouTube video to My Chromecast"
 sequence:
   - service: media_player.play_media
     target:

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -332,19 +332,18 @@ Optional:
 #### Example
 
 ```yaml
-'cast_youtube_to_my_chromecast':
-  alias: "Cast YouTube to My Chromecast"
-  sequence:
-    - target:
-        entity_id: media_player.my_chromecast
-      data:
-        media_content_type: cast
-        media_content_id: '
-          {
-            "app_name": "youtube",
-            "media_id": "dQw4w9WgXcQ"
-          }'
-      service: media_player.play_media
+alias: "Cast YouTube vid0e to My Chromecast"
+sequence:
+  - service: media_player.play_media
+    target:
+      entity_id: media_player.my_chromecast
+    data:
+      media_content_type: cast
+      media_content_id: '
+        {
+          "app_name": "youtube",
+          "media_id": "dQw4w9WgXcQ"
+        }'
 ```
 
 ## Troubleshooting automatic discovery


### PR DESCRIPTION
## Proposed change
<!-- 
  Documentation page for Google Cast has a non-working example on the YouTube cast example.  This fixes the issue, but replacing the example code with something that works
-->



## Type of change
<!--
  Documentation change 
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [ x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
