### PR TITLE
Make the "Order Now" dialog scrollable

### DIFF
--- a/source/skyconnect/index.html
+++ b/source/skyconnect/index.html
@@ -19,6 +19,9 @@ frontpage_image: /images/skyconnect/skyconnect-cover.png
   #landingpage .sub-title {
     margin-top: 100px;
   }
+  #landingpage #buy-dialog {
+    overflow-y: auto;
+  }
   .multi-pan {
     max-width: 750px;
     margin: 100px auto;


### PR DESCRIPTION
## Proposed change
Make the "Order Now" dialog scrollable. Nothing more :)

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
none

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards