### PR TITLE
Change the network "host" mode in docker and docker compose to specifying port 8123.

### DIFF
--- a/source/_includes/installation/container/cli.md
+++ b/source/_includes/installation/container/cli.md
@@ -10,7 +10,7 @@
       --restart=unless-stopped \
       -e TZ=MY_TIME_ZONE \
       -v /PATH_TO_YOUR_CONFIG:/config \
-      --network=host \
+      -p 8123:8123 \
       {{ site.installation.container }}:{{ include.tag | default: 'stable' }}
     ```
 

--- a/source/_includes/installation/container/compose.md
+++ b/source/_includes/installation/container/compose.md
@@ -9,5 +9,6 @@
         - /etc/localtime:/etc/localtime:ro
       restart: unless-stopped
       privileged: true
-      network_mode: host
+      ports:
+        - "8123:8123"
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Changes the network "host" mode in docker and docker compose to specifying port 8123. The network host mode only works on linux, not Windows and MacOS and I have found that port 8123 is not usually used by network mode host, meaning that when users type http://<ip address>:8123/ into their browser, they will be met with an error stating that the website does not exist.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #26614

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
