### PR TITLE
fine tune instruction on allowed types

### DIFF
--- a/source/_dashboards/picture-elements.markdown
+++ b/source/_dashboards/picture-elements.markdown
@@ -370,7 +370,7 @@ conditions:
       type: string
 elements:
   required: true
-  description: One or more elements of any type to show when conditions are met. See below for an example.
+  description: One or more elements of any of the [listed types](#elements)to show when conditions are met. See below for an example.
   type: list
 {% endconfiguration %}
 

--- a/source/_dashboards/picture-elements.markdown
+++ b/source/_dashboards/picture-elements.markdown
@@ -370,7 +370,7 @@ conditions:
       type: string
 elements:
   required: true
-  description: One or more elements of any of the [listed types](#elements)to show when conditions are met. See below for an example.
+  description: One or more elements of any of the [listed types](#elements) to show when conditions are met. See below for an example.
   type: list
 {% endconfiguration %}
 


### PR DESCRIPTION
in conditional element.

users might otherwise use things like:

```
  - type: conditional
    conditions:
      - entity: sensor.presence_daughter
        state: "home"
    elements:
      - type: divider # this is a non listed type, but does meet the current description of 'of any type'
        style:
          top: 85%
```

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
