### PR TITLE
Reference full service call example

### DIFF
--- a/source/_integrations/nfandroidtv.markdown
+++ b/source/_integrations/nfandroidtv.markdown
@@ -59,7 +59,7 @@ interrupt:
   type: boolean
 {% endconfiguration %}
 
-This is a fully customized YAML you can use inside `data` to test how the final notification will look like:
+This is a fully customized YAML you can use inside `data` to test how the final notification will look like (for using this inside a service call look at the service example at the end of this page):
 
 ```yaml
 fontsize: "large"


### PR DESCRIPTION
Note the existing example for a usage inside a full service call to avoid confusion with data inside data (following https://github.com/home-assistant/core/issues/84645#issuecomment-1366161583)

## Proposed change
Helps avoiding confusion with nested use of `data:`.
Instead of adding an additional full service call example, let's just redirect to the existing one at the end of the page (unfortunately example snippets don't have an anchor which would allow to link to).



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes [#84645](https://github.com/home-assistant/core/issues/84645)
- This is my first ever PR. Please advise if handled not correctly so I can improve and contribute better in future.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
