### PR TITLE
Update recorder with sqlite testing info and making backups with external dbs

### DIFF
--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -229,6 +229,14 @@ Call the service `recorder.enable` to start again saving events and states to th
 
 ## Custom database engines
 
+<div class='note'>
+
+SQLite is the most tested, and Home Assistant is highly optimized to perform well when using SQLite.
+
+When choosing another option, you should be comfortable in the role of the database administrator, including making backups of the external database.
+
+</div>
+
 Here are examples to use with the [`db_url`](#db_url) configuration option.
 
 {% configuration_basic %}

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -231,7 +231,7 @@ Call the service `recorder.enable` to start again saving events and states to th
 
 <div class='note'>
 
-SQLite is the most tested, and Home Assistant is highly optimized to perform well when using SQLite.
+SQLite is the most tested, and newer version of Home Assistant are highly optimized to perform well when using SQLite.
 
 When choosing another option, you should be comfortable in the role of the database administrator, including making backups of the external database.
 


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update recorder with sqlite testing info and making backups with external dbs


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
