### PR TITLE
Spotify Integration: link directly to dashboard page of Spotify Developers website

### DIFF
--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -37,7 +37,7 @@ provide you with the Spotify application credentials Home Assistant needs
 to allow you to log in with your Spotify account.
 
 1. If Spotify was previously integrated with your Home Assistant with _outdated_ credentials, it might be required to remove these old Spotify account credentials using the {% my application_credentials title="Home Assistant Application Credentials dashboard" %}.
-2. Log in to the [Spotify Developer](https://developer.spotify.com) Dashboard.
+2. Log in to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard).
 3. Visit the [My Applications](https://developer.spotify.com/my-applications/#!/applications) page.
 4. Click the **CREATE AN APP** button in the top right. Enter a name and
    description; feel free to use any name and description you like.


### PR DESCRIPTION
## Proposed change

Directly link to the dashboard page of the spotify developer website


## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
None
## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
