### PR TITLE
Addition of doc for PR in iframe card

### DIFF
--- a/source/_dashboards/iframe.markdown
+++ b/source/_dashboards/iframe.markdown
@@ -40,7 +40,7 @@ aspect_ratio:
   default: "50%"
 allow_open_top_navigation:
   required: false
-  description: 'Allow the user to open iframe content links by opening the default browser in Home Assistant mobile app. It is false by default because it adds allow-top-navigation-by-user-activation on the iframe sandbox attribute which is a less secure. So set it to true if you need it and are confident with the iframe content.'
+  description: 'Allow the user to open iframe content links by opening the default browser in the Home Assistant mobile app. It is false by default because it adds allow-top-navigation-by-user-activation on the iframe sandbox attribute which is less secure. So set it to true if you need it and are confident with the iframe content.'
   type: boolean
   default: false
 title:

--- a/source/_dashboards/iframe.markdown
+++ b/source/_dashboards/iframe.markdown
@@ -40,7 +40,7 @@ aspect_ratio:
   default: "50%"
 allow_open_top_navigation:
   required:false
-  description: 'Allow the user to open iframe content links by opening the default browser in HomeAssistant mobile app. It is false by default because it adds allow-top-navigation-by-user-activation on the iframe sandbox attribute which is a less secure. So set it to true if you need it and are confident with the iframe content.'
+  description: 'Allow the user to open iframe content links by opening the default browser in Home Assistant mobile app. It is false by default because it adds allow-top-navigation-by-user-activation on the iframe sandbox attribute which is a less secure. So set it to true if you need it and are confident with the iframe content.'
   type: boolean
   default: false
 title:

--- a/source/_dashboards/iframe.markdown
+++ b/source/_dashboards/iframe.markdown
@@ -39,7 +39,7 @@ aspect_ratio:
   type: string
   default: "50%"
 allow_open_top_navigation:
-  required:false
+  required: false
   description: 'Allow the user to open iframe content links by opening the default browser in Home Assistant mobile app. It is false by default because it adds allow-top-navigation-by-user-activation on the iframe sandbox attribute which is a less secure. So set it to true if you need it and are confident with the iframe content.'
   type: boolean
   default: false

--- a/source/_dashboards/iframe.markdown
+++ b/source/_dashboards/iframe.markdown
@@ -38,6 +38,11 @@ aspect_ratio:
   description: 'Forces the height of the image to be a ratio of the width. Valid formats: Height percentage value (`23%`) or ratio expressed with colon or "x" separator (`16:9` or `16x9`). For a ratio, the second element can be omitted and will default to "1" (`1.78` equals `1.78:1`).'
   type: string
   default: "50%"
+allow_open_top_navigation:
+  required:false
+  description: 'Allow the user to open iframe content links by opening the default browser in HomeAssistant mobile app. It is false by default because it adds allow-top-navigation-by-user-activation on the iframe sandbox attribute which is a less secure. So set it to true if you need it and are confident with the iframe content.'
+  type: boolean
+  default: false
 title:
   required: false
   description: The card title.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Addition of for https://github.com/home-assistant/frontend/pull/15063


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/15063
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
