### PR TITLE
Add docs for Nuki callbacks

### DIFF
--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -32,8 +32,7 @@ For faster updates, the callback function of the Nuki bridge can be used. This r
   Host:
     description: Hostname or IP address of your Nuki bridge, e.g., `192.168.1.25`.
   Port:
-    description: Port of the Nuki bridge HTTP API.
-    default: 8080
+    description: Port of the Nuki bridge HTTP API, default: `8080`.
   Token:
     description: Token to authenticate against the Nuki bridge HTTP API.
 {% endconfiguration_basic %}

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate a Nuki Smart Lock devices.
 ha_category:
   - Lock
 ha_release: 0.38
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ha_codeowners:
   - '@pschmitt'
   - '@pvizeli'
@@ -24,8 +24,25 @@ The Nuki integration allows you to control [Nuki Smart Locks](https://nuki.io/en
 ## Prerequisites
 
 To add a Nuki bridge to your installation, you need to enable developer mode on your bridge and define a port and an access token. This can be achieved using the [Android app](https://play.google.com/store/apps/details?id=io.nuki) or [iPhone app](https://apps.apple.com/app/nuki-smart-lock/id1044998081). Go to manage my devices, and select the bridge. Within the bridge configuration turn on the HTTP API and check the details in the screen. Please note that the API token should be 6-20 characters long, even though the app allows you to set a longer one.
+For faster updates you can configure to use the callback function of the Nuki bridge. This requires your Home Assistant to be reachable via HTTP by the Nuki bridge. If required, you can set a custom URL for the callback, which allows HTTP traffic to `/api/nuki/callback/{entry-id}`.
 
 {% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+  Host:
+    description: Hostname or IP address of your Nuki bridge, e.g., `192.168.1.25`.
+  Port:
+    description: Port of the Nuki bridge HTTP API.
+    default: 8080
+  Token:
+    description: Token to authenticate against the Nuki bridge HTTP API.
+  "Enable Nuki callback":
+    description: Enable the callback function of the Nuki bridge HTTP API.
+    default: false
+  "Override Home Assistant URL":
+    description: Override the base URL of the callback. Leave empty to use the Local Network Address of Home Assistant. 
+
+{% endconfiguration_basic %}
 
 ## Services
 

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -24,7 +24,7 @@ The Nuki integration allows you to control [Nuki Smart Locks](https://nuki.io/en
 ## Prerequisites
 
 To add a Nuki bridge to your installation, you need to enable developer mode on your bridge and define a port and an access token. This can be achieved using the [Android app](https://play.google.com/store/apps/details?id=io.nuki) or [iPhone app](https://apps.apple.com/app/nuki-smart-lock/id1044998081). Go to manage my devices, and select the bridge. Within the bridge configuration turn on the HTTP API and check the details in the screen. Please note that the API token should be 6-20 characters long, even though the app allows you to set a longer one.
-For faster updates you can configure to use the callback function of the Nuki bridge. This requires your Home Assistant to be reachable via HTTP by the Nuki bridge. If required, you can set a custom URL for the callback, which allows HTTP traffic to `/api/nuki/callback/{entry-id}`.
+For faster updates, you can configure to use of the callback function of the Nuki bridge. This requires your Home Assistant to be reachable via HTTP by the Nuki bridge. If required, you can set a custom URL for the callback, which allows HTTP traffic to `/api/nuki/callback/{entry-id}`.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -32,7 +32,7 @@ For faster updates, the callback function of the Nuki bridge can be used. This r
   Host:
     description: Hostname or IP address of your Nuki bridge, e.g., `192.168.1.25`.
   Port:
-    description: Port of the Nuki bridge HTTP API, default: `8080`.
+    description: Port of the Nuki bridge HTTP API, default is `8080`.
   Token:
     description: Token to authenticate against the Nuki bridge HTTP API.
 {% endconfiguration_basic %}

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -24,7 +24,7 @@ The Nuki integration allows you to control [Nuki Smart Locks](https://nuki.io/en
 ## Prerequisites
 
 To add a Nuki bridge to your installation, you need to enable developer mode on your bridge and define a port and an access token. This can be achieved using the [Android app](https://play.google.com/store/apps/details?id=io.nuki) or [iPhone app](https://apps.apple.com/app/nuki-smart-lock/id1044998081). Go to manage my devices, and select the bridge. Within the bridge configuration turn on the HTTP API and check the details in the screen. Please note that the API token should be 6-20 characters long, even though the app allows you to set a longer one.
-For faster updates, you can configure to use of the callback function of the Nuki bridge. This requires your Home Assistant to be reachable via HTTP by the Nuki bridge. If required, you can set a custom URL for the callback, which allows HTTP traffic to `/api/nuki/callback/{entry-id}`.
+For faster updates, the callback function of the Nuki bridge can be used. This requires your Home Assistant to be reachable via HTTP by the Nuki bridge, as HTTPS is not supported by the Nuki bridge.
 
 {% include integrations/config_flow.md %}
 
@@ -36,12 +36,6 @@ For faster updates, you can configure to use of the callback function of the Nuk
     default: 8080
   Token:
     description: Token to authenticate against the Nuki bridge HTTP API.
-  "Enable Nuki callback":
-    description: Enable the callback function of the Nuki bridge HTTP API.
-    default: false
-  "Override Home Assistant URL":
-    description: Override the base URL of the callback. Leave empty to use the Local Network Address of Home Assistant. 
-
 {% endconfiguration_basic %}
 
 ## Services


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds instructions on how to use Nuki callbacks. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/88346
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
