### PR TITLE
Add Markdown example

### DIFF
--- a/source/_integrations/habitica.markdown
+++ b/source/_integrations/habitica.markdown
@@ -145,3 +145,12 @@ Also an event `habitica_api_call_success` will be fired with the following data:
     "id": "NEW_TASK_UUID"}
 }
 ```
+
+This Markdown will list the tasks saved in the `sensor.habitica_USER_todos.attributes.items` in a card.
+
+```markdown
+{% for key, value in states.sensor.habitica_USER_todos.attributes.items() %}{%
+  if 'text' in value | string %}{{ value.text }}{%
+  endif %}
+{% endfor %}
+```


### PR DESCRIPTION


## Proposed change
Add a Markdown example to display To Do tasks on the Dashboard. It took me a bit of searching to figure out how to do it, so I thought I'd share it here.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
