### PR TITLE
Add additional tested bluetooth adapters

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -90,6 +90,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 - Kinivo BTD-400 (BCM20702A0)
 - LM Technologies LM1010 (BCM20702A0) 📶
 - Nuu You BT40 (CSR8510A10)
+- ORICO BTA-403 (CSR8510A10)
 - Panda Wireless PBU40 (CSR8510A10)
 - Plugable USB-BT4LE (BCM20702A0)
 - QGOO BT-06A (CSR8510A10)
@@ -173,6 +174,7 @@ These adapters do not have a reset pin. If they stop responding, there is curren
 - tp-link UB400 (CSR4) - Frequent connection failures with active connections
 - tp-link UB500 (RTL8761BU) - Frequent connection failures with active connections
 - Unbranded CSR 4.0 clones with USB id 0a12:0001 - Unrecoverable driver failure
+- 5 CORE CSR 4.0 (CSR CLONE) - Unrecoverable driver failure
 
 ## Multiple adapters
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add additional tested bluetooth adapters
![more_ble](https://user-images.githubusercontent.com/663432/207183513-39b0c833-a3e0-42ae-8f06-c68f2eb9dc28.jpg)



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
