### PR TITLE
Add another hint why some entities are not selectable for long term statistics

### DIFF
--- a/source/more-info/statistics.markdown
+++ b/source/more-info/statistics.markdown
@@ -3,6 +3,9 @@ title: "Expected data source not listed"
 description: "More information on if your expected data source is not listed."
 ---
 
-You're configuring a statistic but you couldn't find your source in the dropdown? That's caused by a bug in the integration providing the entity. Integrations need to configure their entities correctly so Home Assistant knows that we need to track statistics for it and how.
+You're configuring a statistic but you couldn't find your source in the dropdown? There are two possibilities:
+
+You have already selected a first entity e.g. in the statistics graph card and want to add a second one that has a different unit of measurement. After specifying the first one, all others can only be selected with the same unit of measurement. Others are filtered out.
+It is caused by a bug in the integration providing the entity. Integrations need to configure their entities correctly so Home Assistant knows that we need to track statistics for it and how.
 
 Open an issue with the author of the integration and link them to https://developers.home-assistant.io/docs/core/entity/sensor#long-term-statistics.


### PR DESCRIPTION
## Proposed change
There is another possibility why an entity is not selectable as I learned the hard way today...


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
none

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
