### PR TITLE
Add button platform to devolo_home_network

### DIFF
--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -3,6 +3,7 @@ title: devolo Home Network
 description: Instructions on how to integrate devolo Home Network devices with Home Assistant.
 ha_category:
   - Binary Sensor
+  - Button
   - Presence Detection
   - Sensor
   - Switch
@@ -16,6 +17,7 @@ ha_domain: devolo_home_network
 ha_quality_scale: platinum
 ha_platforms:
   - binary_sensor
+  - button
   - device_tracker
   - sensor
   - switch
@@ -36,6 +38,13 @@ Currently the following device types within Home Assistant are supported.
 * Device attached to the router
   * Updates every 5 minutes
   * Is disabled by default because it typically rarely changes
+
+### Buttons
+
+* Identify a PLC device by making its LED blink for 2 minutes
+* Start pairing on a PLC device
+* Restart the device
+* Start WPS
 
 ### Presence Detection
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the new button platform of the devolo Home Control integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85834
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
