### PR TITLE
Document changed light white service call attribute

### DIFF
--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -56,7 +56,7 @@ Most lights do not support all attributes. You can check the integration documen
 | `brightness_pct`| yes | Alternatively, you can specify brightness in percent (a number between 0 and 100), where 0 means the light is off, 1 is the minimum brightness and 100 is the maximum brightness supported by the light.
 | `brightness_step` | yes | Change brightness by an amount. Should be between -255..255.
 | `brightness_step_pct` | yes | Change brightness by a percentage. Should be between -100..100.
-| `white` | yes | Set the light to white mode by setting this to `True`. Note that `white` does not have a corresponding state attribute, the `color_mode` state attribute will to `white`.
+| `white` | yes | Set the light to white mode by setting this to `True`. Note that `white` does not have a corresponding state attribute, so the `color_mode` state attribute will be set to `white`.
 | `flash` | yes | Tell light to flash, can be either value `short` or `long`.
 | `effect`| yes | Applies an effect such as `colorloop` or `random`.
 

--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -56,7 +56,7 @@ Most lights do not support all attributes. You can check the integration documen
 | `brightness_pct`| yes | Alternatively, you can specify brightness in percent (a number between 0 and 100), where 0 means the light is off, 1 is the minimum brightness and 100 is the maximum brightness supported by the light.
 | `brightness_step` | yes | Change brightness by an amount. Should be between -255..255.
 | `brightness_step_pct` | yes | Change brightness by a percentage. Should be between -100..100.
-| `white` | yes | Set the light to white mode and change its brightness, where 0 means the light is off, 1 is the minimum brightness and 255 is the maximum brightness supported by the light. Note that `white` does not have a corresponding state attribute, the `color_mode` state attribute will to `white` and the `brightness` state attribute will be set to the requested brightness.
+| `white` | yes | Set the light to white mode by setting this to `True`. Note that `white` does not have a corresponding state attribute, the `color_mode` state attribute will to `white`.
 | `flash` | yes | Tell light to flash, can be either value `short` or `long`.
 | `effect`| yes | Applies an effect such as `colorloop` or `random`.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document changed light white service call attribute


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/89803
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
