### PR TITLE
Update oralb sensor data and supported devices

### DIFF
--- a/source/_integrations/oralb.markdown
+++ b/source/_integrations/oralb.markdown
@@ -8,6 +8,7 @@ ha_release: 2022.11
 ha_iot_class: Local Push
 ha_codeowners:
   - '@bdraco'
+  - '@conway220'
 ha_domain: oralb
 ha_config_flow: true
 ha_platforms:
@@ -24,17 +25,22 @@ The Oral-B integration will automatically discover devices once the [Bluetooth](
 ## Supported devices
 
 - [IO 4 Series](https://oralb.com/en-us/products/electric-toothbrushes/oralbio)
+- [IO 6 Series](https://oralb.com/en-us/products/electric-toothbrushes/io-series-6-electric-toothbrush-gray-opal/)
 - [IO 7 Series](https://oralb.com/en-us/products/electric-toothbrushes/oralbio)
 - [IO 8 Series](https://oralb.com/en-us/products/electric-toothbrushes/oralbio)
 - [IO 9 Series](https://oralb.com/en-us/products/electric-toothbrushes/oralbio)
+- Smart Series 4000
+- Smart Series 6000
 - [Smart Series 7000](https://oralb.com/en-us/products/electric-toothbrushes/smart-7000-rechargeable-electric-toothbrush/)
+- Smart Series 8000
 - [Genius Series 9000](https://oralb.com/en-us/products/electric-toothbrushes/genius-9600-rechargeable-electric-toothbrush-white/)
+- Triumph V2
 
 ## Sensor
 
 * Mode - selected cleaning mode e.g. daily clean.
 * Number of sectors - brushing areas set in the **Set Pacer Visualisation** in the brushing preferences in the mobile app.
-* Sector - the current area of the mouth you are brushing.
-* Sector time - amount time brushing the current sector in seconds.
+* Sector - the current sector of brush goal you are in (i.e. if brush goal is 2:00 minutes, and you are at 0:37, you are in sector 2)
 * Time - total brushing time in seconds.
 * Toothbrush state - whether the toothbrush is running, idle.
+* Battery - toothbrush battery percentage.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The newest oralb pull request adds support for new devices and a battery sensor. Removed sector time from documentation as it is disabled by default and does not ever do anything.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85800
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
