### PR TITLE
Update Android redirect URIs for Wear OS OAuth without app in China

### DIFF
--- a/source/android/index.markdown
+++ b/source/android/index.markdown
@@ -6,5 +6,7 @@ description: "Landing page for Home Assistant Android app."
 <link rel='redirect_uri' href='homeassistant://auth-callback'>
 <link rel='redirect_uri' href='https://wear.googleapis.com/3p_auth/io.homeassistant.companion.android'>
 <link rel='redirect_uri' href='https://wear.googleapis.com/3p_auth/io.homeassistant.companion.android.debug'>
+<link rel='redirect_uri' href='https://wear.googleapis-cn.com/3p_auth/io.homeassistant.companion.android'>
+<link rel='redirect_uri' href='https://wear.googleapis-cn.com/3p_auth/io.homeassistant.companion.android.debug'>
 
 <script>document.location.href = 'https://companion.home-assistant.io/';</script>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
To support using the OAuth login flow with the Wear OS app when no companion app is installed, we have to use Google's redirect URI. Because using https://wear.googleapis-cn.com/ as the client ID isn't desirable, this PR adds Google's China redirect URI to the client page for both the release and debug builds of the app.

Related: home-assistant/android#3244

(The worldwide version was added in #23909.)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
