### PR TITLE
humidifier card: add current_humidity_sensor param

### DIFF
--- a/source/_dashboards/humidifier.markdown
+++ b/source/_dashboards/humidifier.markdown
@@ -32,6 +32,10 @@ theme:
   required: false
   description: Override the used theme for this card with any loaded theme. For more information about themes, see the [frontend documentation](/integrations/frontend/).
   type: string
+current_humidity_sensor:
+  required: false
+  description: Sensor for the current humidity.
+  type: string
 {% endconfiguration %}
 
 ## Example
@@ -42,4 +46,5 @@ Alternatively, the card can be configured using YAML:
 - type: humidifier
   entity: humidifier.bedroom
   name: Bedroom Humidifier
+  current_humidity_sensor: sensor.bedroom_humidity
 ```

--- a/source/_dashboards/humidifier.markdown
+++ b/source/_dashboards/humidifier.markdown
@@ -34,7 +34,7 @@ theme:
   type: string
 current_humidity_sensor:
   required: false
-  description: Sensor for the current humidity.
+  description: Sensor for the current humidity. Overrides current_humidity attribute.
   type: string
 {% endconfiguration %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add current_humidity_sensor option for the humidifier card.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/frontend/pull/14645
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
