### PR TITLE
device_class and state_class

### DIFF
--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -79,6 +79,14 @@ sql:
       description: Provide a unique id for this sensor.
       required: false
       type: string
+    device_class:
+      description: Provide [device class](https://www.home-assistant.io/integrations/sensor#device-class) for this sensor.
+      required: false
+      type: string
+    state_class:
+      decription: Provide [state class](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes) for this sensor.
+      required: false
+      type: string
 {% endconfiguration %}
 
 ## Information

--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -80,11 +80,11 @@ sql:
       required: false
       type: string
     device_class:
-      description: Provide [device class](/integrations/sensor#device-class) for this sensor.
+      description: "Provide [device class](/integrations/sensor#device-class) for this sensor."
       required: false
       type: string
     state_class:
-      decription: Provide [state class](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes) for this sensor.
+      decription: "Provide [state class](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes) for this sensor."
       required: false
       type: string
 {% endconfiguration %}

--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -84,7 +84,7 @@ sql:
       required: false
       type: string
     state_class:
-      decription: "Provide [state class](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes) for this sensor."
+      description: "Provide [state class](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes) for this sensor."
       required: false
       type: string
 {% endconfiguration %}

--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -80,7 +80,7 @@ sql:
       required: false
       type: string
     device_class:
-      description: Provide [device class](https://www.home-assistant.io/integrations/sensor#device-class) for this sensor.
+      description: Provide [device class](/integrations/sensor#device-class) for this sensor.
       required: false
       type: string
     state_class:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds device_class and state_class to documentation for SQL integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85418
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
