### PR TITLE
Update Lightwave to remove need for proxy

### DIFF
--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -106,8 +106,10 @@ The first use of a light or switch will try to register with your Lightwave WiFi
 
 # TRVs
 
-Lightwave Thermostatic Radiator Values (TRV) are supported but require an additional proxy to capture the current TRV temperature.
-See [LWProxy](https://github.com/ColinRobbins/Homeassistant-Lightwave-TRV)
+Lightwave Thermostatic Radiator Values (TRV) are supported.
+
+Earlier integrations required a proxy - See [LWProxy](https://github.com/ColinRobbins/Homeassistant-Lightwave-TRV).
+This capabilty is still supported, but no longer required.
 
 ```yaml
 # Example TRV configuration.yaml for TRVs
@@ -117,8 +119,6 @@ lightwave:
     R99D1:
       name: Bedroom Light
   trv:
-      proxy_ip: 127.0.0.1       # Proxy address, do not change unless running on a different server
-      proxy_port: 7878          # Do not change, unless a port clash
       trvs:
         R1Dh:                       # The ID of the TRV.
           name: Bedroom TRV


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The Lightwave TRV integration previously required a 3rd party proxy to listen for UDP events from the TRVs.
A PR removed the need for the proxy, by building the UDP listener into the integration.
This updates the documentation to match the PR

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85385
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
