### PR TITLE
Remove deprecated YAML manual config for PVPC Hourly Pricing

### DIFF
--- a/source/_integrations/pvpc_hourly_pricing.markdown
+++ b/source/_integrations/pvpc_hourly_pricing.markdown
@@ -43,43 +43,6 @@ In case you did nothing after the tariff change on 2021-06-01, both powers are e
 You can add up to 2 sensors (one for each geographic zone) by adding them again through the integrations panel,
 and you can change the sensor configuration anytime by going to the integration's options.
 
-### Advanced configuration
-
-PVPC Hourly Pricing allows manual configuration by adding a section to your `configuration.yaml`.
-
-```yaml
-# Set up electricity price sensors as a component:
-pvpc_hourly_pricing:
-  - name: "PVPC"
-    tariff: "2.0TD"
-    power: 3.45
-    power_p3: 4.6
-  - name: "PVPC-CYM"
-    tariff: "2.0TD (Ceuta/Melilla)"
-```
-
-{% configuration %}
-name:
-  description: Custom name for the sensor.
-  required: true
-  type: string
-tariff:
-  description: Electric tariff by geographic zone.
-  required: true
-  default: 2.0TD
-  type: string
-power:
-  description: Contracted electric power in kW.
-  required: false
-  default: 3.3
-  type: float
-power_p3:
-  description: Contracted electric power in kW for valley period (P3).
-  required: false
-  default: 3.3
-  type: float
-{% endconfiguration %}
-
 <div class='note'>
 
 The sensor provides an hourly price for energy consumed, but the variable cost of energy is only one of the factors that add up to the electricity bill:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Remove deprecated YAML manual config for PVPC Hourly Pricing, 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85614
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
