### PR TITLE
Improve example MQTT publish service using the YAML editor

### DIFF
--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -782,9 +782,21 @@ payload_template: "{{ states('device_tracker.paulus') }}"
 
 {% endraw %}
 
-`payload` must be a string. When using Home Assistant's YAML editor for formatting JSON
+`payload` must be a string.
+If you want to send JSON using the YAML editor then you need to format/escape
+it properly. Like:
+
+```yaml
+topic: home-assistant/light/1/state
+payload: "{\"Status\":\"off\", \"Data\":\"something\"}"`
+```
+
+When using Home Assistant's YAML editor for formatting JSON
 you should take special care if `payload` contains template content.
-Make sure you escape the template blocks as like in the example below.
+Home Assistant will force you in to the YAML editor and will treat your
+definition as a template. Make sure you escape the template blocks as like
+in the example below. Home Assistant will convert the result to a string
+and will pass it to the MQTT publish service.
 
 ```yaml
 service: mqtt.publish

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -782,11 +782,27 @@ payload_template: "{{ states('device_tracker.paulus') }}"
 
 {% endraw %}
 
-`payload` must be a string. If you want to send JSON then you need to format/escape it properly. Like:
+`payload` must be a string. When using Home Assistant's YAML editor for formatting JSON
+you should take special care if `payload` contains template content.
+Make sure you escape the template blocks as like in the example below.
 
 ```yaml
-topic: home-assistant/light/1/state
-payload: "{\"Status\":\"off\", \"Data\":\"something\"}"
+service: mqtt.publish
+data:
+  topic: homeassistant/sensor/Acurite-986-1R-51778/config
+  payload: >-
+    {"device_class": "temperature",
+    "name": "Acurite-986-1R-51778-T",
+    "unit_of_measurement": "\u00b0C",
+    "value_template": "{% raw %}{% raw %}{{ value|float }}{%{% endraw %} endraw %}",
+    "state_topic": "rtl_433/rtl433/devices/Acurite-986/1R/51778/temperature_C",
+    "unique_id": "Acurite-986-1R-51778-T",
+    "device": {
+    "identifiers": "Acurite-986-1R-51778",
+    "name": "Acurite-986-1R-51778",
+    "model": "Acurite-986",
+    "manufacturer": "rtl_433" }
+    }
 ```
 
 Example of how to use `qos` and `retain`:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Improve the examples for the MQTT publish service using YAML. The current example shows how to use an escaped JSON payload. but that does not work with templates as HA alswats treats the definition in yaml as a template.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #25182

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
