### PR TITLE
Installation: Add CSS for tabbed-content

### DIFF
--- a/source/_styles/custom/tabbed-block.css
+++ b/source/_styles/custom/tabbed-block.css
@@ -1,0 +1,44 @@
+.tabbed-content-block {
+  background-color: #FAFAFA;
+  margin: 16px 0;
+  overflow: hidden;
+  border-radius: 10px;
+  box-shadow: -1px 0px 0px 0px #dfdfdf, 0px 0px 0px 1px #dfdfdf;
+  box-sizing: border-box;
+}
+.tabbed-content-block .tabbed-content-block-tabs {
+  overflow: hidden;
+  padding: 0 8px;
+}
+.tabbed-content-block .tabbed-content-block-tabs label input {
+  display: none;
+}
+.tabbed-content-block .tabbed-content-block-tabs label input:checked + div {
+  opacity: 1;
+  border-bottom: 2px solid --primary-color;
+}
+.tabbed-content-block .tabbed-content-block-tabs label div {
+  float: left;
+  padding: 8px;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: 0.3s;
+  border-bottom: 2px solid transparent;
+  font-size: 0.8em;
+}
+.tabbed-content-block .tabbed-content-block-tabs label div:hover {
+  opacity: 1;
+}
+.tabbed-content-block .tabbed-content-block-content {
+  padding: 8px 16px 0;
+  display: none;
+  animation: fadeEffect 0.5s;
+}
+@keyframes fadeEffect {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/source/_styles/main.css
+++ b/source/_styles/main.css
@@ -11,6 +11,7 @@
 @import "./custom/topic.css";
 @import "./custom/integrations.css";
 @import "./custom/getting-started.css";
+@import "./custom/tabbed-block.css";
 
 @import 'home.css';
 @import 'post.css';


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Installation: Add CSS for tabbed-content
- to display image paths in a tabbed style, instead of sequentially
- this is used in places such as /installation/odroid/

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`new` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
