### PR TITLE
Add docs for Fire TV (virtual) integration

### DIFF
--- a/source/_integrations/fire_tv.markdown
+++ b/source/_integrations/fire_tv.markdown
@@ -1,0 +1,21 @@
+---
+title: Amazon Fire TV
+description: Instructions on how to integrate Amazon Fire TV devices into Home Assistant.
+ha_category:
+  - Media Player
+ha_domain: fire_tv
+ha_integration_type: virtual
+ha_supporting_domain: androidtv
+ha_supporting_integration: Android TV
+ha_release: 0.7.6
+ha_codeowners:
+  - '@JeffLIrion'
+  - '@ollo69'
+ha_config_flow: true
+ha_platforms:
+  - diagnostics
+  - media_player
+ha_iot_class: Local Polling
+---
+
+{% include integrations/supported_brand.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add docs for Fire TV (virtual) integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85741
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/4030
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
