### PR TITLE
Add info that EU version of Aeotec Z-Stick 7 ..

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -21,12 +21,9 @@ Users should upgrade the firmware on all 700 series controllers to version 7.17.
 </div>
 
 - 700 series controllers
-  - Aeotec Z-Stick 7 USB stick (ZWA010)
-  - Aeotec Z-Pi 7 Raspberry Pi HAT/Shield (ZWA025)
+  - Aeotec Z-Stick 7 USB stick (ZWA010) (the EU version is not recommended due to RF performance issues)
   - Silicon Labs UZB-7 USB Stick (Silabs SLUSB7000A / SLUSB001A)
   - Zooz S2 Stick 700 (ZST10 700)
-  - Z-Wave.Me RaZberry 7 (ZME_RAZBERRY7)
-  - Z-Wave.Me RaZberry 7 Pro (ZMEERAZBERRY7_ANT or ZMEURAZBERRY7_ANT)
 
 - 500 series controllers
   - Aeotec Z-Stick Gen5 (see note below)
@@ -36,13 +33,13 @@ Users should upgrade the firmware on all 700 series controllers to version 7.17.
   - Vision USB stick - Gen5
   - Z-Wave.Me UZB1 stick
 
-- Rasberry Pi Modules
-  - Aeotec Z-Pi 7 (700 series)
-  - Z-Wave.Me RaZberry 7 (700 series)
-  - Z-Wave.Me RaZberry 7 Pro (700 series)
+- Raspberry Pi modules
+  - Aeotec Z-Pi 7 Raspberry Pi HAT/Shield (ZWA025, 700 series)
+  - Z-Wave.Me RaZberry 7 (ZME_RAZBERRY7, 700 series)
+  - Z-Wave.Me RaZberry 7 Pro (ZMEERAZBERRY7_PRO or ZMEURAZBERRY7_PRO, 700 series)
   - Z-Wave.Me Razberry 2 (500 series)
 
-If you are just starting out, we recommend that you purchase a 700 series controller.
+If you are just starting out, we recommend that you purchase a 700 series controller or a Raspberry Pi module.
 
 <div class='note'>
   If you're using Home Assistant OS, Supervised, or Container, it's recommended to use a USB stick, not a module. Passing a module through Docker is more complicated than passing a USB stick through.


### PR DESCRIPTION
- .. is not recommended due to RF issues
- remove duplicate entries
- fix product codes of RaZberri 7 Pro

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
