### PR TITLE
Vermont Castings virtual integration documentation

### DIFF
--- a/source/_integrations/vermont_castings.markdown
+++ b/source/_integrations/vermont_castings.markdown
@@ -1,0 +1,31 @@
+---
+title: "Vermont Castings"
+description: Connect and control your Vermont Casings fireplace using the IntelliFire integration
+ha_category:
+
+- Binary Sensor
+- Climate
+- Fan
+- Light
+- Number
+- Sensor
+- Switch
+ha_codeowners:
+  - '@jeeftor'
+ha_config_flow: true
+ha_release: 2022.3
+ha_domain: vermont_castings
+ha_integration_type: virtual
+ha_supporting_domain: intellifire:
+ha_supporting_integration: IntelliFire
+ha_platforms:
+
+- binary_sensor
+- climate
+- fan
+- light
+- number
+- sensor
+- switch
+ha_dhcp: true
+ha_integration_type: integration

--- a/source/_integrations/vermont_castings.markdown
+++ b/source/_integrations/vermont_castings.markdown
@@ -27,15 +27,4 @@ ha_platforms:
 ha_iot_class: Local Polling
 ---
 
-{% capture name %}{{ include.name | default: page.title }}{% endcapture %}
-
-{{ name }} fireplaces with an installed IntelliFire module can utilize the
-[{{ page.ha_supporting_integration }}](/integrations/{{ page.ha_supporting_domain }})
-integration.
-
-{% include integrations/config_flow.md domain=page.ha_supporting_domain %}
-
-## Usage information
-
-For more documentation on how to use {{ name }} in Home Assistant, please refer to the
-[{{ page.ha_supporting_integration }} integration documentation page](/integrations/{{ page.ha_supporting_domain }}).
+{% include integrations/supported_brand.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documentation for virtual IntelliFire Integration: Vermont Castings

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/89317
- Link to parent pull request in the Brands repository:  https://github.com/home-assistant/brands/pull/4155
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<img width="683" alt="image" src="https://user-images.githubusercontent.com/6491743/223910167-2ef444ef-2f51-42fe-8de3-ed3b7d743ce1.png">
