### PR TITLE
Yellow product page: fix position of buy button

### DIFF
--- a/sass/custom/_landingpage.scss
+++ b/sass/custom/_landingpage.scss
@@ -1194,7 +1194,6 @@ $ha__primary_color: #03a9f4;
     .fab {
       bottom: 12px;
       right: 12px;
-      display: none;
     }
 
     #buy-dialog {

--- a/source/_layouts/landingpage.html
+++ b/source/_layouts/landingpage.html
@@ -76,7 +76,7 @@ layout: page
           });
       });
   });
-  if (document.documentElement.clientWidth < 300) {
+  if (document.documentElement.clientWidth < 480) {
     document.querySelector(".page-content").addEventListener(
       "scroll",
       function (e) {

--- a/source/_layouts/landingpage.html
+++ b/source/_layouts/landingpage.html
@@ -76,7 +76,7 @@ layout: page
           });
       });
   });
-  if (document.documentElement.clientWidth < 480) {
+  if (document.documentElement.clientWidth < 300) {
     document.querySelector(".page-content").addEventListener(
       "scroll",
       function (e) {

--- a/source/skyconnect/index.html
+++ b/source/skyconnect/index.html
@@ -378,7 +378,7 @@ frontpage_image: /images/skyconnect/skyconnect-cover.png
 </div>
 
 <div
-  class="fab"
+  class="fab" style="position: fixed; top: 78px; height: 48px;"
   onclick="showBuyDialog()"
   title="pre-order Home Assistant SkyConnect"
 >

--- a/source/yellow/index.html
+++ b/source/yellow/index.html
@@ -311,7 +311,7 @@ frontpage_image: /images/frontpage/yellow-frontpage.jpg
 </div>
 
 <div
-  class="fab"
+  class="fab" style="position: fixed; top: 78px; height: 48px;"
   onclick="showBuyDialog()"
   title="pre-order Home Assistant Yellow"
 >


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- move position of buy button from bottom to top of page
- disable activate on scroll
- prevent button from disappearing on small screens


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
