### PR TITLE
Single quotes in the template example make the yaml invalid

### DIFF
--- a/source/_integrations/london_air.markdown
+++ b/source/_integrations/london_air.markdown
@@ -68,11 +68,11 @@ To explore the data available within the `data` attribute of a sensor use the `d
 template:
   - sensor:
     - name: "Updated"
-      state: '{{ state_attr('sensor.merton', 'updated') }}'
+      state: "{{ state_attr('sensor.merton', 'updated') }}"
     - name: "Merton PM10"
-      state: '{{ state_attr('sensor.merton', 'data')[0].pollutants[0].summary }}'
+      state: "{{ state_attr('sensor.merton', 'data')[0].pollutants[0].summary }}"
     - name: "Westminster S02"
-      state: '{{ state_attr('sensor.westminster', 'data')[0].pollutants[3].summary }}'
+      state: "{{ state_attr('sensor.westminster', 'data')[0].pollutants[3].summary }}"
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
Fix example template.
Switching to double quotes avoids "expected <block end>, but found Scalar"

## Type of change


- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
n/a

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
