### PR TITLE
Add warning about SwitchBot BTLE security

### DIFF
--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -33,6 +33,10 @@ ha_integration_type: integration
 
 The SwitchBot integration allows you to control SwitchBot [devices](https://www.switch-bot.com/).
 
+<div class='note warning'>
+Many SwitchBot products supported by this integration do not require a pairing step and can be controlled by anyone within Bluetooth range. Use caution and research these products before installing them in places where security/privacy are a concern.
+</div>
+
 ## Prerequisites
 
 In order to use this integration, it is required to have working [Bluetooth](/integrations/bluetooth) set up on the device running Home Assistant. A [SwitchBot Hub](https://switch-bot.com/pages/switchbot-hub-mini) is not required for this integration.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds a warning paragraph informing users that SwitchBot devices cannot be locked down from unauthorized access outside of Home Assistant. This is important context for anyone evaluating using this integration / these products.

![image](https://user-images.githubusercontent.com/33672/230986350-d3a442e7-dc72-4cd0-a67e-2871af7966a5.png)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

Relevant community discussion: https://community.home-assistant.io/t/switchbot-curtain-via-bluetooth-no-security-and-read-only/446913

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
