### PR TITLE
Address breaking change for `systemd-journal-remote` in the supervised installation method

### DIFF
--- a/source/more-info/unsupported/systemd_journal.markdown
+++ b/source/more-info/unsupported/systemd_journal.markdown
@@ -22,5 +22,15 @@ If using Home Assistant Supervised, run the following on the host:
 sudo apt install systemd-journal-remote -y
 ```
 
-and then reboot. If you still see this issue then run the [supervised installer](https://github.com/home-assistant/supervised-installer)
+and then reboot your system
+
+If after upgrading you are still facing this error, reinstall `systemd-journal-remote` with the following command
+
+```sh
+sudo apt-get install --reinstall systemd-journal-remote
+```
+
+and reboot your system
+
+If you still see this issue then run the [supervised installer](https://github.com/home-assistant/supervised-installer)
 on the host as the supervisor service may need an update as well.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->


If upgrading from 1.3.0 to version 1.4.2 you will need to reinstall the `systemd-journal-remote` package as we no longer modify the original file created by the package 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/supervised-installer/pull/277
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes # https://github.com/home-assistant/supervised-installer/issues/247

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
