### PR TITLE
Statistics: add notice on max_age - closes #25506

### DIFF
--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -156,7 +156,6 @@ unique_id:
   type: string
 {% endconfiguration %}
 
-| :exclamation: An important note of `max_age` and `sampling_size`t   |
-|---------------------------------------------------------------------|
+### An important note on `max_age` and `sampling_size`
 
 The `max_age` option is only valid within the measured samples specified by `sampling_size` (default 20). Specify a wide-enough `sampling_size` if using an extended max-age (e.g., when looking for `max_age` 1 hour, a sensor that produces one measurement a minute should have at least a `sampling_size` of 60.

--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -30,7 +30,7 @@ The `statistics` integration is different to [Long-term Statistics](https://deve
 
 ## Characteristics
 
-The following statistical characteristics are available. Pay close attention to the right configuration of `sampling_size` and/or `max_age`, as most characteristics are directly influenced by these settings.
+The following statistical characteristics are available. Pay close attention to the right configuration of `sampling_size` and/or `max_age`, as most characteristics are directly influenced by these settings. 
 
 ### Numeric Source Sensor
 
@@ -155,3 +155,8 @@ unique_id:
   required: false
   type: string
 {% endconfiguration %}
+
+| :exclamation: An important note of `max_age` and `sampling_size`t   |
+|---------------------------------------------------------------------|
+
+The `max_age` variable is only valid within the measured samples specified by `sampling_size` (default 20). Specify a wide-enough `sampling_size` if using an extended max age (eg, when looking for `max_age` 1 hour, a sensor which produces 1 measurement a minute should have at least a `sampling_size` of 60.

--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -30,7 +30,7 @@ The `statistics` integration is different to [Long-term Statistics](https://deve
 
 ## Characteristics
 
-The following statistical characteristics are available. Pay close attention to the right configuration of `sampling_size` and/or `max_age`, as most characteristics are directly influenced by these settings. 
+The following statistical characteristics are available. Pay close attention to the right configuration of `sampling_size` and/or `max_age`, as most characteristics are directly influenced by these settings.
 
 ### Numeric Source Sensor
 

--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -159,4 +159,4 @@ unique_id:
 | :exclamation: An important note of `max_age` and `sampling_size`t   |
 |---------------------------------------------------------------------|
 
-The `max_age` variable is only valid within the measured samples specified by `sampling_size` (default 20). Specify a wide-enough `sampling_size` if using an extended max age (eg, when looking for `max_age` 1 hour, a sensor which produces 1 measurement a minute should have at least a `sampling_size` of 60.
+The `max_age` option is only valid within the measured samples specified by `sampling_size` (default 20). Specify a wide-enough `sampling_size` if using an extended max-age (e.g., when looking for `max_age` 1 hour, a sensor that produces one measurement a minute should have at least a `sampling_size` of 60.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add a notice clarifying the need to specify `sampling_size` when using `max_age` in the statistics module. Closing #25506


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #25506 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
