### PR TITLE
Add number to bmw_connected_drive documentation

### DIFF
--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -7,6 +7,7 @@ ha_category:
   - Car
   - Lock
   - Notifications
+  - Number
   - Presence Detection
   - Select
   - Sensor
@@ -24,6 +25,7 @@ ha_platforms:
   - diagnostics
   - lock
   - notify
+  - number
   - select
   - sensor
 ha_integration_type: integration
@@ -48,6 +50,7 @@ This integration provides the following platforms:
 - [Notifications](/integrations/bmw_connected_drive/#notifications): Send Points of Interest (POI) to your car.
 - [Buttons](/integrations/bmw_connected_drive/#buttons): Turn on air condition, sound the horn, flash the lights, update the vehicle location and update the state.
 - [Selects](/integrations/bmw_connected_drive/#selects): Display and control charging related settings for (PH)EVs.
+- [Numbers](/integrations/bmw_connected_drive/#numbers): Display and control numeric charging related settings for (PH)EVs.
 
 ## Configuration
 
@@ -146,6 +149,14 @@ Using these selects will impact the state of your vehicle. Use them with care!
 - **Charging Mode**: Vehicle can be set to `IMMEDIATE_CHARGING` (charge as soon as plugged in) or `DELAYED_CHARGING` (charge only if within charging window). It can be used to start/stop charging if the charging window is set accordingly.
 - **Target SoC**: The vehicle will charge until this battery level is reached. Not available on all EVs.
 - **AC Charging Limit**: The maximum current a vehicle will charge with. Not available on all EVs.
+
+## Numbers
+
+If you have a (PH)EV, you can control the charging process through Home Assistant. The number entities are created automatically depending on your vehicle's capabilities and can be changed from the UI or using the `number.set_value` service. Please see the [number documentation](/integrations/number/) for more information.
+
+Using these selects will impact the state of your vehicle, use them with care!
+
+- **Target SoC**: Vehicle will charge until this battery level is reached. Not available on all EVs.
 
 ## Disclaimer
 

--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -151,7 +151,7 @@ Using these selects will impact the state of your vehicle. Use them with care!
 
 ## Numbers
 
-If you have a (PH)EV, you can control the charging process through Home Assistant. The number entities are created automatically depending on your vehicle's capabilities and can be changed from the UI or using the `number.set_value` service. Please see the [number documentation](/integrations/number/) for more information.
+If you have a (PH)EV, you can control the charging process through Home Assistant. The number entities are created automatically depending on your vehicle's capabilities and can be changed from the UI or using the `number.set_value` service. For more information, please see the [number documentation](/integrations/number/).
 
 Using these selects will impact the state of your vehicle, use them with care!
 

--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -147,7 +147,6 @@ If you have a (PH)EV, you can control the charging process through Home Assistan
 Using these selects will impact the state of your vehicle. Use them with care!
 
 - **Charging Mode**: Vehicle can be set to `IMMEDIATE_CHARGING` (charge as soon as plugged in) or `DELAYED_CHARGING` (charge only if within charging window). It can be used to start/stop charging if the charging window is set accordingly.
-- **Target SoC**: The vehicle will charge until this battery level is reached. Not available on all EVs.
 - **AC Charging Limit**: The maximum current a vehicle will charge with. Not available on all EVs.
 
 ## Numbers


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documention on the new `number` entities for EV charging in BMW Connected Drive.

~~Needs an additional commit once #26365 is merged (delete one line from there).~~

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/91081
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
