### PR TITLE
Fix typo in 2022.6 change log

### DIFF
--- a/source/changelogs/core-2022.6.markdown
+++ b/source/changelogs/core-2022.6.markdown
@@ -3,7 +3,7 @@ title: Full Changelog for Home Assistant Core 2022.6
 description: Detailed changelog for the Home Assistant Core 2022.6 release
 ---
 
-These are all the changes included in the Home Assistant Core 2202.6 release.
+These are all the changes included in the Home Assistant Core 2022.6 release.
 
 For a summary in a more readable format:
 [Release notes blog for this release](/blog/2022/06/01/release-20226/).


### PR DESCRIPTION
## Proposed change
Fix typo in 2022.6 change log from `2202.6` to `2022.6`

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Just a typo I came across when looking at the 2022.6 change logs, that's all :smile: 

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
