### PR TITLE
Add new service in OpenTherm Gateway integration

### DIFF
--- a/source/_integrations/opentherm_gw.markdown
+++ b/source/_integrations/opentherm_gw.markdown
@@ -174,6 +174,23 @@ For a list of possible modes with explanation, see [LED modes](#led-modes)
 | `id` | no | The LED ID, accepted values are `A` through `F`.
 | `mode` | no | The LED mode to be set.
 
+### Service `opentherm_gw.set_max_ch_setpoint`
+
+ Set the maximum central heating setpoint override on the OpenTherm Gateway. This command is only effective with boilers that support this function.
+ In a normal situation, the thermostat will calculate and control the maximum central heating setpoint on the boiler. Setting this to any value other than 0 will enable the override and allow the OpenTherm Gateway to control this setting. For your boiler's actual maximum and minimum supported setpoint value, please see the `slave_ch_max_setp` and `slave_ch_min_setp` [sensors](#sensors).
+ **You will only need this if you are writing your own software thermostat.**
+
+ | Service data attribute | Optional | Description |
+ | ---------------------- | -------- | ----------- |
+ | `gateway_id` | no | The `gateway_id` as specified during configuration.
+ | `temperature` | no | The maximum central heating setpoint. Values between `0.0` and `90.0` are accepted, but your boiler may not support the full range. Set to `0` to disable the override.
+
+ <div class='note'>
+
+ Please read [this information](http://otgw.tclcode.com/standalone.html) from the designer of the OpenTherm Gateway before considering to write your own software thermostat.
+
+ </div>
+
 ### Service `opentherm_gw.set_max_modulation`
 
 <div class='note warning'>


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add new service Set maximum central heating setpoint to OpenTherm Gateway integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [PR#90064](https://github.com/home-assistant/core/pull/90064)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
