### PR TITLE
Update operating_system.md

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -180,8 +180,9 @@ This can be accomplished either by using a live operating system (e.g. Ubuntu) a
   efibootmgr --create --disk /dev/<drivename> --part 1 --label "HAOS" \
      --loader '\EFI\BOOT\bootx64.efi'
   ```
+
 The efibootmgr command will only work if you booted the live operating system in UEFI mode, so be sure to boot from your USB flash drive in this mode.
-Depending on your privileges on the prompt, you may need to run efibootmgr with sudo.
+Depending on your privileges on the prompt, you may need to run efibootmgr using sudo.
 
 Or else, the BIOS might provide you with a tool to add boot options, there you can specify the path to the EFI file:
 

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -180,6 +180,8 @@ This can be accomplished either by using a live operating system (e.g. Ubuntu) a
   efibootmgr --create --disk /dev/<drivename> --part 1 --label "HAOS" \
      --loader '\EFI\BOOT\bootx64.efi'
   ```
+The efibootmgr command will only work if you booted the live operating system in UEFI mode, so be sure to boot from your USB flash drive in this mode.
+Depending on your privileges on the prompt, you may need to run efibootmgr with sudo.
 
 Or else, the BIOS might provide you with a tool to add boot options, there you can specify the path to the EFI file:
 


### PR DESCRIPTION
Sharing my experience installing HA OS 9.5 on my Asus E35M1-I DELUXE from 2011. Booted up the USB version of Linux Mint Cinnamon 21, wrote the HAOS image to disk using the Disks utility and applied the UEFI bios setting in the same session. It took me a while to realize why I could not run efibootmgr because the system started  without UEFI enabled..

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
