### PR TITLE
Add configuration information for paypload_reset

### DIFF
--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -78,7 +78,7 @@ payload_reset:
   description: The payload value that will have the device's location automatically derived from Home Assistant's zones.
   required: false
   type: string
-  default: "RST"
+  default: "None"
 source_type:
   description: Attribute of a device tracker that affects state when being used to track a [person](/integrations/person/). Valid options are `gps`, `router`, `bluetooth`, or `bluetooth_le`.
   required: false
@@ -214,7 +214,7 @@ payload_reset:
   description: The payload value that will have the device's location automatically derived from Home Assistant's zones.
   required: false
   type: string
-  default: "RST"
+  default: "None"
 qos:
   description: The maximum QoS level of the state topic.
   required: false

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -74,11 +74,11 @@ payload_not_home:
   required: false
   type: string
   default: "not_home"
-payload_auto_zone:
+payload_reset:
   description: The payload value that will have the device's location automatically derived from Home Assistant's zones.
   required: false
   type: string
-  default: auto_zone
+  default: "RST"
 source_type:
   description: Attribute of a device tracker that affects state when being used to track a [person](/integrations/person/). Valid options are `gps`, `router`, `bluetooth`, or `bluetooth_le`.
   required: false
@@ -210,11 +210,11 @@ payload_not_home:
   required: false
   type: string
   default: not_home
-payload_auto_zone:
+payload_reset:
   description: The payload value that will have the device's location automatically derived from Home Assistant's zones.
   required: false
   type: string
-  default: auto_zone
+  default: "RST"
 qos:
   description: The maximum QoS level of the state topic.
   required: false

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -75,7 +75,7 @@ payload_not_home:
   type: string
   default: "not_home"
 payload_auto_zone:
-  description: The payload value that will have the device's location automatically derived from home assistant's zones.
+  description: The payload value that will have the device's location automatically derived from Home Assistant's zones.
   required: false
   type: string
   default: auto_zone
@@ -211,7 +211,7 @@ payload_not_home:
   type: string
   default: not_home
 payload_auto_zone:
-  description: The payload value that will have the device's location automatically derived from home assistant's zones.
+  description: The payload value that will have the device's location automatically derived from Home Assistant's zones.
   required: false
   type: string
   default: auto_zone

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -74,6 +74,11 @@ payload_not_home:
   required: false
   type: string
   default: "not_home"
+payload_auto_zone:
+  description: The payload value that will have the device's location automatically derived from home assistant's zones.
+  required: false
+  type: string
+  default: auto_zone
 source_type:
   description: Attribute of a device tracker that affects state when being used to track a [person](/integrations/person/). Valid options are `gps`, `router`, `bluetooth`, or `bluetooth_le`.
   required: false
@@ -205,6 +210,11 @@ payload_not_home:
   required: false
   type: string
   default: not_home
+payload_auto_zone:
+  description: The payload value that will have the device's location automatically derived from home assistant's zones.
+  required: false
+  type: string
+  default: auto_zone
 qos:
   description: The maximum QoS level of the state topic.
   required: false

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -361,6 +361,7 @@ Configuration variable names in the discovery payload may be abbreviated to cons
     'pl_arm_vacation':     'payload_arm_vacation',
     'pl_prs':              'payload_press',
     'pl_rst':              'payload_reset',
+    'pl_auto_zone':        'payload_auto_zone',
     'pl_avail':            'payload_available',
     'pl_cln_sp':           'payload_clean_spot',
     'pl_cls':              'payload_close',

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -361,7 +361,6 @@ Configuration variable names in the discovery payload may be abbreviated to cons
     'pl_arm_vacation':     'payload_arm_vacation',
     'pl_prs':              'payload_press',
     'pl_rst':              'payload_reset',
-    'pl_aut_zn':           'payload_auto_zone',
     'pl_avail':            'payload_available',
     'pl_cln_sp':           'payload_clean_spot',
     'pl_cls':              'payload_close',

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -361,7 +361,7 @@ Configuration variable names in the discovery payload may be abbreviated to cons
     'pl_arm_vacation':     'payload_arm_vacation',
     'pl_prs':              'payload_press',
     'pl_rst':              'payload_reset',
-    'pl_auto_zone':        'payload_auto_zone',
+    'pl_aut_zn':           'payload_auto_zone',
     'pl_avail':            'payload_available',
     'pl_cln_sp':           'payload_clean_spot',
     'pl_cls':              'payload_close',


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This adds the necessary configuration documentation for MQTT Device Tracker auto-zoning.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/83952

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
