### PR TITLE
Added an alternative solution for the Systemd Journal issue

### DIFF
--- a/source/more-info/unsupported/systemd_journal.markdown
+++ b/source/more-info/unsupported/systemd_journal.markdown
@@ -32,5 +32,20 @@ sudo apt-get install --reinstall systemd-journal-remote
 
 and reboot your system
 
+## Alternative solution
+
+There is another solution you can verify when the `systemd-journal-gatewayd` service does not run.
+Verify whether the service is running with:
+
+```sh
+sudo systemctl status systemd-journal-gatewayd.service
+```
+
+If it is not started then start it with:
+
+```sh
+sudo systemctl start systemd-journal-gatewayd.service
+```
+
 If you still see this issue then run the [supervised installer](https://github.com/home-assistant/supervised-installer)
 on the host as the supervisor service may need an update as well.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
