### PR TITLE
Add IntelliFire sleep timer documentation

### DIFF
--- a/source/_integrations/intellifire.markdown
+++ b/source/_integrations/intellifire.markdown
@@ -67,7 +67,7 @@ The integration provides a light entity if the unit is equipped with lights.
 ### Number
 
 - **Flame height:** Valid flame height vales are `1-5`.
-- **Sleep timer:** `0` will disable the sleep timer. Valid values are `1-180` minutes.
+- **Sleep timer:** `0` will disable the sleep timer. A value in the range of `1-180` minutes will enable the sleep timer and automatically turn off the appliance once that time has elapsed.
 
 ### Sensor Types
 

--- a/source/_integrations/intellifire.markdown
+++ b/source/_integrations/intellifire.markdown
@@ -66,7 +66,8 @@ The integration provides a light entity if the unit is equipped with lights.
 
 ### Number
 
-The integration uses a Number entity to control flame height. Valid flame height vales are `1-5`.
+- **Flame height:** Valid flame height vales are `1-5`.
+- **Sleep timer:** `0` will disable the sleep timer. Valid values are `1-180` minutes.
 
 ### Sensor Types
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adding documentation change for sleep timer in intellifire 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/88709
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
