### PR TITLE
Add homeassistant.reload_all service

### DIFF
--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -23,6 +23,17 @@ The `homeassistant` integration provides services for controlling Home Assistant
 
 Reads the configuration files and checks them for correctness, but **does not** load them into Home Assistant. Creates a persistent notification and log entry if errors are found.
 
+### Service `homeassistant.reload_all`
+
+Reload all YAML configuration that can be reloaded without restarting Home Assistant.
+
+It calls the `reload` service on all domains available on the system. Additionly,
+it reloads the core configuration (equivalent to calling
+`homeassistant.reload_core_config`) and themes (`frontend.reload_themes`).
+
+Prior to reloading, it run a basic configuration check. If that fails, the reload
+will not be performed and will raise an error.
+
 ### Service `homeassistant.reload_config_entry`
 
 Reloads an integration config entry.

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -31,7 +31,7 @@ It calls the `reload` service on all domains that have it available. Additionall
 it reloads the core configuration (equivalent to calling
 `homeassistant.reload_core_config`) and themes (`frontend.reload_themes`).
 
-Prior to reloading, it run a basic configuration check. If that fails, the reload
+Prior to reloading, a basic configuration check is performed. If that fails, the reload
 will not be performed and will raise an error.
 
 ### Service `homeassistant.reload_config_entry`

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -27,7 +27,7 @@ Reads the configuration files and checks them for correctness, but **does not** 
 
 Reload all YAML configuration that can be reloaded without restarting Home Assistant.
 
-It calls the `reload` service on all domains available on the system. Additionly,
+It calls the `reload` service on all domains that have it available. Additionally,
 it reloads the core configuration (equivalent to calling
 `homeassistant.reload_core_config`) and themes (`frontend.reload_themes`).
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new `homeassistant.reload_all` service.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/87769
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
