### PR TITLE
Starlink updated bypass mode warning

### DIFF
--- a/source/_integrations/starlink.markdown
+++ b/source/_integrations/starlink.markdown
@@ -24,7 +24,7 @@ ha_quality_scale: silver
 
 The Starlink integration allows you to integrate your [Starlink](https://www.starlink.com/) into Home Assistant.
 
-**Important:** Your Starlink must **not** be in bypass mode. In this mode, the local API is unavailable, and this integration will not work.
+**Important:** If your Starlink is in bypass mode, you will need to open a route to it so that the local API can be accessed. Otherwise this integration will not work.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change
Starlink API works fine in bypass mode, you just need to make sure that there is a route open so that Home Assistant is able to communicate with the local API. The warning is updated so that it this is clear.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
