### PR TITLE
Remove E1 Pro from supported

### DIFF
--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -45,6 +45,9 @@ The following models have been tested and confirmed to work:
 
 Battery-powered cameras are not yet supported.
 
+The following models are lacking the HTTP webserver API and can therfore not work with this integration:
+- E1 Pro
+
 ## Reolink firmware limitations
 
 - The Reolink NVR only sends event-notifications if motion happens on the camera connected to the first (index "0") channel, therefore the binary sensors of all channels will only be updated when the first channel sees motion.

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -39,7 +39,6 @@ The following models have been tested and confirmed to work:
 - RLC-823A
 - RLC-420-5MP
 - E1 Zoom
-- E1 Pro
 - E1 Outdoor
 - Reolink Video Doorbell PoE
 - Reolink Video Doorbell WiFi


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
My appologies, I made a mistake earlier today.
Multiple users were responding in the same HomeAssistant issue.
The E1 Zoom and E1 Outdoor do work, but the E1 Pro is giving connection issues because it seems like it is lacking the HTTP API.

see issue: https://github.com/home-assistant/core/issues/85158

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
