### PR TITLE
Add section describing broken devices

### DIFF
--- a/source/_integrations/upnp.markdown
+++ b/source/_integrations/upnp.markdown
@@ -43,3 +43,15 @@ logger:
 ```
 
 When creating an issue, please include the (relevant) logging with the issue. Any sensitive information such as IPs can be obfuscated.
+
+## Warnings statistics sensors
+
+Some devices do not follow the UPnP/IGD standard or are simply broken and provide invalid values when the router's traffic counters are read. According to the standard, the traffic counters should provide an increasing value between 0 bytes and 4.294.967.294 bytes. After the maximum value is reached, the counter should roll over to 0 and restart counting.
+
+There are several devices which do not adhere to this standard causing the traffic counters to be unusable. As a result, the traffic sensors might not be working properly, or Home Assistant might even given a warning such `Entity sensor.fritz_box_upload_summe from integration upnp has state class total_increasing, but its state is not strictly increasing. Triggered by state .... Please create a bug report at ...`. This is something the integration can nothing do about.
+
+Devices/brands with **known** defects (incomplete list!):
+* Fritz!
+* Compal Broadband Networks, Inc CH7465LG
+
+When this message is seen, the sensors regarding traffic should be disabled.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add a section to describe problems with some devices.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/82032, https://github.com/home-assistant/core/issues/82599

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
