### PR TITLE
Add ISY994 services to set and delete lock codes

### DIFF
--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -134,7 +134,8 @@ Insteon devices will include entities for setting the device On Level, Ramp Rate
 
 Once loaded, the following services will be exposed with the `isy994.` prefix, to allow advanced control over the ISY and its connected devices:
 
- - Entity services for Home Assistant-connected entities: `send_node_command`, `send_raw_node_command`, and `set_ramp_rate`.
+ - Entity services for all Home Assistant-connected entities: `send_node_command`, `send_raw_node_command`.
+ - ISY Z-Wave Node services: `get_zwave_parameter`, `set_zwave_parameter`, `set_zwave_lock_user_code`, `delete_zwave_lock_user_code`
  - Generic ISY services: `send_program_command`
 
 #### Service `isy994.send_node_command`
@@ -177,6 +178,26 @@ Update a Z-Wave Device parameter via the ISY. The parameter value will also be r
 | `parameter`            | no       | The parameter number to set on the end device.                                                  |
 | `value`                | no       | The value to set for the parameter. May be an integer or byte string (e.g. "0xFFFF").           |
 | `size`                 | no       | The size of the parameter, either 1, 2, or 4 bytes.                                             |
+
+#### Service `isy994.set_zwave_lock_user_code`
+
+Set a Z-Wave Lock User Code via the ISY. 
+
+| Service data attribute | Optional | Description                                                                                     |
+| ---------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `entity_id`            | no       | Name of target entity for the command, e.g., `lock.front_door`. This must be an ISY Z-Wave Lock entity. |
+| `user_num`             | no       | The user slot number to set on the end device.                                                  |
+| `code`                 | no       | The lock code to set for the user slot.                                                         |
+
+
+#### Service `isy994.delete_zwave_lock_user_code`
+
+Delete a Z-Wave Lock User Code via the ISY. 
+
+| Service data attribute | Optional | Description                                                                                     |
+| ---------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `entity_id`            | no       | Name of target entity for the command, e.g., `lock.front_door`. This must be an ISY Z-Wave Lock entity. |
+| `user_num`             | no       | The user slot number for which to delete the code on the end device.                            |
 
 #### Service `isy994.rename_node`
 

--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -185,7 +185,7 @@ Set a Z-Wave Lock User Code via the ISY.
 
 | Service data attribute | Optional | Description                                                                                     |
 | ---------------------- | -------- | ----------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | Name of target entity for the command, e.g., `lock.front_door`. This must be an ISY Z-Wave Lock entity. |
+| `entity_id`            | no       | Name of target entity for the command, e.g., `lock.front_door`. The entity must be an ISY Z-Wave Lock entity. |
 | `user_num`             | no       | The user slot number to set on the end device.                                                  |
 | `code`                 | no       | The lock code to set for the user slot.                                                         |
 
@@ -196,8 +196,8 @@ Delete a Z-Wave Lock User Code via the ISY.
 
 | Service data attribute | Optional | Description                                                                                     |
 | ---------------------- | -------- | ----------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | Name of target entity for the command, e.g., `lock.front_door`. This must be an ISY Z-Wave Lock entity. |
-| `user_num`             | no       | The user slot number for which to delete the code on the end device.                            |
+| `entity_id`            | no       | Name of target entity for the command, e.g., `lock.front_door`. The entity must be an ISY Z-Wave Lock entity. |
+| `user_num`             | no       | The user slot number to delete the code on the end device.                            |
 
 #### Service `isy994.rename_node`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
1. Add custom services to ISY994 to set and delete Z-Wave Lock User Codes, which use a different end-point then other ISY Z-Wave Parameters. Services to be added are:

- `isy994.set_zwave_lock_user_code`
- `isy994.delete_zwave_lock_user_code`



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/88754
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
