### PR TITLE
Add character_encoding doc to REST and Scrape

### DIFF
--- a/source/_integrations/rest.markdown
+++ b/source/_integrations/rest.markdown
@@ -162,7 +162,7 @@ scan_interval:
   required: false
   type: integer
   default: 30
-character_encoding:
+encoding:
   description: The character encoding to use if none provided in the header of the shared data.
   required: false
   type: string

--- a/source/_integrations/rest.markdown
+++ b/source/_integrations/rest.markdown
@@ -162,6 +162,11 @@ scan_interval:
   required: false
   type: integer
   default: 30
+character_encoding:
+  description: The character encoding to use if none provided in the header of the shared data.
+  required: false
+  type: string
+  default: UTF-8
 sensor:
   description: A list of sensors to create from the shared data. All configuration settings that are supported by [RESTful Sensor](/integrations/sensor.rest#configuration-variables) not listed above can be used here.
   required: false

--- a/source/_integrations/scrape.markdown
+++ b/source/_integrations/scrape.markdown
@@ -92,6 +92,11 @@ scan_interval:
   required: false
   type: integer
   default: 600
+character_encoding:
+  description: The character encoding to use if none provided in the header of the shared data.
+  required: false
+  type: string
+  default: UTF-8
 sensor:
   description: A list of sensors to create from the shared data. All configuration settings that are supported by [RESTful Sensor](/integrations/sensor.rest#configuration-variables) not listed above can be used here.
   required: true

--- a/source/_integrations/scrape.markdown
+++ b/source/_integrations/scrape.markdown
@@ -92,7 +92,7 @@ scan_interval:
   required: false
   type: integer
   default: 600
-character_encoding:
+encoding:
   description: The character encoding to use if none provided in the header of the shared data.
   required: false
   type: string


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for a new configuration variable character_encoding.
Related to PR [#90254](https://github.com/home-assistant/core/pull/90254)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#90254](https://github.com/home-assistant/core/pull/90254)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

