### PR TITLE
Clarifying allowed values in entity customization

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -18,9 +18,13 @@ If your entity is not supported, or you cannot customize what you need via this 
 
 ## Customizing entities
 
-By default, all of your devices will be visible and have a default icon determined by their domain. You can customize the look and feel of your front page by altering some of these parameters. This can be done by overriding attributes of specific entities.
+Devices can also be configured using configuration yaml files. By default, all of your devices will be visible and have a default icon determined by their domain. You can customize the look and feel of your front page by overriding attributes of specific entities.
+
+You can also use `customize` to associate arbitrary additional data with an entity. This can be referenced later in automations, scripts, etc.
 
 #### Possible values
+
+Below are some suggested values and an explanation of how they will be interpreted by the UI.
 
 {% configuration customize %}
 friendly_name:
@@ -100,6 +104,8 @@ homeassistant:
     media_player.my_media_player:
       source_list:
         - Channel/input from my available sources
+      # Arbitrary keys and values are supported here
+      additional_metadata: 42
   # Customize all entities in a domain
   customize_domain:
     light:
@@ -126,4 +132,8 @@ Alternatively, you can reload via service call. Navigate to Developer Tools > Se
 
 <div class='note warning'>
 New customize information will be applied the next time the state of the entity gets updated.
+</div>
+
+<div class='note warning'>
+If adding the `homeassistant:` section to the configuration file for the first time, a restart will be required. After which, reloading while running will function as described above.
 </div>


### PR DESCRIPTION
## Proposed change
Adding a few sentences to clarify that it's possible to add arbitrary attributes using customize

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
In discussion with @frenck in https://github.com/home-assistant/core/pull/87666, I realized adding arbitrary attributes via customize could have solved my problem, but the documentation didn't make that clear.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
