### PR TITLE
Update Venstar documentation with current schedule sensor

### DIFF
--- a/source/_integrations/venstar.markdown
+++ b/source/_integrations/venstar.markdown
@@ -46,6 +46,14 @@ The following values are supported for the preset_mode state attribute:
 - `temperature`: *Disables* the schedule and holds the set temperature indefinitely.
 - `away`: Places the thermostat in away mode
 
+The meanings of the values of the climate entity's `schedule_part` state attribute are:
+
+- `0`: morning
+- `1`: day
+- `2`: evening
+- `3`: night
+- `255`: schedule inactive (i.e., the thermostat is in one of the other modes)
+
 Note - Please ensure that you update your thermostat to the latest firmware. Initially tested on firmware 5.10 and currently VH6.79.  
 
 Local API mode needs to be enabled via the thermostat's *Menu > WiFi > Local API Options > Local API - ON*

--- a/source/_integrations/venstar.markdown
+++ b/source/_integrations/venstar.markdown
@@ -39,20 +39,13 @@ Currently supported functionality:
 - Remote temperature sensors
 - Thermostat alerts (Filter replacement/etc)
 - Reading IAQ and CO2 levels (on supported devices, e.g. T3950, only)
+- Reading the current schedule state (morning/day/evening/night/inactive)
 
 The following values are supported for the preset_mode state attribute:
 
 - `none`: *Enables* the scheduling functionality.
 - `temperature`: *Disables* the schedule and holds the set temperature indefinitely.
 - `away`: Places the thermostat in away mode
-
-The meanings of the values of the climate entity's `schedule_part` state attribute are:
-
-- `0`: morning
-- `1`: day
-- `2`: evening
-- `3`: night
-- `255`: schedule inactive (i.e., the thermostat is in one of the other modes)
 
 Note - Please ensure that you update your thermostat to the latest firmware. Initially tested on firmware 5.10 and currently VH6.79.  
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update Venstar integration documentation with schedule_part attribute.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/84332
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
