### PR TITLE
Add conditional notification services in notify groups

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -267,7 +267,7 @@ state_class:
 
 This group is a special case of groups currently only available via YAML configuration.
 
-Notify groups are used to combine multiple notification services into a single service. This allows you to send notification to multiple devices with a single call.
+Notify groups are used to combine multiple notification services into a single service. This allows you to send notification to multiple devices with a single call. You can optionally attach conditions to each receiving service, so that it can be omitted based on context.
 
 ```yaml
 # Example configuration.yaml entry
@@ -279,6 +279,10 @@ notify:
         data:
           target: "macbook"
       - service: html5_nexus
+        condition:
+          - condition: state
+            entity: sun.sun
+            state: above_horizon
 ```
 
 {% configuration %}
@@ -295,6 +299,10 @@ services:
       description: The service part of an entity ID, e.g.,  if you use `notify.html5` normally, just put `html5`. Note that you must put everything in lower case here. Although you might have capitals written in the actual notification services!
       required: true
       type: string
+    condition:
+      description: A list of conditions to evaluate before sending the notification to that particular service. Use the same syntax as for [conditions in automations or services](/docs/scripts/conditions/).
+      required: false
+      type: list
     data:
       description: A dictionary containing parameters to add to all notify payloads. This can be anything that is valid to use in a payload, such as `data`, `message`, `target` or `title`. Parameters specified by the action will override the values configured here.
       required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add a `condition` to the `notify.group` platform, which uses the same syntax for conditions in scripts and automations, that will be evaluated on service call in order to determine if a notification should be forwarded to each `notify` service in a `group`.

Example use-case: use Google Home TTS only when I'm at home, otherwise, only notify my phone.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/91939
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
