### PR TITLE
initial version of waterkotte_heatpump documentation

### DIFF
--- a/source/_integrations/waterkotte_heatpump.markdown
+++ b/source/_integrations/waterkotte_heatpump.markdown
@@ -1,0 +1,21 @@
+---
+title: Waterkotte Heatpump
+description: Integrate waterkotte heatpump sensors home Home Assistant.
+ha_category:
+  - Sensor
+ha_release: '2023.2'
+ha_iot_class: Local Polling
+ha_domain: waterkotte_heatpump
+ha_platforms:
+  - sensor
+ha_config_flow: true
+ha_codeowners:
+  - '@chboland'
+ha_integration_type: integration
+---
+
+The Waterkotte Heatpump integration allows you to monitor [Waterkotte Heatpumps](https://www.waterkotte.eu/heat-pumps) in Home Assistant. All EcoTouch devices should be supported.
+
+Currently only sensors are supported. Other platforms will be supported in future releases.
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
Logo was already present.

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/88140
- Link to parent pull request in the Brands repository: (was already present)
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
