### PR TITLE
Add example template sensor

### DIFF
--- a/source/_integrations/screenlogic.markdown
+++ b/source/_integrations/screenlogic.markdown
@@ -46,6 +46,27 @@ Sets the operation of any connected color-capable lights.
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `target`               | no       | An `area` containing the ScreenLogic device, the ScreenLogic `device` itself, or any `entity` from the ScreenLogic device you wish to set the color mode on. |
 | `color_mode`           | no       | The color mode to set. Valid values are listed below.                                                                                                        |
+## Examples
+
+### Current Pool/Spa Temperature
+
+Some may wish to have the current pool or spa temperature as a separate `sensor` entity in addition to the existing `climate` entity. This can be done with a [template sensor](/integrations/template):
+
+{% raw %}
+
+```yaml
+# Example template sensor
+template:
+  - sensor:
+      - name: "Pool Temperature"
+        # Replace the climate entity with your climate entity
+        state: "{{ state_attr('climate.pentair_XX_XX_XX_pool_heat', 'current_temperature') }}"
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
+```
+
+{% endraw %}
 
 ## Reference
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add template sensor example to expose current temperature of a desired body of water outside of the existing climate entity.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #26242

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
