### PR TITLE
Document tplink_omada update entities

### DIFF
--- a/source/_integrations/tplink_omada.markdown
+++ b/source/_integrations/tplink_omada.markdown
@@ -3,7 +3,7 @@ title: TP-Link Omada SDN Controller
 description: Instructions on integrating TP-Link Omada SDN networking devices to Home Assistant.
 ha_category:
   - Hub
-ha_release: 2023.4
+ha_release: 2023.3
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:
@@ -20,7 +20,7 @@ The integration provides basic configuration and status of Omada devices control
 
 {% include integrations/config_flow.md %}
 
-- Host: Enter the URL, DNS Name or IP Address of the TP-Link Omada Controller. HTTPS will be used be default, if not specified.
+- Host: Enter the URL of the Omada management interface.
 - Verify SSL Certificates: Enable to check the validity of the certificate presented by the Omada controller.
 - Username/Password: A user account with permissions to view & configure the site is required.
 
@@ -43,15 +43,15 @@ Controller versions 5.0.0 and later are supported.
 ### Network Switches
 
 - Support for enabling/disabling Power over Ethernet on a per-port basis.
-- Firmware Update notification and installation.
+- Firmware Update entities.
 
 ### Access Points
 
-- Firmware Update notification and installation.
+- Firmware Update entities.
 
 ### Internet Gateways
 
-- Firmware Update notification and installation.
+- Firmware Update entities.
 
 ## Device Trackers
 

--- a/source/_integrations/tplink_omada.markdown
+++ b/source/_integrations/tplink_omada.markdown
@@ -20,7 +20,7 @@ The integration provides basic configuration and status of Omada devices control
 
 {% include integrations/config_flow.md %}
 
-- Host: Enter the URL, DNS Name or IP Address of the TP-Link Omada Controller. Https will be used be default, if not specified.
+- Host: Enter the URL, DNS Name or IP Address of the TP-Link Omada Controller. HTTPS will be used be default, if not specified.
 - Verify SSL Certificates: Enable to check the validity of the certificate presented by the Omada controller.
 - Username/Password: A user account with permissions to view & configure the site is required.
 

--- a/source/_integrations/tplink_omada.markdown
+++ b/source/_integrations/tplink_omada.markdown
@@ -3,7 +3,7 @@ title: TP-Link Omada SDN Controller
 description: Instructions on integrating TP-Link Omada SDN networking devices to Home Assistant.
 ha_category:
   - Hub
-ha_release: 2023.3
+ha_release: 2023.4
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:
@@ -20,11 +20,12 @@ The integration provides basic configuration and status of Omada devices control
 
 {% include integrations/config_flow.md %}
 
-- Host: Enter the URL of the Omada management interface.
+- Host: Enter the URL, DNS Name or IP Address of the TP-Link Omada Controller. Https will be used be default, if not specified.
 - Verify SSL Certificates: Enable to check the validity of the certificate presented by the Omada controller.
 - Username/Password: A user account with permissions to view & configure the site is required.
 
 ### Multiple Sites
+
 If you have multiple sites managed by your controller, you will be prompted to choose which site to manage.
 
 ## Supported Controllers
@@ -42,14 +43,15 @@ Controller versions 5.0.0 and later are supported.
 ### Network Switches
 
 - Support for enabling/disabling Power over Ethernet on a per-port basis.
+- Firmware Update notification and installation.
 
 ### Access Points
 
-- Not currently supported.
+- Firmware Update notification and installation.
 
 ### Internet Gateways
 
-- Not currently supported.
+- Firmware Update notification and installation.
 
 ## Device Trackers
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding Update entities to the TP-Link Omada devices. This doesn't require a lot of documentation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [89562](https://github.com/home-assistant/core/pull/89562)
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: fixes # N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
