### PR TITLE
Add config flow to dwd_weather_warnings

### DIFF
--- a/source/_integrations/dwd_weather_warnings.markdown
+++ b/source/_integrations/dwd_weather_warnings.markdown
@@ -22,12 +22,8 @@ The `dwd_weather_warnings` integration uses the [Deutscher Wetterdienst (DWD)](h
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}
-Name of the sensor:
-  description: Name that will be part of the sensor's `entity_id`. This is a required field.
 Warncell ID or name:
   description: Identifier of the region. It can either be a so called `warncell ID` (integer) or a `warncell name` (string). It is heavily advised to use `warncell ID` because `warncell name` is not unique in some cases. A list of valid warncell IDs and names can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.html). Some of the warncells are outdated but still listed. If the setup fails, search the list for a similar sounding warncell. In case the `warncell name` is not unique, `" (not unique used ID)!"` will be added to the reported `region_name`. Setting this field is required.
-Monitored conditions:
-  description: The conditions to observe. Can be either current warning level, advance warning level, or both. If not otherwise configured, it selects both conditions.
 {% endconfiguration_basic %}
 
 ### Attributes

--- a/source/_integrations/dwd_weather_warnings.markdown
+++ b/source/_integrations/dwd_weather_warnings.markdown
@@ -1,8 +1,9 @@
 ---
 title: Deutscher Wetterdienst (DWD) Weather Warnings
-description: Instructions on how to integrate Deutsche Wetter Dienst weather warnings into Home Assistant.
+description: Instructions on how to integrate Deutscher Wetterdienst weather warnings into Home Assistant.
 ha_category:
   - Weather
+ha_config_flow: true
 ha_release: 0.51
 ha_iot_class: Cloud Polling
 ha_domain: dwd_weather_warnings
@@ -10,76 +11,43 @@ ha_codeowners:
   - '@runningman84'
   - '@stephan192'
   - '@Hummel95'
+  - '@andarotajo'
 ha_platforms:
   - sensor
 ha_integration_type: integration
 ---
 
-The `dwd_weather_warnings` sensor platform uses the [Deutsche Wetter Dienst (DWD)](https://www.dwd.de) as a source for current and advance warnings.
+The `dwd_weather_warnings` integration uses the [Deutscher Wetterdienst (DWD)](https://www.dwd.de) as a source for current and advance weather warnings. The configured sensor checks for data every 15 minutes.
 
-- A name is optional but if multiple regions are used a name will be required.
-- The sensor checks for new data every 15 minutes.
+{% include integrations/config_flow.md %}
 
-## Configuration
-
-To add the DWD WarnApp sensor to your installation, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: dwd_weather_warnings
-    region_name: Hansestadt Hamburg
-```
-
-<div class="note">
-
-- The `region_name` can either be a so called `warncell id` (integer) or a `warncell name` (string). It is heavily advised to use `warncell id` because `warncell name` is not unique in some cases.  
-A list of valid warncell ids and names can be found at [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.html).
-- Some of the warncells are outdated but still listed. If setup fails search the list for a similar sounding warncell.
-- If you selected a `warncell name` and the name is not unique `" (not unique used ID)!"` will be added to the reported `region_name`.
-
-</div>
-
-{% configuration %}
-region_name:
-  required: true
-  description: The region name = warncell name (string) or region id = warncell id (integer) taken from DWD homepage.
-  type: [string, integer]
-name:
-  required: false
-  description: The name you would like to give to the warnapp sensor.
-  type: string
-  default: DWD-Weather-Warnings
-monitored_conditions:
-  description: List of warnings you want to be informed about.
-  required: false
-  default: all
-  type: list
-  keys:
-    current_warning_level:
-      description: The current warning level.
-    advance_warning_level:
-      description: The expected warning level.
-{% endconfiguration %}
+{% configuration_basic %}
+Name of the sensor:
+  description: Name that will be part of the sensor's `entity_id`. This is a required field.
+Warncell ID or name:
+  description: Identifier of the region. It can either be a so called `warncell ID` (integer) or a `warncell name` (string). It is heavily advised to use `warncell ID` because `warncell name` is not unique in some cases. A list of valid warncell IDs and names can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.html). Some of the warncells are outdated but still listed. If the setup fails, search the list for a similar sounding warncell. In case the `warncell name` is not unique, `" (not unique used ID)!"` will be added to the reported `region_name`. Setting this field is required.
+Monitored conditions:
+  description: The conditions to observe. Can be either current warning level, advance warning level, or both. If not otherwise configured, it selects both conditions.
+{% endconfiguration_basic %}
 
 ### Attributes
 
 | Attribute    | Description                            |
 | ------------ | -------------------------------------- |
 | `last_update` | *(time)* Time and date (UTC) of last update from DWD. |
-| `region_name` | *(str)* Requested region name. This should be the same as the region name in the configuration if a name was given. |
-| `region_id` | *(int)* Region ID assigned by DWD. This should be the same as the region id in the configuration if an id was given. |
+| `region_name` | *(str)* Requested region name. This should be the same as the region name in the configuration, if a name was given. |
+| `region_id` | *(int)* Region ID assigned by DWD. This should be the same as the region id in the configuration, if an id was given. |
 | `warning_count` | *(int)* Number of issued warnings. There can be more than one warning issued at once. |
 | `warning_<x>` | *(list)* The warning as a whole object containing the following attributes as nested attributes. |
 | `warning_<x>_level` | *(int)* Issued warning level (0 - 4).<br/>0: Keine Warnungen <br/>1: Wetterwarnungen <br/>2: Warnungen vor markantem Wetter<br/>3: Unwetterwarnungen<br/>4: Warnungen vor extremem Unwetter |
-| `warning_<x>_type` | *(int)* Issued warning type. <br/>More information can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/warning_codes_pdf.pdf?__blob=publicationFile&v=5). |
-| `warning_<x>_name` | *(str)* Warning name correlates with the warning type and represents it as a short string. |
+| `warning_<x>_type` | *(int)* Issued warning type. More information can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/warning_codes_pdf.pdf?__blob=publicationFile&v=5). |
+| `warning_<x>_name` | *(str)* Warning name correlated with the warning type and represented as a short string. |
 | `warning_<x>_headline` | *(str)* Official headline of the weather warning. |
 | `warning_<x>_start` | *(time)* Starting time and date (UTC) of the issued warning. |
 | `warning_<x>_end` | *(time)* Ending time and date (UTC) of the issued warning. |
 | `warning_<x>_description` | *(str)* Details for the issued warning. |
 | `warning_<x>_instruction` | *(str)* The DWD sometimes provides helpful information about precautions to take for the issued warning. |
-| `warning_<x>_parameters` | *(list)* A list of additional warning parameters. <br/>More information can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/warning_codes_pdf.pdf?__blob=publicationFile&v=5). |
+| `warning_<x>_parameters` | *(list)* A list of additional warning parameters. More information can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/warning_codes_pdf.pdf?__blob=publicationFile&v=5). |
 | `warning_<x>_color` | *(str)* The DWD color of the warning encoded as `#rrggbb`. |
 
 <div class="note">

--- a/source/_integrations/dwd_weather_warnings.markdown
+++ b/source/_integrations/dwd_weather_warnings.markdown
@@ -17,13 +17,13 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `dwd_weather_warnings` integration uses the [Deutscher Wetterdienst (DWD)](https://www.dwd.de) as a source for current and advance weather warnings. The configured sensor checks for data every 15 minutes.
+The Deutscher Wetterdienst Weather Warnings integration uses the [Deutscher Wetterdienst (DWD)](https://www.dwd.de) as a source for current and advance weather warnings. The configured sensor checks for data every 15 minutes.
 
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}
 Warncell ID or name:
-  description: Identifier of the region. It can either be a so called `warncell ID` (integer) or a `warncell name` (string). It is heavily advised to use `warncell ID` because `warncell name` is not unique in some cases. A list of valid warncell IDs and names can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.html). Some of the warncells are outdated but still listed. If the setup fails, search the list for a similar sounding warncell. In case the `warncell name` is not unique, `" (not unique used ID)!"` will be added to the reported `region_name`. Setting this field is required.
+  description: Identifier of the region. It can be a warncell ID (integer) or a warncell name. It is heavily advised to use warncell ID because a warncell name is sometimes not unique. A list of valid warncell IDs and names can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.html). Some of the warncells are outdated but still listed. If the setup fails, search the list for a similar sounding warncell. If the warncell name is not unique, `" (not unique used ID)!"` will be added to the reported `region_name`. Setting this field is required.
 {% endconfiguration_basic %}
 
 ### Attributes


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Change dwd_weather_warnings documentation for the addition of config flow from the parent PR.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/91040
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
