### PR TITLE
Fix button name for restarting system

### DIFF
--- a/source/more-info/unhealthy/setup.markdown
+++ b/source/more-info/unhealthy/setup.markdown
@@ -19,7 +19,7 @@ This can also be done with the CLI, by running the following command:
 ha supervisor restart
 ```
 
-If this does not help or you do not have any way to access the CLI, you can try to reboot the host. This can be done by going to {% my hardware title="Settings -> System -> Hardware" %}, opening the menu in the top right corner, and selecting "Reboot Host".
+If this does not help or you do not have any way to access the CLI, you can try to reboot the host. This can be done by going to {% my hardware title="Settings -> System -> Hardware" %}, opening the menu in the top right corner, and selecting "Reboot system".
 
 To help us make the setup more robust, please enable the sharing of diagnostics and crash logs on the {% my analytics title="Settings > System > Analytics" %} panel.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The name of the button/option has changes. This PR updates the documentation to reflect that.
Reported in #25500

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #25500

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
