### PR TITLE
Add documentation for home-assistant/core#86357

### DIFF
--- a/source/_integrations/powerwall.markdown
+++ b/source/_integrations/powerwall.markdown
@@ -25,6 +25,7 @@ There is currently support for the following device types within Home Assistant:
 
 - [Binary Sensor](#binary-sensor)
 - [Sensor](#sensor)
+- [Switch](#switch)
 
 {% include integrations/config_flow.md %}
 
@@ -34,6 +35,7 @@ The following binary sensors are added for each Powerwall:
 
 - Grid Services - On/ Off
 - Grid Status - On/ Off
+- Off-grid Status - On/ Off
 - Powerwall Charging - Charging/ Not Charging
 - Powerwall Connected to Tesla - Connected / Not Connected
 - Powerwall Status - On/ Off
@@ -64,6 +66,12 @@ The following sensors show the direction of energy:
 - Powerwall Load Import - Load energy imported in kWh
 - Powerwall Generator Export - Generator energy exported in kWh
 - Powerwall Generator Import - Generator energy imported in kWh
+
+### Switch
+
+The following switches are added for each Powerwall:
+
+- Take Powerwall Off-Grid - Go off-grid (simulate a grid outage)
 
 ### Device Info
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds a "Take Powerwall Off-Grid" switch which allows powerwall users to take their battery off grid programmatically.

This is a feature I (and other powerwall users) have been after for a while, as it would allow us to use power price data from other integrations to add home assistant automations around this behaviour.

Personally, I've taken the time to write this because where I live (Australia) and the power provider I use (Amber Electric) offers negative feed in for solar exports at certain times of the day. This feature would allow me to take my home off-grid (and effectively curtail solar generation) during these negative Feed in events.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/86357

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
