### PR TITLE
Remove unnecessary step from setup instructions

### DIFF
--- a/source/_integrations/google_assistant_sdk.markdown
+++ b/source/_integrations/google_assistant_sdk.markdown
@@ -44,21 +44,20 @@ This section explains how to generate a Client ID and Client Secret on
 1. First go to the Google Developers Console to enable [Google Assistant API](https://console.developers.google.com/apis/api/embeddedassistant.googleapis.com/overview)
 2. Select an existing project or create a new one from the dropdown menu in the upper left corner.
 3. Click to enable this API.
-4. From the left sidebar click on [Credentials](https://console.cloud.google.com/apis/credentials)
-5. Click on the field on the left of the screen, **OAuth Consent Screen**.
-6. Select **External** and **Create**.
-7. Set the *App Name* (the name of the application asking for consent) to anything you want e.g.  *Home Assistant*.
-8. You then need to select a *Support email*. To do this, simply click the drop down box and select your email address.
-9. You finally need to complete the section: *Developer contact information*. To do this, simply enter your email address (same as above is fine).
-10. Scroll to the bottom and click **Save and Continue**. Don't have to fill out anything else or it may enable additional review.
-11. You will then be automatically taken to the Scopes page. You do not need to add any scopes here so click Save and Continue to move to the Optional info page. You do not need to add anything to the Optional info page so click Save and Continue which will take you to the Summary page. Click Back to Dashboard.
-12. Click **OAuth consent screen** again and set *Publish Status* to **Production** otherwise your credentials will expire every 7 days.
-13. Make sure **Publishing status** is set to production.
-14. Click **Credentials** in the menu on the left hand side of the screen, then click **Create credentials** (at the top of the screen), then select *OAuth client ID*.
-15. Set the Application type to *Web application* and give this credential set a name (like "Home Assistant Credentials").
-16. Add https://my.home-assistant.io/redirect/oauth to *Authorized redirect URIs* then click **Create**.
-17. You will then be presented with a pop-up saying *OAuth client created* showing *Your Client ID* and *Your Client Secret*. Make a note of these (for example, copy and paste them into a text editor) as you will need these shortly. Once you have noted these strings, click **OK**. If you need to find these credentials again at any point then simply navigate to *APIs & Services > Credentials* and you will see *Home Assistant Credentials* (or whatever you named them in the previous step) under *OAuth 2.0 Client IDs*. To view both the *Client ID* and *Client secret*, click on the pencil icon, this will take you to the settings page for these credentials and the information will be on the right hand side of the page.
-18. Double check that the *Google Assistant API* has been automatically enabled. To do this, select **Library** from the menu, then search for *Google Assistant API*. If it is enabled you will see *API Enabled* with a green tick next to it. If it is not enabled, then enable it.
+4. Click on the field on the left of the screen, **OAuth Consent Screen**.
+5. Select **External** and **Create**.
+6. Set the *App Name* (the name of the application asking for consent) to anything you want e.g.  *Home Assistant*.
+7. You then need to select a *Support email*. To do this, simply click the drop down box and select your email address.
+8. You finally need to complete the section: *Developer contact information*. To do this, simply enter your email address (same as above is fine).
+9. Scroll to the bottom and click **Save and Continue**. Don't have to fill out anything else or it may enable additional review.
+10. You will then be automatically taken to the Scopes page. You do not need to add any scopes here so click Save and Continue to move to the Optional info page. You do not need to add anything to the Optional info page so click Save and Continue which will take you to the Summary page. Click Back to Dashboard.
+11. Click **OAuth consent screen** again and set *Publish Status* to **Production** otherwise your credentials will expire every 7 days.
+12. Make sure **Publishing status** is set to production.
+13. Click **Credentials** in the menu on the left hand side of the screen, then click **Create credentials** (at the top of the screen), then select *OAuth client ID*.
+14. Set the Application type to *Web application* and give this credential set a name (like "Home Assistant Credentials").
+15. Add https://my.home-assistant.io/redirect/oauth to *Authorized redirect URIs* then click **Create**.
+16. You will then be presented with a pop-up saying *OAuth client created* showing *Your Client ID* and *Your Client Secret*. Make a note of these (for example, copy and paste them into a text editor) as you will need these shortly. Once you have noted these strings, click **OK**. If you need to find these credentials again at any point then simply navigate to *APIs & Services > Credentials* and you will see *Home Assistant Credentials* (or whatever you named them in the previous step) under *OAuth 2.0 Client IDs*. To view both the *Client ID* and *Client secret*, click on the pencil icon, this will take you to the settings page for these credentials and the information will be on the right hand side of the page.
+17. Double check that the *Google Assistant API* has been automatically enabled. To do this, select **Library** from the menu, then search for *Google Assistant API*. If it is enabled you will see *API Enabled* with a green tick next to it. If it is not enabled, then enable it.
 
 {% enddetails %}
 


### PR DESCRIPTION
The menu in the Google Cloud console has the items "Credentials" and "OAuth Consent Screen" right next to each other on the same level, so it's not needed to click "Credentials" before "OAuth Consent Screen". This might be a copy-paste error as the click on "Credentials" is needed in step 13 (was 14).

## Proposed change

Remove step 4 of the setup instructions


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
