### PR TITLE
Fixer.io changed the free request rate

### DIFF
--- a/source/_integrations/fixer.markdown
+++ b/source/_integrations/fixer.markdown
@@ -17,7 +17,7 @@ To get an overview about the available [currencies](https://fixer.io/symbols).
 
 ## Setup
 
-You need to create an [API key](https://fixer.io/product). The free account is limited to only EUR as a base currency, allows 250 requests per month, and updates every hour.
+You need to create an [API key](https://fixer.io/product). The free account is limited to only EUR as a base currency, allows 100 requests per month, and updates every hour.
 
 ## Configuration
 


### PR DESCRIPTION
## Proposed change
Changed from 250 requests per month to 100.

## Type of change
Documentation change.

## Additional information
See here: https://apilayer.com/marketplace/fixer-api#pricing

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
