### PR TITLE
Remove p text-shadow

### DIFF
--- a/sass/oscailte/homepage/_hero_unit.scss
+++ b/sass/oscailte/homepage/_hero_unit.scss
@@ -57,7 +57,6 @@
   h1 {
     font-size: 3.5em;
     line-height: 1em;
-    text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.75);
   }
 
   hr {

--- a/sass/oscailte/homepage/_hero_unit.scss
+++ b/sass/oscailte/homepage/_hero_unit.scss
@@ -66,7 +66,6 @@
   }
 
   p {
-    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.75);
     small {
       color: $grayLighter;
       font-size: .65em;


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The header and paragraph in the hero section of the homepage use text-shadow and the ones in https://developers.home-assistant.io/ don't. It also looks better without in my opinion.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Before:
![image](https://user-images.githubusercontent.com/94064167/236132703-c4783adc-3df6-401e-975a-0edd2a3da747.png)

After:
![image](https://user-images.githubusercontent.com/94064167/236132868-78f435f2-943a-4406-8ff8-21acaf2a5c59.png)

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
