### PR TITLE
adding new parameters as per PR on the code

### DIFF
--- a/source/_integrations/mastodon.markdown
+++ b/source/_integrations/mastodon.markdown
@@ -17,7 +17,12 @@ The `mastodon` platform uses [Mastodon](https://joinmastodon.org/) to deliver no
 
 ### Setup
 
-Go to **Preferences** in the Mastodon web interface, then to **Development** and create a new application.
+Go to **Preferences** in the Mastodon web interface, then to **Development** and create a new application. This
+integration currently only support sending notifications, so the API only has to be able to `write` to the
+account.
+
+NB: although the parameter is called `client_id`, the web front-end of (at least) version 4.0.2 calls this parameter
+Client key.
 
 ### Configuration
 
@@ -59,3 +64,48 @@ base_url:
 {% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
+
+### Services
+
+#### sending Toots
+Sending a Toot is done by calling the service `notify.<name>` with the relevant parameters. Here `<name>` should be
+replaced by the name that was given to this integration during configuration.
+
+Example:
+```yaml
+  action:
+    service: notify.NOTIFIER_NAME
+    data:
+      message: "A message to @john@mastodon.social"
+      data:
+        visibility: "direct"
+        language: "en"
+        spoiler_text: "Beware! Spoiler Alert"
+```
+
+Parameters to pass are documented below. Additional data can specify different aspects of the Toot that will be sent.
+
+{% configuration %}
+message:
+  description: "The message to be sent, potentially including the full handles of referenced other Mastodon users."
+  required: true
+  type: string
+  default: ""
+visibility:
+  description: "determines the scope of how the Toot is going to be sent. Can be any of: ‘direct’ - post will be 
+visible only to mentioned users; ‘private’ - post will be visible only to followers; ‘unlisted’ - post will be 
+public but not appear on the public timeline; ‘public’ - post will be public (the default)"
+  required: false
+  type: string
+  default: "public"
+language:
+  description: "Can be set to override automatic language detection. The parameter accepts all valid 
+ISO 639-1 (2-letter) or for languages where that do not have one, 639-3 (three letter) language codes."
+  required: false
+  type: string
+spoiler_text:
+  description: "Text that should be shown as a warning before the actual message. Readers of this Toot will have
+to click a button to reveal the actual message."
+  required: false
+  type: string
+{% endconfiguration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
These changes describe how the additional parameters (unlocked through https://github.com/wasperen/hass-core/commit/d7825c31b4fb97d55964f488da2f9615867943ba) can be used.

Also made it clear that `client_id` is actually called "Client key" on the current version of the Mastadon UI.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/wasperen/hass-core/commit/d7825c31b4fb97d55964f488da2f9615867943ba

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
