### PR TITLE
Add documentation for as_mutable

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -64,6 +64,7 @@ To improve the experience of writing Jinja templates, we have enabled the follow
 extensions:
 
 * [Loop Controls](https://jinja.palletsprojects.com/en/3.0.x/extensions/#loop-controls) (`break` and `continue`)
+* [Expression Statements](https://jinja.palletsprojects.com/en/3.0.x/templates/#expression-statement) (`do`)
 
 ## Home Assistant template extensions
 
@@ -987,6 +988,21 @@ To evaluate a response, go to **{% my developer_template title="Developer Tools 
          } }%}
 
 {{value_json.data.hum[:-1]}}
+```
+
+{% endraw %}
+
+### Mutable dictionaries and lists
+
+- Filter `as_mutable` takes a list or dictionary and returns a mutable copy that you can modify using the standard python methods and the [`do` syntax](https://jinja.palletsprojects.com/en/3.0.x/templates/#expression-statement).
+
+For example:
+
+{% raw %}
+
+```text
+{% set dict = {} | as_mutable %}
+{% do dict.update({"key": "value"}) %} {# dict now contains key->value #}
 ```
 
 {% endraw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -994,7 +994,7 @@ To evaluate a response, go to **{% my developer_template title="Developer Tools 
 
 ### Mutable dictionaries and lists
 
-- Filter `as_mutable` takes a list or dictionary and returns a mutable copy that you can modify using the standard python methods and the [`do` syntax](https://jinja.palletsprojects.com/en/3.0.x/templates/#expression-statement).
+- Filter `as_mutable` takes a list or dictionary and returns a mutable copy that you can modify using the standard Python methods and the [`do` syntax](https://jinja.palletsprojects.com/en/3.0.x/templates/#expression-statement).
 
 For example:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds documentation for as_mutable as defined here: https://github.com/home-assistant/core/pull/88626

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/88626
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
