### PR TITLE
Add snooz transition services

### DIFF
--- a/source/_integrations/snooz.markdown
+++ b/source/_integrations/snooz.markdown
@@ -97,13 +97,13 @@ Once the transition completes, the volume level is restored to the value before 
 
 ```yaml
 automation:
-  trigger:
-    platform: time
-    at: "16:20:00"
-  action:
-    - service: snooz.transition_off
-      target:
-        entity_id: fan.snooz_abcd
-      data:
-        duration: 120
+  - trigger:
+      - platform: time
+        at: "16:20:00"
+    action:
+      - service: snooz.transition_off
+        target:
+          entity_id: fan.snooz_abcd
+        data:
+          duration: 120
 ```

--- a/source/_integrations/snooz.markdown
+++ b/source/_integrations/snooz.markdown
@@ -81,7 +81,7 @@ automation:
 
 ### Service `snooz.transition_off`
 
-Transition the volume level to the lowest setting over over the specified duration, then power off the device.
+Transition the volume level to the lowest setting over the specified duration, then power off the device.
 
 <div class='note'>
 Once the transition completes, the volume level is restored to the value before the transition started.

--- a/source/_integrations/snooz.markdown
+++ b/source/_integrations/snooz.markdown
@@ -49,3 +49,61 @@ Fan speed percentage is mapped to the device volume level.
 <div class='note'>
 Speed percentages less than 10 have no effect - they all map to a value of 1 on the device.
 </div>
+
+## Services
+
+### Service `snooz.transition_on`
+
+Transition the volume level over the specified duration. If the device is powered off, the transition will start at the lowest volume level.
+
+{% my developer_call_service badge service="snooz.transition_on" %}
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `duration` | yes | Number of seconds to transition to target volume.
+| `volume` | yes | Percentage volume level. If not specified, the volume on the device is used.
+
+#### Automation example
+
+```yaml
+automation:
+  trigger:
+    platform: time
+    at: "04:20:00"
+  action:
+    - service: snooz.transition_on
+      target:
+        entity_id: fan.snooz_abcd
+      data:
+        volume: 33
+        duration: 120
+```
+
+### Service `snooz.transition_off`
+
+Transition the volume level to the lowest setting over over the specified duration, then power off the device.
+
+<div class='note'>
+Once the transition completes, the volume level is restored to the value before the transition started.
+</div>
+
+{% my developer_call_service badge service="snooz.transition_off" %}
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `duration` | yes | Number of seconds to complete the transition.
+
+#### Automation example
+
+```yaml
+automation:
+  trigger:
+    platform: time
+    at: "16:20:00"
+  action:
+    - service: snooz.transition_off
+      target:
+        entity_id: fan.snooz_abcd
+      data:
+        duration: 120
+```

--- a/source/_integrations/snooz.markdown
+++ b/source/_integrations/snooz.markdown
@@ -67,16 +67,16 @@ Transition the volume level over the specified duration. If the device is powere
 
 ```yaml
 automation:
-  trigger:
-    platform: time
-    at: "04:20:00"
-  action:
-    - service: snooz.transition_on
-      target:
-        entity_id: fan.snooz_abcd
-      data:
-        volume: 33
-        duration: 120
+  - trigger:
+      - platform: time
+        at: "04:20:00"
+    action:
+      - service: snooz.transition_on
+        target:
+          entity_id: fan.snooz_abcd
+        data:
+          volume: 33
+          duration: 120
 ```
 
 ### Service `snooz.transition_off`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds new `snooz` services for transitioning volume level.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/83515
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
