### PR TITLE
Fix capitalization of OwnTone integration

### DIFF
--- a/source/_integrations/forked_daapd.markdown
+++ b/source/_integrations/forked_daapd.markdown
@@ -1,6 +1,6 @@
 ---
-title: Owntone
-description: Instructions on how to integrate an Owntone server into Home Assistant.
+title: OwnTone
+description: Instructions on how to integrate an OwnTone server into Home Assistant.
 ha_category:
   - Media Player
 ha_release: '0.110'
@@ -15,26 +15,26 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The Owntone integration allows you to control your [OwnTone (previously forked-daapd)](https://github.com/owntone/owntone-server) server from Home Assistant. This integration can control the Owntone outputs (zones) with limited playback control (play/pause, previous/next track) and media info support. Playlist manipulation is not supported.
+The OwnTone integration allows you to control your [OwnTone (previously forked-daapd)](https://github.com/owntone/owntone-server) server from Home Assistant. This integration can control the OwnTone outputs (zones) with limited playback control (play/pause, previous/next track) and media info support. Playlist manipulation is not supported.
 
 ## Requirements
 
-The Owntone integration requires an OwnTone server built with libwebsockets enabled, version >= 27.0.
+The OwnTone integration requires an OwnTone server built with libwebsockets enabled, version >= 27.0.
 
 {% include integrations/config_flow.md %}
 
 ## Outputs
 
-Once the Owntone integration is set up, outputs will automatically be loaded from the server and added to HA in real-time.
+Once the OwnTone integration is set up, outputs will automatically be loaded from the server and added to HA in real-time.
 
 ## Pipes
 
-As OwnTone supports playing audio input via a pipe, this integration supports the forwarding of basic player controls (play, pause, next track, previous track) directly to the pipe's source. Currently, only the pipe source librespot-java is supported. To use this, configure your Owntone server to autostart pipes and name your librespot-java pipe "librespot-java" (accompanying metadata is also supported through Owntone via a metadata pipe named "librespot-java.metadata"). The Owntone integration will find the librespot-java pipe in the database and will set it up as a source.
+As OwnTone supports playing audio input via a pipe, this integration supports the forwarding of basic player controls (play, pause, next track, previous track) directly to the pipe's source. Currently, only the pipe source librespot-java is supported. To use this, configure your OwnTone server to autostart pipes and name your librespot-java pipe "librespot-java" (accompanying metadata is also supported through OwnTone via a metadata pipe named "librespot-java.metadata"). The OwnTone integration will find the librespot-java pipe in the database and will set it up as a source.
 
 ## Playlists
 
-The Owntone integration will treat playlists in the database as sources. The number of playlists shown as sources can be set in the integration's configuration options.
+The OwnTone integration will treat playlists in the database as sources. The number of playlists shown as sources can be set in the integration's configuration options.
 
 ## Spotify
 
-The Owntone integration supports media browsing via the [Spotify integration](/integrations/spotify). However, to play Spotify content, your Owntone instance must be logged in with Spotify. This can be done through Owntone's own web interface. For more details, see [Owntone's notes on Spotify](https://owntone.github.io/owntone-server/integrations/spotify/#spotify). You should log in with the same Spotify account for both the Owntone server and the Home Assistant [Spotify integration](/integrations/spotify).
+The OwnTone integration supports media browsing via the [Spotify integration](/integrations/spotify). However, to play Spotify content, your OwnTone instance must be logged in with Spotify. This can be done through OwnTone's own web interface. For more details, see [OwnTone's notes on Spotify](https://owntone.github.io/owntone-server/integrations/spotify/#spotify). You should log in with the same Spotify account for both the OwnTone server and the Home Assistant [Spotify integration](/integrations/spotify).

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -147,7 +147,7 @@ Currently only supported on [Denon AVR](/integrations/denonavr/) and  [Songpal](
 
 #### Service `media_player.shuffle_set`
 
-Currently only supported on [Sonos](/integrations/sonos), [Spotify](/integrations/spotify), [MPD](/integrations/mpd), [Kodi](/integrations/kodi), [Roon](/integrations/roon), [Owntone](/integrations/forked_daapd), [Squeezebox](/integrations/squeezebox) and [Universal](/integrations/universal).
+Currently only supported on [Sonos](/integrations/sonos), [Spotify](/integrations/spotify), [MPD](/integrations/mpd), [Kodi](/integrations/kodi), [Roon](/integrations/roon), [OwnTone](/integrations/forked_daapd), [Squeezebox](/integrations/squeezebox) and [Universal](/integrations/universal).
 
 | Service data attribute | Optional | Description                                          |
 | ---------------------- | -------- | ---------------------------------------------------- |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fix the capitalization of "OwnTone" in the OwnTone integration. According to the [official site](https://owntone.github.io/owntone-server/), the correct capitalization is "OwnTone".


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/88219
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
