### PR TITLE
Add support for Livisi remotes and wall buttons

### DIFF
--- a/source/_integrations/livisi.markdown
+++ b/source/_integrations/livisi.markdown
@@ -22,6 +22,7 @@ The following devices are currently supported by this integration:
  
 - Indoor Smart Plug (PSS)
 - Room Heating Control (VRCC) that includes support for physical heating devices such as RSTx, WRT, FSC8
+- Remotes and wall buttons
  
 ## Prequisites
  
@@ -40,3 +41,7 @@ The current integration will not find your SHC automatically and needs to be con
 ## Device Discovery
 
 All devices are automatically discovered and included by the integration. If you include a new device in LIVISI SmartHome, the device will automatically appear in Home Assistant after a few minutes.
+
+## Remotes and wall buttons
+
+Livisi remotes such as the 8 Button remote (BRC8) and wall buttons (WSC2) are stateless devices, meaning that they do not have a on/off state like regular entities in Home Assistant. Instead, such devices emit the event `livisi_event` when a button is pressed. You can test what events come in using the event {% my developer_events title="developer tools in Home Assistant" %} and subscribe to the `livisi_event`. Once you know what the event data looks like, you can use this to create automations.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document support for Livisi wall buttons similar to the [Hue integration docs](https://www.home-assistant.io/integrations/hue/#hue-remotes-and-switches)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/89258
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
