### PR TITLE
Add note for Reusable Templates Formatting

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -98,6 +98,11 @@ In your automations, you could then reuse this macro by importing it:
 
 {% endraw %}
 
+NOTE: Two important formatting concerns to remember when reusing templates:
+
+1. The value returned is always a string.  If you want a number or a boolean you need to use ```|int()```, ```|float(),``` or ```|bool``` filters.
+1. You may need to use the a hyphen to prevent stray whitespace in all your opening and closing tags. Example:```{{- -}}``` or ```{%- -%}```
+
 ## Home Assistant template extensions
 
 Extensions allow templates to access all of the Home Assistant specific states and adds other convenience functions and filters.

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -101,7 +101,7 @@ In your automations, you could then reuse this macro by importing it:
 NOTE: Two important formatting concerns to remember when reusing templates:
 
 1. The value returned is always a string.  If you want a number or a boolean you need to use ```|int()```, ```|float(),``` or ```|bool``` filters.
-1. You may need to use a hyphen to prevent stray whitespace in all your opening and closing tags. Example:```{{- -}}``` or ```{%- -%}```
+* If you don't add a hyphen to all your opening and closing tags (so use `{%-`, `-%}`, `{{-` and `-}}`) you're result will include unintended whitespace.
 
 ## Home Assistant template extensions
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -101,7 +101,7 @@ In your automations, you could then reuse this macro by importing it:
 NOTE: Two important formatting concerns to remember when reusing templates:
 
 1. The value returned is always a string.  If you want a number or a boolean you need to use ```|int()```, ```|float(),``` or ```|bool``` filters.
-1. You may need to use the a hyphen to prevent stray whitespace in all your opening and closing tags. Example:```{{- -}}``` or ```{%- -%}```
+1. You may need to use a hyphen to prevent stray whitespace in all your opening and closing tags. Example:```{{- -}}``` or ```{%- -%}```
 
 ## Home Assistant template extensions
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -101,7 +101,7 @@ In your automations, you could then reuse this macro by importing it:
 NOTE: Two important formatting concerns to remember when reusing templates:
 
 1. The value returned is always a string.  If you want a number or a boolean you need to use ```|int()```, ```|float(),``` or ```|bool``` filters.
-* If you don't add a hyphen to all your opening and closing tags (so use `{%-`, `-%}`, `{{-` and `-}}`) you're result will include unintended whitespace.
+1. If you don't add a hyphen to all your opening and closing tags (so use `{%-`, `-%}`, `{{-` and `-}}`) you're result will include unintended whitespace.
 
 ## Home Assistant template extensions
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -101,7 +101,7 @@ In your automations, you could then reuse this macro by importing it:
 NOTE: Two important formatting concerns to remember when reusing templates:
 
 1. The value returned is always a string.  If you want a number or a boolean you need to use ```|int()```, ```|float(),``` or ```|bool``` filters.
-1. If you don't add a hyphen to all your opening and closing tags (so use `{%-`, `-%}`, `{{-` and `-}}`) you're result will include unintended whitespace.
+1. If you don't add a hyphen to all your opening and closing tags (so use `{%-`, `-%}`, `{{-`, and `-}}`) you're result will include unintended whitespace.
 
 ## Home Assistant template extensions
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add additional information to help the user with reusable templates


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
This was pointed out to me on Discord, and I offered to extend the documentation to include the information.
https://discord.com/channels/330944238910963714/672223497736421388/1106643448943095938

QUOTE:
TheFes — 05/12/2023 1:05 PM
Important to know:
* The result of an imported macro is always a string
* If you don't add a hyphen to all your opening and closing tags (so use {%-, -%}, {{- and -}}) you're result will include unintended whitespace.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
