### PR TITLE
Document new select entity services

### DIFF
--- a/source/_integrations/select.markdown
+++ b/source/_integrations/select.markdown
@@ -15,10 +15,127 @@ Keeps track on `select` entities in your environment, their state, and allows
 you to control them. This integration allows other integrations to offer
 a limited set of selectable options for the entity.
 
-### Services
+## Services
 
-The Select entities registers the following services:
+The select entity exposes additional to control the entity in, for example,
+automation or scripts. These service can be created via the UI, but are
+also available in YAML (for which examples are provided below).
 
-| Service | Data | Description |
-| ------- | ---- | ----------- |
-| `select_option` | `option`<br>`entity_id(s)`<br>`area_id(s)` | Set the current select option of specific `select` entities
+### Service `select.select_first`
+
+The {% my developer_call_service service="select.select_first" %} service
+changes the selected option of the select entity to the first option in the
+list of options available.
+
+This service does not have additional options.
+
+ {% my developer_call_service badge service="select.select_first" %}
+
+An example in YAML:
+
+```yaml
+service: select.select_first
+target:
+  entity_id: select.my_entity
+```
+
+### Service `select.select_last`
+
+The {% my developer_call_service service="select.select_last" %} service changes
+the selected option of the select entity to the last option in the list of
+options available.
+
+This service does not have additional options.
+
+{% my developer_call_service badge service="select.select_last" %}
+
+An example in YAML:
+
+```yaml
+service: select.select_last
+target:
+  entity_id: select.my_entity
+```
+
+### Service `select.select_next`
+
+The {% my developer_call_service service="select.select_next" %} service changes
+the selected option of the select entity to the next option in the list of
+options available. If the current select option is unknown, the first option
+in the list is selected instead.
+
+In case the current select option is the last option in the list, it will by
+default, cycle back the first option and select that one instead. This cycle
+behavior can be disabled by setting the `cycle` option to `false` in the
+service call data.
+
+{% my developer_call_service badge service="select.select_next" %}
+
+Examples in YAML:
+
+```yaml
+service: select.select_next
+target:
+  entity_id: select.my_entity
+```
+
+```yaml
+# Disable cycling back to the first option
+service: select.select_next
+target:
+  entity_id: select.my_entity
+data:
+  cycle: false
+```
+
+### Service `select.select_option`
+
+The {% my developer_call_service service="select.select_option" %} service
+changes the selected option to a specific desired option provided in the
+service call using the required `option` service call data.
+
+The service call wil not succeed if the selected option is not available in
+the list of options for the targeted entity.
+
+{% my developer_call_service badge service="select.select_option" %}
+
+An example in YAML:
+
+```yaml
+service: select.select_option
+target:
+  entity_id: select.my_entity
+data:
+  option: "example_option"
+```
+
+### Service `select.select_previous`
+
+The {% my developer_call_service service="select.select_previous" %} service
+changes the selected option of the select entity to the previous option in the
+list of options available. If the current select option is unknown, the
+last option in the list is selected instead.
+
+In case the current select option is the first option in the list, it will by
+default, cycle back the last option and select that one instead. This cycle
+behavior can be disabled by setting the `cycle` option to `false` in the
+service call data.
+
+{% my developer_call_service badge service="select.select_previous" %}
+
+Examples in YAML:
+
+```yaml
+service: select.select_previous
+target:
+  entity_id: select.my_entity
+```
+
+```yaml
+# Disable cycling back to the last option
+service: select.select_previous
+target:
+  entity_id: select.my_entity
+data:
+  cycle: false
+```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new services for the `select` entity that are now here as we synced input_select with select.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/87255
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
