### PR TITLE
Update alarmdecoder.markdown

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -130,17 +130,25 @@ Using a combination of the available services and attributes, you can create swi
       friendly_name: Chime
       value_template: "{{ is_state_attr('alarm_control_panel.alarm_panel', 'chime', true) }}"
       turn_on:
-        service: alarmdecoder.alarm_toggle_chime
-        target:
+        - condition: state
           entity_id: alarm_control_panel.alarm_panel
-        data:
-          code: !secret alarm_code
+          attribute: chime
+          state: False
+        - service: alarmdecoder.alarm_toggle_chime
+          target:
+            entity_id: alarm_control_panel.alarm_panel
+          data:
+            code: !secret alarm_code
       turn_off:
-        service: alarmdecoder.alarm_toggle_chime
-        target:
+        - condition: state
           entity_id: alarm_control_panel.alarm_panel
-        data:
-          code: !secret alarm_code
+          attribute: chime
+          state: True
+        - service: alarmdecoder.alarm_toggle_chime
+          target:
+            entity_id: alarm_control_panel.alarm_panel
+          data:
+            code: !secret alarm_code
       icon_template: >-
         {% if is_state_attr('alarm_control_panel.alarm_panel', 'chime', true) %}
           mdi:bell-ring


### PR DESCRIPTION
## Proposed change
The switch template example in alarmdecoder.markdown very helpfully shows how to expose the alarm chime as a controllable switch. However it blindly calls alarm_toggle_chime which breaks idempotence as calling turn_on multiple times will end up doing a toggle back to off. It also makes it hard to simply call turn_on in automations and walk away :) This PR adds conditions to the example to check current state before alarm_toggle_chime is called.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ X ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [ X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ X ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
