### PR TITLE
Adding neevo intregration documentation

### DIFF
--- a/source/_integrations/neevo.markdown
+++ b/source/_integrations/neevo.markdown
@@ -2,7 +2,8 @@
 title: "OTODATA Nee-Vo Tank Monitoring"
 description: "Integration for OTODATA Nee-Vo Tank Monitoring system"
 ha_release: "2023.1.3"
-ha_category: Sensor
+ha_category:
+  - Sensor
 ha_iot_class: "Cloud Polling"
 ha_config_flow: true
 ha_platforms:

--- a/source/_integrations/neevo.markdown
+++ b/source/_integrations/neevo.markdown
@@ -1,0 +1,28 @@
+---
+title: "OTODATA Nee-Vo Tank Monitoring"
+description: "Integration for OTODATA Nee-Vo Tank Monitoring system"
+ha_release: "2023.1.3"
+ha_category: Sensor
+ha_iot_class: "Cloud Polling"
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_codeowners:
+  - '@davidflypei'
+ha_domain: neevo
+---
+
+The OTODATA Nee-Vo Tank Monitoring integration gets data from [OTODATA tank monitors](https://www.otodatatankmonitors.com/) linked to a Nee-Vo account. 
+
+{% include integrations/config_flow.md %}
+
+## Sensors
+
+Sensors available in this integration.
+
+### Tank Monitor
+
+| Name | Unit | Description |
+| ---- | ---- | ----------- |
+| Tank Level | % | Tank level in percent |
+| Tank Last Pressure | kPa (default) | Tank pressure. Unit defaults to kPa unless the monitor is configured with something else |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds OTODATA Nee-Vo integration documentation


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85557
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/4021

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
