### PR TITLE
Fix headings in configuration/events

### DIFF
--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -124,7 +124,7 @@ This event is fired when a state has changed. It contains the entity identifier 
 
 This event is fired after a theme has been set or reloaded. It contains no additional data.
 
-## `user_added`
+### `user_added`
 
 This event is fired when a user has been added.
 
@@ -132,7 +132,7 @@ This event is fired when a user has been added.
 | --------- | ------------------------------- |
 | `user_id` | Identification of the new user. |
 
-## `user_removed`
+### `user_removed`
 
 This event is fired when a user has been removed.
 
@@ -140,9 +140,9 @@ This event is fired when a user has been removed.
 | --------- | ----------------------------------- |
 | `user_id` | Identification of the removed user. |
 
-### Built-in events (default integrations)
+## Built-in events (default integrations)
 
-## `automation_reloaded`
+### `automation_reloaded`
 
 Integration: [`automation`](/integrations/automation/)
 
@@ -150,7 +150,7 @@ This event is fired when automations have been reloaded and thus might have chan
 
 This event contains no additional data.
 
-## `automation_triggered`
+### `automation_triggered`
 
 Integration: [`automation`](/integrations/automation/)
 
@@ -161,7 +161,7 @@ This event is fired when an automation is triggered.
 | `name`      | The name of the automation.       |
 | `entity_id` | The identifier of the automation. |
 
-## `scene_reloaded`
+### `scene_reloaded`
 
 Integration: [`homeassistant`](/integrations/homeassistant/)
 
@@ -169,7 +169,7 @@ This event is fired when scenes have been reloaded and thus might have changed.
 
 This event contains no additional data.
 
-## `script_started`
+### `script_started`
 
 Integration: [`script`](/integrations/script/)
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The [events](https://www.home-assistant.io/docs/configuration/events/) page changes header level halfway through the event list. This PR fixes that.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
