### PR TITLE
Added docs for evse_wifi integration

### DIFF
--- a/source/_integrations/evse_wifi.markdown
+++ b/source/_integrations/evse_wifi.markdown
@@ -1,16 +1,13 @@
 ---
 title: EVSE WiFi
-description: Instructions on how to integrate a WiFi-equipped Simple EVSE Charging station with Home Assistant
+description: Instructions on how to integrate a Wi-Fi-equipped Simple EVSE Charging station with Home Assistant
 ha_category:
   - Car
-ha_release: 0.38
+ha_release: 2023.1.1
 ha_iot_class: Local Polling
 ha_domain: evse_wifi
 ha_platforms:
   - sensor
-  - switch
-  - button
-  - number
 ha_integration_type: integration
 ---
 
@@ -19,6 +16,8 @@ This EVSE WiFi device platform pulls data from an [SimpleEvse-WiFi](https://gith
 ## Configuration
 
 To enable this sensor in your installation, search for "Evse-Wifi" in the Integrations and add it via the Configuration-Flow
+
+{% include integrations/config-flow.md %}
 
 ## Sensors
 
@@ -35,15 +34,3 @@ To enable this sensor in your installation, search for "Evse-Wifi" in the Integr
 - Milage [km] (Milage charged in current charge phase)
 - Vehicle State (State of the Vehicle as Integer)
 - Vehicle State Text (State of the Vehilce as a String)
-
-## Buttons
-
-- Reboot Evse ESP
-
-## Switches 
-
-- Charge State
-
-## Numbers
-
-- Charge Current

--- a/source/_integrations/evse_wifi.markdown
+++ b/source/_integrations/evse_wifi.markdown
@@ -1,0 +1,49 @@
+---
+title: EVSE WiFi
+description: Instructions on how to integrate a WiFi-equipped Simple EVSE Charging station with Home Assistant
+ha_category:
+  - Car
+ha_release: 0.38
+ha_iot_class: Local Polling
+ha_domain: evse_wifi
+ha_platforms:
+  - sensor
+  - switch
+  - button
+  - number
+ha_integration_type: integration
+---
+
+This EVSE WiFi device platform pulls data from an [SimpleEvse-WiFi](https://github.com/CurtRod/SimpleEVSE-WiFi) Charging station equipped with an ESP8266-based Wi-Fi connection.
+
+## Configuration
+
+To enable this sensor in your installation, search for "Evse-Wifi" in the Integrations and add it via the Configuration-Flow
+
+## Sensors
+
+- Actual Power [kW]
+- Charge Duration [s]
+- Current P1 [A]
+- Current P2 [A]
+- Current P3 [A]
+- Energy [kWh] (Energy charged in current charge phase)
+- Last Action Uid 
+- Last Action User
+- Max Current [A] (Max current set in EVSE settings)
+- Meter Reading [kW] (Meter Reading - Can be used in Energy Dashboard)
+- Milage [km] (Milage charged in current charge phase)
+- Vehicle State (State of the Vehicle as Integer)
+- Vehicle State Text (State of the Vehilce as a String)
+
+## Buttons
+
+- Reboot Evse ESP
+
+## Switches 
+
+- Charge State
+
+## Numbers
+
+- Charge Current

--- a/source/_integrations/evse_wifi.markdown
+++ b/source/_integrations/evse_wifi.markdown
@@ -13,10 +13,6 @@ ha_integration_type: integration
 
 This EVSE WiFi device platform pulls data from an [SimpleEvse-WiFi](https://github.com/CurtRod/SimpleEVSE-WiFi) Charging station equipped with an ESP8266-based Wi-Fi connection.
 
-## Configuration
-
-To enable this sensor in your installation, search for "Evse-Wifi" in the Integrations and add it via the Configuration-Flow
-
 {% include integrations/config_flow.md %}
 
 ## Sensors

--- a/source/_integrations/evse_wifi.markdown
+++ b/source/_integrations/evse_wifi.markdown
@@ -17,7 +17,7 @@ This EVSE WiFi device platform pulls data from an [SimpleEvse-WiFi](https://gith
 
 To enable this sensor in your installation, search for "Evse-Wifi" in the Integrations and add it via the Configuration-Flow
 
-{% include integrations/config-flow.md %}
+{% include integrations/config_flow.md %}
 
 ## Sensors
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Added the documentation for the new evse_wifi integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
https://github.com/home-assistant/core/pull/85438
## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
