### PR TITLE
MQTT Button - Add a hint for other button services

### DIFF
--- a/source/_integrations/button.mqtt.markdown
+++ b/source/_integrations/button.mqtt.markdown
@@ -212,3 +212,8 @@ mqtt:
       entity_category: "config"
       device_class: "restart"
 ```
+
+### Automation
+
+MQTT Button offers limited automation capabilites - to make a remotely controlled button/press event see [`device_trigger.mqtt`](/integrations/device_trigger.mqtt/) or [`binary_sensor.mqtt`](/integrations/binary_sensor.mqtt/)
+


### PR DESCRIPTION
I spent several hours trying to get MQTT button working for my automation while what I really needed was `device_trigger`. This hint would have saved my day.

## Proposed change
Added a strategic hint to MQTT Button to guide users to alternative options.

## Type of change
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
