### PR TITLE
Correct documentaion links to templating docs

### DIFF
--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -24,7 +24,7 @@ trace:
     stored_traces: 1
 ```
 
-[template]: /topics/templating/
+[template]: /docs/configuration/templating/
 
 ## Testing your automation
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -11,7 +11,7 @@ This is an advanced feature of Home Assistant. You'll need a basic understanding
 Templating is a powerful feature that allows you to control information going into and out of the system. It is used for:
 
 - Formatting outgoing messages in, for example, the [notify](/integrations/notify/) platforms and [Alexa](/integrations/alexa/) component.
-- Process incoming data from sources that provide raw data, like [MQTT](/integrations/mqtt/), [`rest` sensor](/integrations/rest/) or the [`command_line` sensor](/integrations/sensor.command_line/).
+- Process incoming data from sources that provide raw data, like [MQTT](/docs/configuration/templating/#using-templates-with-the-mqtt-integration), [`rest` sensor](/integrations/rest/) or the [`command_line` sensor](/integrations/sensor.command_line/).
 - [Automation Templating](/docs/automation/templating/).
 
 ## Building templates

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -514,7 +514,7 @@ It's also supported in script or automation `condition` actions:
 
 {% endraw %}
 
-[template]: /topics/templating/
+[template]: /docs/configuration/templating/
 [automation-templating]: /getting-started/automation-templating/
 
 ## Time condition

--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -136,7 +136,7 @@ There are four `homeassistant` services that aren't tied to any single domain, t
 
 Complete service details and examples can be found on the [Home Assistant integration][homeassistant-integration-services] page.
 
-[templating]: /topics/templating/
+[templating]: /docs/configuration/templating/
 [google travel time]: /integrations/google_travel_time/
 [template sensor]: /integrations/template/
 [light]: /integrations/light/

--- a/source/_integrations/alexa.flash_briefings.markdown
+++ b/source/_integrations/alexa.flash_briefings.markdown
@@ -84,7 +84,7 @@ Please refer to the [Amazon documentation][flash-briefing-api-docs] for more inf
 [flash-briefing-api-docs]: https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/flash-briefing-skill-api-feed-reference
 [large-icon]: /images/integrations/alexa/alexa-512x512.png
 [small-icon]: /images/integrations/alexa/alexa-108x108.png
-[templates]: /topics/templating/
+[templates]: /docs/configuration/templating/
 [zero-three-one]: /blog/2016/10/22/flash-briefing-updater-hacktoberfest/
 [alexa-settings-site]: https://alexa.amazon.com/
 [emulated-hue-component]: /integrations/emulated_hue/

--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -394,5 +394,5 @@ Alexa will now respond with a random phrase each time. You can use the include f
 [amazon-dev-console]: https://developer.amazon.com
 [large-icon]: /images/integrations/alexa/alexa-512x512.png
 [small-icon]: /images/integrations/alexa/alexa-108x108.png
-[templates]: /topics/templating/
+[templates]: /docs/configuration/templating/
 [generate-long-lived-access-token]: https://developers.home-assistant.io/docs/auth_api/#long-lived-access-token

--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -24,13 +24,13 @@ Home Assistant will serve the images via its server, making it possible to view 
 
 You must enter a URL in at least one of the fields **Still Image URL** or **Stream Source URL**, the others are optional.
 
-[Templates](/topics/templating/) are allowed in the URL fields, which can be used to select different images or parameterize the URL depending on the status of sensors.  Template validity and network access are checked during the configuration steps.
+[Templates](/docs/configuration/templating/) are allowed in the URL fields, which can be used to select different images or parameterize the URL depending on the status of sensors.  Template validity and network access are checked during the configuration steps.
 
 {% configuration_basic %}
 Still Image URL:
-  description: "The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/topics/templating/). Usernames and passwords are allowed in the URL, but if none are provided, the `Username` and `Password` settings will be used during authentication.  At least one of still_image_url or stream_source must be provided."
+  description: "The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/docs/configuration/templating/). Usernames and passwords are allowed in the URL, but if none are provided, the `Username` and `Password` settings will be used during authentication.  At least one of still_image_url or stream_source must be provided."
 Stream Source:
-  description: "The URL your camera serves the live stream on, e.g., `rtsp://192.168.1.21:554/`. Can be a [template](/topics/templating/). Usernames and passwords are allowed in the URL, but if none are provided, the `Username` and `Password` settings will be used during authentication.  At least one of still_image_url or stream_source must be provided. Note that a stream_source without a still_image_url can only be used if the [stream integration](/integrations/stream/) is configured."
+  description: "The URL your camera serves the live stream on, e.g., `rtsp://192.168.1.21:554/`. Can be a [template](/docs/configuration/templating/). Usernames and passwords are allowed in the URL, but if none are provided, the `Username` and `Password` settings will be used during authentication.  At least one of still_image_url or stream_source must be provided. Note that a stream_source without a still_image_url can only be used if the [stream integration](/integrations/stream/) is configured."
 Username:
   description: The username for accessing your camera. Note that this applies to both still_image_url and stream_source.
 Password:

--- a/source/_integrations/history_stats.markdown
+++ b/source/_integrations/history_stats.markdown
@@ -80,7 +80,7 @@ duration:
 
   You have to provide **exactly 2** of `start`, `end` and `duration`.
 <br/>
-  You can use [template extensions](/topics/templating/#home-assistant-template-extensions) such as `now()` or `as_timestamp()` to handle dynamic dates, as shown in the examples below.
+  You can use [template extensions](/docs/configuration/templating/#home-assistant-template-extensions) such as `now()` or `as_timestamp()` to handle dynamic dates, as shown in the examples below.
 
 </div>
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -749,7 +749,7 @@ script:
 
 ## Publish & Dump services
 
-The MQTT integration will register the service `mqtt.publish` which allows publishing messages to MQTT topics. There are two ways of specifying your payload. You can either use `payload` to hard-code a payload or use `payload_template` to specify a [template](/topics/templating/) that will be rendered to generate the payload.
+The MQTT integration will register the service `mqtt.publish` which allows publishing messages to MQTT topics. There are two ways of specifying your payload. You can either use `payload` to hard-code a payload or use `payload_template` to specify a [template](/docs/configuration/templating/#using-templates-with-the-mqtt-integration) that will be rendered to generate the payload.
 
 ### Service `mqtt.publish`
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -26,7 +26,7 @@ Once loaded, the `notify` platform will expose a service that can be called to s
 | `target`               |      yes | Some platforms allow specifying a recipient that will receive the notification. See your platform page if it is supported.
 | `data`                 |      yes | On platforms who have extended functionality. See your platform page if it is supported.
 
-The notify integration supports specifying [templates](/topics/templating/). This will allow you to use the current state of Home Assistant in your notifications.
+The notify integration supports specifying [templates](/docs/configuration/templating/). This will allow you to use the current state of Home Assistant in your notifications.
 
 In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) it could look like this with a customized subject.
 

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -24,8 +24,8 @@ The service `persistent_notification.create` takes in `message`, `title`, and `n
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `message`              |       no | Body of the notification. Accepts [templates](/topics/templating/).
-| `title`                |      yes | Title of the notification. Accepts [templates](/topics/templating/).
+| `message`              |       no | Body of the notification. Accepts [templates](/docs/configuration/templating/).
+| `title`                |      yes | Title of the notification. Accepts [templates](/docs/configuration/templating/).
 | `notification_id`      |      yes | If `notification_id` is given, it will overwrite the notification if there already was a notification with that ID.
 
 Here is how an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) with static content could look like.
@@ -38,7 +38,7 @@ action:
     title: "Custom subject"
 ```
 
-If you want to show some runtime information, you have to use [templates](/topics/templating/).
+If you want to show some runtime information, you have to use [templates](/docs/configuration/templating/).
 
 {% raw %}
 

--- a/source/_integrations/rss_feed_template.markdown
+++ b/source/_integrations/rss_feed_template.markdown
@@ -44,7 +44,7 @@ feed_id:
   required: true
   type: string
 title:
-  description: The title of the feed, which is parsed as [template](/topics/templating/).
+  description: The title of the feed, which is parsed as [template](/docs/configuration/templating/).
   required: false
   type: template
 items:
@@ -53,11 +53,11 @@ items:
   type: list
   keys:
     title:
-      description: The title of the item, which is parsed as [template](/topics/templating/).
+      description: The title of the item, which is parsed as [template](/docs/configuration/templating/).
       required: false
       type: template
     description:
-      description: The description of the item, which is parsed as [template](/topics/templating/).
+      description: The description of the item, which is parsed as [template](/docs/configuration/templating/).
       required: false
       type: template
 {% endconfiguration %}

--- a/source/_integrations/switch.rest.markdown
+++ b/source/_integrations/switch.rest.markdown
@@ -50,12 +50,12 @@ timeout:
   type: integer
   default: 10
 body_on:
-  description: "The body of the POST request that commands the switch to become enabled. This value can be a [template](/topics/templating/)."
+  description: "The body of the POST request that commands the switch to become enabled. This value can be a [template](/docs/configuration/templating/)."
   required: false
   type: string
   default: "ON"
 body_off:
-  description: "The body of the POST request that commands the switch to become disabled. This value can also be a [template](/topics/templating/)."
+  description: "The body of the POST request that commands the switch to become disabled. This value can also be a [template](/docs/configuration/templating/)."
   required: false
   type: string
   default: "OFF"
@@ -94,7 +94,7 @@ Make sure that the URL matches exactly your endpoint or resource.
 
 ### Switch with templated value
 
-This example shows a switch that uses a [template](/topics/templating/) to allow Home Assistant to determine its state. In this example, the REST endpoint returns this JSON response with true indicating the switch is on.
+This example shows a switch that uses a [template](/docs/configuration/templating/) to allow Home Assistant to determine its state. In this example, the REST endpoint returns this JSON response with true indicating the switch is on.
 
 ```json
 {"is_active": "true"}

--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -71,7 +71,7 @@ children:
   required: false
   type: list
 state_template:
-  description: "A [template](/topics/templating/) can be specified to render the state of the media player. In this way, the state may depend on entities that are not themselves media players, like switches or input booleans."
+  description: "A [template](/docs/configuration/templating/) can be specified to render the state of the media player. In this way, the state may depend on entities that are not themselves media players, like switches or input booleans."
   required: false
   type: template
 commands:

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -86,7 +86,7 @@ charging_topic:
   required: false
   type: string
 cleaning_template:
-  description: Defines a [template](/topics/templating/) to define the cleaning state of the vacuum. This is required if `cleaning_topic` is set.
+  description: Defines a [template](/docs/configuration/templating/#using-templates-with-the-mqtt-integration) to define the cleaning state of the vacuum. This is required if `cleaning_topic` is set.
   required: false
   type: string
 cleaning_topic:
@@ -98,7 +98,7 @@ command_topic:
   required: false
   type: string
 docked_template:
-  description: Defines a [template](/topics/templating/) to define the docked state of the vacuum. This is required if `docked_topic` is set.
+  description: Defines a [template](/docs/configuration/templating/#using-templates-with-the-mqtt-integration) to define the docked state of the vacuum. This is required if `docked_topic` is set.
   required: false
   type: string
 docked_topic:
@@ -121,7 +121,7 @@ entity_category:
   type: string
   default: None
 error_template:
-  description: Defines a [template](/topics/templating/) to define potential error messages emitted by the vacuum. This is required if `error_topic` is set.
+  description: Defines a [template](/docs/configuration/templating/#using-templates-with-the-mqtt-integration) to define potential error messages emitted by the vacuum. This is required if `error_topic` is set.
   required: false
   type: string
 error_topic:
@@ -133,7 +133,7 @@ fan_speed_list:
   required: false
   type: [string, list]
 fan_speed_template:
-  description: Defines a [template](/topics/templating/) to define the fan speed of the vacuum. This is required if `fan_speed_topic` is set.
+  description: Defines a [template](/docs/configuration/templating/#using-templates-with-the-mqtt-integration) to define the fan speed of the vacuum. This is required if `fan_speed_topic` is set.
   required: false
   type: string
 fan_speed_topic:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Correct links to the MQTT templating docs.
Replace old redirected links to the templating docs.

Omitted the links in blog posts.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
