### PR TITLE
Add event(s) for failed login and IP ban

### DIFF
--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -169,6 +169,28 @@ This event is fired when scenes have been reloaded and thus might have changed.
 
 This event contains no additional data.
 
+## `login_failed`
+
+Integration: [`http`](/integrations/http/)
+
+This event is fired when a login attempt is unsuccessful.
+
+| Field       | Description                              |
+| ----------- | ---------------------------------------- |
+| `ip`        | IP address that attempted the login.     |
+| `hostname`  | Hostname that attempted the login.       |
+
+## `ip_ban`
+
+Integration: [`http`](/integrations/http/)
+
+This event fires when an IP address is banned.
+
+| Field       | Description                              |
+| ----------- | ---------------------------------------- |
+| `ip`        | IP address that has been banned.         |
+| `hostname`  | Hostname of the IP that has been banned. |
+
 ## `script_started`
 
 Integration: [`script`](/integrations/script/)

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -139,7 +139,7 @@ If you want to apply additional IP filtering, and automatically ban brute force 
   banned_at: "2016-11-16T19:20:03"
 ```
 
-After a ban is added a Persistent Notification is populated to the Home Assistant frontend.
+After a ban is added a Persistent Notification is populated to the Home Assistant frontend. Additionally, an event `ban_ip` is triggered with `ip` and `hostname` of the banned IP is fired onto the event bus.
 
 ## Hosting files
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add two events to the `http` integration. One event, `login_failed`, to indicate an unsuccessful login. A second event, `ip_ban`, to indicate an IP address has been banned. IP address and hostname are included in the event data.

This will allow someone to create an automation and do something with this data. Quick examples would be sending a notification to another system (firewall or centralized logging). Or maybe send a notification to a mobile device to react in more real time.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85125
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
