### PR TITLE
Add Reload to glossary

### DIFF
--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -287,9 +287,9 @@
     Updates Home Assistant configuration files. Changes are normally
     automatically updated. However, when changes are made outside of the UI
     and at a file level, Home Assistant is not aware of these changes and
-    require the configuration file(s) to be reloaded to pick up any changes
+    requires the configuration file(s) to be reloaded to pick up any changes
     made by going to *YAML configuration reloading* section in
-    **Developer tools > YAML**.
+    **Developer tools** > **YAML**.
   excerpt: >
     Updates Home Assistant configuration files. Changes are normally
     automatically updated.

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -282,6 +282,18 @@
     other integrations.
   link: /docs/configuration/platform_options/
 
+- term: Reload
+  definition: >-
+    Updates Home Assistant configuration files. Changes are normally
+    automatically updated. However, when changes are done outside of the UI
+    and at a file level, Home Assistant is not aware of these changes and
+    require the configuration file(s) to be reloaded to pick up any changes
+    made by going to *YAML configuration reloading* section in
+    **Developer tools > YAML**.
+  excerpt: >
+    Updates Home Assistant configuration files. Changes are normally
+    automatically updated.
+
 - term: Scene
   definition: >-
     Scenes capture the states you want certain entities to be. For example,

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -285,7 +285,7 @@
 - term: Reload
   definition: >-
     Updates Home Assistant configuration files. Changes are normally
-    automatically updated. However, when changes are done outside of the UI
+    automatically updated. However, when changes are made outside of the UI
     and at a file level, Home Assistant is not aware of these changes and
     require the configuration file(s) to be reloaded to pick up any changes
     made by going to *YAML configuration reloading* section in

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -288,8 +288,9 @@
     automatically updated. However, when changes are made outside of the UI
     and at a file level, Home Assistant is not aware of these changes and
     requires the configuration file(s) to be reloaded to pick up any changes
-    made by going to *YAML configuration reloading* section in
-    **Developer tools** > **YAML**.
+    made by going to **Settings** > **System** > **Restart Home Assistant**
+    (top right) > **Quick reload**. More granular reload options are available
+    in *YAML configuration reloading* section in **Developer tools** > **YAML**.
   excerpt: >
     Updates Home Assistant configuration files. Changes are normally
     automatically updated.


### PR DESCRIPTION
## Proposed change
There are references to reload in various places such as:
* Glossary page
* Scenes integration
* [Automation services](https://www.home-assistant.io/docs/automation/services/)

so I thought adding the term to the glossary makes sense and not an obvious meaning behind the word.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
