### PR TITLE
Add network resource button entities to ISY994

### DIFF
--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -49,6 +49,8 @@ There is currently support for the following device types within Home Assistant:
 
 Home Assistant is capable of communicating with any binary sensor, cover, fan, light, lock, sensor and switch that is configured on the controller. Using the programs on the controller, custom binary sensors, covers, fans, locks, and switches can also be created.
 
+ISY Networking Module Resources can be executed using the Buttons created.
+
 {% include integrations/config_flow.md %}
 
 ## Manual configuration
@@ -160,7 +162,7 @@ Insteon Secondary Keypad buttons and Remote buttons are added to Home Assistant 
 Once loaded, the following services will be exposed with the `isy994.` prefix, to allow advanced control over the ISY and its connected devices:
 
  - Entity services for Home Assistant-connected entities: `send_node_command`, `send_raw_node_command`, `set_on_level`, and `set_ramp_rate`.
- - Generic ISY services: `system_query`, `set_variable`, `send_program_command`, and `run_network_resource`.
+ - Generic ISY services: `system_query`, `set_variable`, and `send_program_command`.
  - Management services for the ISY Home Assistant integration: `reload` and `cleanup_entities`.
 
 #### Service `isy994.send_node_command`
@@ -263,16 +265,6 @@ Send a command to control an ISY program or folder. Valid commands are `run`, `r
 | `address` | yes | The address of the program to control (optional, use either `address` or `name`), e.g., `"04B1"` |
 | `name` | yes | The name of the program to control (optional, use either `address` or `name`), e.g., `"My Program"` |
 | `isy` | yes | (Optional) If you have more than one ISY connected, provide the name of the ISY to query (as shown on the Device Registry or as the top-first node in the ISY Admin Console).  If you have the same program name or address on multiple ISYs, omitting this will run the command on them all, e.g., `"ISY"` |
-
-#### Service `isy994.run_network_resource`
-
-Run a network resource on the ISY.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `address` | yes | The address of the network resource to execute (optional, use either `address` or `name`), e.g., `121` |
-| `name` | yes | The name of the network resource to execute (optional, use either `address` or `name`), e.g., `"Network Resource 1"` |
-| `isy` | yes | (Optional) If you have more than one ISY connected, provide the name of the ISY to query (as shown on the Device Registry or as the top-first node in the ISY Admin Console).  If you have the same resource name or address on multiple ISYs, omitting this will run the command on them all, e.g., `"ISY"` |
 
 #### Service `isy994.reload`
 

--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -49,7 +49,7 @@ There is currently support for the following device types within Home Assistant:
 
 Home Assistant is capable of communicating with any binary sensor, cover, fan, light, lock, sensor and switch that is configured on the controller. Using the programs on the controller, custom binary sensors, covers, fans, locks, and switches can also be created.
 
-ISY Networking Module Resources can be executed using the Buttons created.
+ISY Networking Module Resources can be executed using the buttons created.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add full support for the ISY/IoX's Network Resources by creating button entities to trigger each resource. Previously these were only possible to control from Home Assistant using the integration-specific service `isy994.run_network_resource`. These are being added as buttons because they are one-shot executions with no return values (they operate similar to the [rest_command](https://www.home-assistant.io/integrations/rest_command/) integration.

The `isy994.run_network_resource` has been deprecated and will be removed in a future release. Network Resources have been added as button entities and those should be used instead.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85429
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
