### PR TITLE
yalexs_ble: Mention Support For Yale Unity Screen Door Lock

### DIFF
--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -36,6 +36,7 @@ Devices must have a Yale Access module installed to function with this integrati
 - YRD256 (Yale Assure Lock Keypad)
 - YRD420 (Yale Assure Lock 2)
 - YRD450 (Yale Assure Lock 2 Key Free)
+- YUR/SSDL/1/SIL (Yale Unity Screen Door Lock - Australia)
 - ASL-05 (August WiFi Smart Lock - Gen 4)
 - ASL-03 (August Smart Lock Pro - Gen 3)
 - ASL-02 (August Smart Lock Pro - Gen 2)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add a line in the Yale Bluetooth integration page to let users know that the Yale YUR/SSDL/1/SIL lock is also supported.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

Attached is a screenshot of the lock working correctly in Home Assistant.
![image](https://user-images.githubusercontent.com/12470297/210677292-c41901c2-be44-4d87-8f85-8642abb87e57.png)


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
