### PR TITLE
Clarify the use of effects in Twinkly

### DIFF
--- a/source/_integrations/twinkly.markdown
+++ b/source/_integrations/twinkly.markdown
@@ -19,6 +19,7 @@ ha_integration_type: integration
 The Twinkly integration allows you to control [Twinkly](https://twinkly.com/) LED string from Home Assistant.
 
 ## Effects
+
 For devices with software version > 2.7.1, you can also control the effects on your Twinklys.
 
 The Twinkly devices do not initially have any effects stored locally. Effects must be added from the Twinkly application before they become visible in Home Assistant.

--- a/source/_integrations/twinkly.markdown
+++ b/source/_integrations/twinkly.markdown
@@ -18,10 +18,15 @@ ha_integration_type: integration
 
 The Twinkly integration allows you to control [Twinkly](https://twinkly.com/) LED string from Home Assistant.
 
+## Effects
+For devices with software version > 2.7.1, you can also control the effects on your Twinklys.
+
 The Twinkly devices do not initially have any effects stored locally. Effects must be added from the Twinkly application before they become visible in Home Assistant.
 
-Make sure the latest firmware is installed on your Twinkly devices and add effects by "apply"-ing them from the Twinkly app.
-This integration can then be used to switch between static colors and effects, and to turn your Twinklys on and off.  Playlists and Music modes are currently not supported.
+Make sure the latest firmware is installed on your Twinkly devices and add effects by _apply_-ing them from the Twinkly app.
+This integration can then be used to switch between static colors and effects, and to turn your Twinklys on and off.  
+
+Playlists and Music modes are currently not supported.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

Just updating the docs to make the usage of effects a bit clearer.

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/83145
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
