### PR TITLE
Add onetracker docs

### DIFF
--- a/source/_integrations/onetracker.markdown
+++ b/source/_integrations/onetracker.markdown
@@ -1,0 +1,47 @@
+---
+title: OneTracker
+description: Instructions on how to set up OneTracker sensors within Home Assistant.
+ha_category:
+  - Postal Service
+ha_release: 2023.03
+ha_iot_class: Cloud Polling
+ha_domain: OneTracker
+ha_platforms:
+  - sensor
+ha_integration_type: integration
+---
+
+The `OneTracker` platform allows one to track deliveries by [OneTracker](https://onetracker.app), a service that supports 490+ couriers worldwide. To use the tracking API functionality, the Essentials plan is required. This plan includes 100 shipments per month. There are various paid-for tiers after that.
+
+The sensor value shows the number of packages that are not in `Delivered` state. As attributes are the number of packages per status.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+email:
+  description: Email used for OneTracker account.
+  required: true
+  type: string
+password:
+  description: Password used for OneTracker account.
+  required: true
+  type: string
+{% endconfiguration_basic %}
+
+## Setup
+
+To use this sensor, you need an [OneTracker Account](https://onetracker.app/signin). If you need to create an account you will need to download the [Android](https://play.google.com/store/apps/details?id=app.onetracker.android)
+or [iOS](https://itunes.apple.com/us/app/onetracker-package-tracking/id1409295535) application.
+
+## Sensor
+
+The OneTracker integration lets you monitor various states of packages monitored by OneTracker.
+
+Each package is a sensor with the following data:
+
+- Tracking status
+- Tracking ID
+- Tracking Location
+- Carrier Name
+- Estimated Delivery Time
+- Actual Delivery Time

--- a/source/_integrations/onetracker.markdown
+++ b/source/_integrations/onetracker.markdown
@@ -28,7 +28,7 @@ password:
   type: string
 {% endconfiguration_basic %}
 
-## Setup
+## Prerequisites
 
 To use this sensor, you need an [OneTracker Account](https://onetracker.app/signin). If you need to create an account you will need to download the [Android](https://play.google.com/store/apps/details?id=app.onetracker.android)
 or [iOS](https://itunes.apple.com/us/app/onetracker-package-tracking/id1409295535) application.

--- a/source/_integrations/onetracker.markdown
+++ b/source/_integrations/onetracker.markdown
@@ -15,6 +15,11 @@ The OneTracker integration allows one to track deliveries by [OneTracker](https:
 
 The sensor value shows the number of packages that are not in `Delivered` state. As attributes are the number of packages per status.
 
+## Prerequisites
+
+To use this sensor, you need an [OneTracker Account](https://onetracker.app/signin). If you need to create an account you will need to download the [Android](https://play.google.com/store/apps/details?id=app.onetracker.android)
+or [iOS](https://itunes.apple.com/us/app/onetracker-package-tracking/id1409295535) application.
+
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}
@@ -23,11 +28,6 @@ email:
 password:
   description: Password used for OneTracker account.
 {% endconfiguration_basic %}
-
-## Prerequisites
-
-To use this sensor, you need an [OneTracker Account](https://onetracker.app/signin). If you need to create an account you will need to download the [Android](https://play.google.com/store/apps/details?id=app.onetracker.android)
-or [iOS](https://itunes.apple.com/us/app/onetracker-package-tracking/id1409295535) application.
 
 ## Sensor
 

--- a/source/_integrations/onetracker.markdown
+++ b/source/_integrations/onetracker.markdown
@@ -11,7 +11,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `OneTracker` platform allows one to track deliveries by [OneTracker](https://onetracker.app), a service that supports 490+ couriers worldwide. To use the tracking API functionality, the Essentials plan is required. This plan includes 100 shipments per month. There are various paid-for tiers after that.
+The OneTracker integration allows one to track deliveries by [OneTracker](https://onetracker.app), a service that supports 490+ couriers worldwide. To use the tracking API functionality, the Essentials plan is required. This plan includes 100 shipments per month. There are various paid-for tiers after that.
 
 The sensor value shows the number of packages that are not in `Delivered` state. As attributes are the number of packages per status.
 
@@ -20,12 +20,8 @@ The sensor value shows the number of packages that are not in `Delivered` state.
 {% configuration_basic %}
 email:
   description: Email used for OneTracker account.
-  required: true
-  type: string
 password:
   description: Password used for OneTracker account.
-  required: true
-  type: string
 {% endconfiguration_basic %}
 
 ## Prerequisites


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add docs for OneTracker integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/86921
- Link to parent pull request in the Brands repository:  https://github.com/home-assistant/brands/pull/4088

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
