### PR TITLE
Add a Jasco integration page

### DIFF
--- a/source/_integrations/jasco.markdown
+++ b/source/_integrations/jasco.markdown
@@ -1,0 +1,26 @@
+---
+title: Jasco
+description: Connect and control your Jasco Z-Wave devices using the Z-Wave integration
+ha_release: '2022.11'
+ha_iot_class: Local Push
+ha_category:
+  - Switch
+  - Plug
+ha_domain: jasco
+ha_integration_type: brand
+works_with:
+  - zwave
+ha_platforms:
+  - Switch
+  - Plug
+ha_iot_standard: zwave
+ha_brand: true
+---
+
+[Jasco](https://byjasco.com/) is a member of the Works with Home Assistant partner program for their Z-Wave products. Jasco is committed to making sure their products are up-to-date and ready to use in Home Assistant.
+
+Jasco Z-Wave devices work locally and integrate seamlessly with the Z-Wave integration in Home Assistant (Z-Wave stick required). As all connectivity is happening locally, status updates and controlling your devices happen instantly in Home Assistant.
+
+{% my add_zwave_device badge domain=page.ha_domain %}
+
+[Learn more about Z-Wave in Home Assistant.](/integrations/zwave_js/)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add a Jasco integration page


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
The core change is quite old and the partnership was announced, yet the integration page was forgotten!

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards