### PR TITLE
Document new humidifier support for VeSync integration

### DIFF
--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -15,6 +15,7 @@ ha_codeowners:
 ha_domain: vesync
 ha_platforms:
   - fan
+  - humidifier
   - light
   - sensor
   - switch
@@ -30,6 +31,7 @@ The following platforms are supported:
 - **light**
 - **switch**
 - **fan**
+- **humidifier**
 - **sensor**
 
 ## Supported Devices
@@ -61,6 +63,10 @@ This integration supports devices controllable by the VeSync App.  The following
 - Core 400S: Smart True HEPA Air Purifier
 - Core 600S: Smart True HEPA Air Purifier
 - LEVOIT Smart Wifi Air Purifier (LV-PUR131S)
+
+## Humidifiers
+
+- LEVOIT LV600S: Smart Hybrid Ultrasonic Humidifier
 
 ## Prerequisite
 
@@ -98,6 +104,14 @@ All VeSync air purifiers expose the remaining filter life, and some also expose 
 | `filter_life`           | Remaining percentage of the filter. (LV-PUR131S, Core200S/300s/400s/600s)         | 142       |
 | `air_quality`           | The current air quality reading. (LV-PUR131S, Core300s/400s/600s)                      | excellent |
 | `pm2_5`                 | The current air quality reading. (Core300s/400s/600s)                                  | 8         |
+
+## Humidifier Exposed Sensors
+
+VeSync humidifiers will expose the following details:
+
+| Sensor                                  | Description    | Example |
+| --------------------------------------- | -------------- | ------- |
+| `humidity`           | Measured Humidity.                | 45      |
 
 ## Fan Exposed Attributes
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document new humidifier support for VeSync integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/90878
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
