### PR TITLE
workday: Document date ranges in `add_holidays`

### DIFF
--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -65,7 +65,7 @@ days_offset:
   type: integer
   default: 0
 add_holidays:
-  description: "Add custom holidays (such as company, personal holidays or vacations). Needs to formatted as `YYYY-MM-DD`."
+  description: "Add custom holidays (such as company, personal holidays or vacations). Can be a single date or an inclusive range of dates, formatted as `YYYY-MM-DD`."
   required: false
   type: list
 remove_holidays:
@@ -90,7 +90,7 @@ One other thing to watch is how the `holiday` keyword is used. Your first instin
 
 ## Full examples
 
-This example excludes Saturdays and Sundays but not pre-configured holidays. Two custom holidays are added.
+This example excludes Saturdays and Sundays but not pre-configured holidays. It adds custom holidays on Feb 24, Apr 25, and the days between-and-including Apr 30 to May 4.
 
 ```yaml
 # Example 1 configuration.yaml entry
@@ -102,6 +102,7 @@ binary_sensor:
     add_holidays:
       - "2020-02-24"
       - "2020-04-25"
+      - ["2020-04-30", "2020-05-04"]
 ```
 
 This example excludes Saturdays, Sundays and holidays. One custom holiday is added.


### PR DESCRIPTION
## Proposed change

This documents using date ranges in the `add_holidays` field. https://github.com/home-assistant/core/pull/86398


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
