### PR TITLE
Google assistant: Add missing domains

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -271,21 +271,23 @@ Currently, the following domains are available to be used with Google Assistant,
 - alarm_control_panel (arm/disarm)
 - button (scene)
 - camera (streaming, requires compatible camera)
-- group (on/off)
-- input_boolean (on/off)
-- input_select (option/setting/mode/value)
-- scene (on)
-- script (on)
-- switch (on/off)
+- climate (temperature setting, hvac_mode)
+- cover (on/off/set position)
 - fan (on/off/speed percentage/preset mode)
+- group (on/off)
+- humidifier (humidity setting/on/off/mode)
+- input_boolean (on/off)
+- input_button
+- input_select (option/setting/mode/value)
 - light (on/off/brightness/rgb color/color temp)
 - lock
-- cover (on/off/set position)
 - media_player (on/off/set volume (via set volume)/source (via set input source)/control playback)
-- climate (temperature setting, hvac_mode)
-- vacuum (dock/start/stop/pause)
+- scene (on)
+- script (on)
+- select
 - sensor (temperature setting for temperature sensors and humidity setting for humidity sensors)
-- humidifier (humidity setting/on/off/mode)
+- switch (on/off)
+- vacuum (dock/start/stop/pause)
 
 <div class='note'>
 


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Google assistant: Add missing domains
- according to google_config.py
- input_button
- select
- sort in alphabetical order

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
