### PR TITLE
Clarify home_connect prerequisites

### DIFF
--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -43,6 +43,8 @@ Note that it depends on the appliance and on API permissions which of the featur
 - OAuth Flow: Authorization Code Grant Flow
 - Redirect URI: `https://my.home-assistant.io/redirect/oauth`
 
+*Important*: after performing the steps above **log out** of your Home Connect Developer account. If you don't so this, the configuration steps below will fail during OAuth authentication with the message `“error”: “unauthorized_client”`.
+
 {% details "I have manually disabled My Home Assistant" %}
 
 If you don't have [My Home Assistant](/integrations/my) on your installation,


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Clarify that the user must log out of their developer account. Otherwise, the OAuth dance will fail with
```
“error”: “unauthorized_client”,
“error_description”: “request rejected by client authorization authority (developer portal)”,
“state”:
```
See https://community.home-assistant.io/t/home-connect-integration-error/440268 for details


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

This probably fixes #24017

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
