### PR TITLE
Indicate that MPD can connect with Hostnames

### DIFF
--- a/source/_integrations/mpd.markdown
+++ b/source/_integrations/mpd.markdown
@@ -26,7 +26,7 @@ media_player:
 
 {% configuration %}
 host:
-  description: IP address of the Host where Music Player Daemon is running.
+  description: Hostname or IP address of the Host where Music Player Daemon is running.
   required: true
   type: string
 port:


### PR DESCRIPTION
## Proposed change

Currently, the documentation states that connection to an MPD server must be done via an IP address, however this is untrue.

This integration uses the python-mpd2 package to establish connection to an MPD server. That package has the ability to connect via TCP using a hostname or IP addresses. [It does this by using socket.getaddrinfo() to do an IP lookup of the hostname](https://github.com/Mic92/python-mpd2/blob/d632d7b48fd8e5ed4ce39651755ef40b61d5276d/mpd/base.py#L742). I've confirmed this works within home assistant with two separate MPD servers.

Python-mpd2 documentation specifies that it can also connect to local sockets using absolute paths starting with `/` or via the MPD convention using `@`. Can be seen in [this if statement and the following one](https://github.com/Mic92/python-mpd2/blob/d632d7b48fd8e5ed4ce39651755ef40b61d5276d/mpd/base.py#L791) I haven't tested with sockets, so I haven't added it to the proposed changes.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
