### PR TITLE
Add links to the support documentation.

### DIFF
--- a/source/_integrations/google_domains.markdown
+++ b/source/_integrations/google_domains.markdown
@@ -9,7 +9,7 @@ ha_iot_class: Cloud Polling
 ha_integration_type: integration
 ---
 
-With the Google Domains integration you can keep your Google Domains record up to date.
+With the Google Domains integration you can keep your Google Domains **dynamic** DNS record up to date. To setup a dynamic domain name using Goole Domains, refer to the [_Use Dynamic DNS_ section in the Google support documentation](https://support.google.com/domains/answer/6147083).
 
 ## Configuration
 
@@ -25,15 +25,15 @@ google_domains:
 
 {% configuration %}
   domain:
-    description: Your FQDN.
+    description: Your fully qualified domain name (FQDN) that you have chosen for your Home Assistant server.
     required: true
     type: string
   username:
-    description: The generated username for this DDNS record.
+    description: The generated username for this Dynamic DNS record. See your [Google Domains record](https://support.google.com/domains/answer/6147083) for details.
     required: true
     type: string
   password:
-    description: The generated password for this DDNS record.
+    description: The generated password for this Dynamic DNS record. See your [Google Domains record](https://support.google.com/domains/answer/6147083) for details.
     required: true
     type: string
   timeout:


### PR DESCRIPTION
It took me a few seconds to understand fully what this extension was about and how to start using it. By being a bit more explicit about the `D` standing for _dynamic_ and adding links to the Google domains documentation, I believe it makes it more accessible. Ironically the "description" meta-data here was already more explicit about the _dynamic_ part but was not visible on the documentation itself.

## Proposed change

* Be a bit more descriptive, especially around acronyms.
* Add links to Google documentation

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

n/a 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
