### PR TITLE
Update providers.markdown

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -20,7 +20,7 @@ If you decide to use `trusted_networks` as your `auth_provider` there won't be a
 </div>
 
 Authentication providers are configured in your `configuration.yaml` under the `homeassistant:` block. 
-If you are moving configuration to packages, this particular configuration must stay within 'configuration.yaml'. See Issue 16441 in the warning-block at the bottom of this page
+If you are moving configuration to packages, this particular configuration must stay within 'configuration.yaml'. See Issue 16441 in the warning block at the bottom of this page.
 
 
 You can supply more than one, for example:

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -19,7 +19,11 @@ If you decide to use `trusted_networks` as your `auth_provider` there won't be a
 
 </div>
 
-Authentication providers are configured in your `configuration.yaml` under the `homeassistant:` block. You can supply more than one, for example:
+Authentication providers are configured in your `configuration.yaml` under the `homeassistant:` block. 
+If you are moving configuration to packages, this particular configuration must stay within 'configuration.yaml'. See Issue 16441 in the warning-block at the bottom of this page
+
+
+You can supply more than one, for example:
 
 ```yaml
 homeassistant:


### PR DESCRIPTION
I've moved all configuration to packages, and left only include packages in my configuration.yaml (after inspiration from Frenck) when adding autp_providers: type trusted_network in a package, this did not load/work
When moving config from packages to configuration.yaml it works   -  so I guess the Issue 16441 is not just for the type: legacy_api_password, but for all auth_providers,, so the warning should be higher up - and better explained?
(at least I would have benefit from that  ;)  :)

## Proposed change
Move warning for legacy api loading not in packages to general warning?


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
