### PR TITLE
Add recorder engine to analytics documentation

### DIFF
--- a/source/_integrations/analytics.markdown
+++ b/source/_integrations/analytics.markdown
@@ -75,7 +75,7 @@ This includes:
 
 - The names of all your core integrations
 - The names and versions of all your custom integrations if you have any
-- The engine used for the [recorder integration](/integrations/recorder)
+- The name and version of the engine used in the [recorder integration](/integrations/recorder)
 - Boolean to indicate that the [energy integration](/integrations/energy) is configured
 - Boolean to indicate that [HTTP certificate](https://www.home-assistant.io/integrations/http/#ssl_certificate) is configured
 
@@ -117,6 +117,7 @@ If your system includes the Supervisor, this will also contain:
   },
   "recorder": {
     "engine": "sqlite",
+    "version": "123"
   },
   "certificate": false
 }

--- a/source/_integrations/analytics.markdown
+++ b/source/_integrations/analytics.markdown
@@ -75,6 +75,7 @@ This includes:
 
 - The names of all your core integrations
 - The names and versions of all your custom integrations if you have any
+- The engine used for the [recorder integration](/integrations/recorder)
 - Boolean to indicate that the [energy integration](/integrations/energy) is configured
 - Boolean to indicate that [HTTP certificate](https://www.home-assistant.io/integrations/http/#ssl_certificate) is configured
 
@@ -113,6 +114,9 @@ If your system includes the Supervisor, this will also contain:
   ],
   "energy": {
     "configured": true
+  },
+  "recorder": {
+    "engine": "sqlite",
   },
   "certificate": false
 }


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for upcoming changes in analytics collection.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/87784
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
