### PR TITLE
Add vertical option to tile card

### DIFF
--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -41,6 +41,11 @@ show_entity_picture:
   description: If your entity has a picture, it will replace the icon.
   type: boolean
   default: false
+vertical:
+  required: false
+  description: Displays the icon above the name and state
+  type: boolean
+  default: false
 tap_action:
   required: false
   description: Action taken on card tap. See [action documentation](/dashboards/actions/#tap-action). By default, it will show the "more-info" dialog.
@@ -75,6 +80,12 @@ color: yellow
 type: tile
 entity: person.anne_therese
 show_entity_picture: true
+```
+
+```yaml
+type: tile
+entity: person.anne_therese
+vertical: true
 ```
 
 ```yaml

--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -43,7 +43,7 @@ show_entity_picture:
   default: false
 vertical:
   required: false
-  description: Displays the icon above the name and state
+  description: Displays the icon above the name and state.
   type: boolean
   default: false
 tap_action:


### PR DESCRIPTION
## Proposed change

Add documentation for `vertical` option for tile card.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
