### PR TITLE
Add docs for new ONVIF aux command.

### DIFF
--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -98,3 +98,46 @@ If your ONVIF camera supports PTZ auxiliary commands (e.g. for running the wiper
 | -----------------------| ----------- |
 | `entity_id` | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
 | `cmd` | Command to send (e.g. `tt:Wiper|On`). Options depend on camera capability. |
+
+### Service `onvif.set_imaging_settings`
+
+Allos you to set various Imaging Settings as defined in [The ONVIF Imaging
+Service Spec](https://www.onvif.org/specs/srv/img/ONVIF-Imaging-Service-Spec-v210.pdf). 
+
+| Service data attribute | Description |
+| -----------------------| ----------- |
+| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
+| `settings` | Command to send (e.g. `tt:Wiper|On`). Options depend on camera capability. |
+
+Valid setting keys depend on your camera capabilities, but may include:
+
+* `BacklightCompensation`
+* `Brightness`
+* `ColorSaturation`
+* `Contrast`
+* `Exposure`
+* `Focus`
+* `IrCutFilter`
+* `Sharpness`
+* `WideDynamicRange`
+* `WhiteBalance`
+
+Some settings take simple values while others take data structures. For example,
+to turn on auto-focus, you would run:
+
+  service: onvif.set_imaging_settings
+  data:
+    settings:
+      Focus:
+        AutoFocusMode: AUTO
+  target:
+    entity_id: camera.skycam_media_profile1
+
+To force the IR lamp to turn on, you would run:
+
+  service: onvif.set_imaging_settings
+  data:
+    settings:
+      IrLampCutoff: OFF
+  target:
+    entity_id: camera.skycam_media_profile1

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -72,6 +72,8 @@ To help with development of this component, enable `info` level logging for `hom
 | Last Clock Synchronization | Sensor | Timestamp | When the device clock was last synchronized. |
 | Last Backup | Sensor | Timestamp | When the last backup of the device configuration has been retrieved. |
 
+If you are running into trouble with this sensor, please refer to the [Troubleshooting section](/integrations/ffmpeg/#troubleshooting).
+
 ### Service `onvif.ptz`
 
 If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your camera.
@@ -88,4 +90,11 @@ If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your ca
 | `move_mode` | PTZ moving mode. Allowed values: `ContinuousMove`, `RelativeMove`, `AbsoluteMove`, `GotoPreset`, `Stop`. Default :`RelativeMove` |
 | `continuous_duration` | Set ContinuousMove delay in seconds before stopping the move. Allowed values: floating point numbers or integer. Default : 0.5 |
 
-If you are running into trouble with this sensor, please refer to the [Troubleshooting section](/integrations/ffmpeg/#troubleshooting).
+### Service `onvif.aux`
+
+If your ONVIF camera supports PTZ auxiliary commands (e.g. for running the wiper or turning on the heater), you will be able to run them with this service.
+
+| Service data attribute | Description |
+| -----------------------| ----------- |
+| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
+| `cmd` | Command to send (e.g. `tt:Wiper|On`). Options depend on camera capability. |

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -138,6 +138,6 @@ To force the IR lamp to turn on, you would run:
   service: onvif.set_imaging_settings
   data:
     settings:
-      IrLampCutoff: OFF
+      IrCutFilter: OFF
   target:
     entity_id: camera.skycam_media_profile1

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -90,54 +90,12 @@ If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your ca
 | `move_mode` | PTZ moving mode. Allowed values: `ContinuousMove`, `RelativeMove`, `AbsoluteMove`, `GotoPreset`, `Stop`. Default :`RelativeMove` |
 | `continuous_duration` | Set ContinuousMove delay in seconds before stopping the move. Allowed values: floating point numbers or integer. Default : 0.5 |
 
-### Service `onvif.aux`
+### Supported Switches
 
-If your ONVIF camera supports PTZ auxiliary commands (e.g. for running the wiper or turning on the heater), you will be able to run them with this service.
+This integration uses the ONVIF auxiliary command and imaging service to send certain settings and information to the camera via switch entities. Below is a list of currently supported switches.
 
-| Service data attribute | Description |
-| -----------------------| ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-| `cmd` | Command to send (e.g. `tt:Wiper|On`). Options depend on camera capability. |
-
-### Service `onvif.set_imaging_settings`
-
-Allos you to set various Imaging Settings as defined in [The ONVIF Imaging
-Service Spec](https://www.onvif.org/specs/srv/img/ONVIF-Imaging-Service-Spec-v210.pdf). 
-
-| Service data attribute | Description |
-| -----------------------| ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-| `settings` | Command to send (e.g. `tt:Wiper|On`). Options depend on camera capability. |
-
-Valid setting keys depend on your camera capabilities, but may include:
-
-* `BacklightCompensation`
-* `Brightness`
-* `ColorSaturation`
-* `Contrast`
-* `Exposure`
-* `Focus`
-* `IrCutFilter`
-* `Sharpness`
-* `WideDynamicRange`
-* `WhiteBalance`
-
-Some settings take simple values while others take data structures. For example,
-to turn on auto-focus, you would run:
-
-  service: onvif.set_imaging_settings
-  data:
-    settings:
-      Focus:
-        AutoFocusMode: AUTO
-  target:
-    entity_id: camera.skycam_media_profile1
-
-To force the IR lamp to turn on, you would run:
-
-  service: onvif.set_imaging_settings
-  data:
-    settings:
-      IrCutFilter: OFF
-  target:
-    entity_id: camera.skycam_media_profile1
+| Name | Entity Name |  Description |
+|----------|-------------|-------------|
+| IR lamp  | `ir_lamp` |  Turn infrared lamp on and off via `IrCutFilter` ONVIF imaging setting. |
+| Autofocus  | `autofocus` |  Turn autofocus on and off via `AutoFocusMode` ONVIF imaging setting. |
+| Wiper  | `wiper` |  Turn on the lens wiper on and off via the `Wiper` ONVIF auxiliary command. |

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -15,6 +15,7 @@ ha_platforms:
   - camera
   - diagnostics
   - sensor
+  - switch
 ha_integration_type: integration
 ---
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add docs about new feature added to existing ONVIF integration.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/84317
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
