### PR TITLE
Documentation page: add links to Yellow and SkyConnect docs

### DIFF
--- a/source/_includes/asides/docs_navigation.html
+++ b/source/_includes/asides/docs_navigation.html
@@ -177,6 +177,16 @@
           <li>{% active_link /integrations/mqtt/#logging Logging %}</li>
         </ul>
       </li>
+      <li>
+        <b>Hardware</b>
+        <ul>          
+          <li>
+            <a href="https://yellow.home-assistant.io/">Home Assistant Yellow</a>
+          </li>
+          <li>
+            <a href="https://skyconnect.home-assistant.io/">Home Assistant SkyConnect</a>
+        </ul>
+      </li>
     </ul>
   </div>
 </section>

--- a/source/_includes/site/header.html
+++ b/source/_includes/site/header.html
@@ -40,6 +40,15 @@
               </li>
               <li>
                 <a href="/dashboards/">Dashboards</a>
+              </li>              
+              <li>
+                <a href="/docs/assist">Assist</a>
+              </li>
+              <li>
+                <a href="https://yellow.home-assistant.io/">Home Assistant Yellow</a>
+              </li>
+              <li>
+                <a href="https://skyconnect.home-assistant.io/">Home Assistant SkyConnect</a>
               </li>
             </ul>
           </li>

--- a/source/_includes/site/header.html
+++ b/source/_includes/site/header.html
@@ -40,15 +40,6 @@
               </li>
               <li>
                 <a href="/dashboards/">Dashboards</a>
-              </li>              
-              <li>
-                <a href="/docs/assist">Assist</a>
-              </li>
-              <li>
-                <a href="https://yellow.home-assistant.io/">Home Assistant Yellow</a>
-              </li>
-              <li>
-                <a href="https://skyconnect.home-assistant.io/">Home Assistant SkyConnect</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
- attempt to make it easier to find Yellow and SkyConnect documentation
- add links to Documentation menu in navigation bar
- add links in aside

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
