### PR TITLE
manual_mqtt: add custom bypass mode

### DIFF
--- a/source/_integrations/manual_mqtt.markdown
+++ b/source/_integrations/manual_mqtt.markdown
@@ -22,6 +22,7 @@ The integration will accept the following commands from your Alarm Panel via the
 - `ARM_AWAY`
 - `ARM_NIGHT`
 - `ARM_VACATION`
+- `ARM_CUSTOM_BYPASS`
 
 When the state of the manual alarm changes, Home Assistant will publish one of the following states to the `state_topic`:
 
@@ -30,6 +31,7 @@ When the state of the manual alarm changes, Home Assistant will publish one of t
 - 'armed_away'
 - 'armed_night'
 - 'armed_vacation'
+- 'armed_custom_bypass'
 - 'pending'
 - 'triggered'
 
@@ -93,7 +95,7 @@ disarm_after_trigger:
   required: false
   type: boolean
   default: false
-armed_home/armed_away/armed_night/armed_vacation/disarmed/triggered:
+armed_home/armed_away/armed_night/armed_vacation/armed_custom_bypass/disarmed/triggered:
   description: State specific settings
   required: false
   type: list
@@ -155,6 +157,11 @@ payload_arm_vacation:
   required: false
   type: string
   default: ARM_VACATION
+payload_arm_custom_bypass:
+  description: The payload to set armed-custom bypass mode on this Alarm Panel.
+  required: false
+  type: string
+  default: ARM_CUSTOM_BYPASS
 {% endconfiguration %}
 
 ## Examples
@@ -197,6 +204,7 @@ To change the state of the alarm, publish one of the following messages to the `
  - `ARM_AWAY`
  - `ARM_NIGHT`
  - `ARM_VACATION`
+ - `ARM_CUSTOM_BYPASS`
 
 To receive state updates from HA, subscribe to the `state_topic`. Home Assistant will publish a new message whenever the state changes:
 
@@ -205,5 +213,6 @@ To receive state updates from HA, subscribe to the `state_topic`. Home Assistant
  - `armed_away`
  - `armed_night`
  - `armed_vacation`
+ - `armed_custom_bypass`
  - `pending`
  - `triggered`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add configuration entries related to the ARMED_CUSTOM_BYPASS state of the manual_mqtt platform. The linked PR is also adding ARMED_VACATION, but this had been added already by mistake.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#84264
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
