### PR TITLE
Sensor configuration requires InfluxDB server definition

### DIFF
--- a/source/_integrations/influxdb.markdown
+++ b/source/_integrations/influxdb.markdown
@@ -539,6 +539,9 @@ sensor:
 sensor:
   - platform: influxdb
     api_version: 2
+    ssl: false
+    host: localhost
+    port: 9999
     token: GENERATED_AUTH_TOKEN
     organization: RANDOM_16_DIGIT_HEX_ID
     bucket: BUCKET_NAME


### PR DESCRIPTION
Using the provided InfluxDB 2 sensor definition does not work unless you include the host, port and ssl definitions.

## Proposed change

Include the three missing parameters in the sensor example.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

I had presumed that the Influx recorder definition would provide these settings - certainly, the documentation seems to imply a linkage.

## Checklist

Well, I clicked the "edit" button on the page... I hope this is useful.

Thanks for maintaining a great project.

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
