### PR TITLE
Update list of configuration variables that blocks editing General Settings in UI

### DIFF
--- a/source/_docs/configuration/basic.markdown
+++ b/source/_docs/configuration/basic.markdown
@@ -32,7 +32,7 @@ homeassistant:
 
 <div class='note'>
 
-  You will not be able to edit anything in {% my general title="Settings > System > General" %} in the UI if you are using YAML configuration for any of the following: name, latitude, longitude, elevation, unit_system, temperature_unit, time_zone, external_url, internal_url. Additionally, some options are only visible after "Advanced Mode" is enabled on your {% my profile title="User Profile" %}.
+  You will not be able to edit anything in {% my general title="Settings > System > General" %} in the UI if you are using YAML configuration for any of the following: name, latitude, longitude, elevation, unit_system, temperature_unit, time_zone, external_url, internal_url, country, currency. Additionally, some options are only visible after "Advanced Mode" is enabled on your {% my profile title="User Profile" %}.
 
 </div>
 


### PR DESCRIPTION
## Proposed change
Add `currency` and `country` to the list of configuration variables which will cause that you wiil not be able to edit anything in [Settings > System > General](https://my.home-assistant.io/redirect/general) in the UI

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.