### PR TITLE
Google Assistant SDK: configure language code

### DIFF
--- a/source/_integrations/google_assistant_sdk.markdown
+++ b/source/_integrations/google_assistant_sdk.markdown
@@ -82,6 +82,10 @@ The integration setup will next give you instructions to enter the [Application 
 
 If you have an error with your credentials you can delete them in the [Application Credentials](/integrations/application_credentials/) user interface.
 
+## Configuration
+
+In the configure page you can set the language code of the interactions with Google Assistant. If not configured, the integration picks one based on the Home Assistant configured language and country.
+
 ## Services
 
 ### Service `google_assistant_sdk.send_text_command`

--- a/source/_integrations/google_assistant_sdk.markdown
+++ b/source/_integrations/google_assistant_sdk.markdown
@@ -84,7 +84,7 @@ If you have an error with your credentials you can delete them in the [Applicati
 
 ## Configuration
 
-In the configure page you can set the language code of the interactions with Google Assistant. If not configured, the integration picks one based on the Home Assistant configured language and country.
+On the configure page, you can set the language code of the interactions with Google Assistant. If not configured, the integration picks one based on Home Assistant's configured language and country.
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update documentation that Google Assistant SDK integrations supports configuring language code.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/84028
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
