### PR TITLE
Fix example for workday sensor

### DIFF
--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -90,7 +90,7 @@ One other thing to watch is how the `holiday` keyword is used. Your first instin
 
 ## Full examples
 
-This example excludes Saturdays and Sundays but not pre-configured holidays. Two custom holidays are added.
+This example excludes Saturdays and Sundays but not pre-configured holidays.
 
 ```yaml
 # Example 1 configuration.yaml entry
@@ -99,9 +99,6 @@ binary_sensor:
     country: US
     workdays: [mon, tue, wed, thu, fri]
     excludes: [sat, sun]
-    add_holidays:
-      - "2020-02-24"
-      - "2020-04-25"
 ```
 
 This example excludes Saturdays, Sundays and holidays. One custom holiday is added.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The first example does not actually work, i.e. if you do not add the term "holiday" to the `excludes` lists, then any dates specified in `add_holidays` won't affect this binary sensor.
The example of adding holidays is already covered in example 2.

This partially fixes https://github.com/home-assistant/core/issues/85996

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
