### PR TITLE
Add switch documentation to bmw_connected_drive

### DIFF
--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -7,7 +7,6 @@ ha_category:
   - Car
   - Lock
   - Notifications
-  - Number
   - Presence Detection
   - Select
   - Sensor
@@ -26,10 +25,9 @@ ha_platforms:
   - diagnostics
   - lock
   - notify
-  - number
   - select
   - sensor
-  - -switch
+  - switch
 ha_integration_type: integration
 ---
 
@@ -52,7 +50,6 @@ This integration provides the following platforms:
 - [Notifications](/integrations/bmw_connected_drive/#notifications): Send Points of Interest (POI) to your car.
 - [Buttons](/integrations/bmw_connected_drive/#buttons): Turn on air condition, sound the horn, flash the lights, update the vehicle location and update the state.
 - [Selects](/integrations/bmw_connected_drive/#selects): Display and control charging related settings for (PH)EVs.
-- [Numbers](/integrations/bmw_connected_drive/#numbers): Display and control numeric charging related settings for (PH)EVs.
 - [Switches](/integrations/bmw_connected_drive/#switches): Display and toggle settings on your car.
 
 ## Configuration
@@ -152,15 +149,7 @@ Using these selects will impact the state of your vehicle. Use them with care!
 - **Charging Mode**: Vehicle can be set to `IMMEDIATE_CHARGING` (charge as soon as plugged in) or `DELAYED_CHARGING` (charge only if within charging window). It can be used to start/stop charging if the charging window is set accordingly.
 - **AC Charging Limit**: The maximum current a vehicle will charge with. Not available on all EVs.
 
-## Numbers
-
-If you have a (PH)EV, you can control the charging process through Home Assistant. The number entities are created automatically depending on your vehicle's capabilities and can be changed from the UI or using the `number.set_value` service. For more information, please see the [number documentation](/integrations/number/).
-
-Using these selects will impact the state of your vehicle, use them with care!
-
-- **Target SoC**: Vehicle will charge until this battery level is reached. Not available on all EVs.
-
-## Numbers
+## Switches
 
 If supported by your vehicle, you can display and toggle remote services with start/stop functionality.
 

--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -7,9 +7,11 @@ ha_category:
   - Car
   - Lock
   - Notifications
+  - Number
   - Presence Detection
   - Select
   - Sensor
+  - Switch
 ha_release: 0.64
 ha_iot_class: Cloud Polling
 ha_config_flow: true
@@ -24,8 +26,10 @@ ha_platforms:
   - diagnostics
   - lock
   - notify
+  - number
   - select
   - sensor
+  - -switch
 ha_integration_type: integration
 ---
 
@@ -48,6 +52,8 @@ This integration provides the following platforms:
 - [Notifications](/integrations/bmw_connected_drive/#notifications): Send Points of Interest (POI) to your car.
 - [Buttons](/integrations/bmw_connected_drive/#buttons): Turn on air condition, sound the horn, flash the lights, update the vehicle location and update the state.
 - [Selects](/integrations/bmw_connected_drive/#selects): Display and control charging related settings for (PH)EVs.
+- [Numbers](/integrations/bmw_connected_drive/#numbers): Display and control numeric charging related settings for (PH)EVs.
+- [Switches](/integrations/bmw_connected_drive/#switches): Display and toggle settings on your car.
 
 ## Configuration
 
@@ -144,8 +150,23 @@ If you have a (PH)EV, you can control the charging process through Home Assistan
 Using these selects will impact the state of your vehicle. Use them with care!
 
 - **Charging Mode**: Vehicle can be set to `IMMEDIATE_CHARGING` (charge as soon as plugged in) or `DELAYED_CHARGING` (charge only if within charging window). It can be used to start/stop charging if the charging window is set accordingly.
-- **Target SoC**: The vehicle will charge until this battery level is reached. Not available on all EVs.
 - **AC Charging Limit**: The maximum current a vehicle will charge with. Not available on all EVs.
+
+## Numbers
+
+If you have a (PH)EV, you can control the charging process through Home Assistant. The number entities are created automatically depending on your vehicle's capabilities and can be changed from the UI or using the `number.set_value` service. For more information, please see the [number documentation](/integrations/number/).
+
+Using these selects will impact the state of your vehicle, use them with care!
+
+- **Target SoC**: Vehicle will charge until this battery level is reached. Not available on all EVs.
+
+## Numbers
+
+If supported by your vehicle, you can display and toggle remote services with start/stop functionality.
+
+Using these selects will impact the state of your vehicle, use them with care!
+
+- **Climate**: Toggle vehicle climatization. It is not possible to force it to heating/cooling, the vehicle will decide on its own. If turned on, it will run for 30 minutes (as if toggled via the MyBMW app).
 
 ## Disclaimer
 

--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -107,10 +107,6 @@ The air conditioning of the vehicle can be activated with the `button.<your_vehi
 
 What exactly is started here depends on the type of vehicle. It might range from just ventilation over auxiliary heating to real air conditioning. If your vehicle is equipped with auxiliary heating, only trigger this service if the vehicle is parked in a location where it is safe to use it (e.g., not in an underground parking or closed garage).
 
-Some newer cars also support stopping an active air conditioning with the `button.<your_vehicle>_deactivate_air_conditioning` button.
-
-This will only work if you have the option to stop the AC in the *MyBMW* app. If your car doesn't support this service, nothing will happen.
-
 ### Sound the horn
 
 The `button.<your_vehicle>_sound_horn` button sounds the horn of the vehicle. This option is not available in some countries (among which  the UK). Use this feature responsibly, as it might annoy your neighbors.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for https://github.com/home-assistant/core/pull/92962.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/92962
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
