### PR TITLE
Update operating_system.md with UEFI for VMware Player 17

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -287,7 +287,7 @@ _All these can be extended if your usage calls for more resources._
     4. Select “Use Bridged Networking”
     5. Select “Use an existing virtual disk” and select the VMDK file above,
 
-    After creation of VM go to “Settings” and “Options” then “Advanced” and select “Firmware type” to “UEFI”.
+    After creation of VM go to “Settings” and “Options” then “Advanced” and select “Firmware type” to “UEFI”. In Player 17, this must be done by opening the .vmx configuration file for the VM and adding the line ```firmware = "efi"```
 
 {% elsif page.installation_type == 'alternative' %}
 


### PR DESCRIPTION
Added instructions for VMWare Player to edit the .vmx file and add the UEFI setting as this option is not present in the Player GUI

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
