### PR TITLE
Add Marantz CINEMA 50 to known working devices

### DIFF
--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -72,6 +72,7 @@ Known supported devices:
 - Marantz AV7702
 - Marantz AV7703
 - Marantz AV7704
+- Marantz CINEMA 50
 - Marantz M-CR510
 - Marantz M-CR511
 - Marantz M-CR603


### PR DESCRIPTION
## Proposed change

Adding the CINEMA 50 to the list of working devices, have been testing for a couple of weeks with no issues.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
