### PR TITLE
feat: add docs for entities sorting

### DIFF
--- a/source/_dashboards/entities.markdown
+++ b/source/_dashboards/entities.markdown
@@ -423,6 +423,7 @@ ignore_case:
   default: false
 {% endconfiguration %}
 
+<!-- textlint-disable terminology -->
 ### ip
 
 Sort the entities by interpreting the values as IP addresses.
@@ -437,6 +438,7 @@ reverse:
   description: Reverse the sort order.
   default: false
 {% endconfiguration %}
+<!-- textlint-enable terminology -->
 
 ### random
 

--- a/source/_dashboards/entities.markdown
+++ b/source/_dashboards/entities.markdown
@@ -31,6 +31,16 @@ show_header_toggle:
   description: Button to turn on/off all entities.
   type: boolean
   default: true
+sort_by_state:
+  required: false
+  description: Sort entities by state (numeric).
+  type: boolean
+  default: false
+reverse_sort_order:
+  required: false
+  description: Reverse the sort order (disabled means `descending`).
+  type: boolean
+  default: false
 theme:
   required: false
   description: Override the used theme for this card with any loaded theme. For more information about themes, see the [frontend documentation](/integrations/frontend/).

--- a/source/_dashboards/entities.markdown
+++ b/source/_dashboards/entities.markdown
@@ -449,10 +449,6 @@ type:
   required: true
   description: "`random`"
   type: string
-reverse:
-  required: false
-  description: Reverse the sort order.
-  default: false
 {% endconfiguration %}
 
 ### last_changed

--- a/source/_dashboards/entities.markdown
+++ b/source/_dashboards/entities.markdown
@@ -422,6 +422,7 @@ reverse:
 ignore_case:
   required: false
   description: Ignore the case while sorting.
+  type: boolean
   default: false
 {% endconfiguration %}
 

--- a/source/_dashboards/entities.markdown
+++ b/source/_dashboards/entities.markdown
@@ -31,16 +31,15 @@ show_header_toggle:
   description: Button to turn on/off all entities.
   type: boolean
   default: true
-sort_by_state:
+enable_sorting:
   required: false
-  description: Sort entities by state (numeric).
+  description: Sort entities by state.
   type: boolean
   default: false
-reverse_sort_order:
+sort_configs:
   required: false
-  description: Reverse the sort order (disabled means `descending`).
-  type: boolean
-  default: false
+  description: "A list of sort configurations that should be applied (see below)"
+  type: list
 theme:
   required: false
   description: Override the used theme for this card with any loaded theme. For more information about themes, see the [frontend documentation](/integrations/frontend/).
@@ -383,6 +382,122 @@ download:
   default: false
 {% endconfiguration %}
 
+## Options for sort configurations
+
+Each configured sort method is applied to given entities until an order can be
+established. If a method can't sort two given values (because they are equal),
+the next method will be applied. If no method works, the order won't be changed.
+
+### numeric
+
+Sorts the entities by their numeric value.
+
+{% configuration %}
+type:
+  required: true
+  description: "`numeric`"
+  type: string
+reverse:
+  required: false
+  description: Reverse the sort order.
+  default: false
+{% endconfiguration %}
+
+### alpha
+
+Sort the entities by alphabetical order. Numeric values will be sorted after
+alphabetical/mixed values.
+
+{% configuration %}
+type:
+  required: true
+  description: "`alpha`"
+  type: string
+reverse:
+  required: false
+  description: Reverse the sort order.
+  default: false
+ignore_case:
+  required: false
+  description: Ignore the case while sorting.
+  default: false
+{% endconfiguration %}
+
+### ip
+
+Sort the entities by interpreting the values as IP addresses.
+
+{% configuration %}
+type:
+  required: true
+  description: "`ip`"
+  type: string
+reverse:
+  required: false
+  description: Reverse the sort order.
+  default: false
+{% endconfiguration %}
+
+### random
+
+Sort the entities randomly.
+
+{% configuration %}
+type:
+  required: true
+  description: "`random`"
+  type: string
+reverse:
+  required: false
+  description: Reverse the sort order.
+  default: false
+{% endconfiguration %}
+
+### last_changed
+
+Sort the entities by the last changed time.
+
+{% configuration %}
+type:
+  required: true
+  description: "`last_changed`"
+  type: string
+reverse:
+  required: false
+  description: Reverse the sort order.
+  default: false
+{% endconfiguration %}
+
+### last_updated
+
+Sort the entities by the last update time.
+
+{% configuration %}
+type:
+  required: true
+  description: "`last_update`"
+  type: string
+reverse:
+  required: false
+  description: Reverse the sort order.
+  default: false
+{% endconfiguration %}
+
+### last_triggered
+
+Sort the entities by the last trigger time.
+
+{% configuration %}
+type:
+  required: true
+  description: "`last_triggered`"
+  type: string
+reverse:
+  required: false
+  description: Reverse the sort order.
+  default: false
+{% endconfiguration %}
+
 ## Examples
 
 ### Entity rows
@@ -478,4 +593,25 @@ entities:
       confirmation:
         text: Are you sure you want to restart?
       service: script.libreelec_power_cycle
+```
+
+### Sorted entity rows
+
+In this example the entities will be first sorted by their numeric value
+and then by the last time they changed. Therefore the most recently changed
+sensor with the highest temperature will at the first place.
+
+```yaml
+type: entities
+title: Sorted entities card sample
+enable_sorting: true
+sort_configs:
+  - type: numeric
+    reverse: true
+  - type: last_changed
+    reverse: true
+entities:
+  - sensor.office_temperature
+  - sensor.kitchen_temperature
+  - sensor.garden_temperature
 ```

--- a/source/_dashboards/entities.markdown
+++ b/source/_dashboards/entities.markdown
@@ -400,6 +400,7 @@ type:
 reverse:
   required: false
   description: Reverse the sort order.
+  type: boolean
   default: false
 {% endconfiguration %}
 
@@ -416,6 +417,7 @@ type:
 reverse:
   required: false
   description: Reverse the sort order.
+  type: boolean
   default: false
 ignore_case:
   required: false
@@ -436,6 +438,7 @@ type:
 reverse:
   required: false
   description: Reverse the sort order.
+  type: boolean
   default: false
 {% endconfiguration %}
 <!-- textlint-enable terminology -->
@@ -463,6 +466,7 @@ type:
 reverse:
   required: false
   description: Reverse the sort order.
+  type: boolean
   default: false
 {% endconfiguration %}
 
@@ -478,6 +482,7 @@ type:
 reverse:
   required: false
   description: Reverse the sort order.
+  type: boolean
   default: false
 {% endconfiguration %}
 
@@ -493,6 +498,7 @@ type:
 reverse:
   required: false
   description: Reverse the sort order.
+  type: boolean
   default: false
 {% endconfiguration %}
 


### PR DESCRIPTION
## Proposed change

Documentation for new sort options in case https://github.com/home-assistant/frontend/pull/14900 gets merged.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/14900 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
