### PR TITLE
Add Insteon ramp rate select entities to ISY994, deprecate service

### DIFF
--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -11,6 +11,7 @@ ha_category:
   - Light
   - Lock
   - Number
+  - Select
   - Sensor
   - Switch
 ha_release: 0.28
@@ -30,6 +31,7 @@ ha_platforms:
   - light
   - lock
   - number
+  - select
   - sensor
   - switch
 ha_dhcp: true
@@ -50,6 +52,7 @@ There is currently support for the following platforms within Home Assistant:
 - Fan
 - Lock
 - Number
+- Select
 - Sensor
 - Switch
 
@@ -180,15 +183,6 @@ Rename a node or group (scene) on the ISY994. Note: this will not automatically 
 | ---------------------- | -------- | -------------------------------------------------------------- |
 | `entity_id`            | no       | Name of target entity for the command, e.g., `light.front_porch`. |
 | `name`                 | no       | The new name to use within the ISY.                         |
-
-#### Service `isy994.set_ramp_rate`
-
-Send an ISY set_ramp_rate command to a `light` Node to set the devices' ramp rate. Refer to the PyISY documentation for the [available values](https://github.com/automicus/PyISY/blob/d053369f7531370a907136bf25a177632adccd1e/pyisy/constants.py#L630).
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id`            |     no   | Name(s) of target entities for the command, e.g., `light.front_porch`. |
-| `value` | no | The integer index value to set the Ramp Rate to in a range of `0` (9.5 minutes) to `31` (0.1 Seconds), e.g., `28` |
 
 #### Service `isy994.send_program_command`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Insteon ramp rate select entities to ISY994


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/85895
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
