### PR TITLE
Update workday binary_sensor documentation for usage with no specified country.

### DIFF
--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -43,7 +43,8 @@ name:
 country:
   description: >
     Country code according to [holidays](https://pypi.org/project/holidays/) notation.
-  required: true
+    If not provided, an empty set of holidays will be used.
+  required: false
   type: string
 province:
   description: Subdivision code according to [holidays](https://pypi.org/project/holidays/) notation.
@@ -65,17 +66,21 @@ days_offset:
   type: integer
   default: 0
 add_holidays:
-  description: "Add custom holidays (such as company, personal holidays or vacations). Needs to formatted as `YYYY-MM-DD`."
+  description: >
+    Add custom holidays (such as company, personal holidays or vacations). Needs to formatted as `YYYY-MM-DD`.
+    Works even if no country is provided.
   required: false
   type: list
 remove_holidays:
-  description: "Remove holidays (treat holiday as workday). Can be formatted as `YYYY-MM-DD` or by name for a partial string match (e.g. Thanksgiving)."
+  description: >
+    Remove holidays (treat holiday as workday). Can be formatted as `YYYY-MM-DD` or by name for a partial string match (e.g. Thanksgiving).
+    Cannot be used to mark weekends as workdays; only holidays can be removed.
   required: false
   type: list
 {% endconfiguration %}
 
 Days are specified as follows: `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun`.
-The keyword `holiday` is used for public holidays identified by the holidays module.
+The keyword `holiday` is used for public holidays identified by the holidays module and holidays added by the `add_holidays` configuration option.
 
 <div class='note warning'>
 
@@ -96,9 +101,8 @@ This example excludes Saturdays and Sundays but not pre-configured holidays. Two
 # Example 1 configuration.yaml entry
 binary_sensor:
   - platform: workday
-    country: US
     workdays: [mon, tue, wed, thu, fri]
-    excludes: [sat, sun]
+    excludes: [sat, sun, holiday]
     add_holidays:
       - "2020-02-24"
       - "2020-04-25"


### PR DESCRIPTION
## Proposed change

Update workday binary_sensor documentation for usage with no specified country.

The first documentation example was incorrect and its described functionality was impossible until the below PR was implemented.

See:
- https://github.com/home-assistant/core/issues/85996
- https://github.com/home-assistant/core/pull/87222


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/87222
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
