### PR TITLE
Add `active_child_template` to universal media player

### DIFF
--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -72,7 +72,7 @@ children:
   required: false
   type: list
 active_child_template:
-  description: "A [template](/docs/configuration/templating/) that will allow to select (override) active child. Must return the `entity_id` of the child that will be selected as active, or `None` to use the default behavior."
+  description: "A [template](/docs/configuration/templating/) that will allow to select (override) active child. Must return the `entity_id` of the child selected as active, or `None` to use the default behavior."
   required: false
   type: template
 state_template:
@@ -103,7 +103,7 @@ unique_id:
 
 The Universal Media Player will primarily imitate one of its `children`. The Universal Media Player will control the first child on the list that is active (not idle/off). The Universal Media Player will also inherit its state from the first active child if a `state_template` is not provided. Entities in the `children:` list must be media players, but the state template can contain any entity.
 
-Using `active_child_template` will allow you to specify an active entity if the default behavior is not suitable for your task. Template must return the `entity_id` of the child that will be selected as active, or `None` to return the default behavior.
+Using `active_child_template` will allow you to specify an active entity if the default behavior is unsuitable for your task. The template must return the `entity_id` of the child that will be selected as active or `None` to return the default behavior.
 
 It is recommended that the command `turn_on`, the command `turn_off`, and the attribute `state` all be provided together. The `state` attribute indicates if the media player is on or off. If `state` indicates the media player is off, this status will take precedence over the states of the children. If all the children are idle/off and `state` is on, the Universal Media Player's state will be on. If not provided, the `toggle` command will delegate to `turn_on` or `turn_off` based on the `state`.
 

--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -71,7 +71,7 @@ children:
   description: Ordered list of child media players that this entity will control.
   required: false
   type: list
-active_children_template:
+active_child_template:
   description: "A [template](/docs/configuration/templating/) that will allow to select (override) active child. Must return the `entity_id` of the child that will be selected as active, or `None` to use the default behavior."
   required: false
   type: template
@@ -103,7 +103,7 @@ unique_id:
 
 The Universal Media Player will primarily imitate one of its `children`. The Universal Media Player will control the first child on the list that is active (not idle/off). The Universal Media Player will also inherit its state from the first active child if a `state_template` is not provided. Entities in the `children:` list must be media players, but the state template can contain any entity.
 
-Using `active_children_template` will allow you to specify an active children entity if the default behavior is not suitable for your task. Template must return the `entity_id` of the child that will be selected as active, or `None` to return the default behavior.
+Using `active_child_template` will allow you to specify an active entity if the default behavior is not suitable for your task. Template must return the `entity_id` of the child that will be selected as active, or `None` to return the default behavior.
 
 It is recommended that the command `turn_on`, the command `turn_off`, and the attribute `state` all be provided together. The `state` attribute indicates if the media player is on or off. If `state` indicates the media player is off, this status will take precedence over the states of the children. If all the children are idle/off and `state` is on, the Universal Media Player's state will be on. If not provided, the `toggle` command will delegate to `turn_on` or `turn_off` based on the `state`.
 
@@ -329,7 +329,7 @@ media_player:
 
 ### Override active children
 
-This example shows how you can use `active_children_template`:
+This example shows how you can use `active_child_template`:
 
 {% raw %}
 
@@ -341,7 +341,7 @@ media_player:
     children:
       - media_player.sony_tv_cast
       - media_player.sony_tv_psk
-    active_children_template: >
+    active_child_template: >
       {% if is_state_attr('media_player.sony_tv_cast', 'app_name', 'TV') %}
          media_player.sony_tv_psk
       {% else %}

--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -123,6 +123,8 @@ In this example, a switch is available to control the power to the television. S
 
 The children are a Chromecast and a Kodi player. If the Chromecast is playing, the Universal Media Player will reflect its status. If the Chromecast is idle and Kodi is playing, the universal media player will change to reflect its status.
 
+{% raw %}
+
 ```yaml
 media_player:
   platform: universal
@@ -172,6 +174,8 @@ media_player:
     source_list: media_player.receiver|source_list
 ```
 
+{% endraw %}
+
 ### Kodi CEC-TV control
 
 In this example, a [Kodi Media Player](/integrations/kodi) runs in a CEC capable device (OSMC/OpenElec running in a Raspberry Pi 24/7, for example), and, with the JSON-CEC Kodi add-on installed, it can turn on and off the attached TV.
@@ -181,6 +185,8 @@ We store the state of the attached TV in an [input boolean](/integrations/input_
 Because the input boolean used to store the TV state is only changing when using the Home Assistant `turn_on` and `turn_off` actions, and Kodi could be controlled by so many ways, we also define some automations to update this Input Boolean when needed.
 
 The complete configuration is:
+
+{% raw %}
 
 ```yaml
 homeassistant:
@@ -195,9 +201,11 @@ media_player:
   - platform: universal
     name: Kodi TV
     state_template: >
-      {% if is_state('media_player.kodi', 'idle') and
-      is_state('input_boolean.kodi_tv_state', 'off') %} off {% else %} {{
-      states('media_player.kodi') }} {% endif %}
+      {% if is_state('media_player.kodi', 'idle') and is_state('input_boolean.kodi_tv_state', 'off') %}
+        off
+      {% else %}
+        {{ states('media_player.kodi') }}
+      {% endif %}
     children:
       - media_player.kodi
     commands:
@@ -268,9 +276,13 @@ automation:
           entity_id: media_player.kodi_tv
 ```
 
+{% endraw %}
+
 ### Harmony Remote Example
 
 The complete configuration is:
+
+{% raw %}
 
 ```yaml
 media_player:
@@ -313,9 +325,13 @@ media_player:
     unique_id: media_room_harmony_hub
 ```
 
+{% endraw %}
+
 ### Override active children
 
 This example shows how you can use `active_children_template`:
+
+{% raw %}
 
 ```yaml
 media_player:
@@ -332,3 +348,5 @@ media_player:
          media_player.sony_tv_cast
       {% endif %}
 ```
+
+{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Docs related to core PR: https://github.com/home-assistant/core/pull/88816
I also slightly formatted the example sections.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/88816
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
