### PR TITLE
Add two newly tested bluetooth adapters

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -120,6 +120,7 @@ There is currently no supported method to install these patch files when using H
 - IOGEAR GBU521W6 (BCM20702A0)
 - INSIGNIA NS-PCY5BMA (BCM20702A0)
 - Kinivo BTD-400 (BCM20702A0)
+- LM Technologies LM506 (BCM20702A1)
 - LM Technologies LM1010 (BCM20702A0) 📶
 - Plugable USB-BT4LE (BCM20702A0)
 - SoundBot SB342 (BCM20702A0)
@@ -171,6 +172,7 @@ These adapters do not have a reset pin. If they stop responding, there is curren
 - ISEKIE KW-B3519 (RTL8761BU)
 - Maxuni BT-501 (RTL8761BU)
 - MPOW BH45A (RTL8761BU)
+- Plugable USB-BT5 (RTL8761BU)
 - StarTech USBA-BLUETOOTH-V5-C2 (RTL8761BU)
 - SUMEE BT501 (RTL8761BU)
 - UGREEN CM390 (RTL8761BU)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add two newly tested bluetooth adapters

- LM Technologies LM506 (BCM20702A1)
- Plugable USB-BT5 (RTL8761BU)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
