### PR TITLE
Add documentation for base64_encode and base64_decode jinja filters

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -869,7 +869,7 @@ Some examples:
 
 </div>
 
-- Filter `value | base64_decode` will base64 decode a string to bytes and decode it back to a string using `utf-8` by default. [Other encodings](https://docs.python.org/3/library/codecs.html#standard-encodings) can be used to decode back to a string by passing the encoding to the filter: `value | base64_decode(ascii)`. The filter can also be used to decode the base64 encoded string to `bytes`, bypassing `raw` for the encoding `value | base64_decode(raw)`
+- Filter `value | base64_decode` will base64 decode a string to bytes and decode it back to a string using `utf-8` by default. [Other encodings](https://docs.python.org/3/library/codecs.html#standard-encodings) can be used to decode back to a string by passing the encoding to the filter: `value | base64_decode(ascii)`. The filter can also be used to decode the base64 encoded string to `bytes`, by passing `raw` for the encoding `value | base64_decode(raw)`
 - Filter `value | base64_encode` will encode a string to a base64 string.
 
 ### String filters

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -869,7 +869,7 @@ Some examples:
 
 </div>
 
-- Filter `value | base64_decode` will base64 decode a string to bytes and decode it back to a string using `utf-8` by default. [Other encodings](https://docs.python.org/3/library/codecs.html#standard-encodings) can be used to decode back to string by passing the encoding to the filter: `value | base64_decode(ascii)`. The filter can also be used to decode the base64 encoded string to `bytes`, by passing `raw` for the encoding `value | base64_decode(raw)`
+- Filter `value | base64_decode` will base64 decode a string to bytes and decode it back to a string using `utf-8` by default. [Other encodings](https://docs.python.org/3/library/codecs.html#standard-encodings) can be used to decode back to a string by passing the encoding to the filter: `value | base64_decode(ascii)`. The filter can also be used to decode the base64 encoded string to `bytes`, bypassing `raw` for the encoding `value | base64_decode(raw)`
 - Filter `value | base64_encode` will encode a string to a base64 string.
 
 ### String filters

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -869,6 +869,9 @@ Some examples:
 
 </div>
 
+- Filter `value | base64_decode` will base64 decode a string to bytes and decode it back to a string using `utf-8` by default. [Other encodings](https://docs.python.org/3/library/codecs.html#standard-encodings) can be used to decode back to string by passing the encoding to the filter: `value | base64_decode(ascii)`. The filter can also be used to decode the base64 encoded string to `bytes`, by passing `raw` for the encoding `value | base64_decode(raw)`
+- Filter `value | base64_encode` will encode a string to a base64 string.
+
 ### String filters
 
 - Filter `urlencode` will convert an object to a percent-encoded ASCII text string (e.g., for HTTP requests using `application/x-www-form-urlencoded`).


### PR DESCRIPTION
## Proposed change
Adds documentation for base64_decode and base64_encode jinja filters.
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Besides documentation for the existing base64_decode and base64_encode filters, the linked pull request to the homeassistant core repository adds the encoding argument to the base64_decode filter. The added documentation also covers this new feature.
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [core](https://github.com/home-assistant/core/pull/86971)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
