### PR TITLE
Fix: Typo in airq.markdown

### DIFF
--- a/source/_integrations/airq.markdown
+++ b/source/_integrations/airq.markdown
@@ -56,7 +56,7 @@ Currently, the integration supports the following sensors:
 | Propane              | %                   |
 | SO2                  | µg/m³               |
 | Noise                | dBa                 |
-| Noise (Maxumum)      | dBa                 |
+| Noise (Maximum)      | dBa                 |
 | Radon                | Bq/m³               |
 | Temperature          | °C                  |
 | VOC                  | ppb                 |


### PR DESCRIPTION
## Proposed change

Typo

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
