### PR TITLE
Assist docs: add glossary tooltip for term intent

### DIFF
--- a/source/_integrations/conversation.markdown
+++ b/source/_integrations/conversation.markdown
@@ -33,7 +33,7 @@ In English, you can say things like "turn on kitchen lights" or "turn off lights
 
 ## Adding custom sentences
 
-You can add your own [sentence templates](https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax) to teach Home Assistant about new sentences. These sentences can work with the [built-in intents](https://developers.home-assistant.io/docs/intent_builtin/) or trigger a custom action by defining custom intents with the [intent script integration](/integrations/intent_script/).
+You can add your own [sentence templates](https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax) to teach Home Assistant about new sentences. These sentences can work with the [built-in intents](https://developers.home-assistant.io/docs/intent_builtin/) or trigger a custom action by defining custom {% term intents %} with the [intent script integration](/integrations/intent_script/).
 
 To get started, create a `custom_sentences/<language>` directory in your Home Assistant `config` directory where `<language>` is the [language code](https://developers.home-assistant.io/docs/voice/intent-recognition/supported-languages) of your language, such as `en` for English. These YAML files are automatically merged, and may contain intents, lists, or expansion rules.
 
@@ -53,7 +53,7 @@ intents:
 
 {% endraw %}
 
-To teach Home Assistant how to handle the custom `CustomOutsideHumidity` intent, create an `intent_script` entry in your `configuration.yaml` file:
+To teach Home Assistant how to handle the custom `CustomOutsideHumidity` {% term intent %}, create an `intent_script` entry in your `configuration.yaml` file:
 
 {% raw %}
 
@@ -72,7 +72,7 @@ More complex [actions](/docs/scripts/) can be done in `intent_script`, such as c
 
 ## Extending built-in intents
 
-Extending the built-in intents, such as `HassTurnOn` and `HassTurnOff`, can be done as well.
+Extending the built-in {% term intents %}, such as `HassTurnOn` and `HassTurnOff`, can be done as well.
 
 For example, create the file `config/custom_sentences/en/on_off.yaml` and add:
 

--- a/source/docs/assist/builtin_sentences.markdown
+++ b/source/docs/assist/builtin_sentences.markdown
@@ -36,7 +36,7 @@ To get an idea of the specific sentences that are supported for your language, y
 1. Take a look at the test sentences:
     * On github, in the [tests](https://github.com/home-assistant/intents/tree/main/sentences) folder, open the subfolder for your language.
     * Look through the test files to see the example sentences that have been tested.
-    * The second part of the file name shows the intent, the first part shows the domain. For some domains, such as covers, fans, and light, there are specific sentences.
+    * The second part of the file name shows the {% term intent %}, the first part shows the domain. For some domains, such as covers, fans, and light, there are specific sentences.
         The other domains are covered by the generic *homeassistant_*.
 
         ![Example of a folder of assistant sentence test files](/images/assist/intents-test-files.png)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Assist docs: 
- add glossary tooltip for term _intent_

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
