### PR TITLE
Add lifetime_total documentation

### DIFF
--- a/source/_integrations/lifetime_total.markdown
+++ b/source/_integrations/lifetime_total.markdown
@@ -1,0 +1,30 @@
+---
+title: Lifetime Total
+description: Instructions on how to integrate lifetime_total sensor into Home Assistant.
+ha_category:
+  - Helper
+  - Sensor
+  - Utility
+ha_iot_class: Calculated
+ha_release: 2022.04
+ha_quality_scale: internal
+ha_codeowners:
+  - '@avee87'
+ha_domain: lifetime_total
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_integration_type: helper
+---
+
+Lifetime Total helper converts periodically resetting measurement (i.e., utility meter reading) into always-increasing total value.
+For example, if your electricity meter goes from 0 to 10kWh every day, corresponding lifetime total will keep going up by 10kWh every day. This behavior is similar to how [total_increasing](https://developers.home-assistant.io/docs/core/entity/sensor#state-class-total_increasing) sensors are treated for long-term statistics.
+
+If input sensor state is unavailable or unknown, it will be ignored until the next correct value.
+
+{% include integrations/config_flow.md %}
+{% configuration_basic %}
+Name:
+description: The name the sensor should have. You can change it again later.
+Input entity:
+description: The sensor to convert to lifetime total. Should ideally be an entity with `total_increasing` state type


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding docs for the new helper integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/brands/pull/4166
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/4166
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
