### PR TITLE
Flashing ODROID: add info that Allen key is needed

### DIFF
--- a/source/_includes/common-tasks/flashing_n2_otg.md
+++ b/source/_includes/common-tasks/flashing_n2_otg.md
@@ -67,13 +67,13 @@ This will configure the ODROID-N2+ and OTG to act as a memory card reader:
 
 1. When the flash process is complete, disconnect the ODROID-N2+ from your PC.
    * Remove the power cable.
-   * Remove the USB and HDMI cable.
+   * Remove the USB and HDMI cables.
    * Make sure to toggle the boot mode switch back to MMC.
 
 1. Put the ODROID back in its case.
 1. Connect your ODROID-N2+ to your network with an Ethernet cable and plug in power.
 
-1. If your router supports mDNS, you will be able to reach your installation on `http://homeassistant.local:8123`. 
+1. If your router supports mDNS, you can reach your installation at `http://homeassistant.local:8123`. 
    * If your network doesn’t support mDNS, you’ll have to use the IP address of your ODROID-N2+ instead of `homeassistant.local`. For example, `http://192.168.0.9:8123`. 
    * You should be able to find the IP address of your ODROID-N2+ from the admin interface of your router.
 1. Continue with [onboarding](/getting-started/onboarding/).

--- a/source/_includes/common-tasks/flashing_n2_otg.md
+++ b/source/_includes/common-tasks/flashing_n2_otg.md
@@ -11,6 +11,7 @@ To flash your eMMC using Petitboot and OTG-USB, you will need the following item
 - HDMI cable and monitor
 - USB keyboard
 - USB 2.0 to micro-USB cable
+- If your board came in a Home Assistant Blue: No.2 hex key to open the case
 
 #### Enabling SPI boot mode
 
@@ -45,13 +46,13 @@ You can safely ignore this message and proceed with the installation
 
 </div>
 
-2. Use the following command at the console to confirm the storage device node:
+1. Use the following command at the console to confirm the storage device node:
 
    ```bash
    ls /dev/mmc*
    ```
 
-3. Set the storage device on the ODROID-N2+ as a mass storage device using the `ums` command (USB Mass storage mode).
+1. Set the storage device on the ODROID-N2+ as a mass storage device using the `ums` command (USB Mass storage mode).
 This will configure the ODROID-N2+ and OTG to act as a memory card reader:
 
    ```bash
@@ -60,10 +61,19 @@ This will configure the ODROID-N2+ and OTG to act as a memory card reader:
 
 #### Flashing Home Assistant
 
-Connect the ODROID-N2+ to your PC via the micro-USB port at the front of the ODROID-N2+. When the ODROID-N2 is recognized as a USB connected storage device, you can flash the eMMC with [Etcher](https://www.balena.io/etcher/) using the latest stable version of Home Assistant OS for the [ODROID-N2+](https://github.com/home-assistant/operating-system/releases/download/{{site.data.version_data.hassos['odroid-n2']}}/haos_odroid-n2-{{site.data.version_data.hassos['odroid-n2']}}.img.xz) (haos_odroid-n2-{{site.data.version_data.hassos['odroid-n2']}}.img.xz).
+1. Connect the ODROID-N2+ to your PC via the micro-USB port at the front of the ODROID-N2+. 
+1. When the ODROID-N2 is recognized as a USB connected storage device, you can flash the eMMC with [Etcher](https://www.balena.io/etcher/).
+   * Use the latest stable version of Home Assistant OS for the [ODROID-N2+](https://github.com/home-assistant/operating-system/releases/download/{{site.data.version_data.hassos['odroid-n2']}}/haos_odroid-n2-{{site.data.version_data.hassos['odroid-n2']}}.img.xz) (haos_odroid-n2-{{site.data.version_data.hassos['odroid-n2']}}.img.xz).
 
-When the flash process is complete, disconnect the ODROID-N2+ from your PC and remove the power cable. Remove the USB and HDMI cable, and make sure to toggle the boot mode switch back to MMC.
+1. When the flash process is complete, disconnect the ODROID-N2+ from your PC.
+   * Remove the power cable.
+   * Remove the USB and HDMI cable.
+   * Make sure to toggle the boot mode switch back to MMC.
 
-Once it is back in its case, connect your ODROID-N2+ to your network with an Ethernet cable and plug in power.
+1. Put the ODROID back in its case.
+1. Connect your ODROID-N2+ to your network with an Ethernet cable and plug in power.
 
-If your router supports mDNS, you will be able to reach your installation on `http://homeassistant.local:8123`.  If your network doesn’t support mDNS, you’ll have to use the IP address of your ODROID-N2+ instead of `homeassistant.local`. For example, `http://192.168.0.9:8123`. You should be able to find the IP address of your ODROID-N2+ from the admin interface of your router.
+1. If your router supports mDNS, you will be able to reach your installation on `http://homeassistant.local:8123`. 
+   * If your network doesn’t support mDNS, you’ll have to use the IP address of your ODROID-N2+ instead of `homeassistant.local`. For example, `http://192.168.0.9:8123`. 
+   * You should be able to find the IP address of your ODROID-N2+ from the admin interface of your router.
+1. Continue with [onboarding](/getting-started/onboarding/).


### PR DESCRIPTION
- as not everyone has one of these at home
- minor editing: turn running text into numbered steps.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
