### PR TITLE
Date Time Improvements

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -666,9 +666,15 @@ If for your use case this is undesired, you could consider using the automation 
 
 The time trigger is configured to fire once a day at a specific time, or at a specific time on a specific date. There are three allowed formats:
 
-### Time String
+### Date and Time String
 
-A string that represents a time to fire on each day. Can be specified as `HH:MM` or `HH:MM:SS`. If the seconds are not specified, `:00` will be used.
+A general date and time of the form `YYYY-MM-DD HH:MM:SS` The Date part is `YYYY-MM-DD` and the Time part is `HH:MM:SS` If the seconds are not specified, :00 will be used.
+
+Date Provide | Time Provided | Description
+-|-|-
+`true` | `true` | Will fire at specified date & time.
+`true` | `false` | Will fire at midnight on specified date.
+`false` | `true` | Will fire once a day at specified time.
 
 ```yaml
 automation:

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -349,11 +349,21 @@ The date selector shows a date input that allows the user to specify a date.
 
 ![Screenshot of the Date selector](/images/blueprints/selector-date.png)
 
-This selector does not have any other options; therefore, it only has its key.
+In its most basic form, this selector does not have any required options; therefore, it only has its key.
 
 ```yaml
 date:
 ```
+
+{% configuration date %}
+multiple:
+  description: >
+    Allows selecting multiple dates. If set to `true`, the resulting value of
+    this selector will be a list instead of a single string value.
+  type: boolean
+  default: false
+  required: false
+{% endconfiguration %}
 
 The output of this selector will contain the date in Year-Month-Day
 (`YYYY-MM-DD`) format, for example, `2022-02-22`.
@@ -365,11 +375,21 @@ date with a specific time.
 
 ![Screenshot of the Date & time selector](/images/blueprints/selector-datetime.png)
 
-This selector does not have any other options; therefore, it only has its key.
+In its most basic form, this selector does not have any required options; therefore, it only has its key.
 
 ```yaml
 datetime:
 ```
+
+{% configuration datetime %}
+multiple:
+  description: >
+    Allows selecting multiple datetime values. If set to `true`, the resulting value of
+    this selector will be a list instead of a single string value.
+  type: boolean
+  default: false
+  required: false
+{% endconfiguration %}
 
 The output of this selector will contain the date in Year-Month-Day
 (`YYYY-MM-DD`) format and the time in 24-hour format, for example:
@@ -1173,11 +1193,21 @@ of the day.
 
 ![Screenshot of a time selector](/images/blueprints/selector-time.png)
 
-This selector does not have any other options; therefore, it only has its key.
+In its most basic form, this selector does not have any required options; therefore, it only has its key.
 
 ```yaml
 time:
 ```
+
+{% configuration time %}
+multiple:
+  description: >
+    Allows selecting multiple times. If set to `true`, the resulting value of
+    this selector will be a list instead of a single string value.
+  type: boolean
+  default: false
+  required: false
+{% endconfiguration %}
 
 The output of this selector will contain the time in 24-hour format,
 for example, `23:59:59`.


### PR DESCRIPTION
## Proposed change

Allow the Date, DateTime, and Time selectors to optionally support multiple selections.
Update the Time platform trigger to accept a Date and DateTime string as well as the current Time string.
The semantics are the same as the input_datetime with date, time, or date and time options.
This allows blueprints to setup inputs for multiple date, time or datetime, triggers.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/92046
- Link to frontend pull request:  https://github.com/home-assistant/frontend/pull/16312

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
