### PR TITLE
Update required permissions for fritzbox_callmonitor

### DIFF
--- a/source/_integrations/fritzbox_callmonitor.markdown
+++ b/source/_integrations/fritzbox_callmonitor.markdown
@@ -19,7 +19,7 @@ It can also access the internal phone book of the router to look up the names co
 
 ## Prerequisites
 
-To use the FRITZ!Box call monitor in your installation, a user with at least `FRITZ!Box Settings` and `Voice messages, faxes, FRITZ!App Fon and call list` rights has to be created:
+To use the FRITZ!Box call monitor in your installation, a user with at least `Voice messages, faxes, FRITZ!App Fon and call list` rights has to be created:
 
 1.  Open the web user interface via `fritz.box` or the IP address of your FRITZ!Box (e.g. `192.168.1.1`).
 2.  Log in with your admin user credentials. The default admin user credentials can be found at the bottom of your FRITZ!Box.
@@ -27,7 +27,7 @@ To use the FRITZ!Box call monitor in your installation, a user with at least `FR
 4.  Click the `Add User` button.
 5.  Enable the option `User account enabled`.
 6.  Enter a user name and password.
-7.  Check the rights boxes next to `FRITZ!Box Settings`, which automatically checks the boxes for `Voice messages, faxes, FRITZ!App Fon and call list` and `Smart Home`.
+7.  Check the rights box next to `Voice messages, faxes, FRITZ!App Fon and call list`.
 8.  Click the `Apply` button.
 
 ## Setup


### PR DESCRIPTION
## Proposed change
With the change in Home Assistant core, only the `Voice messages, faxes, FRITZ!App Fon and call list` permission will be required. It's no longer necessary to select `FRITZ!Box Settings`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/87089
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
