### PR TITLE
MQTT Climate: Add documentation for receiving the current humidity

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -83,6 +83,14 @@ availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
+current_humidity_template:
+  description: A template with which the value received on `current_humidity_topic` will be rendered.
+  required: false
+  type: template
+current_humidity_topic:
+  description: The MQTT topic on which to listen for the current humidity.
+  required: false
+  type: string
 current_temperature_template:
   description: A template with which the value received on `current_temperature_topic` will be rendered.
   required: false

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -197,10 +197,20 @@ json_attributes_topic:
   description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor attributes. Usage example can be found in [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-topic-configuration) documentation.
   required: false
   type: string
+max_humidity:
+  description: The minimum target humidity percentage that can be set.
+  required: false
+  type: integer
+  default: 99
 max_temp:
   description: Maximum set point available.
   type: float
   required: false
+min_humidity:
+  description: The maximum target humidity percentage that can be set.
+  required: false
+  type: integer
+  default: 30
 min_temp:
   description: Minimum set point available.
   type: float
@@ -321,6 +331,22 @@ swing_modes:
   required: false
   default: ['on', 'off']
   type: list
+target_humidity_command_template:
+  description: Defines a [template](/docs/configuration/templating/#using-templates-with-the-mqtt-integration) to generate the payload to send to `target_humidity_command_topic`.
+  required: false
+  type: template
+target_humidity_command_topic:
+  description: The MQTT topic to publish commands to change the target humidity.
+  required: false
+  type: string
+target_humidity_state_topic:
+  description: The MQTT topic subscribed to receive the target humidity. If this is not set, the target humidity works in optimistic mode (see below).
+  required: false
+  type: string
+target_humidity_state_template:
+  description: Defines a [template](/docs/configuration/templating/#using-templates-with-the-mqtt-integration) to extract a value for the climate `target_humidity` state.
+  required: false
+  type: string
 temperature_command_template:
   description: A template to render the value sent to the `temperature_command_topic` with.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This change introduces new variables to the MQTT Climate to control the humidity:
- current_humidity_template
- current_humidity_topic
- target_humidity_command_template:
- target_humidity_command_topic:
- target_humidity_state_topic:
- target_humidity_state_template:
 target_humidity_command_topic
- target_humidity_state_topic:
- target_humidity_state_template:

These allow you to control the climate humidity and let you set set the current humidity of the MQTT Climate, and work in a similar way to `current_temperature_template` and `current_temperature_topic` respectively.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/84592
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
