### PR TITLE
Add periodically resetting utility meter config option

### DIFF
--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -55,6 +55,10 @@ Net consumption:
 Delta values:
   description: >
     Enable this if the source values are delta values since the last reading instead of absolute values. When this option is enabled, each new value received will be added as-is to the utility meter instead of adding the _difference_ between the new value and previous value.
+Periodically resetting:
+  description: >
+    Enable this if the source sensor state is expected to reset to 0, for example a smart plug that resets on boot.
+    When this options is disabled (for example if the source sensor is a domestic utility meter that never resets during the device's lifetime), the _difference_ between the new value and last valid value is added to the utility meter, which avoids the loss of a meter reading after the source sensor becomes available after being unavailable.
 {% endconfiguration_basic %}
 
 If the meter reset cycle and reset offsets are to limited for your use case,
@@ -117,6 +121,11 @@ tariffs:
   required: false
   default: []
   type: list
+periodically_resetting:
+  description: Enable this if the source sensor state is expected to reset to 0, for example a smart plug that resets on boot. When this options is disabled (for example if the source sensor is a domestic utility meter that never resets during the device's lifetime), the _difference_ between the new value and last valid value is added to the utility meter, which avoids the loss of a meter reading after the source sensor becomes available after being unavailable.
+  required: false
+  default: true
+  type: boolean
 {% endconfiguration %}
 
 <p class='note warning'>

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -57,8 +57,8 @@ Delta values:
     Enable this if the source values are delta values since the last reading instead of absolute values. When this option is enabled, each new value received will be added as-is to the utility meter instead of adding the _difference_ between the new value and previous value.
 Periodically resetting:
   description: >
-    Enable this if the source sensor state is expected to reset to 0, for example a smart plug that resets on boot.
-    When this options is disabled (for example if the source sensor is a domestic utility meter that never resets during the device's lifetime), the _difference_ between the new value and last valid value is added to the utility meter, which avoids the loss of a meter reading after the source sensor becomes available after being unavailable.
+    Enable this if the source sensor state is expected to reset to 0, for example, a smart plug that resets on boot.
+    When this option is disabled (for example, if the source sensor is a domestic utility meter that never resets during the device's lifetime), the _difference_ between the new value and the last valid value is added to the utility meter, which avoids the loss of a meter reading after the source sensor becomes available after being unavailable.
 {% endconfiguration_basic %}
 
 If the meter reset cycle and reset offsets are to limited for your use case,
@@ -122,7 +122,7 @@ tariffs:
   default: []
   type: list
 periodically_resetting:
-  description: Enable this if the source sensor state is expected to reset to 0, for example a smart plug that resets on boot. When this options is disabled (for example if the source sensor is a domestic utility meter that never resets during the device's lifetime), the _difference_ between the new value and last valid value is added to the utility meter, which avoids the loss of a meter reading after the source sensor becomes available after being unavailable.
+  description: Enable this if the source sensor state is expected to reset to 0, for example, a smart plug that resets on boot. When this option is disabled (for example, if the source sensor is a domestic utility meter that never resets during the device's lifetime), the _difference_ between the new value and the last valid value is added to the utility meter, which avoids the loss of a meter reading after the source sensor becomes available after being unavailable.
   required: false
   default: true
   type: boolean


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The documentation is added to describe the new `periodically_resetting` option of the utility meter, proposed in the attached PR.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/88446

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
