### PR TITLE
Update value_template example for json response

### DIFF
--- a/source/_integrations/sensor.rest.markdown
+++ b/source/_integrations/sensor.rest.markdown
@@ -177,7 +177,7 @@ sensor:
   - platform: rest
     resource: http://ip.jsontest.com
     name: External IP
-    value_template: "{{ value_json.ip }}"
+    value_template: "{{ value_json["ip"] }}"
 ```
 
 {% endraw %}
@@ -193,7 +193,7 @@ sensor:
   - platform: rest
     resource: http://IP_ADRRESS:61208/api/2/mem/used
     name: Used mem
-    value_template: "{{ value_json.used| multiply(0.000000954) | round(0) }}"
+    value_template: "{{ value_json["used"] | multiply(0.000000954) | round(0) }}"
     unit_of_measurement: MB
 ```
 
@@ -212,7 +212,7 @@ sensor:
   - platform: rest
     resource: http://IP_ADDRESS:8123/api/states/sensor.weather_temperature
     name: Temperature
-    value_template: "{{ value_json.state }}"
+    value_template: "{{ value_json["state"] }}"
     unit_of_measurement: "°C"
 ```
 
@@ -274,7 +274,7 @@ sensor:
     username: YOUR_GITHUB_USERNAME
     password: YOUR_GITHUB_ACCESS_TOKEN
     authentication: basic
-    value_template: "{{ value_json.tag_name }}"
+    value_template: "{{ value_json["tag_name"] }}"
     headers:
       Accept: application/vnd.github.v3+json
       Content-Type: application/json
@@ -297,7 +297,7 @@ sensor:
       - date
       - milliseconds_since_epoch
     resource: http://date.jsontest.com/
-    value_template: "{{ value_json.time }}"
+    value_template: "{{ value_json["time"] }}"
   - platform: template
     sensors:
       date:


### PR DESCRIPTION
Updated examples to avoid issues when an object contains dashes, such as in the issue https://github.com/home-assistant/core/issues/85827

## Proposed change
Fixing example configuration in RESTful sensor documentation by replacing format
`    value_template: "{{ value_json.ip }}"`
with:
`    value_template: "{{ value_json["ip"] }}"`

This should demonstrate how correctly to use json objects event with dash in object name.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.
