### PR TITLE
Add config flow to IMAP integration

### DIFF
--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -9,65 +9,18 @@ ha_domain: imap
 ha_platforms:
   - sensor
 ha_integration_type: integration
+ha_codeowners:
+  - '@engrbm87'
+ha_config_flow: true
 ---
 
-The `imap` integration is observing your [IMAP server](https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol) and reporting the amount of unread emails.
+The `imap` integration is observing your [IMAP server](https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol) and reporting the amount of unread emails. Other search criteria can be used as shown in the example below.
 
-## Configuration
-
-To enable this sensor, add the following lines to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: imap
-    server: YOUR_IMAP_SERVER
-    username: YOUR_USERNAME
-    password: YOUR_PASSWORD
-```
-
-{% configuration %}
-server:
-  description: The IP address or hostname of the IMAP server.
-  required: true
-  type: string
-port:
-  description: The port where the server is accessible.
-  required: false
-  default: 993
-  type: integer
-name:
-  description: Name of the IMAP sensor.
-  required: false
-  type: string
-username:
-  description: Username for the IMAP server.
-  required: true
-  type: string
-password:
-  description: Password for the IMAP server.
-  required: true
-  type: string
-folder:
-  description: The IMAP folder to watch.
-  required: false
-  default: inbox
-  type: string
-search:
-  description: The IMAP search to perform on the watched folder.
-  required: false
-  default: UnSeen UnDeleted
-  type: string
-charset:
-  description: The character set used for this connection.
-  required: false
-  default: utf-8
-  type: string
-{% endconfiguration %}
+{% include integrations/config_flow.md %}
 
 ### Gmail with App Password
 
-If you’re going to use Gmail, it’s always good practice to create a [App Password](https://support.google.com/mail/answer/185833).
+If you’re going to use Gmail, you need to create a [App Password](https://support.google.com/mail/answer/185833).
 
 1. Go to your [Google Account](https://myaccount.google.com/)
 2. Select **Security**
@@ -84,27 +37,24 @@ By default, this integration will count unread emails. By configuring the search
 * `FROM`, `TO`, `SUBJECT` to find emails in a folder (see [IMAP RFC for all standard options](https://tools.ietf.org/html/rfc3501#section-6.4.4))
 * [Gmail's IMAP extensions](https://developers.google.com/gmail/imap/imap-extensions) allow raw Gmail searches, like `X-GM-RAW "in: inbox older_than:7d"` to show emails older than one week in your inbox. Note that raw Gmail searches will ignore your folder configuration and search all emails in your account!
 
-#### Full configuration sample with search
+#### Config entry sample with search examples
 
-```yaml
-# Example configuration.yaml entry for gmail
-sensor:
-  - platform: imap
-    server: imap.gmail.com
-    port: 993
-    username: YOUR_USERNAME
-    password: YOUR_PASSWORD
-    search: FROM <sender@email.com>, SUBJECT <subject here>
-    # Or use X-GM-RAW search-term like this, to find unread emails from the last 7 days in your inbox
-    # search: 'X-GM-RAW "in: inbox newer_than:7d is:unread"'
+```
+  server: imap.gmail.com
+  port: 993
+  username: YOUR_USERNAME
+  password: YOUR_PASSWORD
+  folder: INBOX
+  search: FROM <sender@email.com>, SUBJECT <subject here>
+  # Or use X-GM-RAW search-term like this, to find unread emails from the last 7 days in your inbox
+  # search: 'X-GM-RAW "in: inbox newer_than:7d is:unread"'
 
-# Example configuration.yaml entry for Office 365
-sensor:
-  - platform: imap
-    server: outlook.office365.com
-    port: 993
-    username: email@address.com
-    password: password
-    search: FROM <sender@email.com>, SUBJECT <subject here>
-    charset: US-ASCII
+# Example entry for Office 365
+
+  server: outlook.office365.com
+  port: 993
+  username: email@address.com
+  password: password
+  search: FROM <sender@email.com>, SUBJECT <subject here>
+  charset: US-ASCII
 ```

--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -14,20 +14,23 @@ ha_codeowners:
 ha_config_flow: true
 ---
 
-The `imap` integration is observing your [IMAP server](https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol) and reporting the amount of unread emails. Other search criteria can be used as shown in the example below.
+The IMAP integration is observing your [IMAP server](https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol) and reporting the number of unread emails. Other search criteria can be used, as shown in the example below.
 
 {% include integrations/config_flow.md %}
 
 ### Gmail with App Password
 
-If you’re going to use Gmail, you need to create a [App Password](https://support.google.com/mail/answer/185833).
+If you’re going to use Gmail, you need to create an [App Password](https://support.google.com/mail/answer/185833).
 
 1. Go to your [Google Account](https://myaccount.google.com/)
 2. Select **Security**
 3. Under “Signing in to Google” select **App Passwords**
 4. Sign in to your Account, and create a new App Password for Gmail.
-
-You can now use this as your password for Gmail, in your configuration.
+5. Then you can setup the intergation as below:
+    - Server: `imap.gmail.com`
+    - Port: `993`
+    - Username: Your full email address
+    - Password: The new app password
 
 ### Configuring IMAP Searches
 
@@ -37,24 +40,12 @@ By default, this integration will count unread emails. By configuring the search
 * `FROM`, `TO`, `SUBJECT` to find emails in a folder (see [IMAP RFC for all standard options](https://tools.ietf.org/html/rfc3501#section-6.4.4))
 * [Gmail's IMAP extensions](https://developers.google.com/gmail/imap/imap-extensions) allow raw Gmail searches, like `X-GM-RAW "in: inbox older_than:7d"` to show emails older than one week in your inbox. Note that raw Gmail searches will ignore your folder configuration and search all emails in your account!
 
-#### Config entry sample with search examples
+### Selecting a charset supported by the imap server
 
-```
-  server: imap.gmail.com
-  port: 993
-  username: YOUR_USERNAME
-  password: YOUR_PASSWORD
-  folder: INBOX
-  search: FROM <sender@email.com>, SUBJECT <subject here>
-  # Or use X-GM-RAW search-term like this, to find unread emails from the last 7 days in your inbox
-  # search: 'X-GM-RAW "in: inbox newer_than:7d is:unread"'
-
-# Example entry for Office 365
-
-  server: outlook.office365.com
-  port: 993
-  username: email@address.com
-  password: password
-  search: FROM <sender@email.com>, SUBJECT <subject here>
-  charset: US-ASCII
-```
+Below is an example for setting up the integration to connect to your Microsoft 365 account that requires `US_ASCII` as charset:
+  - Server: `outlook.office365.com`
+  - Port: `993`
+  - Username: Your full email address
+  - Password: Your password
+  - Charset: `US-ASCII`
+  


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update documentation for IMAP integration now supporting config flow.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/74623
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
