### PR TITLE
Add hint why some entities are not selectable after choosing the first one

### DIFF
--- a/source/_dashboards/statistics-graph.markdown
+++ b/source/_dashboards/statistics-graph.markdown
@@ -30,7 +30,7 @@ type:
   type: string
 entities:
   required: true
-  description: "A list of entity IDs or `entity` objects (see below), or an external statistic id"
+  description: "A list of entity IDs or `entity` objects (see below), or an external statistic id. Note: After specifying the first one, all others can only be selected with the same unit of measurement."
   type: list
 days_to_show:
   required: false


### PR DESCRIPTION
## Proposed change
Add a hint because I didn't get any in the ui, why the entities list ist filtered. 
With the history graph card this works so I think it is worth it

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
none

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
