### PR TITLE
Change value_json.XXX to value_json['XXX'] in docs

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -165,7 +165,7 @@ automation:
     - platform: mqtt
       topic: "living_room/switch/ac"
       payload: "on"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json['state'] }}"
 ```
 
 {% endraw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -588,7 +588,7 @@ Example using `is_defined` to parse a JSON payload:
 {% raw %}
 
 ```text
-{{ value_json.val | is_defined }}
+{{ value_json['val'] | is_defined }}
 ```
 
 {% endraw %}
@@ -825,7 +825,7 @@ The template for `on` would be:
 {% raw %}
 
 ```yaml
-'{{value_json.on}}'
+'{{value_json['on']}}'
 ```
 
 {% endraw %}
@@ -864,7 +864,7 @@ The following overview contains a couple of options to get the needed values:
 {"primes": [2, 3, 5, 7, 11, 13]}
 
 # Extract first prime number 
-{{ value_json.primes[0] }}
+{{ value_json['primes'][0] }}
 
 # Format output
 {{ "%+.1f" | value_json }}
@@ -880,9 +880,9 @@ The following overview contains a couple of options to get the needed values:
 {{ sqrt(e) }}
 
 # Timestamps
-{{ value_json.tst | timestamp_local }}
-{{ value_json.tst | timestamp_utc }}
-{{ value_json.tst | timestamp_custom('%Y', True) }}
+{{ value_json['tst'] | timestamp_local }}
+{{ value_json['tst'] | timestamp_utc }}
+{{ value_json['tst'] | timestamp_custom('%Y', True) }}
 ```
 
 {% endraw %}
@@ -900,7 +900,7 @@ To evaluate a response, go to **{% my developer_template title="Developer Tools 
          "hum":"35%"
          } }%}
 
-{{value_json.data.hum[:-1]}}
+{{value_json['data']['hum'][:-1]}}
 ```
 
 {% endraw %}
@@ -924,7 +924,7 @@ With given payload:
 { "state": "ON", "temperature": 21.902 }
 ```
 
-Template {% raw %}```{{ value_json.temperature | round(1) }}```{% endraw %} renders to `21.9`.
+Template {% raw %}```{{ value_json['temperature'] | round(1) }}```{% endraw %} renders to `21.9`.
 
 Additional the MQTT entity attributes `entity_id`, `name` and `this` can be used as variables in the template. The `this` attribute refers to the [entity state](/docs/configuration/state_object) of the MQTT item.
 

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -270,7 +270,7 @@ mqtt:
   alarm_control_panel:
     - name: "Alarm Panel With Numeric Keypad"
       state_topic: "alarmdecoder/panel"
-      value_template: "{{value_json.state}}"
+      value_template: "{{value_json['state']}}"
       command_topic: "alarmdecoder/panel/set"
       code: mys3cretc0de
 ```
@@ -289,7 +289,7 @@ mqtt:
   alarm_control_panel:
     - name: "Alarm Panel With Text Code Dialog"
       state_topic: "alarmdecoder/panel"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json['state'] }}"
       command_topic: "alarmdecoder/panel/set"
       code: REMOTE_CODE_TEXT
       command_template: >
@@ -302,7 +302,7 @@ mqtt:
   alarm_control_panel:
     - name: "Alarm Panel With Numeric Keypad"
       state_topic: "alarmdecoder/panel"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json['state'] }}"
       command_topic: "alarmdecoder/panel/set"
       code: REMOTE_CODE
       command_template: >

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -239,7 +239,7 @@ mqtt:
           payload_not_available: "offline"
       qos: 0
       device_class: opening
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json['state'] }}"
 ```
 
 {% endraw %}

--- a/source/_integrations/binary_sensor.rest.markdown
+++ b/source/_integrations/binary_sensor.rest.markdown
@@ -154,7 +154,7 @@ binary_sensor:
     method: GET
     name: Light
     device_class: light
-    value_template: '{{ value_json.return_value }}'
+    value_template: '{{ value_json['return_value'] }}'
 ```
 
 {% endraw %}

--- a/source/_integrations/dweet.markdown
+++ b/source/_integrations/dweet.markdown
@@ -67,7 +67,7 @@ To use Dweet.io sensors in your installation, add the following to your `configu
 sensor:
   - platform: dweet
     device: THING_NAME
-    value_template: "{{ value_json.VARIABLE }}"
+    value_template: "{{ value_json['VARIABLE'] }}"
 ```
 
 {% endraw %}
@@ -104,7 +104,7 @@ sensor:
   - platform: dweet
     name: Temperature
     device: THING_NAME
-    value_template: "{{ value_json.VARIABLE }}"
+    value_template: "{{ value_json['VARIABLE'] }}"
     unit_of_measurement: "°C"
 ```
 

--- a/source/_integrations/file.markdown
+++ b/source/_integrations/file.markdown
@@ -111,7 +111,7 @@ sensor:
   - platform: file
     name: Temperature
     file_path: /home/user/.homeassistant/sensor.json
-    value_template: '{{ value_json.temperature }}'
+    value_template: '{{ value_json['temperature'] }}'
     unit_of_measurement: "°C"
 ```
 

--- a/source/_integrations/garadget.markdown
+++ b/source/_integrations/garadget.markdown
@@ -132,7 +132,7 @@ cover:
     state_topic: "garadget/device_name/status"
     payload_open: "open"
     payload_close: "close"
-    value_template: "{{ value_json.status }}"
+    value_template: "{{ value_json['status'] }}"
 ```
 
 Replace device_name with the name of the device provided when configuring garadget.

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -419,9 +419,9 @@ mqtt:
       brightness_command_topic: "office/rgb1/brightness/set"
       rgb_state_topic: "office/rgb1/rgb/status"
       rgb_command_topic: "office/rgb1/rgb/set"
-      state_value_template: "{{ value_json.state }}"
-      brightness_value_template: "{{ value_json.brightness }}"
-      rgb_value_template: "{{ value_json.rgb | join(',') }}"
+      state_value_template: "{{ value_json['state'] }}"
+      brightness_value_template: "{{ value_json['brightness'] }}"
+      rgb_value_template: "{{ value_json['rgb'] | join(',') }}"
       qos: 0
       payload_on: "ON"
       payload_off: "OFF"
@@ -1139,12 +1139,12 @@ mqtt:
         {%- endif -%}
         }
       command_off_template: '{"state": "off"}'
-      state_template: '{{ value_json.state }}'
-      brightness_template: '{{ value_json.brightness }}'
-      red_template: '{{ value_json.color[0] }}'
-      green_template: '{{ value_json.color[1] }}'
-      blue_template: '{{ value_json.color[2] }}'
-      effect_template: '{{ value_json.effect }}'
+      state_template: '{{ value_json['state'] }}'
+      brightness_template: '{{ value_json['brightness'] }}'
+      red_template: '{{ value_json['color'][0] }}'
+      green_template: '{{ value_json['color'][1] }}'
+      blue_template: '{{ value_json['color'][2] }}'
+      effect_template: '{{ value_json['effect'] }}'
 ```
 
 {% endraw %}
@@ -1177,9 +1177,9 @@ mqtt:
         {%- endif -%}
         }
       command_off_template: '{"turn":"off", "mode": "white"}'
-      state_template: "{% if value_json.ison and value_json.mode == 'white' %}on{% else %}off{% endif %}"
-      brightness_template: "{{ value_json.brightness | float | multiply(2.55) | round(0) }}"
-      color_temp_template: "{{ (1000000 / value_json.temp | float) | round(0) }}"
+      state_template: "{% if value_json['ison'] and value_json['mode'] == 'white' %}on{% else %}off{% endif %}"
+      brightness_template: "{{ value_json['brightness'] | float | multiply(2.55) | round(0) }}"
+      color_temp_template: "{{ (1000000 / value_json['temp'] | float) | round(0) }}"
       payload_available: "true"
       payload_not_available: "false"
       max_mireds: 334

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -566,9 +566,9 @@ For more details please refer to the [MQTT testing section](/docs/mqtt/testing/)
 Setting up a sensor with multiple measurement values requires multiple consecutive configuration topic submissions.
 
 - Configuration topic no1: `homeassistant/sensor/sensorBedroomT/config`
-- Configuration payload no1: `{"device_class": "temperature", "name": "Temperature", "state_topic": "homeassistant/sensor/sensorBedroom/state", "unit_of_measurement": "°C", "value_template": "{% raw %}{{ value_json.temperature}}{% endraw %}" }`
+- Configuration payload no1: `{"device_class": "temperature", "name": "Temperature", "state_topic": "homeassistant/sensor/sensorBedroom/state", "unit_of_measurement": "°C", "value_template": "{% raw %}{{ value_json['temperature']}}{% endraw %}" }`
 - Configuration topic no2: `homeassistant/sensor/sensorBedroomH/config`
-- Configuration payload no2: `{"device_class": "humidity", "name": "Humidity", "state_topic": "homeassistant/sensor/sensorBedroom/state", "unit_of_measurement": "%", "value_template": "{% raw %}{{ value_json.humidity}}{% endraw %}" }`
+- Configuration payload no2: `{"device_class": "humidity", "name": "Humidity", "state_topic": "homeassistant/sensor/sensorBedroom/state", "unit_of_measurement": "%", "value_template": "{% raw %}{{ value_json['humidity']}}{% endraw %}" }`
 - Common state payload: `{ "temperature": 23.20, "humidity": 43.70 }`
 
 #### Entities with command topics

--- a/source/_integrations/plant.markdown
+++ b/source/_integrations/plant.markdown
@@ -142,27 +142,27 @@ sensor:
   - platform: mqtt
     name: my_plant_moisture
     state_topic: my_plant_topic
-    value_template: "{{ value_json.moisture | int }}"
+    value_template: "{{ value_json['moisture'] | int }}"
     unit_of_measurement: "%"
   - platform: mqtt
     name: my_plant_battery
     state_topic: my_plant_topic
-    value_template: "{{ value_json.battery | int }}"
+    value_template: "{{ value_json['battery'] | int }}"
     unit_of_measurement: "%"
   - platform: mqtt
     name: my_plant_temperature
     state_topic: my_plant_topic
-    value_template: "{{ value_json.temperature | float }}"
+    value_template: "{{ value_json['temperature'] | float }}"
     unit_of_measurement: "°C"
   - platform: mqtt
     name: my_plant_conductivity
     state_topic: my_plant_topic
-    value_template: "{{ value_json.conductivity | int }}"
+    value_template: "{{ value_json['conductivity'] | int }}"
     unit_of_measurement: "µS/cm"
   - platform: mqtt
     name: my_plant_brightness
     state_topic: my_plant_topic
-    value_template: "{{ value_json.brightness | int }}"
+    value_template: "{{ value_json['brightness'] | int }}"
     unit_of_measurement: "Lux"
 ```
 

--- a/source/_integrations/sensor.command_line.markdown
+++ b/source/_integrations/sensor.command_line.markdown
@@ -201,7 +201,7 @@ sensor:
       - date
       - milliseconds_since_epoch
     command: "python3 /home/pi/.homeassistant/scripts/datetime.py"
-    value_template: "{{ value_json.time }}"
+    value_template: "{{ value_json['time'] }}"
 ```
 
 {% endraw %}

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -217,7 +217,7 @@ mqtt:
     - name: "RSSI"
       state_topic: "home/sensor1/infojson"
       unit_of_measurement: "dBm"
-      value_template: "{{ value_json.RSSI }}"
+      value_template: "{{ value_json['RSSI'] }}"
       availability:
         - topic: "home/sensor1/status"
       payload_available: "online"
@@ -229,7 +229,7 @@ mqtt:
 
 ### JSON attributes template configuration
 
-The example sensor below shows a configuration example which uses a JSON dict: `{"Timer1":{"Arm": <status>, "Time": <time>}, "Timer2":{"Arm": <status>, "Time": <time>}}` on topic `tele/sonoff/sensor` with a template to add `Timer1.Arm` and `Timer1.Time` as extra attributes. To instead only add `Timer1.Arm`as an extra attribute, change `json_attributes_template` to: {% raw %}`"{{ {'Arm': value_json.Timer1} | tojson }}"`{% endraw %}.
+The example sensor below shows a configuration example which uses a JSON dict: `{"Timer1":{"Arm": <status>, "Time": <time>}, "Timer2":{"Arm": <status>, "Time": <time>}}` on topic `tele/sonoff/sensor` with a template to add `Timer1.Arm` and `Timer1.Time` as extra attributes. To instead only add `Timer1.Arm`as an extra attribute, change `json_attributes_template` to: {% raw %}`"{{ {'Arm': value_json['Timer1']} | tojson }}"`{% endraw %}.
 
 Extra attributes will be displayed in the frontend and can also be extracted in [Templates](/docs/configuration/templating/#attributes). For example, to extract the `Arm` attribute from the sensor below, use a template similar to: {% raw %}`{{ state_attr('sensor.timer1', 'Arm') }}`{% endraw %}.
 
@@ -241,14 +241,14 @@ mqtt:
   sensor:
     - name: "Timer 1"
       state_topic: "tele/sonoff/sensor"
-      value_template: "{{ value_json.Timer1.Arm }}"
+      value_template: "{{ value_json['Timer1'].Arm'] }}"
       json_attributes_topic: "tele/sonoff/sensor"
-      json_attributes_template: "{{ value_json.Timer1 | tojson }}"
+      json_attributes_template: "{{ value_json['Timer1'] | tojson }}"
     - name: "Timer 2"
       state_topic: "tele/sonoff/sensor"
-      value_template: "{{ value_json.Timer2.Arm }}"
+      value_template: "{{ value_json['Timer2'].Arm'] }}"
       json_attributes_topic: "tele/sonoff/sensor"
-      json_attributes_template: "{{ value_json.Timer2 | tojson }}"
+      json_attributes_template: "{{ value_json['Timer2'] | tojson }}"
 ```
 
 {% endraw %}
@@ -296,7 +296,7 @@ mqtt:
     - name: "Battery Tablet"
       state_topic: "owntracks/tablet/tablet"
       unit_of_measurement: "%"
-      value_template: "{{ value_json.batt }}"
+      value_template: "{{ value_json['batt'] }}"
 ```
 
 {% endraw %}
@@ -324,11 +324,11 @@ mqtt:
     - name: "Temperature"
       state_topic: "office/sensor1"
       unit_of_measurement: "°C"
-      value_template: "{{ value_json.temperature }}"
+      value_template: "{{ value_json['temperature'] }}"
     - name: "Humidity"
       state_topic: "office/sensor1"
       unit_of_measurement: "%"
-      value_template: "{{ value_json.humidity }}"
+      value_template: "{{ value_json['humidity'] }}"
 ```
 
 {% endraw %}

--- a/source/_integrations/sensor.rest.markdown
+++ b/source/_integrations/sensor.rest.markdown
@@ -177,7 +177,7 @@ sensor:
   - platform: rest
     resource: http://ip.jsontest.com
     name: External IP
-    value_template: "{{ value_json.ip }}"
+    value_template: "{{ value_json['ip'] }}"
 ```
 
 {% endraw %}
@@ -193,7 +193,7 @@ sensor:
   - platform: rest
     resource: http://IP_ADRRESS:61208/api/2/mem/used
     name: Used mem
-    value_template: "{{ value_json.used| multiply(0.000000954) | round(0) }}"
+    value_template: "{{ value_json['used']| multiply(0.000000954) | round(0) }}"
     unit_of_measurement: MB
 ```
 
@@ -212,7 +212,7 @@ sensor:
   - platform: rest
     resource: http://IP_ADDRESS:8123/api/states/sensor.weather_temperature
     name: Temperature
-    value_template: "{{ value_json.state }}"
+    value_template: "{{ value_json['state'] }}"
     unit_of_measurement: "°C"
 ```
 
@@ -274,7 +274,7 @@ sensor:
     username: YOUR_GITHUB_USERNAME
     password: YOUR_GITHUB_ACCESS_TOKEN
     authentication: basic
-    value_template: "{{ value_json.tag_name }}"
+    value_template: "{{ value_json['tag_name'] }}"
     headers:
       Accept: application/vnd.github.v3+json
       Content-Type: application/json
@@ -297,7 +297,7 @@ sensor:
       - date
       - milliseconds_since_epoch
     resource: http://date.jsontest.com/
-    value_template: "{{ value_json.time }}"
+    value_template: "{{ value_json['time'] }}"
   - platform: template
     sensors:
       date:

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -289,7 +289,7 @@ mqtt:
       command_topic: "cmnd/SIREN/POWER"
       availability_topic: "tele/SIREN/LWT"
       command_template: "{{ value }}"
-      state_value_template: "{{ value_json.POWER }}"
+      state_value_template: "{{ value_json['POWER'] }}"
       payload_on: "ON"
       payload_off: "OFF"
       payload_available: "Online"

--- a/source/_integrations/switch.command_line.markdown
+++ b/source/_integrations/switch.command_line.markdown
@@ -108,9 +108,9 @@ switch:
           curl -X PUT -d '{"on":false}' "http://ip_address/api/sensors/27/config/"
         command_state: curl http://ip_address/api/sensors/27/
         value_template: >
-          {{value_json.config.on}}
+          {{value_json['config']['on']}}
         icon_template: >
-          {% if value_json.config.on == true %} mdi:toggle-switch
+          {% if value_json['config']['on'] == true %} mdi:toggle-switch
           {% else %} mdi:toggle-switch-off
           {% endif %}
 ```

--- a/source/_integrations/switch.rest.markdown
+++ b/source/_integrations/switch.rest.markdown
@@ -108,7 +108,7 @@ switch:
     resource: http://IP_ADDRESS/led_endpoint
     body_on: '{"active": "true"}'
     body_off: '{"active": "false"}'
-    is_on_template: "{{ value_json.is_active }}"
+    is_on_template: "{{ value_json['is_active'] }}"
     headers:
       Content-Type: application/json
       X-Custom-Header: '{{ states("input_text.the_custom_header") }}'

--- a/source/_integrations/tag.mqtt.markdown
+++ b/source/_integrations/tag.mqtt.markdown
@@ -85,7 +85,7 @@ Discover the tag scanner:
 {% raw %}
 
 ```bash
-mosquitto_pub -h 127.0.0.1 -t homeassistant/tag/0AFFD2/config -m '{"topic": "0AFFD2/tag_scanned", "value_template": "{{ value_json.PN532.UID }}"}'
+mosquitto_pub -h 127.0.0.1 -t homeassistant/tag/0AFFD2/config -m '{"topic": "0AFFD2/tag_scanned", "value_template": "{{ value_json['PN532'].UID'] }}"}'
 ```
 
 {% endraw %}

--- a/source/_integrations/update.mqtt.markdown
+++ b/source/_integrations/update.mqtt.markdown
@@ -290,7 +290,7 @@ mqtt:
     - name: "Amazing Device Update"
       title: "Device Firmware"
       state_topic: "amazing-device/state-topic"
-      value_template: "{{ {'installed_version': value_json.installed_ver, 'latest_version': value_json.new_ver } | to_json }}"
+      value_template: "{{ {'installed_version': value_json['installed_ver'], 'latest_version': value_json['new_ver'] } | to_json }}"
       device_class: "firmware"
       command_topic: "amazing-device/command"
       payload_install: "install"

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -263,17 +263,17 @@ mqtt:
         - send_command
       command_topic: "vacuum/command"
       battery_level_topic: "vacuum/state"
-      battery_level_template: "{{ value_json.battery_level }}"
+      battery_level_template: "{{ value_json['battery_level'] }}"
       charging_topic: "vacuum/state"
-      charging_template: "{{ value_json.charging }}"
+      charging_template: "{{ value_json['charging'] }}"
       cleaning_topic: "vacuum/state"
-      cleaning_template: "{{ value_json.cleaning }}"
+      cleaning_template: "{{ value_json['cleaning'] }}"
       docked_topic: "vacuum/state"
-      docked_template: "{{ value_json.docked }}"
+      docked_template: "{{ value_json['docked'] }}"
       error_topic: "vacuum/state"
-      error_template: "{{ value_json.error }}"
+      error_template: "{{ value_json['error'] }}"
       fan_speed_topic: "vacuum/state"
-      fan_speed_template: "{{ value_json.fan_speed }}"
+      fan_speed_template: "{{ value_json['fan_speed'] }}"
       set_fan_speed_topic: "vacuum/set_fan_speed"
       fan_speed_list:
         - min

--- a/source/_posts/2016-10-08-hassbian-rest-digital-ocean.markdown
+++ b/source/_posts/2016-10-08-hassbian-rest-digital-ocean.markdown
@@ -53,7 +53,7 @@ sensor
     username: YOUR_GITHUB_USERNAME
     password: YOUR_GITHUB_ACCESS_TOKEN
     authentication: basic
-    value_template: "{{ value_json.tag_name }}"
+    value_template: "{{ value_json['tag_name'] }}"
     headers:
       Accept: application/vnd.github.v3+json
       Content-Type: application/json

--- a/source/_posts/2020-01-15-release-104.markdown
+++ b/source/_posts/2020-01-15-release-104.markdown
@@ -320,7 +320,7 @@ Make sure to fill in all fields of the issue template, that is helping us a lot!
      - platform: mqtt
        command_topic: "/dev/ha/lock/cmd"
        state_topic:   "/dev/ha/lock/state"
-       value_template: "{{ value_json.state }}"
+       value_template: "{{ value_json['state'] }}"
        state_locked: "locked"
        state_unlocked: "unlocked"
    ```

--- a/source/_posts/2020-02-26-release-106.markdown
+++ b/source/_posts/2020-02-26-release-106.markdown
@@ -281,7 +281,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
         - "spatemp"
         - "airtemp"
       json_attributes_path: "$.response.temp"
-      value_template: "{{ value_json.response.temp.poolsp }}"
+      value_template: "{{ value_json['response']['temp']['poolsp'] }}"
     - platform: rest
       resource: http://192.168.1.5/status.xml
       json_attributes:


### PR DESCRIPTION
## Proposed change
Although I understand the aesthetics and simplicity for beginners of using periods for accessing items of a dict and calling methods (`a.key.method()`), it should not be done in value_json specifically. value_json implies values from the outside world: a radio REST API, a robot vacuum, or a cheap MQTT device, none of them made specifically for home assistant. If the vendor stumble upon naming something that's a python dict's method... well, debugging will (was) unpleasant. 
As an example:
```
{% set my_test_json = {
  "update": {"time":"123"},
  "u": {"time":"456"}
} %}
bracket update: {{ my_test_json['update']['time'] }}
bracket u: {{ my_test_json['u']['time'] }}
period update: {{ my_test_json.update.time }} <- Will break because update is a python method for dict
period u: {{ my_test_json.u.time }}
```
[Here's a list of word that will break templating when using period](https://www.w3schools.com/python/python_ref_dictionary.asp)
I fully understand this PR implies decision-making, weighting user-friendlyness and consistency across the hassio documentation... 

## Type of change
Change value_json.XXX to value_json['XXX'] in docs


## Additional information
None

## Checklist
- [X] Spelling, grammar or other readability improvements (`current` branch).