### PR TITLE
Correct Amcrest integration Example

### DIFF
--- a/source/_integrations/amcrest.markdown
+++ b/source/_integrations/amcrest.markdown
@@ -289,7 +289,7 @@ elements:
     tap_action:
       action: call-service
       service: amcrest.ptz_control
-      data:
+      service_data:
         entity_id: camera.lakehouse
         movement: up
   - type: icon
@@ -301,7 +301,7 @@ elements:
     tap_action:
       action: call-service
       service: amcrest.ptz_control
-      data:
+      service_data:
         entity_id: camera.lakehouse
         movement: down
   - type: icon
@@ -313,7 +313,7 @@ elements:
     tap_action:
       action: call-service
       service: amcrest.ptz_control
-      data:
+      service_data:
         entity_id: camera.lakehouse
         movement: left
   - type: icon
@@ -325,7 +325,7 @@ elements:
     tap_action:
       action: call-service
       service: amcrest.ptz_control
-      data:
+      service_data:
         entity_id: camera.lakehouse
         movement: right
   - type: icon
@@ -337,7 +337,7 @@ elements:
     tap_action:
       action: call-service
       service: amcrest.ptz_control
-      data:
+      service_data:
         entity_id: camera.lakehouse
         movement: left_up
   - type: icon
@@ -349,7 +349,7 @@ elements:
     tap_action:
       action: call-service
       service: amcrest.ptz_control
-      data:
+      service_data:
         entity_id: camera.lakehouse
         movement: right_up
   - type: icon
@@ -361,7 +361,7 @@ elements:
     tap_action:
       action: call-service
       service: amcrest.ptz_control
-      data:
+      service_data:
         entity_id: camera.lakehouse
         movement: left_down
   - type: icon
@@ -373,7 +373,7 @@ elements:
     tap_action:
       action: call-service
       service: amcrest.ptz_control
-      data:
+      service_data:
         entity_id: camera.lakehouse
         movement: right_down
   - type: icon
@@ -385,7 +385,7 @@ elements:
     tap_action:
       action: call-service
       service: amcrest.ptz_control
-      data:
+      service_data:
         entity_id: camera.lakehouse
         movement: zoom_in
     hold_action:


### PR DESCRIPTION
Changed all 'data:' to 'service_data:' to make card example functional. Will not function without that change.

## Proposed change
<!-- 
Changed all 'data:' to 'service_data:' to make example functional in Amcrest integration page https://www.home-assistant.io/integrations/amcrest/. Example card will not function currently without that change. Throws out error "Failed to call service amcrest/ptz_control. required key not provided @ data['movement']" without change.
-->



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
No idea what I am doing never done this before but spent 2 hours figuring out the problem thought I should pass that along.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ X] This PR uses the correct branch, based on one of the following:
  X  made a change to the existing documentation and used the `current` branch.
- [X ] The documentation follows the Home Assistant documentation [standards].


