### PR TITLE
Add missing QNAP QSW documentation

### DIFF
--- a/source/_integrations/qnap_qsw.markdown
+++ b/source/_integrations/qnap_qsw.markdown
@@ -39,9 +39,15 @@ Password:
 
 The following *binary sensors* are created:
 
-| Condition           | Description                        |
+| Binary Sensor       | Description                        |
 | :------------------ | :--------------------------------- |
 | anomaly             | Device anomaly.                    |
+
+The following *binary sensors* are created for each port (or LACP):
+
+| Binary Sensor       | Description                        |
+| :------------------ | :--------------------------------- |
+| link                | Link status.                       |
 
 ## Buttons
 
@@ -55,16 +61,22 @@ The following *buttons* are created:
 
 The following *sensors* are created:
 
-| Condition           | Description                        |
+| Sensors             | Description                        |
 | :------------------ | :--------------------------------- |
 | fan_1_speed         | Fan 1 Speed.                       |
 | fan_2_speed         | Fan 2 Speed.                       |
+| ports               | Number of used ports.              |
+| rx                  | Total RX bytes.                    |
+| rx_errors           | Total number of RX errors.         |
+| rx_speed            | Total RX speed.                    |
 | temperature         | Switch temperature.                |
+| tx                  | Total TX bytes.                    |
+| tx_speed            | Total TX speed.                    |
 | uptime              | Uptime seconds.                    |
 
-The following sensors are created for each port (or LACP):
+The following *sensors* are created for each port (or LACP):
 
-| Condition           | Description                        |
+| Sensors             | Description                        |
 | :------------------ | :--------------------------------- |
 | link_speed          | Link speed.                        |
 | rx                  | RX bytes.                          |


### PR DESCRIPTION
## Proposed change
Add missing QNAP QSW documentation.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
