### PR TITLE
Add IoT Class filter to integrations page

### DIFF
--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -23,6 +23,7 @@ regenerate: false
 {%- assign components = site.integrations | sort: 'title' -%}
 {%- assign components_by_version = site.integrations | group_components_by_release -%}
 {%- assign categories = components | map: 'ha_category' | join: ',' | join: ',' | split: ',' | uniq | sort -%}
+{%- assign iot_classes = components | map: 'ha_iot_class' | join: ',' | split: ',' | uniq | sort -%}
 
 <p class='note'>
   Support for these integrations is provided by the Home Assistant community.
@@ -44,6 +45,16 @@ regenerate: false
           </optgroup>
           {%- endfor -%}
         </select></div>
+
+      <h3 class="title">IoT Class</h3>
+      {%- for iot_class in iot_classes -%}
+      {%- assign iot_class_count = components | where: 'ha_iot_class', iot_class | size -%}
+      {%- if iot_class and iot_class != 'Other' and iot_class_count != 0 -%}
+      <a href='#{{ iot_class | slugify }}' class="btn" onclick="document.querySelector('.page-content').scrollTop = 0">{{ iot_class }} ({{ iot_class_count }})</a>
+      {%- endif -%}
+      {%- endfor -%}
+
+      <h3 class="title">Category</h3>
       {%- for category in categories -%}
       {%- assign components_count = components | where: 'ha_category', category | size -%}
       {%- if category and category != 'Other' and components_count != 0 -%}
@@ -103,7 +114,7 @@ var allComponents = [
         {% capture category %}"{{ ha_category | slugify | downcase }}"{% endcapture %}
         {% assign categories = categories | push: category %}
       {%- endfor -%}
-      {url:"{{ component.url }}", title:"{{component.title}}", cat: [{{categories|join: ","}}], featured: {% if component.featured %}true{% else %}false{% endif %}, v: "{{major_version}}.{{minor_version}}", logo: "{{component.logo}}", domain: "{{component.ha_domain}}"},
+      {url:"{{ component.url }}", title:"{{component.title}}", cat: [{{categories|join: ","}}], featured: {% if component.featured %}true{% else %}false{% endif %}, v: "{{major_version}}.{{minor_version}}", logo: "{{component.logo}}", domain: "{{component.ha_domain}}", iot_class: "{{ component.ha_iot_class | slugify | downcase }}"},
     {% endif -%}
   {%- endfor -%}
   false
@@ -208,7 +219,7 @@ allComponents.pop(); // remove placeholder element at the end
           // regular filter categories
           search = hash.substring(1);
           filter = function (comp) {
-            return comp.cat.includes(search);
+            return comp.cat.includes(search) || comp.iot_class === search;
           };
         }
 


### PR DESCRIPTION
## Proposed change
A long requested feature to add a filter for IoT Class on the integrations page :
- https://community.home-assistant.io/t/wth-why-cant-i-filter-integrations-by-iot-class-on-ha-website/472973
- https://community.home-assistant.io/t/website-filter-components-e-g-iot-class-local-polling/36563
- https://community.home-assistant.io/t/ui-filters-in-the-integration-page/424473



## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: fixes #5073

## Checklist


- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
