### PR TITLE
Allow to use color_temp, xy and hs without brighness configured for MQTT JSON light

### DIFF
--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -554,7 +554,7 @@ availability_topic:
   required: false
   type: string
 brightness:
-  description: Flag that defines if the light supports brightness. This value is implicit `true` when the light supports `color_temp` as `color_mode`.
+  description: Flag that defines if the light supports brightness. This value is implicit `true` when the light supports `color_temp`, `hs` or `xy` as `color_mode`.
   required: false
   type: boolean
   default: false

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -555,6 +555,7 @@ availability_topic:
   type: string
 brightness:
   description: Flag that defines if the light supports brightness.
+  This value is implicit `true` when the light supports `color_temp` as `color_mode`.
   required: false
   type: boolean
   default: false
@@ -748,6 +749,22 @@ mqtt:
       brightness: true
       color_mode: true
       supported_color_modes: ["rgb"]
+```
+
+### Color temp and RGB support
+
+To enable a light with color_temp and RGB support in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+mqtt:
+  light:
+    - schema: json
+      name: mqtt_json_light_1
+      state_topic: "home/rgb1"
+      command_topic: "home/rgb1/set"
+      color_mode: true
+      supported_color_modes: ["rgb", "color_temp"]
 ```
 
 ### Brightness and no RGB support

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -554,8 +554,7 @@ availability_topic:
   required: false
   type: string
 brightness:
-  description: Flag that defines if the light supports brightness.
-  This value is implicit `true` when the light supports `color_temp` as `color_mode`.
+  description: Flag that defines if the light supports brightness. This value is implicit `true` when the light supports `color_temp` as `color_mode`.
   required: false
   type: boolean
   default: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds an example for the MQTT JSON light schema with supported `color_temp` and `rgb`. The `brightness` option is not needed as a brightness attribute is always respected when a light that supports color mode `color_temp`, `xy` or `hs` is turned on.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/84708
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
