### PR TITLE
Add optional domain filter for *_entities template functions

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -379,6 +379,7 @@ The same thing can also be expressed as a test:
 ### Devices
 
 - `device_entities(device_id)` returns a list of entities that are associated with a given device ID. Can also be used as a filter.
+- `device_entities(device_id, domain)` returns a list of entities that are associated with a given device ID filtered by `domain`. Can also be used as a filter (e.g. `{{ 'deadbeefdeadbeefdeadbeefdeadbeef' | device_entities('light') }}`).
 - `device_attr(device_or_entity_id, attr_name)` returns the value of `attr_name` for the given device or entity ID. Can also be used as a filter. Not supported in [limited templates](#limited-templates).
 - `is_device_attr(device_or_entity_id, attr_name, attr_value)` returns whether the value of `attr_name` for the given device or entity ID matches `attr_value`. Can also be used as a test. Not supported in [limited templates](#limited-templates).
 - `device_id(entity_id)` returns the device ID for a given entity ID or device name. Can also be used as a filter.
@@ -420,7 +421,8 @@ The same thing can also be expressed as a test:
 - `areas()` returns the full list of area IDs
 - `area_id(lookup_value)` returns the area ID for a given device ID, entity ID, or area name. Can also be used as a filter.
 - `area_name(lookup_value)` returns the area name for a given device ID, entity ID, or area ID. Can also be used as a filter.
-- `area_entities(area_name_or_id)` returns the list of entity IDs tied to a given area ID or name. Can also be used as a filter.
+- `area_entities(area_name_or_id)` returns the list of entity IDs tied to a given area ID or name. Can also be used as a filter. `domain` can optionally be used to filter the list of entity IDs returned.
+- `area_entities(area_name_or_id, domain)` returns the list of entity IDs tied to a given area ID or name filtered by `domain`. Can also be used as a filter (e.g. `{{ 'blah' | area_entities('sensor') }}`).
 - `area_devices(area_name_or_id)` returns the list of device IDs tied to a given area ID or name. Can also be used as a filter.
 
 #### Areas examples
@@ -456,7 +458,11 @@ The same thing can also be expressed as a test:
 ```
 
 ```text
-{{ area_entities('deadbeefdeadbeefdeadbeefdeadbeef') }}  # ['sensor.sony']
+{{ area_entities('deadbeefdeadbeefdeadbeefdeadbeef') }}  # ['sensor.sony', 'light.sony']
+```
+
+```text
+{{ area_entities('deadbeefdeadbeefdeadbeefdeadbeef', 'sensor') }}  # ['sensor.sony']
 ```
 
 ```text
@@ -469,17 +475,22 @@ The same thing can also be expressed as a test:
 
 - `integration_entities(integration)` returns a list of entities that are associated with a given integration, such as `hue` or `zwave_js`.
 - `integration_entities(title)` if you have multiple instances set-up for an integration, you can also use the title you've set for the integration in case you only want to target a specific device bridge.
+- `integration_entities(integration_or_title, domain)` will filter the returned entity ID list by `domain`.
 
 #### Integrations examples
 
 {% raw %}
 
 ```text
-{{ integration_entities('hue') }}  # ['light.hue_light_upstairs', 'light.hue_light_downstairs']
+{{ integration_entities('hue') }}  # ['light.hue_light_upstairs', 'light.hue_light_downstairs', 'sensor.hue_battery_level_upstairs']
 ```
 
 ```text
 {{ integration_entities('Hue bridge downstairs') }}  # ['light.hue_light_downstairs']
+```
+
+```text
+{{ integration_entities('hue', 'sensor') }}  # ['sensor.hue_battery_level_upstairs']
 ```
 
 {% endraw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -379,7 +379,7 @@ The same thing can also be expressed as a test:
 ### Devices
 
 - `device_entities(device_id)` returns a list of entities that are associated with a given device ID. Can also be used as a filter.
-- `device_entities(device_id, domain)` returns a list of entities that are associated with a given device ID filtered by `domain`. Can also be used as a filter (e.g. `{{ 'deadbeefdeadbeefdeadbeefdeadbeef' | device_entities('light') }}`).
+- `device_entities(device_id, domain)` returns a list of entities that are associated with a given device ID filtered by `domain`. Can also be used as a filter (e.g. `'deadbeefdeadbeefdeadbeefdeadbeef' | device_entities('light')`).
 - `device_attr(device_or_entity_id, attr_name)` returns the value of `attr_name` for the given device or entity ID. Can also be used as a filter. Not supported in [limited templates](#limited-templates).
 - `is_device_attr(device_or_entity_id, attr_name, attr_value)` returns whether the value of `attr_name` for the given device or entity ID matches `attr_value`. Can also be used as a test. Not supported in [limited templates](#limited-templates).
 - `device_id(entity_id)` returns the device ID for a given entity ID or device name. Can also be used as a filter.
@@ -422,7 +422,7 @@ The same thing can also be expressed as a test:
 - `area_id(lookup_value)` returns the area ID for a given device ID, entity ID, or area name. Can also be used as a filter.
 - `area_name(lookup_value)` returns the area name for a given device ID, entity ID, or area ID. Can also be used as a filter.
 - `area_entities(area_name_or_id)` returns the list of entity IDs tied to a given area ID or name. Can also be used as a filter. `domain` can optionally be used to filter the list of entity IDs returned.
-- `area_entities(area_name_or_id, domain)` returns the list of entity IDs tied to a given area ID or name filtered by `domain`. Can also be used as a filter (e.g. `{{ 'blah' | area_entities('sensor') }}`).
+- `area_entities(area_name_or_id, domain)` returns the list of entity IDs tied to a given area ID or name filtered by `domain`. Can also be used as a filter (e.g. `'blah' | area_entities('sensor')`).
 - `area_devices(area_name_or_id)` returns the list of device IDs tied to a given area ID or name. Can also be used as a filter.
 
 #### Areas examples


### PR DESCRIPTION
## Proposed change
This PR documents a new optional `domain` input to `area_entities`, `device_entities`, and `integration_entities` that filters the lists returned from the template functions.





## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/89936
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
