### PR TITLE
Add warning about a window size larger than one with many states

### DIFF
--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -117,7 +117,7 @@ filters:
 
 <div class="note warning">
 
-When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity each time your filter updates. If you have modified the [Recorder `keep_days`](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can to respond poorly during startup.
+When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity during Home Assistant startup. If you have modified the [Recorder `keep_days`](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can to respond poorly during startup.
 
 </div>
 

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -117,7 +117,7 @@ filters:
 
 <div class="note warning">
 
-When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity during Home Assistant startup. If you have modified the [Recorder `keep_days`](/integrations/recorder/#purge_keep_days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can to respond poorly during startup.
+When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity during Home Assistant startup. If you have modified the [Recorder `purge_keep_days`](/integrations/recorder/#purge_keep_days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can to respond poorly during startup.
 
 </div>
 

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -117,7 +117,7 @@ filters:
 
 <div class="note warning">
 
-Configuring a `window_size` larger than the default of `1` will require the database to examine every state for that entity each time your filter updates. If you have modified the [Recorder keep_days](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause instability.
+When configuring a `window_size` that is not a time, and using a value larger than the default of `1` will require the database to examine every state for that entity each time your filter updates. If you have modified the [Recorder keep_days](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance will be unstable and respond poorly.
   
 </div>
 

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -117,7 +117,7 @@ filters:
 
 <div class="note warning">
 
-When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity each time your filter updates. If you have modified the [Recorder `keep_days`](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can respond poorly during startup.
+When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity each time your filter updates. If you have modified the [Recorder `keep_days`](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can to respond poorly during startup.
 
 </div>
 

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -117,7 +117,7 @@ filters:
 
 <div class="note warning">
 
-When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity during Home Assistant startup. If you have modified the [Recorder `keep_days`](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can to respond poorly during startup.
+When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity during Home Assistant startup. If you have modified the [Recorder `keep_days`](/integrations/recorder/#purge_keep_days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can to respond poorly during startup.
 
 </div>
 

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -117,7 +117,7 @@ filters:
 
 <div class="note warning">
 
-When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity each time your filter updates. If you have modified the [Recorder `keep_days`](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can become unstable and respond poorly.
+When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity each time your filter updates. If you have modified the [Recorder `keep_days`](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can respond poorly during startup.
 
 </div>
 

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -56,6 +56,7 @@ sensor:
 
 Filters can be chained and are applied according to the order present in the configuration file.
 
+
 {% configuration %}
 entity_id:
   description: The entity ID of the sensor to be filtered.
@@ -114,6 +115,12 @@ filters:
       type: float
       default: positive infinity
 {% endconfiguration %}
+
+<div class="note warning">
+
+Configuring a `window_size` larger than the default of `1` will require the database to examine every state for that entity each time your filter updates. If you have modified the [Recorder keep_days](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause instability.
+  
+</div>
 
 ## Filters
 

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -56,7 +56,6 @@ sensor:
 
 Filters can be chained and are applied according to the order present in the configuration file.
 
-
 {% configuration %}
 entity_id:
   description: The entity ID of the sensor to be filtered.

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -117,7 +117,7 @@ filters:
 
 <div class="note warning">
 
-When configuring a `window_size` that is not a time, and using a value larger than the default of `1` will require the database to examine every state for that entity each time your filter updates. If you have modified the [Recorder keep_days](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance will be unstable and respond poorly.
+When configuring a `window_size` that is not a time, and using a value larger than the default of `1` will require the database to examine every state for that entity each time your filter updates. If you have modified the [Recorder keep_days](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can become unstable and respond poorly.
   
 </div>
 

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -117,8 +117,8 @@ filters:
 
 <div class="note warning">
 
-When configuring a `window_size` that is not a time, and with a value larger than the default of `1`, the database will have to examine nearly every stored state for that entity each time your filter updates. If you have modified the [Recorder `keep_days`](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can become unstable and respond poorly.
-  
+When configuring a `window_size` that is not a time and with a value larger than the default of `1`, the database must examine nearly every stored state for that entity each time your filter updates. If you have modified the [Recorder `keep_days`](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can become unstable and respond poorly.
+
 </div>
 
 ## Filters

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -117,7 +117,7 @@ filters:
 
 <div class="note warning">
 
-When configuring a `window_size` that is not a time, and using a value larger than the default of `1` will require the database to examine every state for that entity each time your filter updates. If you have modified the [Recorder keep_days](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can become unstable and respond poorly.
+When configuring a `window_size` that is not a time, and with a value larger than the default of `1`, the database will have to examine nearly every stored state for that entity each time your filter updates. If you have modified the [Recorder `keep_days`](/integrations/recorder/#keep-days) value or have many states stored in the database for the filtered entity, this can cause your Home Assistant instance can become unstable and respond poorly.
   
 </div>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add warning about a window size larger than one with many states with the filter integration causing instability during startup

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/90211
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
