### PR TITLE
Rename Android TV to Android Debug Bridge

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -1,6 +1,6 @@
 ---
-title: Android TV
-description: Instructions on how to integrate Android TV and Fire TV devices into Home Assistant.
+title: Android Debug Bridge
+description: Instructions on how to integrate Android and Fire TV devices into Home Assistant.
 ha_category:
   - Media Player
 ha_release: 0.7.6
@@ -16,7 +16,7 @@ ha_platforms:
 ha_integration_type: device
 ---
 
-The `androidtv` platform allows you to control an Android TV device or [Amazon Fire TV](https://www.amazon.com/b/?node=8521791011) device.
+The Android Debug Bridge integration allows you to control an Android device or [Amazon Fire TV](https://www.amazon.com/b/?node=8521791011) device.
 
 <div class='note'>
 
@@ -26,7 +26,7 @@ When setting up this integration, it is recommended that you do NOT use an ADB s
 
 ## Device preparation
 
-To set up your device, you will need to find its IP address and enable ADB debugging. For Android TV devices, please consult the documentation for your device.
+To set up your device, you will need to find its IP address and enable ADB debugging. For Android devices, please consult the documentation for your device.
 
 For Fire TV devices, the instructions are as follows:
 
@@ -62,11 +62,11 @@ Configure State Detection Rules:
 
 ## ADB Setup
 
-This integration works by sending ADB commands to your Android TV / Fire TV device. There are two ways to accomplish this.
+This integration works by sending ADB commands to your Android / Fire TV device. There are two ways to accomplish this.
 
 <div class='note'>
 
-When connecting to your device for the first time, a dialog will appear on your Android TV / Fire TV asking you to approve the connection. Check the box that says "always allow connections from this device" and hit OK.
+When connecting to your device for the first time, a dialog will appear on your Android / Fire TV asking you to approve the connection. Check the box that says "always allow connections from this device" and hit OK.
 
 </div>
 
@@ -84,7 +84,7 @@ Prior to Home Assistant 0.101, this approach did not work well for newer devices
 
 ### 2. ADB Server
 
-The second option is to use an ADB server to connect to your Android TV and Fire TV devices.
+The second option is to use an ADB server to connect to your Android and Fire TV devices.
 
 <div class='note'>
 
@@ -92,21 +92,21 @@ To configure ADB server on integration setup, you need to enable [advanced mode]
 
 </div>
 
-Using this approach, Home Assistant will send the ADB commands to the server, which will then send them to the Android TV / Fire TV device and report back to Home Assistant. To use this option, add the `adb_server_ip` option to your configuration. If you are running the server on the same machine as Home Assistant, you can use `127.0.0.1` for this value.
+Using this approach, Home Assistant will send the ADB commands to the server, which will then send them to the Android / Fire TV device and report back to Home Assistant. To use this option, add the `adb_server_ip` option to your configuration. If you are running the server on the same machine as Home Assistant, you can use `127.0.0.1` for this value.
 
 ## ADB Troubleshooting
 
-If the setup for your Android TV or Fire TV device fails, then there is probably an issue with your ADB connection. Here are some possible causes.
+If the setup for your Android or Fire TV device fails, then there is probably an issue with your ADB connection. Here are some possible causes.
 
 1. You have the wrong IP address for the device.
 
 2. ADB is not enabled on your device.
 
-3. You are already connected to the Android TV / Fire TV via ADB from another device. Only one device can be connected, so disconnect the other device, restart the Android TV / Fire TV (for good measure), and then restart Home Assistant.
+3. You are already connected to the Android / Fire TV via ADB from another device. Only one device can be connected, so disconnect the other device, restart the Android / Fire TV (for good measure), and then restart Home Assistant.
 
 4. You need to approve the ADB connection; see the note in the [ADB Setup](#adb-setup) section above.
 
-5. Some Android TV devices (e.g., Philips TVs running Android TV) only accept the initial ADB connection request over their Wi-Fi interface. If you have the TV wired, you need to connect it to Wi-Fi and try the initial connection again. Once the authentication has been granted via Wi-Fi, you can connect to the TV over the wired interface as well.
+5. Some Android devices (e.g., Philips TVs running Android TV) only accept the initial ADB connection request over their Wi-Fi interface. If you have the TV wired, you need to connect it to Wi-Fi and try the initial connection again. Once the authentication has been granted via Wi-Fi, you can connect to the TV over the wired interface as well.
 
 6. If your device drops off WiFi, breaking the ADB connection and causing the entity to become unavailable in Home Assistant, you could install a wake lock utility (such as [Wakelock](https://github.com/d4rken/wakelock-revamp)) to prevent this from happening. Some users have reported this problem with Xiaomi Mi Box devices.
 
@@ -138,11 +138,11 @@ stop_netflix:
 
 ### `androidtv.adb_command`
 
-The service `androidtv.adb_command` allows you to send either keys or ADB shell commands to your Android TV / Fire TV device. If there is any output, it will be stored in the `'adb_response'` attribute (i.e., `state_attr('media_player.android_tv_living_room', 'adb_response')` in a template) and logged at the INFO level.
+The service `androidtv.adb_command` allows you to send either keys or ADB shell commands to your Android / Fire TV device. If there is any output, it will be stored in the `'adb_response'` attribute (i.e., `state_attr('media_player.android_tv_living_room', 'adb_response')` in a template) and logged at the INFO level.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |       no | Name(s) of Android TV / Fire TV entities.
+| `entity_id`            |       no | Name(s) of Android / Fire TV entities.
 | `command`              |       no | Either a key command or an ADB shell command.
 
 In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) it could look like this:
@@ -177,14 +177,14 @@ A list of various intents can be found [here](https://gist.github.com/mcfrojd/9e
 
 ### `androidtv.learn_sendevent` (for faster ADB commands)
 
-When sending commands like UP, DOWN, HOME, etc. via ADB, the device can be slow to respond. The problem isn't ADB, but rather the Android command `input` that is used to perform those actions. A faster way to send these commands is using the Android `sendevent` command. The challenge is that these commands are device-specific. To assist users in learning commands for their device, the Android TV integration provides the `androidtv.learn_sendevent` service. Its usage is as follows:
+When sending commands like UP, DOWN, HOME, etc. via ADB, the device can be slow to respond. The problem isn't ADB, but rather the Android command `input` that is used to perform those actions. A faster way to send these commands is using the Android `sendevent` command. The challenge is that these commands are device-specific. To assist users in learning commands for their device, the Android debug bridge integration provides the `androidtv.learn_sendevent` service. Its usage is as follows:
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |       no | Name(s) of Android TV / Fire TV entities.
+| `entity_id`            |       no | Name(s) of Android / Fire TV entities.
 
 1. Call the `androidtv.learn_sendevent` service.
-2. Within 8 seconds, hit a single button on your Android TV / Fire TV remote.
+2. Within 8 seconds, hit a single button on your Android / Fire TV remote.
 3. After 8 seconds, a persistent notification will appear that contains the equivalent command that can be sent via the `androidtv.adb_command` service. This command can also be found in the `adb_response` attribute of the media player in Home Assistant, and it will be logged at the INFO level.
 
 As an example, a service call in a [script](/docs/scripts) could be changed from this:
@@ -211,25 +211,25 @@ to this:
 
 ### `androidtv.download` and `androidtv.upload`
 
-You can use the `androidtv.download` service to download a file from your Android TV / Fire TV device to your Home Assistant instance.
+You can use the `androidtv.download` service to download a file from your Android / Fire TV device to your Home Assistant instance.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |       no | Name of Android TV / Fire TV entity.
-| `device_path`          |       no | The filepath on the Android TV / Fire TV device.
+| `entity_id`            |       no | Name of Android / Fire TV entity.
+| `device_path`          |       no | The filepath on the Android / Fire TV device.
 | `local_path`           |       no | The filepath on your Home Assistant instance.
 
-Similarly, you can use the `androidtv.upload` service to upload a file from Home Assistant instance to Android TV / Fire TV devices.
+Similarly, you can use the `androidtv.upload` service to upload a file from Home Assistant instance to Android / Fire TV devices.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |       no | Name(s) of Android TV / Fire TV entities.
-| `device_path`          |       no | The filepath on the Android TV / Fire TV device.
+| `entity_id`            |       no | Name(s) of Android / Fire TV entities.
+| `device_path`          |       no | The filepath on the Android / Fire TV device.
 | `local_path`           |       no | The filepath on your Home Assistant instance.
 
 ## Custom State Detection
 
-The Android TV integration works by polling the Android TV / Fire TV device at a regular interval and collecting a handful of properties. Unfortunately, there is no standard API for determining the state of the device to which all apps adhere. Instead, the backend `androidtv` package uses three of the properties that it collects to determine the state: `audio_state`, `media_session_state`, and `wake_lock_size`. The correct logic for determining the state differs depending on the current app, and the backend `androidtv` package implements app-specific state detection logic for a handful of apps. Of course, it is not feasible to implement custom logic for each and every app in the `androidtv` package. Moreover, the correct state detection logic may differ across devices and device configurations.
+The Android Debug Bridge integration works by polling the Android / Fire TV device at a regular interval and collecting a handful of properties. Unfortunately, there is no standard API for determining the state of the device to which all apps adhere. Instead, the backend `androidtv` package uses three of the properties that it collects to determine the state: `audio_state`, `media_session_state`, and `wake_lock_size`. The correct logic for determining the state differs depending on the current app, and the backend `androidtv` package implements app-specific state detection logic for a handful of apps. Of course, it is not feasible to implement custom logic for each and every app in the `androidtv` package. Moreover, the correct state detection logic may differ across devices and device configurations.
 
 The solution to this problem is the `state_detection_rules` configuration parameter, which allows you to provide your own rules for state detection.  The keys are app IDs, and the values are lists of rules that are evaluated in order.  Valid rules are:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Rename Android TV to Android Debug Bridge per Paulus' request in https://github.com/home-assistant/core/pull/89935#issuecomment-1493195164


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/90657
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
