### PR TITLE
Add prerequisites section to Netdata readme

### DIFF
--- a/source/_integrations/netdata.markdown
+++ b/source/_integrations/netdata.markdown
@@ -13,7 +13,15 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `netdata` sensor platform allows you to display information collected by [Netdata](https://my-netdata.io/).
+The `netdata` sensor platform allows you to display information collected by [Netdata](https://www.netdata.cloud/).
+
+## Prerequisites
+
+A running Netdata instance, accessible from your Home Assistant. The Netdata instance may be manually installed
+on the same host Home Assistant is running on, or on a different host. You can validate that Netdata is 
+and accessible, by running:
+
+```curl -X GET "http://[Netdata_Instance]:19999/api/v1/info"```
 
 ## Setup
 

--- a/source/_integrations/netdata.markdown
+++ b/source/_integrations/netdata.markdown
@@ -17,11 +17,7 @@ The `netdata` sensor platform allows you to display information collected by [Ne
 
 ## Prerequisites
 
-A running Netdata instance, accessible from your Home Assistant. The Netdata instance may be manually installed
-on the same host Home Assistant is running on, or on a different host. You can validate that Netdata is 
-and accessible, by running:
-
-```curl -X GET "http://[Netdata_Instance]:19999/api/v1/info"```
+A running Netdata instance, accessible from your Home Assistant instance. For more information on setting up Netdata, [check out their documentation](https://learn.netdata.cloud/docs/).
 
 ## Setup
 


### PR DESCRIPTION
Clarify that a Netdata instance must be running and be accessible from HomeAssistant.

## Proposed change

Users seem to be confused about how Netdata is integrated with Home Assistant. We weren't sure about how it works ourselves on first use, so we added a prerequisites section to ensure that users don't expect Netdata to be magically installed. 

## Type of change


- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
