### PR TITLE
Clarify meaning of start duration

### DIFF
--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -90,7 +90,7 @@ You can also use `entity_id: all` and all active timers will be started.
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id`            |      no  | Name of the entity to take action, e.g., `timer.timer0`. |
-| `duration`             |      yes | Duration in seconds or `00:00:00` until the timer finishes. |
+| `duration`             |      yes | Duration in seconds or `01:23:45` format until the timer finishes. |
 
 ### Service `timer.pause`
 


### PR DESCRIPTION
## Proposed change

The initial text (Duration in seconds or `00:00:00` until the timer finishes) may lead to the misconception that `00:00:00` has a special meaning. I think it is better to use the same wording as in the paragraph above.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].
