### PR TITLE
Modbus nan values

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1014,7 +1014,7 @@ sensors:
       required: false
       type: float
     nan_value:
-      description: If a modbus sensor has a defined NaN value, this value can be set as hex string starting with `0x` containing one or more bytes (e.g. `0xFFFF` or `0x80000000`) or provided as integer directly. If triggered, the sensor becomes `unavailable`. Please note that the hex to int conversion for `nan_value` does currently not obey home-assistants modbus encoding using the `data_type`, `structure` or `swap` arguments.
+      description: If a Modbus sensor has a defined NaN value, this value can be set as a hex string starting with `0x` containing one or more bytes (for example, `0xFFFF` or `0x80000000`) or provided as an integer directly. If triggered, the sensor becomes `unavailable`. Please note that the hex to int conversion for `nan_value` does currently not obey home-assistants Modbus encoding using the `data_type`, `structure`, or `swap` arguments.
       required: false
       type: string
     zero_suppress:

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1014,9 +1014,9 @@ sensors:
       required: false
       type: float
     nan_value:
-      description: The NaN value if the sensor has an explicit NaN return. Can be float, integer or in hex notation
+      description: If a modbus sensor has a vendor defined NaN value, this value can be set here as hex string (e.g. `0xFFFFFFFF`) and, if triggered, the sensor becomes `unavailable`.
       required: false
-      type: int
+      type: string
     zero_suppress:
       description: Suppress values close to zero. If -zero_suppress <= value <= +zero_suppress --> 0. Can be float or integer
       required: false
@@ -1030,7 +1030,7 @@ sensors:
       required: false
       type: string
     slave_count:
-      description: Generates x-1 slave sensors, allowing read of multiple registers with a single read messsage.
+      description: Generates x-1 slave sensors, allowing read of multiple registers with a single read message.
       required: false
       type: integer
 {% endconfiguration %}

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1014,7 +1014,7 @@ sensors:
       required: false
       type: float
     nan_value:
-      description: If a modbus sensor has a vendor defined NaN value, this value can be set here as hex string (e.g. `0xFFFFFFFF`) and, if triggered, the sensor becomes `unavailable`.
+      description: If a modbus sensor has a defined NaN value, this value can be set as hex string starting with `0x` containing one or more bytes (e.g. `0xFFFF` or `0x80 00 00 00`). If triggered, the sensor becomes `unavailable`.
       required: false
       type: string
     zero_suppress:

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1013,6 +1013,10 @@ sensors:
       description: The maximum allowed value of a sensor. If value > max_value --> max_value. Can be float or integer
       required: false
       type: float
+    nan_value:
+      description: The NaN value if the sensor has an explicit NaN return. Can be float, integer or in hex notation
+      required: false
+      type: int
     zero_suppress:
       description: Suppress values close to zero. If -zero_suppress <= value <= +zero_suppress --> 0. Can be float or integer
       required: false

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1014,7 +1014,7 @@ sensors:
       required: false
       type: float
     nan_value:
-      description: If a modbus sensor has a defined NaN value, this value can be set as hex string starting with `0x` containing one or more bytes (e.g. `0xFFFF` or `0x80 00 00 00`). If triggered, the sensor becomes `unavailable`.
+      description: If a modbus sensor has a defined NaN value, this value can be set as hex string starting with `0x` containing one or more bytes (e.g. `0xFFFF` or `0x80000000`) or provided as integer directly. If triggered, the sensor becomes `unavailable`. Please note that the hex to int conversion for `nan_value` does currently not obey home-assistants modbus encoding using the `data_type`, `structure` or `swap` arguments.
       required: false
       type: string
     zero_suppress:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
add documentation to optional modbus parameter: nan_value


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/90800
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/core/issues/69656
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
