### PR TITLE
Add ISY994 variables as number entities

### DIFF
--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -119,7 +119,7 @@ If your leak or door/window sensor supports heartbeats, a new binary_sensor devi
 
 ### ISY/IoX Variables
 
-Integer and State Variables from the ISY are imported as `number` entities. You can choose which variables are enabled by default by setting the "Variable Sensor String" Config Option and using it as part of the variable name in the ISY Admin Console (e.g. `HA.` in options and `HA.Variable Name` on the ISY) or you can manually enable the entities you need from the ISY Variables device in Home Assistant.
+Integer and State Variables from the ISY are imported as `number` entities. You can choose which variables are enabled by default by setting the "Variable Sensor String" Config Option and using it as part of the variable name in the ISY Admin Console (e.g., `HA.` in options and `HA.Variable Name` on the ISY) or you can manually enable the entities you need from the ISY Variables device in Home Assistant.
 
 ### Handling Insteon or Other ISY Control Events
 

--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -9,6 +9,7 @@ ha_category:
   - Hub
   - Light
   - Lock
+  - Number
   - Sensor
   - Switch
 ha_release: 0.28
@@ -26,6 +27,7 @@ ha_platforms:
   - fan
   - light
   - lock
+  - number
   - sensor
   - switch
 ha_dhcp: true
@@ -44,6 +46,7 @@ There is currently support for the following device types within Home Assistant:
 - Light
 - Fan
 - Lock
+- Number
 - Sensor
 - Switch
 
@@ -112,7 +115,9 @@ Each Insteon leak sensor will also show up as a single Binary Sensor as opposed 
 
 If your leak or door/window sensor supports heartbeats, a new binary_sensor device will be added to Home Assistant to represent the battery state. The sensor will stay "Off" so long as the daily heartbeats occur. If a heartbeat is missed, the sensor will flip to "On". The name of this device will be based on the heartbeat node in the ISY.
 
-Integer and State Variables from the ISY can be used as sensors by setting the `variable_sensor_string` and adding it as part of the variable name in the ISY. For example, if you have a variable named `HA.my_variable` and a `variable_sensor_string` of `"HA."`, it will be automatically added as a `sensor` in Home Assistant.
+### ISY/IoX Variables
+
+Integer and State Variables from the ISY are imported as `number` entities. You can choose which variables are enabled by default by setting the "Variable Sensor String" Config Option and using it as part of the variable name in the ISY Admin Console (e.g. `HA.` in options and `HA.Variable Name` on the ISY) or you can manually enable the entities you need from the ISY Variables device in Home Assistant.
 
 ### Handling Insteon or Other ISY Control Events
 
@@ -160,7 +165,7 @@ Insteon Secondary Keypad buttons and Remote buttons are added to Home Assistant 
 Once loaded, the following services will be exposed with the `isy994.` prefix, to allow advanced control over the ISY and its connected devices:
 
  - Entity services for Home Assistant-connected entities: `send_node_command`, `send_raw_node_command`, `set_on_level`, and `set_ramp_rate`.
- - Generic ISY services: `system_query`, `set_variable`, `send_program_command`, and `run_network_resource`.
+ - Generic ISY services: `system_query`, `send_program_command`, and `run_network_resource`.
  - Management services for the ISY Home Assistant integration: `reload` and `cleanup_entities`.
 
 #### Service `isy994.send_node_command`
@@ -239,19 +244,6 @@ Request the ISY Query the connected devices.
 | ---------------------- | -------- | ----------- |
 | `address` | yes | ISY Address to Query. Omitting this requests a system-wide scan (typically recommended by UDI to be scheduled once per day), e.g., `"1A 2B 3C 1"` |
 | `isy` | yes | If you have more than one ISY connected, provide the name of the ISY to query (as shown on the Device Registry or as the top-first node in the ISY Admin Console). Omitting this will cause all ISYs to be queried, e.g., `"ISY"` |
-
-#### Service `isy994.set_variable`
-
-Set an ISY variable's current or initial value. Variables can be set by either type/address or by name.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `value` | no | The integer value to be sent, e.g., `255` |
-| `address` | no | The address of the variable for which to set the value, e.g., `5` |
-| `type` | no | The variable type, 1 = Integer, 2 = State, e.g., `2` |
-| `name` | yes | The name of the variable to set (Optional, use `name` instead of `type` and `address`), e.g., `"my_variable_name"` |
-| `init` | yes | If True, the initial (init) value will be updated instead of the current value, e.g., `false` |
-| `isy` | yes | If you have more than one ISY connected, provide the name of the ISY to query (as shown on the Device Registry or as the top-first node in the ISY Admin Console).  If you have the same variable name or address on multiple ISYs, omitting this will run the command on them all, e.g., `"ISY"` |
 
 #### Service `isy994.send_program_command`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add the `number` platform to ISY994 and move ISY/IoX Variables from `sensor` with a custom service to the new platform.

There is an existing Config Option for choosing which Variables are added to Home Assistant. This is now used to determine which entities are enabled by default, but all Variables can now be imported.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85511
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
