### PR TITLE
Change wording for SkyConnect page

### DIFF
--- a/source/skyconnect/index.html
+++ b/source/skyconnect/index.html
@@ -2,7 +2,7 @@
 layout: landingpage
 title: "Home Assistant SkyConnect"
 description: "Best way to add Zigbee and Matter to Home Assistant"
-date: 2023-01-04
+date: 2022-10-05
 tagline: Home Assistant SkyConnect
 tagline_wide: false
 og_image: /images/skyconnect/skyconnect-cover.png

--- a/source/skyconnect/index.html
+++ b/source/skyconnect/index.html
@@ -2,7 +2,7 @@
 layout: landingpage
 title: "Home Assistant SkyConnect"
 description: "Best way to add Zigbee and Matter to Home Assistant"
-date: 2022-10-05
+date: 2023-01-04
 tagline: Home Assistant SkyConnect
 tagline_wide: false
 og_image: /images/skyconnect/skyconnect-cover.png
@@ -28,7 +28,7 @@ frontpage_image: /images/skyconnect/skyconnect-cover.png
 <div class="content">
   <div class="material-card text banner-overlay with-box">
     <div>
-      <div class="banner-overlay-header">Available soon</div>
+      <div class="banner-overlay-header">Available now</div>
       <div class="banner-overlay-content">
         The Home Assistant SkyConnect is the easiest way to add Zigbee support
         to your Home Assistant instance and make it Matter-ready.
@@ -50,7 +50,7 @@ frontpage_image: /images/skyconnect/skyconnect-cover.png
         </div>
       </div>
       <div class="banner-overlay-button" onclick="showBuyDialog()">
-        <div>Pre-order</div>
+        <div>Order now</div>
       </div>
     </div>
   </div>
@@ -329,7 +329,7 @@ frontpage_image: /images/skyconnect/skyconnect-cover.png
       d="M17,18C15.89,18 15,18.89 15,20A2,2 0 0,0 17,22A2,2 0 0,0 19,20C19,18.89 18.1,18 17,18M1,2V4H3L6.6,11.59L5.24,14.04C5.09,14.32 5,14.65 5,15A2,2 0 0,0 7,17H19V15H7.42A0.25,0.25 0 0,1 7.17,14.75C7.17,14.7 7.18,14.66 7.2,14.63L8.1,13H15.55C16.3,13 16.96,12.58 17.3,11.97L20.88,5.5C20.95,5.34 21,5.17 21,5A1,1 0 0,0 20,4H5.21L4.27,2M7,18C5.89,18 5,18.89 5,20A2,2 0 0,0 7,22A2,2 0 0,0 9,20C9,18.89 8.1,18 7,18Z"
     />
   </svg>
-  PRE-ORDER SKYCONNECT
+  ORDER SKYCONNECT
 </div>
 
 <script>


### PR DESCRIPTION
Change wording for SkyConnect page to reflect the maturity it has reached

## Proposed change
* Change "Available soon" to "Available now"
* Change "Pre-Order" to "Order"

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards