### PR TITLE
Update ecowitt.markdown

### DIFF
--- a/source/_integrations/ecowitt.markdown
+++ b/source/_integrations/ecowitt.markdown
@@ -27,7 +27,7 @@ The following steps must be performed to set up this integration. For security r
 2. Pick your station -> Menu Others -> DIY Upload Servers.
 3. Hit next and select 'Customized'
 4. Pick the protocol Ecowitt, and put in the ip/hostname of your Home Assistant server.
-5. Path have to match!
+5. Path have to match! If using the Ecowitt App, remove the first forward slash from the API token ad the app will prepend one itself.
 6. Save configuration.
 
 Ecowitt doesn't support TLS/SSL, you can use the NGINX TLS Proxy Add-on to support HTTPS and HTTP at the same time.

--- a/source/_integrations/ecowitt.markdown
+++ b/source/_integrations/ecowitt.markdown
@@ -27,7 +27,7 @@ The following steps must be performed to set up this integration. For security r
 2. Pick your station -> Menu Others -> DIY Upload Servers.
 3. Hit next and select 'Customized'
 4. Pick the protocol Ecowitt, and put in the ip/hostname of your Home Assistant server.
-5. Path have to match! If using the Ecowitt App, remove the first forward slash from the API token ad the app will prepend one itself.
+5. Path has to match! If using the Ecowitt App, remove the first forward slash from the API token, as the app will prepend one.
 6. Save configuration.
 
 Ecowitt doesn't support TLS/SSL, you can use the NGINX TLS Proxy Add-on to support HTTPS and HTTP at the same time.


### PR DESCRIPTION
It seems that the Ecowitt App prepends a forward slash to the Path field, resulting in
```
//api/webhook/25dce489a3b813257b22fed49c17xxxx
```
which does not work.  Once I removed the extra forward slash, my device and entities then appeared.

I realize this is not a problem with the integration, but the Ecowitt app instead, but it is unclear that you need to remove the first slash from the api token you are given.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
