### PR TITLE
Add Example how to use a input_boolean as a device_tracker

### DIFF
--- a/source/_integrations/device_tracker.markdown
+++ b/source/_integrations/device_tracker.markdown
@@ -104,6 +104,7 @@ The state of your tracked device will be `'home'` if it is in the [home zone](/i
 ## `device_tracker.see` service
 
 The `device_tracker.see` service can be used to manually update the state of a device tracker:
+(Note: If the Device don't exist, it will create a new one!)
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -114,3 +115,34 @@ The `device_tracker.see` service can be used to manually update the state of a d
 | `gps`                  |      yes | If you're providing a location, for example `[51.513845, -0.100539]` |
 | `gps_accuracy`         |      yes | The accuracy of the GPS fix |
 | `battery`              |      yes | The battery level of the device |
+
+### Device Tracker with a Toggle Button
+You want to "track" a guest e.g. for a guest room, who cannot be tracked manual.
+A solution can be to create a Helper Toggle Button. In the example the button will be called "Guest"
+Then you create the following automation:
+```yaml
+alias: Guest as Button
+description: ""
+trigger:
+  - platform: state
+    entity_id:
+      - input_boolean.guest
+condition: []
+action:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ states('input_boolean.guest') == 'on' }}"
+        sequence:
+          - service: device_tracker.see
+            data:
+              location_name: home
+              dev_id: guest
+    default:
+      - service: device_tracker.see
+        data:
+          dev_id: guest
+          location_name: not_home
+mode: single
+```
+After you Toggle the Button the first time a device_tracker.guest will apear which you can use e.g. for person (with the name Guest)


### PR DESCRIPTION
My first pr, pls be gentle by crushing me ;)

## Proposed change
It's asked in several forum threads (e.g. https://community.home-assistant.io/t/using-an-input-boolean-for-presence-detection/302645/5?u=jokergermany ) and therefore i thought it would help if it would be documented as simple as possible.

This was the hint which i needed to make it myselft: https://community.home-assistant.io/t/device-tracker-from-input-boolean/402391/2?u=jokergermany



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
