### PR TITLE
Added docs for ip command

### DIFF
--- a/source/_integrations/systemmonitor.markdown
+++ b/source/_integrations/systemmonitor.markdown
@@ -111,7 +111,7 @@ sensor:
 ## Linux specific
 
 To retrieve all available network interfaces on a Linux System, execute the
-`ifconfig` or `ip` command. The command differ based on your operation systm and version.
+`ifconfig` or `ip` command. The command differs based on your operation system and version.
 
 ```bash
 ifconfig -a | sed 's/[ \t].*//;/^$/d'

--- a/source/_integrations/systemmonitor.markdown
+++ b/source/_integrations/systemmonitor.markdown
@@ -111,10 +111,14 @@ sensor:
 ## Linux specific
 
 To retrieve all available network interfaces on a Linux System, execute the
-`ifconfig` command.
+`ifconfig` or `ip` command. The command differ based on your operation systm and version.
 
 ```bash
 ifconfig -a | sed 's/[ \t].*//;/^$/d'
+```
+
+```bash
+ip link show
 ```
 
 ## Windows specific


### PR DESCRIPTION
## Proposed change

On newer linux version the ifconfig command is deprecated so you have to use ip instead.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
 -

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
