### PR TITLE
Add documentation for to_json options

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -657,7 +657,7 @@ The `to_json` filter serializes an object to a JSON string. In some cases, it ma
 
 `to_json` also accepts boolean arguments for `pretty_print`, which will pretty print the JSON with a 2-space indent to make it more human-readable, and `sort_keys`, which will sort the keys of the JSON object, ensuring that the resulting string is consistent for the same input.
 
-If you need to generate JSON that will be used by a parser that lacks support for unicode characters, you can add  `ensure_ascii=True` to have `to_json` generate unicode escape sequences in strings.
+If you need to generate JSON that will be used by a parser that lacks support for Unicode characters, you can add  `ensure_ascii=True` to have `to_json` generate Unicode escape sequences in strings.
 
 The `from_json` filter operates similarly, but in the other direction, de-serializing a JSON string back into an object.
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -655,7 +655,9 @@ To fix it, enforce the ISO conversion via `isoformat()`:
 
 The `to_json` filter serializes an object to a JSON string. In some cases, it may be necessary to format a JSON string for use with a webhook, as a parameter for command-line utilities or any number of other applications. This can be complicated in a template, especially when dealing with escaping special characters. Using the `to_json` filter, this is handled automatically.
 
-`to_json` also accepts arguments for `pretty_print`, which will pretty print the JSON with a 2-space indent to make it more human-readable, and `sort_keys`, which will sort the keys of the JSON object, ensuring that the resulting string is consistent for the same input.
+`to_json` also accepts boolean arguments for `pretty_print`, which will pretty print the JSON with a 2-space indent to make it more human-readable, and `sort_keys`, which will sort the keys of the JSON object, ensuring that the resulting string is consistent for the same input.
+
+If you need to generate JSON that will be used by a parser that lacks support for unicode characters, you can add  `ensure_ascii=True` to have `to_json` generate unicode escape sequences in strings.
 
 The `from_json` filter operates similarly, but in the other direction, de-serializing a JSON string back into an object.
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -651,15 +651,18 @@ To fix it, enforce the ISO conversion via `isoformat()`:
 
 {% endraw %}
 
-### To/From JSON
+### As/From JSON
 
-The `to_json` filter serializes an object to a JSON string. In some cases, it may be necessary to format a JSON string for use with a webhook, as a parameter for command-line utilities or any number of other applications. This can be complicated in a template, especially when dealing with escaping special characters. Using the `to_json` filter, this is handled automatically.
+The `as_json` filter serializes an object to a JSON string. In some cases, it may be necessary to format a JSON string for use with a webhook, as a parameter for command-line utilities or any number of other applications. This can be complicated in a template, especially when dealing with escaping special characters. Using the `as_json` filter, this is handled automatically.
 
-Similarly to the Python equivalent, the filter accepts an `ensure_ascii` parameter, defaulting to `True`. If `ensure_ascii` is `True`, the output is guaranteed to have all incoming non-ASCII characters escaped. If `ensure_ascii` is false, these characters will be output as-is.
+`as_json` also accepts arguments for `pretty_print`, which will pretty print the JSON with a 2-space indent to make it more human-readable, and `sort_keys`, which will sort the keys of the JSON object, ensuring that the resulting string is consistent for the same input.
 
 The `from_json` filter operates similarly, but in the other direction, de-serializing a JSON string back into an object.
 
-### To/From JSON examples
+The `to_json` filter has been deprecated and will be removed in Home Assistant 2023.8.  `as_json` is more performant and more consistent with use across Home Assistant.
+
+
+### As/From JSON examples
 
 In this example, the special character '°' will be automatically escaped in order to produce valid JSON. The difference between the stringified object and the actual JSON is evident.
 
@@ -670,7 +673,7 @@ In this example, the special character '°' will be automatically escaped in ord
 ```text
 {% set temp = {'temperature': 25, 'unit': '°C'} %}
 stringified object: {{ temp }}
-object|to_json: {{ temp|to_json(ensure_ascii=False) }}
+object|as_json: {{ temp|as_json(sort_keys=True) }}
 ```
 
 {% endraw %}
@@ -681,7 +684,7 @@ object|to_json: {{ temp|to_json(ensure_ascii=False) }}
 
 ```text
 stringified object: {'temperature': 25, 'unit': '°C'}
-object|to_json: {"temperature": 25, "unit": "\u00b0C"}
+object|as_json: {"temperature": 25, "unit": "°C"}
 ```
 
 {% endraw %}
@@ -693,7 +696,7 @@ Conversely, `from_json` can be used to de-serialize a JSON string back into an o
 {% raw %}
 
 ```text
-{% set temp = '{"temperature": 25, "unit": "\u00b0C"}'|from_json %}
+{% set temp = '{"temperature": 25, "unit": "°C"}'|from_json %}
 The temperature is {{ temp.temperature }}{{ temp.unit }}
 ```
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -651,18 +651,16 @@ To fix it, enforce the ISO conversion via `isoformat()`:
 
 {% endraw %}
 
-### As/From JSON
+### To/From JSON
 
-The `as_json` filter serializes an object to a JSON string. In some cases, it may be necessary to format a JSON string for use with a webhook, as a parameter for command-line utilities or any number of other applications. This can be complicated in a template, especially when dealing with escaping special characters. Using the `as_json` filter, this is handled automatically.
+The `to_json` filter serializes an object to a JSON string. In some cases, it may be necessary to format a JSON string for use with a webhook, as a parameter for command-line utilities or any number of other applications. This can be complicated in a template, especially when dealing with escaping special characters. Using the `to_json` filter, this is handled automatically.
 
-`as_json` also accepts arguments for `pretty_print`, which will pretty print the JSON with a 2-space indent to make it more human-readable, and `sort_keys`, which will sort the keys of the JSON object, ensuring that the resulting string is consistent for the same input.
+`to_json` also accepts arguments for `pretty_print`, which will pretty print the JSON with a 2-space indent to make it more human-readable, and `sort_keys`, which will sort the keys of the JSON object, ensuring that the resulting string is consistent for the same input.
 
 The `from_json` filter operates similarly, but in the other direction, de-serializing a JSON string back into an object.
 
 
-### As/From JSON examples
-
-In this example, the special character '°' will be automatically escaped in order to produce valid JSON. The difference between the stringified object and the actual JSON is evident.
+### To/From JSON examples
 
 #### Template
 
@@ -671,7 +669,7 @@ In this example, the special character '°' will be automatically escaped in ord
 ```text
 {% set temp = {'temperature': 25, 'unit': '°C'} %}
 stringified object: {{ temp }}
-object|as_json: {{ temp|as_json(sort_keys=True) }}
+object|to_json: {{ temp|to_json(sort_keys=True) }}
 ```
 
 {% endraw %}
@@ -682,7 +680,7 @@ object|as_json: {{ temp|as_json(sort_keys=True) }}
 
 ```text
 stringified object: {'temperature': 25, 'unit': '°C'}
-object|as_json: {"temperature": 25, "unit": "°C"}
+object|to_json: {"temperature": 25, "unit": "°C"}
 ```
 
 {% endraw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -659,8 +659,6 @@ The `as_json` filter serializes an object to a JSON string. In some cases, it ma
 
 The `from_json` filter operates similarly, but in the other direction, de-serializing a JSON string back into an object.
 
-The `to_json` filter has been deprecated and will be removed in Home Assistant 2023.8.  `as_json` is more performant and more consistent with use across Home Assistant.
-
 
 ### As/From JSON examples
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for pretty printing and key sorting for `to_json`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/91253
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
