### PR TITLE
Clarify behaviour of counter restore option

### DIFF
--- a/source/_integrations/counter.markdown
+++ b/source/_integrations/counter.markdown
@@ -52,7 +52,7 @@ counter:
       type: integer
       default: 0
     restore:
-      description: Try to restore the last known value when Home Assistant starts.
+      description: Try to restore the last known value when Home Assistant starts. If this is true, future changes to `maximum`, `minimum`, `initial` and `step` can only be made using the `counter.configure` service.
       required: false
       type: boolean
       default: true


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
When configuring a counter in `configuration.yaml`, the `restore` option  applies to `maximum`, `minimum`, `initial` and `step`, as well as the value. This makes sense as it avoids programmatic changes being lost, but is not intuitive - see https://github.com/home-assistant/core/issues/32469#

Clarification to avoid further confusion as it doesn't seem like any changes to the behaviour are being worked on.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/32469#

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
