### PR TITLE
Add query button entities to ISY994 devices and hub

### DIFF
--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -163,7 +163,7 @@ Insteon Secondary Keypad buttons and Remote buttons are added to Home Assistant 
 Once loaded, the following services will be exposed with the `isy994.` prefix, to allow advanced control over the ISY and its connected devices:
 
  - Entity services for Home Assistant-connected entities: `send_node_command`, `send_raw_node_command`, `set_on_level`, and `set_ramp_rate`.
- - Generic ISY services: `system_query`, `set_variable`, `send_program_command`, and `run_network_resource`.
+ - Generic ISY services: `set_variable`, `send_program_command`, and `run_network_resource`.
  - Management services for the ISY Home Assistant integration: `reload` and `cleanup_entities`.
 
 #### Service `isy994.send_node_command`
@@ -233,17 +233,6 @@ Send an ISY set_ramp_rate command to a `light` Node to set the devices' ramp rat
 | ---------------------- | -------- | ----------- |
 | `entity_id`            |     no   | Name(s) of target entities for the command, e.g., `light.front_porch`. |
 | `value` | no | The integer index value to set the Ramp Rate to in a range of `0` (9.5 minutes) to `31` (0.1 Seconds), e.g., `28` |
-
-#### Service `isy994.system_query` (Deprecated)
-
-Request the ISY Query the connected devices. 
-
-⚠️ DEPRECATED in 2023.2.0 ⚠️: Use the Query button entities or `button.press` service instead. This service will be removed in 2023.5.0.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `address` | yes | ISY Address to Query. Omitting this requests a system-wide scan (typically recommended by UDI to be scheduled once per day), e.g., `"1A 2B 3C 1"` |
-| `isy` | yes | If you have more than one ISY connected, provide the name of the ISY to query (as shown on the Device Registry or as the top-first node in the ISY Admin Console). Omitting this will cause all ISYs to be queried, e.g., `"ISY"` |
 
 #### Service `isy994.set_variable`
 

--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -3,6 +3,7 @@ title: Universal Devices ISY/IoX
 description: Instructions on how to setup an ISY controller within Home Assistant.
 ha_category:
   - Binary Sensor
+  - Button
   - Climate
   - Cover
   - Fan
@@ -21,6 +22,7 @@ ha_codeowners:
 ha_ssdp: true
 ha_platforms:
   - binary_sensor
+  - button
   - climate
   - cover
   - fan
@@ -36,9 +38,10 @@ ISY is a home automation controller capable of controlling Insteon, X10, Z-Wave 
 
 This integration supports the legacy ISY994 hardware family, as well as current ISY-on-Anything (IoX) hardware, such as the [eisy](https://www.universal-devices.com/product/eisy-home/) or [Polisy](https://www.universal-devices.com/polisy/) devices.
 
-There is currently support for the following device types within Home Assistant:
+There is currently support for the following platforms within Home Assistant:
 
 - Binary Sensor
+- Button
 - Climate
 - Cover
 - Light
@@ -47,7 +50,7 @@ There is currently support for the following device types within Home Assistant:
 - Sensor
 - Switch
 
-Home Assistant is capable of communicating with any binary sensor, cover, fan, light, lock, sensor and switch that is configured on the controller. Using the programs on the controller, custom binary sensors, covers, fans, locks, and switches can also be created.
+Home Assistant is capable of communicating with any binary sensor, cover, fan, light, lock, sensor and switch that is configured on the controller. Using the programs on the controller, custom binary sensors, covers, fans, locks, and switches can also be created. Each device and the ISY hub also include a Query button to query the device.
 
 {% include integrations/config_flow.md %}
 
@@ -231,9 +234,11 @@ Send an ISY set_ramp_rate command to a `light` Node to set the devices' ramp rat
 | `entity_id`            |     no   | Name(s) of target entities for the command, e.g., `light.front_porch`. |
 | `value` | no | The integer index value to set the Ramp Rate to in a range of `0` (9.5 minutes) to `31` (0.1 Seconds), e.g., `28` |
 
-#### Service `isy994.system_query`
+#### Service `isy994.system_query` (Deprecated)
 
-Request the ISY Query the connected devices.
+Request the ISY Query the connected devices. 
+
+⚠️ DEPRECATED in 2023.2.0 ⚠️: Use the Query button entities or `button.press` service instead. This service will be removed in 2023.5.0.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Deprecate the `isy994.system_query` service in favor of Query button entities.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85337
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
