### PR TITLE
Add Rain Bird Rain Delay Number entity and remove deprecated sensor/service

### DIFF
--- a/source/_integrations/rainbird.markdown
+++ b/source/_integrations/rainbird.markdown
@@ -25,7 +25,7 @@ This `rainbird` integration allows interacting with [LNK WiFi](https://www.rainb
 There is currently support for the following device types within Home Assistant:
 
 - [Binary Sensor](#binary-sensor)
-- [Sensor](#sensor)
+- [Number](#number)
 - [Switch](#switch)
 
 {% include integrations/config_flow.md %}
@@ -39,10 +39,9 @@ will run when turning on a zone switch (default is 6 minutes). This can be overr
 
 The `rainsensor` sensor will tell if you if the device has detected rain.
 
-## Sensor
+## Number
 
-The `raindelay` sensor reports the number of days, if any, the automatic irrigation schedule
-has been delayed.
+The Rain Delay Number Entity lets you set and view  the number of days, if any, the automatic irrigation schedule has been delayed.
 
 ## Switch
 
@@ -76,13 +75,3 @@ automation:
           entity_id: switch.rain_bird_sprinkler_1
           duration: 5
 ```
-
-### `rainbird.set_rain_delay`
-
-Sets the number of days to disable automatic irrigation. This service accepts a target of
-a Rain Bird config entry.
-
-| Service Data Attribute | Optional | Description                                            |
-| ---------------------- | -------- | ------------------------------------------------------ |
-| `config_entry`         | no       | The configuration entry id for the rainbird controller |
-| `duration`             | no       | Number of days for the device to be turned off.        |


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Rain Bird Rain Delay Number entity which lets you view and set the number of days that irrigation is paused. This removes the deprecated sensor/service that had the same functionality.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/86208
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
