### PR TITLE
Cleanup stale documentation for manual MQTT items using old format

### DIFF
--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -28,6 +28,7 @@ The integration can control your Alarm Panel by publishing to the `command_topic
 ## Configuration
 
 <a id='new_format'></a>
+
 To enable this platform, add the following lines to your `configuration.yaml`:
 
 ```yaml

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -43,7 +43,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `alarm_control_panel` platform key
-should no longer be used and is deprecated.
+is no longer available.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -27,6 +27,7 @@ The integration can control your Alarm Panel by publishing to the `command_topic
 
 ## Configuration
 
+<a id='new_format'></a>
 To enable this platform, add the following lines to your `configuration.yaml`:
 
 ```yaml
@@ -36,26 +37,6 @@ mqtt:
     - state_topic: "home/alarm"
       command_topic: "home/alarm/set"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `alarm_control_panel` platform key
-is no longer available.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-alarm_control_panel:
-  - platform: mqtt
-    state_topic: "home/alarm"
-    command_topic: "home/alarm/set"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -20,6 +20,7 @@ Stateless devices such as buttons, remote controls etc are better represented by
 
 The `mqtt` binary sensor platform optionally supports a list of  `availability` topics to receive online and offline messages (birth and LWT messages) from the MQTT device. During normal operation, if the MQTT sensor device goes offline (i.e., publishes `payload_not_available` to an `availability` topic), Home Assistant will display the binary sensor as `unavailable`. If these messages are published with the `retain` flag set, the binary sensor will receive an instant update after subscription and Home Assistant will display the correct availability state of the binary sensor when Home Assistant starts up. If the `retain` flag is not set, Home Assistant will display the binary sensor as `unavailable` when Home Assistant starts up. If no `availability` topic is defined, Home Assistant will consider the MQTT device to be `available` and will display its state.
 
+<a id='new_format'></a>
 To use an MQTT binary sensor in your installation,
 add the following to your `configuration.yaml` file:
 
@@ -29,25 +30,6 @@ mqtt:
   binary_sensor:
     - state_topic: "home-assistant/window/contact"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `binary_sensor` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-binary_sensor:
-  - platform: mqtt
-    state_topic: "home-assistant/window/contact"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -36,7 +36,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `binary_sensor` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/button.mqtt.markdown
+++ b/source/_integrations/button.mqtt.markdown
@@ -12,31 +12,14 @@ The `mqtt` button platform lets you send an MQTT message when the button is pres
 
 ## Configuration
 
+<a id='new_format'></a>
+
 ```yaml
 # Example configuration.yaml entry
 mqtt:
   button:
     - command_topic: "home/bedroom/switch1/reboot"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `button` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-button:
-  - platform: mqtt
-    command_topic: "home/bedroom/switch1/reboot"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/button.mqtt.markdown
+++ b/source/_integrations/button.mqtt.markdown
@@ -25,7 +25,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `button` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -29,7 +29,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `camera` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -15,6 +15,7 @@ This can be used with an application or a service capable of sending images thro
 ## Configuration
 
 <a id='new_format'></a>
+
 To enable this camera in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -14,6 +14,7 @@ This can be used with an application or a service capable of sending images thro
 
 ## Configuration
 
+<a id='new_format'></a>
 To enable this camera in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -22,25 +23,6 @@ mqtt:
   camera:
     - topic: zanzito/shared_locations/my-device
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `camera` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-camera:
-  - platform: mqtt
-    topic: zanzito/shared_locations/my-device
-```
-
-{% enddetails %}
 
 The sample configuration above can be tested by publishing an image to the topic from the console:
 

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -28,7 +28,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `climate` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -12,6 +12,7 @@ The `mqtt` climate platform lets you control your MQTT enabled HVAC devices.
 
 ## Configuration
 
+<a id='new_format'></a>
 To enable this climate platform in your installation, first add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -21,26 +22,6 @@ mqtt:
     - name: Study
       mode_command_topic: "study/ac/mode/set"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `climate` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-climate:
-  - platform: mqtt
-    name: Study
-    mode_command_topic: "study/ac/mode/set"
-```
-
-{% enddetails %}
 
 {% configuration %}
 action_template:

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -13,6 +13,7 @@ The `mqtt` climate platform lets you control your MQTT enabled HVAC devices.
 ## Configuration
 
 <a id='new_format'></a>
+
 To enable this climate platform in your installation, first add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -42,7 +42,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `cover` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -28,6 +28,7 @@ Optimistic mode can be forced, even if a `state_topic` / `position_topic` is def
 The `mqtt` cover platform optionally supports a list of `availability` topics to receive online and offline messages (birth and LWT messages) from the MQTT cover device. During normal operation, if the MQTT cover device goes offline (i.e., publishes a matching `payload_not_available` to any `availability` topic), Home Assistant will display the cover as "unavailable". If these messages are published with the `retain` flag set, the cover will receive an instant update after subscription and Home Assistant will display correct availability state of the cover when Home Assistant starts up. If the `retain` flag is not set, Home Assistant will display the cover as "unavailable" when Home Assistant starts up.
 
 <a id='new_format'></a>
+
 To use your MQTT cover in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -27,6 +27,7 @@ Optimistic mode can be forced, even if a `state_topic` / `position_topic` is def
 
 The `mqtt` cover platform optionally supports a list of `availability` topics to receive online and offline messages (birth and LWT messages) from the MQTT cover device. During normal operation, if the MQTT cover device goes offline (i.e., publishes a matching `payload_not_available` to any `availability` topic), Home Assistant will display the cover as "unavailable". If these messages are published with the `retain` flag set, the cover will receive an instant update after subscription and Home Assistant will display correct availability state of the cover when Home Assistant starts up. If the `retain` flag is not set, Home Assistant will display the cover as "unavailable" when Home Assistant starts up.
 
+<a id='new_format'></a>
 To use your MQTT cover in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -35,25 +36,6 @@ mqtt:
   cover:
     - command_topic: "home-assistant/cover/set"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `cover` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-cover:
-  - platform: mqtt
-    command_topic: "home-assistant/cover/set"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -11,12 +11,9 @@ ha_domain: mqtt
 
 The `mqtt` device tracker platform allows you to define new device_trackers through [manual YAML configuration](#yaml-configuration) in `configuration.yaml` and also to automatically discover device_trackers [using the MQTT Discovery protocol](#using-the-discovery-protocol).
 
-<div class='note info'>
-  At the moment, manual configured device trackers can only reloaded by restarting Home Assistant.
-</div>
-
 ## Configuration
 
+<a id='new_format'></a>
 To use this device tracker in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -27,32 +24,6 @@ mqtt:
     state_topic: "location/annetherese"
   - name: "paulus_oneplus"
     state_topic: "location/paulus"
-```
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `switch` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example and deprecated configuration schema:
-
-```yaml
-device_tracker:
-  - platform: mqtt
-    devices:
-      paulus_oneplus: "location/paulus"
-      annetherese_n4: "location/annetherese"
-```
-
-To set the state of the device_tracker then you need to publish a JSON message to the topic (e.g., via mqtt.publish service). As an example, the following JSON message would set the `paulus_oneplus` device_tracker to `home`:
-
-```json
-{
-  "topic": "location/paulus",
-  "payload": "home"
-}
 ```
 
 {% configuration %}

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -28,34 +28,6 @@ mqtt:
 ```
 
 {% configuration %}
-devices:
-  description: List of devices with their topic.
-  required: true
-  type: list
-qos:
-  description: The QoS level of the topic.
-  required: false
-  type: integer
-payload_home:
-  description: The payload value that represents the 'home' state for the device.
-  required: false
-  type: string
-  default: "home"
-payload_not_home:
-  description: The payload value that represents the 'not_home' state for the device.
-  required: false
-  type: string
-  default: "not_home"
-source_type:
-  description: Attribute of a device tracker that affects state when being used to track a [person](/integrations/person/). Valid options are `gps`, `router`, `bluetooth`, or `bluetooth_le`.
-  required: false
-  type: string
-  default: gps
-{% endconfiguration %}
-
-{% enddetails %}
-
-{% configuration %}
 availability:
   description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
   required: false

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -14,6 +14,7 @@ The `mqtt` device tracker platform allows you to define new device_trackers thro
 ## Configuration
 
 <a id='new_format'></a>
+
 To use this device tracker in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -33,7 +33,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `switch` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example and deprecated configuration schema:

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -18,6 +18,7 @@ When a `state_topic` is not available, the fan will work in optimistic mode. In 
 
 Optimistic mode can be forced even if a `state_topic` is available. Try to enable it if you are experiencing incorrect fan operation.
 
+<a id='new_format'></a>
 To enable MQTT fans in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -26,25 +27,6 @@ mqtt:
   fan:
     - command_topic: "bedroom_fan/on/set"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `fan` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-fan:
-  - platform: "mqtt"
-    command_topic: "bedroom_fan/on/set"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -19,6 +19,7 @@ When a `state_topic` is not available, the fan will work in optimistic mode. In 
 Optimistic mode can be forced even if a `state_topic` is available. Try to enable it if you are experiencing incorrect fan operation.
 
 <a id='new_format'></a>
+
 To enable MQTT fans in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -33,7 +33,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `fan` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -19,6 +19,7 @@ When a `state_topic` is not available, the humidifier will work in optimistic mo
 Optimistic mode can be forced even if a `state_topic` is available. Try to enable it if you are experiencing incorrect humidifier operation.
 
 <a id='new_format'></a>
+
 To enable MQTT humidifiers in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -34,7 +34,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `light` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -18,6 +18,7 @@ When a `state_topic` is not available, the humidifier will work in optimistic mo
 
 Optimistic mode can be forced even if a `state_topic` is available. Try to enable it if you are experiencing incorrect humidifier operation.
 
+<a id='new_format'></a>
 To enable MQTT humidifiers in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -27,26 +28,6 @@ mqtt:
     - command_topic: "bedroom_humidifier/on/set"
       target_humidity_command_topic: "bedroom_humidifier/humidity/set"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `light` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-humidifier:
-  - platform: mqtt
-    command_topic: "bedroom_humidifier/on/set"
-    target_humidity_command_topic: "bedroom_humidifier/humidity/set"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -42,31 +42,14 @@ Optimistic mode can be forced, even if the `state_topic` is available. Try to en
 Home Assistant internally assumes that a light's state corresponds to a defined `color_mode`.
 The state of MQTT lights with default schema and support for both color and color temperature will set the `color_mode` according to the last received valid color or color temperature. Optionally, a `color_mode_state_topic` can be configured for explicit control of the `color_mode`
 
+<a id='new_format'></a>
+
 ```yaml
 # Example configuration.yaml entry
 mqtt:
   light:
     - command_topic: "office/rgb1/light/switch"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `light` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-light:
-  - platform: "mqtt"
-    command_topic: "office/rgb1/light/switch"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -55,7 +55,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `light` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:
@@ -524,10 +524,6 @@ In an ideal scenario, the MQTT device will have a state topic to publish state c
 When a state topic is not available, the light will work in optimistic mode. In this mode, the light will immediately change state after every command. Otherwise, the light will wait for state confirmation from the device (message from `state_topic`).
 
 Optimistic mode can be forced, even if state topic is available. Try enabling it if the light is operating incorrectly.
-
-<div class='note warning'>
-The way manual MQTT Fans are configured has changed. Placing configurations under the `fan` platform key is deprecated.
-</div>
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -21,6 +21,7 @@ Optimistic mode can be forced, even if state topic is available. Try to enable i
 It's mandatory for locks to support `lock` and `unlock`. A lock may optionally support `open`, (e.g. to open the bolt in addition to the latch), in this case, `payload_open` is required in the configuration. If the lock is in optimistic mode, it will change states to `unlocked` when handling the `open` command.
 
 <a id='new_format'></a>
+
 To enable MQTT locks in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -20,6 +20,7 @@ Optimistic mode can be forced, even if state topic is available. Try to enable i
 
 It's mandatory for locks to support `lock` and `unlock`. A lock may optionally support `open`, (e.g. to open the bolt in addition to the latch), in this case, `payload_open` is required in the configuration. If the lock is in optimistic mode, it will change states to `unlocked` when handling the `open` command.
 
+<a id='new_format'></a>
 To enable MQTT locks in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -28,25 +29,6 @@ mqtt:
   lock:
     - command_topic: "home/frontdoor/set"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `lock` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-lock:
-  - platform: mqtt
-    command_topic: "home/frontdoor/set"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -35,7 +35,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `lock` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -13,6 +13,7 @@ The `mqtt` Number platform allows you to integrate devices that might expose con
 ## Configuration
 
 <a id='new_format'></a>
+
 To enable MQTT Number in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -12,6 +12,7 @@ The `mqtt` Number platform allows you to integrate devices that might expose con
 
 ## Configuration
 
+<a id='new_format'></a>
 To enable MQTT Number in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -20,16 +21,6 @@ mqtt:
   number:
     - command_topic: my-device/threshold
 ```
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `number` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
 
 ```yaml
 number:

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -23,14 +23,6 @@ mqtt:
     - command_topic: my-device/threshold
 ```
 
-```yaml
-number:
-  - platform: mqtt
-    command_topic: my-device/threshold
-```
-
-{% enddetails %}
-
 {% configuration %}
 availability:
   description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -26,7 +26,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `number` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -27,7 +27,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `scene` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -12,6 +12,7 @@ The `mqtt` scene platform lets you control your MQTT enabled scenes.
 
 ## Configuration
 
+<a id='new_format'></a>
 To enable a MQTT scene in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -20,25 +21,6 @@ mqtt:
   scene:
     - command_topic: zigbee2mqtt/living_room_group/set
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `scene` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-scene:
-  - platform: mqtt
-    command_topic: zigbee2mqtt/living_room_group/set
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -13,6 +13,7 @@ The `mqtt` scene platform lets you control your MQTT enabled scenes.
 ## Configuration
 
 <a id='new_format'></a>
+
 To enable a MQTT scene in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -13,6 +13,7 @@ The `mqtt` Select platform allows you to integrate devices that might expose con
 ## Configuration
 
 <a id='new_format'></a>
+
 To enable MQTT Select in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -12,6 +12,7 @@ The `mqtt` Select platform allows you to integrate devices that might expose con
 
 ## Configuration
 
+<a id='new_format'></a>
 To enable MQTT Select in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -24,29 +25,6 @@ mqtt:
           - "Option 1"
           - "Option 2"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `select` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-select:
-    - platform: mqtt
-      command_topic: topic
-      name: "Test Select"
-      options:
-       - "Option 1"
-       - "Option 2"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -31,7 +31,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `select` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -27,7 +27,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `sensor` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -12,6 +12,7 @@ This `mqtt` sensor platform uses the MQTT message payload as the sensor value. I
 
 ## Configuration
 
+<a id='new_format'></a>
 To use your MQTT sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -20,25 +21,6 @@ mqtt:
   sensor:
     - state_topic: "home/bedroom/temperature"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `sensor` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-sensor:
-  - platform: mqtt
-    state_topic: "home/bedroom/temperature"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -13,6 +13,7 @@ This `mqtt` sensor platform uses the MQTT message payload as the sensor value. I
 ## Configuration
 
 <a id='new_format'></a>
+
 To use your MQTT sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -32,7 +32,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `siren` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -18,6 +18,7 @@ When a `state_topic` is not available, the siren will work in optimistic mode. I
 
 Optimistic mode can be forced, even if the `state_topic` is available. Try to enable it, if experiencing incorrect operation.
 
+<a id='new_format'></a>
 To enable this siren in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -26,24 +27,6 @@ mqtt:
   siren:
     - command_topic: "home/bedroom/siren/set"
 ```
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `siren` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-siren:
-  - platform: mqtt
-    command_topic: "home/bedroom/siren/set"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -19,6 +19,7 @@ When a `state_topic` is not available, the siren will work in optimistic mode. I
 Optimistic mode can be forced, even if the `state_topic` is available. Try to enable it, if experiencing incorrect operation.
 
 <a id='new_format'></a>
+
 To enable this siren in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -19,6 +19,7 @@ When a `state_topic` is not available, the switch will work in optimistic mode. 
 Optimistic mode can be forced, even if the `state_topic` is available. Try to enable it, if experiencing incorrect switch operation.
 
 <a id='new_format'></a>
+
 To enable this switch in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -33,7 +33,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `switch` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -18,6 +18,7 @@ When a `state_topic` is not available, the switch will work in optimistic mode. 
 
 Optimistic mode can be forced, even if the `state_topic` is available. Try to enable it, if experiencing incorrect switch operation.
 
+<a id='new_format'></a>
 To enable this switch in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -26,25 +27,6 @@ mqtt:
   switch:
     - command_topic: "home/bedroom/switch1/set"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `switch` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-switch:
-  - platform: mqtt
-    command_topic: "home/bedroom/switch1/set"
-```
-
-{% enddetails %}
 
 {% configuration %}
 availability:

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -18,6 +18,7 @@ This documentation has 3 sections. Configuration for `legacy` vacuum with exampl
 ## Configuration
 
 <a id='new_format'></a>
+
 To add your MQTT vacuum to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -32,7 +32,7 @@ mqtt:
 
 The configuration format of manual configured MQTT items has changed.
 The old format that places configurations under the `vacuum` platform key
-should no longer be used and is deprecated.
+does not work anymore.
 
 The above example shows the new and modern way,
 this is the previous/old example:

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -17,6 +17,7 @@ This documentation has 3 sections. Configuration for `legacy` vacuum with exampl
 
 ## Configuration
 
+<a id='new_format'></a>
 To add your MQTT vacuum to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -25,25 +26,6 @@ mqtt:
   vacuum:
     - command_topic: "vacuum/command"
 ```
-
-<a id='new_format'></a>
-
-{% details "Previous configuration format" %}
-
-The configuration format of manual configured MQTT items has changed.
-The old format that places configurations under the `vacuum` platform key
-does not work anymore.
-
-The above example shows the new and modern way,
-this is the previous/old example:
-
-```yaml
-vacuum:
-  - platform: mqtt
-    command_topic: "vacuum/command"
-```
-
-{% enddetails %}
 
 ## Legacy Configuration
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The platform doc pages still mention the deprection status of configuring manual items using the `mqtt` platform key. Since 2022.12 support has been removed for this, so we should say it is no longer available.
The warning and note to explain the new format will remain till HA 2023.6. From then the repair will be removed too,


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
