### PR TITLE
Small documentation improvements

### DIFF
--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -13,7 +13,7 @@ Quick links:
 
 Automations based on a blueprint only need to be configured to be used. What needs to be configured differs on each blueprint.
 
-To create your first automation based on a blueprint, go to **{% my blueprints title="Settings -> Automations & Scenes -> Blueprints" %}**. Find the blueprint that you want to use and click on "Create Automation".
+To create your first automation based on a blueprint, go to **{% my blueprints title="Settings > Automations & Scenes > Blueprints" %}**. Find the blueprint that you want to use and select **Create Automation**.
 
 This will open the automation editor with the blueprint selected. Give it a name and configure the blueprint and click on the blue button "Save Automation" in the bottom right.
 

--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -13,11 +13,11 @@ Quick links:
 
 Automations based on a blueprint only need to be configured to be used. What needs to be configured differs on each blueprint.
 
-To create your first automation based on a blueprint, go to **{% my helpers title="Settings -> Automations & Scenes -> Blueprints" %}**. Find the blueprint that you want to use and click on "Create Automation".
+To create your first automation based on a blueprint, go to **{% my blueprints title="Settings -> Automations & Scenes -> Blueprints" %}**. Find the blueprint that you want to use and click on "Create Automation".
 
 This will open the automation editor with the blueprint selected. Give it a name and configure the blueprint and click on the blue button "Save Automation" in the bottom right.
 
-Done! If you want to revisit the configuration values, you can find it by going to **Settings** and then **{% my automations %}**.
+Done! If you want to revisit the configuration values, you can find it by going to **Settings** and then **{% my blueprints %}**.
 
 ## Importing blueprints
 

--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -13,11 +13,11 @@ Quick links:
 
 Automations based on a blueprint only need to be configured to be used. What needs to be configured differs on each blueprint.
 
-To create your first automation based on a blueprint, go to **{% my config %}** -> **Automations & Scenes** -> **{% my blueprints %}**. Find the blueprint that you want to use and click on "Create Automation".
+To create your first automation based on a blueprint, go to **{% my helpers title="Settings -> Automations & Scenes -> Blueprints" %}**. Find the blueprint that you want to use and click on "Create Automation".
 
 This will open the automation editor with the blueprint selected. Give it a name and configure the blueprint and click on the blue button "Save Automation" in the bottom right.
 
-Done! If you want to revisit the configuration values, you can find it by going to **{% my config %}** and then **{% my automations %}**.
+Done! If you want to revisit the configuration values, you can find it by going to **Settings** and then **{% my automations %}**.
 
 ## Importing blueprints
 

--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -116,6 +116,6 @@ Turns one or multiple lights off.
 
 ### Service `light.toggle`
 
-Toggles the state of one or multiple lights. Takes the same arguments as [`light.turn_on`](#service-lightturn_on) service.
+Toggles the state of one or multiple lights. Takes the same arguments as the [`light.turn_on`](#service-lightturn_on) service.
 
 *Note*: If `light.toggle` is used for a group of lights, it will toggle the individual state of each light. If you want the lights to be treated as a single light, use [Light Groups](/integrations/group#binary-sensor-light-and-switch-groups) instead.

--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -116,6 +116,6 @@ Turns one or multiple lights off.
 
 ### Service `light.toggle`
 
-Toggles the state of one or multiple lights. Takes the same arguments as [`turn_on`](#service-lightturn_on) service.
+Toggles the state of one or multiple lights. Takes the same arguments as [`light.turn_on`](#service-lightturn_on) service.
 
 *Note*: If `light.toggle` is used for a group of lights, it will toggle the individual state of each light. If you want the lights to be treated as a single light, use [Light Groups](/integrations/group#binary-sensor-light-and-switch-groups) instead.

--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -43,7 +43,7 @@ Most lights do not support all attributes. You can check the integration documen
 | ---------------------- | -------- | ----------- |
 | `entity_id`  | no  | String or list of strings that point at `entity_id`s of lights. To target all lights, set `entity_id` to `all`.
 | `transition` | yes | Number that represents the time (in seconds) the light should take to transition to the new state.
-| `profile` | yes | String with the name of one of the [built-in profiles](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/light/light_profiles.csv) (relax, energize, concentrate, reading) or one of the custom profiles defined in `light_profiles.csv` in the current working directory. Light profiles define an xy color, brightness and a transition value (if no transition is desired, set to 0 or leave out the column entirely). If a profile is given, and a brightness is set, then the profile brightness will be overwritten.
+| `profile` | yes | String with the name of one of the [built-in profiles](https://github.com/home-assistant/core/blob/master/homeassistant/components/light/light_profiles.csv) (relax, energize, concentrate, reading) or one of the custom profiles defined in `light_profiles.csv` in the current working directory. Light profiles define an xy color, brightness and a transition value (if no transition is desired, set to 0 or leave out the column entirely). If a profile is given, and a brightness is set, then the profile brightness will be overwritten.
 | `hs_color` | yes | A list containing two floats representing the hue and saturation of the color you want the light to be. Hue is scaled 0-360, and saturation is scaled 0-100.
 | `xy_color` | yes | A list containing two floats representing the xy color you want the light to be. Two comma-separated floats that represent the color in XY.
 | `rgb_color` | yes | A list containing three integers between 0 and 255 representing the RGB color you want the light to be. Three comma-separated integers that represent the color in RGB, within square brackets.
@@ -118,4 +118,4 @@ Turns one or multiple lights off.
 
 Toggles the state of one or multiple lights. Takes the same arguments as [`turn_on`](#service-lightturn_on) service.
 
-*Note*: If `light.toggle` is used for a group of lights, it will toggle the individual state of each light. If you want the lights to be treated as a single light, use [Light Groups](/integrations/light.group/) instead.
+*Note*: If `light.toggle` is used for a group of lights, it will toggle the individual state of each light. If you want the lights to be treated as a single light, use [Light Groups](/integrations/group#binary-sensor-light-and-switch-groups) instead.

--- a/source/examples/index.markdown
+++ b/source/examples/index.markdown
@@ -21,7 +21,7 @@ A great place to find popular configurations is on this
 
 ## Popular Blueprints
 
-This is a list of the most popular [blueprints](/integrations/blueprint) in the [Blueprint Exchange category on the forums](https://www.home-assistant.io/get-blueprints).
+This is a list of the most popular [blueprints](/docs/automation/using_blueprints/) in the [Blueprint Exchange category on the forums](https://www.home-assistant.io/get-blueprints).
 
 {% for post in site.data.blueprint_exchange_data limit:25 %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- Updates the URLs in the Light integration.
- Updates the URLs on the examples page.
- Small improvements to the blueprint documentation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
