### PR TITLE
Add DIGITUS DN-30210-1 to the CSR based dongle list

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -83,6 +83,7 @@ If you experience an unreliable Bluetooth connection, installing a short USB ext
 
 - ANNE PRO CSR 4.0 (CSR8510A10)
 - Avantree BTDG-40S (CSR8510A10)
+- DIGITUS DN-30210-1 (CSR8510A10)
 - Enbiawit BT403 (CSR8510A10)
 - Feasycom FSC-BP119 (CSR8510A10) 📶
 - HIDEEZ BT0015-01 (CSR8510A10)


### PR DESCRIPTION
## Proposed change

This is a minor change but may be helpful. I didn't find any listed dongle available and it took some time to find another compatible dongle for me.

Device info:
```
CSR8510 A10 (0a12:0001)
by cyber-blue(HK)Ltd
```

For a reference:
  * Frequency range: 2402 - 2480 MHz
  * Transmit Power: 7.92 dBm EIRP

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
