### PR TITLE
Binary sensors added to the kodi platform

### DIFF
--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -5,6 +5,7 @@ ha_category:
   - Media Player
   - Media Source
   - Notifications
+  - Binary Sensor
 ha_release: pre 0.7
 ha_iot_class: Local Push
 ha_codeowners:
@@ -16,6 +17,7 @@ ha_zeroconf: true
 ha_platforms:
   - media_player
   - notify
+  - binary_sensor
 ha_integration_type: integration
 ---
 
@@ -27,6 +29,7 @@ There is currently support for the following device types within Home Assistant:
 
 - [Media Player](#configuration)
 - [Notifications](#notifications)
+- [Binary Sensor](#binary-sensors)
 
 {% include integrations/config_flow.md %}
 
@@ -390,3 +393,9 @@ data:
 {% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
+
+## Binary Sensors
+
+Binary sensors are added to show the state of the following internal `kodi` information:
+- Screensaver
+- Energy saving/DPMS


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding information for the introduction of binary sensors to the kodi platform.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/91000
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
