### PR TITLE
Clarify the example is below the sentence

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -163,42 +163,48 @@ Other state examples:
 
 The examples below show the output of a temperature sensor with state `20.001`, unit `°C` and user configured presentation rounding set to 1 decimal.
 
-This results in the number `20.001`:
+The following example results in the number `20.001`:
+
 {% raw %}
 ```text
 {{ states('sensor.temperature') }}
 ```
 {% endraw %}
 
-This results in the string `"20.0 °C"`:
+The following example results in the string `"20.0 °C"`:
+
 {% raw %}
 ```text
 {{ states('sensor.temperature', with_unit=True) }}
 ```
 {% endraw %}
 
-This results in the string `"20.001 °C"`:
+The following example result in the string `"20.001 °C"`:
+
 {% raw %}
 ```text
 {{ states('sensor.temperature', with_unit=True, rounded=False) }}
 ```
 {% endraw %}
 
-This results in the number `20.0`:
+The following example results in the number `20.0`:
+
 {% raw %}
 ```text
 {{ states('sensor.temperature', rounded=True) }}
 ```
 {% endraw %}
 
-This results in the number `20.001`:
+The following example results in the number `20.001`:
+
 {% raw %}
 ```text
 {{ states.sensor.temperature.state }}
 ```
 {% endraw %}
 
-This results in the string `"20.0 °C"`:
+The following example results in the string `"20.0 °C"`:
+
 {% raw %}
 ```text
 {{ states.sensor.temperature.state_with_unit }}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

It was raised in the beta channel as potentially unclear if the example above or below was for the result shown. This fixes that.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ x Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
