### PR TITLE
Z-Wave controllers on Yellow: Add additional modules to list

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -121,7 +121,13 @@ You should also check the README for details on the overlays. You might find it 
 
 </div>
 
-#### Aeotec Z-Pi 7 Raspberry Pi HAT/Shield on Home Assistant Yellow
+#### Setting up a Raspberry Pi Z-Wave module on Home Assistant Yellow
+
+This procedure has been tested with the following modules:
+
+  * Aeotec Z-Pi 7 Raspberry Pi HAT/Shield
+  * Z-Wave.Me RaZberry 7
+  * Z-Wave.Me RaZberry 7 Pro
 
 1. Make sure the Aeotec Z-Pi 7 is properly seated on the Home Assistant Yellow. 
    ![Aeotex Z-Pi 7 on Home Assistant Yellow](/images/docs/z-wave/zpi-7-yellow.jpg).

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -129,8 +129,8 @@ This procedure has been tested with the following modules:
   * Z-Wave.Me RaZberry 7
   * Z-Wave.Me RaZberry 7 Pro
 
-1. Make sure the Aeotec Z-Pi 7 is properly seated on the Home Assistant Yellow. 
-   ![Aeotex Z-Pi 7 on Home Assistant Yellow](/images/docs/z-wave/zpi-7-yellow.jpg).
+1. Make sure the module is properly seated on the Home Assistant Yellow. 
+   ![Aeotec Z-Pi 7 on Home Assistant Yellow](/images/docs/z-wave/zpi-7-yellow.jpg).
 1. Carefully [close the case](https://yellow.home-assistant.io/guides/add-ssd-existing-installation/#reassembling-top-part) and power up Home Assistant Yellow.
 1. Follow the procedure on [setting up a Z-Wave JS server](/integrations/zwave_js/#setting-up-a-z-wave-js-server).
    1. In step 2, follow the manual setup steps to install the Z-Wave integration.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Procedure on how to setup a -Z-Wave module on Yellow:
- Tested setup with additional modules
- added modules to procedure


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
