### PR TITLE
Add docs for Netgear LTE config flow

### DIFF
--- a/source/_integrations/netgear_lte.markdown
+++ b/source/_integrations/netgear_lte.markdown
@@ -39,7 +39,7 @@ Splitting of long SMS messages is not supported so notifications can contain a m
 
 ## Notification Service
 
-The integration will create a `notify` service matching the name of the config entry. This is the model name if the device by default.
+The integration will create a `notify` service matching the name of the integration entry. This is the model name of the device by default.
 
 ## Events
 

--- a/source/_integrations/netgear_lte.markdown
+++ b/source/_integrations/netgear_lte.markdown
@@ -8,11 +8,14 @@ ha_category:
   - Notifications
   - Sensor
 ha_iot_class: Local Polling
+ha_config_flow: true
 ha_domain: netgear_lte
 ha_platforms:
   - binary_sensor
   - notify
   - sensor
+ha_codeowners:
+  - '@tkdrob'
 ha_integration_type: integration
 ---
 
@@ -32,106 +35,11 @@ Splitting of long SMS messages is not supported so notifications can contain a m
 
 </div>
 
-## Configuration
+{% include integrations/config_flow.md %}
 
-To enable the integration, add the following lines to your `configuration.yaml` file:
+## Notification Service
 
-```yaml
-# Example configuration.yaml entry
-netgear_lte:
-  - host: IP_ADDRESS
-    password: SECRET
-    notify:
-      - name: sms
-        recipient: "+15105550123"
-    sensor:
-      monitored_conditions:
-        - usage
-        - sms
-    binary_sensor:
-      monitored_conditions:
-        - wire_connected
-        - mobile_connected
-```
-
-{% configuration %}
-host:
-  description: The IP address of the modem web interface.
-  required: true
-  type: string
-password:
-  description: The password used for the modem web interface.
-  required: true
-  type: string
-notify:
-  description: A list of notification services connected to this specific host.
-  required: false
-  type: list
-  keys:
-    recipient:
-      description: The phone number of a default recipient or a list with multiple recipients.
-      required: false
-      type: [string, list]
-    name:
-      description: The name of the notification service.
-      required: false
-      default: "`netgear_lte`"
-      type: string
-sensor:
-  description: Configuration options for sensors.
-  required: false
-  type: map
-  keys:
-    monitored_conditions:
-      description: Sensor types to create.
-      required: false
-      default: usage
-      type: list
-      keys:
-        cell_id:
-          description: The Cell ID, a number identifying the base station.
-        connection_text:
-          description: A connection text, e.g., "4G".
-        connection_type:
-          description: The connection type, e.g., "IPv4Only".
-        current_band:
-          description: The radio band used, e.g., "LTE B3".
-        current_ps_service_type:
-          description: The service type, e.g.,  "LTE".
-        radio_quality:
-          description: A number with the radio quality in percent, e.g., "55"
-        register_network_display:
-          description: The name of the service provider.
-        rx_level:
-          description: The RSRP value, a measurement of the received power level, e.g., "-95".
-        sms:
-          description: Number of unread SMS messages in the modem inbox.
-        sms_total:
-          description: Number of SMS messages in the modem inbox.
-        tx_level:
-          description: Transmit power, e.g., "23".
-        upstream:
-          description: Current upstream connection, "WAN" or "LTE".
-        usage:
-          description: Amount of data transferred.
-binary_sensor:
-  description: Configuration options for binary sensors.
-  required: false
-  type: map
-  keys:
-    monitored_conditions:
-      description: Binary sensor types to create.
-      required: false
-      default: mobile_connected
-      type: list
-      keys:
-        mobile_connected:
-          description: The LTE connection state.
-        wire_connected:
-          description: The wired uplink connection state.
-        roaming:
-          description: The current roaming state.
-{% endconfiguration %}
+The integration will create a `notify` service matching the name of the config entry. This is the model name if the device by default.
 
 ## Events
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add docs for Netgear LTE config flow

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/93002
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
