### PR TITLE
Remove reference to template sensors

### DIFF
--- a/source/_integrations/solaredge.markdown
+++ b/source/_integrations/solaredge.markdown
@@ -26,19 +26,3 @@ The SolarEdge Monitoring API has a daily rate limit of 300 requests. In order to
 
 {% include integrations/config_flow.md %}
 
-## Additional template sensor
-
-In case you would like to convert the values for example to kWh instead of the default Wh, you can use the [template platform](/integrations/template).
-
-{% raw %}
-
-```yaml
-# Example configuration.yaml entry for template platform
-template:
-  - sensor:
-    - name: solaredge_energy_this_year_template
-      unit_of_measurement: kWh
-      state: "{{ (states('sensor.solaredge_energy_this_year') | float / 1000) | round(2) }}"
-```
-
-{% endraw %}

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -63,19 +63,3 @@ sensor:
     name: SolarEdge
     ip_address: 192.168.1.123
 ```
-
-In case you would like to convert the values for example to kWh instead of the default Wh, you can use the [template platform](/integrations/template).
-
-{% raw %}
-
-```yaml
-# Example configuration.yaml entry for sensor template platform
-template:
-  - sensor:
-    - name: solaredge_energy_this_year_template
-      state: "{{ (states('sensor.solaredge_energy_this_year') | float / 1000) | round(2) }}"
-      unit_of_measurement: "KWh"
-      icon: "mdi:solar-power"
-```
-
-{% endraw %}


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove reference to template sensors, these are now handled by unit conversions

SolarEdge uses unit conversions since core#84221
SolarEdge Local uses unit conversions since core#83821

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [X] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
