### PR TITLE
Adds sensor to group

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -254,7 +254,7 @@ unit_of_measurement:
   type: string
   required: false
 device_class:
-  description: Only available for `sensor` group. Set the device class for the sensor according to [available options](https://www.home-assistant.io/integrations/sensor/#device-class).
+  description: Only available for `sensor` group. Set the device class for the sensor according to [available options](/integrations/sensor/#device-class).
   type: string
   required: false
 state_class:

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -105,7 +105,7 @@ In short, when any group member entity is `unlocked`, the group will also be `un
 - The group state is combined / calculated based on `type` selected to determine the minimum, maximum, latest (last), mean, median, range or sum of the collected states.
 - Members can be any `sensor`, `number` or `input_number` holding numeric states.
 - The group state is `unavailable` if all group members are `unavailable`.
-- If `all` is True then group state will be `unavailable` if one member is `unavailable` or does not have a numeric state.
+- If `ignore_non_numeric` is `false` then group state will be `unavailable` if one member is `unavailable` or does not have a numeric state.
 
 ## Managing groups
 
@@ -241,25 +241,25 @@ all:
   type: boolean
   default: false
 type:
-  description: Only available for `sensor` group. The type of sensor: `min`, `max`, `last`, `mean`, `median`, `range` or `sum`
+  description: Only available for `sensor` group. The type of sensor: `min`, `max`, `last`, `mean`, `median`, `range` or `sum`.
   type: string
   required: false
   default: max
-round_digits:
-  description: Only available for `sensor` group. Round value to specified number of digits.
-  type: int
+ignore_non_numeric:
+  description: Only available for `sensor` group. Set this to `true` if the group state should ignore sensors with non numeric values.
+  type: boolean
   required: false
-  default: 2
+  default: false
 unit_of_measurement:
   description: Only available for `sensor` group. Set the unit of measurement for the sensor.
   type: string
   required: false
 device_class:
-  description: Only available for `sensor` group. Set the device class for the sensor according to [available options](https://www.home-assistant.io/integrations/sensor/#device-class)
+  description: Only available for `sensor` group. Set the device class for the sensor according to [available options](https://www.home-assistant.io/integrations/sensor/#device-class).
   type: string
   required: false
 state_class:
-  description: Only available for `sensor` group. Set the state class for the sensor according to [available options](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes)
+  description: Only available for `sensor` group. Set the state class for the sensor according to [available options](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes).
   type: string
   required: false
 {% endconfiguration %}

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -241,7 +241,7 @@ all:
   type: boolean
   default: false
 type:
-  description: Only available for `sensor` group. The type of sensor: `min`, `max`, `last`, `mean`, `median`, `range` or `sum`.
+  description: "Only available for `sensor` group. The type of sensor: `min`, `max`, `last`, `mean`, `median`, `range`, or `sum`."
   type: string
   required: true
 ignore_non_numeric:

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -243,8 +243,7 @@ all:
 type:
   description: Only available for `sensor` group. The type of sensor: `min`, `max`, `last`, `mean`, `median`, `range` or `sum`.
   type: string
-  required: false
-  default: max
+  required: true
 ignore_non_numeric:
   description: Only available for `sensor` group. Set this to `true` if the group state should ignore sensors with non numeric values.
   type: boolean

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -11,6 +11,7 @@ ha_category:
   - Media Player
   - Notifications
   - Organization
+  - Sensor
   - Switch
 ha_release: pre 0.7
 ha_iot_class: Calculated
@@ -27,6 +28,7 @@ ha_platforms:
   - lock
   - media_player
   - notify
+  - sensor
   - switch
 ha_integration_type: helper
 ---
@@ -97,6 +99,13 @@ In short, when any group member entity is `unlocked`, the group will also be `un
 - Otherwise, the group state is `playing` if all group members are `playing`.
 - Otherwise, the group state is `on` if at least one group member is not `off`, `unavailable` or `unknown`.
 - Otherwise, the group state is `off`.
+
+### Sensor groups
+
+- The group state is combined / calculated based on `type` selected to determine the minimum, maximum, latest (last), mean, median, range or sum of the collected states.
+- Members can be any `sensor`, `number` or `input_number` holding numeric states.
+- The group state is `unavailable` if all group members are `unavailable`.
+- If `all` is True then group state will be `unavailable` if one member is `unavailable` or does not have a numeric state.
 
 ## Managing groups
 
@@ -190,6 +199,18 @@ media_player:
       - media_player.living_room_tv
 ```
 
+Example YAML configuration of a sensor group:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: group
+    type: mean
+    entities:
+      - sensor.temperature_kitchen
+      - sensor.temperature_hallway
+```
+
 Example YAML configuration of a switch group:
 
 ```yaml
@@ -219,6 +240,28 @@ all:
   required: false
   type: boolean
   default: false
+type:
+  description: Only available for `sensor` group. The type of sensor: `min`, `max`, `last`, `mean`, `median`, `range` or `sum`
+  type: string
+  required: false
+  default: max
+round_digits:
+  description: Only available for `sensor` group. Round value to specified number of digits.
+  type: int
+  required: false
+  default: 2
+unit_of_measurement:
+  description: Only available for `sensor` group. Set the unit of measurement for the sensor.
+  type: string
+  required: false
+device_class:
+  description: Only available for `sensor` group. Set the device class for the sensor according to [available options](https://www.home-assistant.io/integrations/sensor/#device-class)
+  type: string
+  required: false
+state_class:
+  description: Only available for `sensor` group. Set the state class for the sensor according to [available options](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes)
+  type: string
+  required: false
 {% endconfiguration %}
 
 ## Notify Groups


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds sensor into group for combining/calculating states.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/83186
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
