### PR TITLE
Remove 32 bits from guides

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -203,14 +203,10 @@ installation:
       board: Raspberry Pi
       installation_media: "SD card"
       variants:
-        - name: "Raspberry Pi 4 64-bit"
+        - name: "Raspberry Pi 4"
           key: "rpi4-64"
-        - name: "Raspberry Pi 4 32-bit"
-          key: "rpi4"
-        - name: "Raspberry Pi 3 64-bit"
+        - name: "Raspberry Pi 3"
           key: "rpi3-64"
-        - name: "Raspberry Pi 3 32-bit"
-          key: "rpi3"
 
     tinkerboard:
       board: ASUS Tinkerboard


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR removes the 32-bit installation instructions/references for the Raspberry Pi 3 & 4.
Both variants can run 64-bit (which was already shown by default).

As for the future, we run into more issues with 32 bits all the time. There is simply no long-term future for those (as support for it is dropping across the Linux world).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
