### PR TITLE
Remove frontier_silicon from discovery integration

### DIFF
--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -18,7 +18,6 @@ This integration is limited to detect:
  * [Bluesound speakers](/integrations/bluesound)
  * [Bose Soundtouch speakers](/integrations/soundtouch)
  * [Enigma2 media player](/integrations/enigma2)
- * [Frontier Silicon internet radios](/integrations/frontier_silicon)
  * [Linn / Openhome](/integrations/openhome)
  * [SABnzbd downloader](/integrations/sabnzbd)
  * [Yamaha media player](/integrations/yamaha)
@@ -49,7 +48,6 @@ Valid values for ignore are:
  * `bluesound`: Bluesound speakers
  * `bose_soundtouch`: Bose Soundtouch speakers
  * `enigma2`: Enigma2 media players
- * `frontier_silicon`: Frontier Silicon internet radios
  * `lg_smart_device`: LG Soundbars
  * `openhome`: Linn / Openhome
  * `sabnzbd`: SABnzbd downloader


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Discovery of Frontier Silicon devices moved from `discovery` plugin to its own config flow.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/89496
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
