### PR TITLE
Support multiple TLS/SSL configurations on the webserver

### DIFF
--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -42,7 +42,7 @@ servers:
       type: [list, string]
       default: "0.0.0.0, ::"
     server_port:
-      description: Let you set a port to use.
+      description: Let's you set a port to use.
       required: false
       type: integer
       default: 8123

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -31,7 +31,7 @@ servers:
       type: [list, string]
       default: "0.0.0.0, ::"
     server_port:
-      description: "Let's you set a port to use."
+      description: "The port to listen on for this server."
       required: false
       type: integer
       default: 8123

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -113,7 +113,9 @@ The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-us
 
 ## TLS/SSL Configuration per port
 
-The below sample will listen on multiple ports which can be useful for devices that use webhooks that do no work with SSL or use an older TLS/SSL standard. 
+The below sample will listen on multiple ports which can be useful for devices that use webhooks that do no work with SSL or use an older TLS/SSL standard.
+
+Configuring the first one with the most secure settings when using multiple servers, as it will be used by default when determining the external URL.
 
 - 8123 - TLS with the modern TLS/SSL profile
 - 8124 - TLS with the intermediate TLS/SSL profile

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -35,33 +35,34 @@ servers:
   description: "List of servers"
   required: false
   type: list
-  server_host:
-    description: "Only listen to incoming requests on specific IP/host. By default the `http` integration auto-detects IPv4/IPv6 and listens on all connections. Use `server_host: 0.0.0.0` if you want to only listen to IPv4 addresses. The default listed assumes support for IPv4 and IPv6."
-    required: false
-    type: [list, string]
-    default: "0.0.0.0, ::"
-  server_port:
-    description: Let you set a port to use.
-    required: false
-    type: integer
-    default: 8123
-  ssl_certificate:
-    description: Path to your TLS/SSL certificate to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt) this will be at `/ssl/fullchain.pem`. We recommend to use the [NGINX add-on](https://github.com/home-assistant/addons/tree/master/nginx_proxy) instead of using this option.
-    required: false
-    type: string
-  ssl_peer_certificate:
-    description: Path to the client/peer TLS/SSL certificate to accept secure connections from.
-    required: false
-    type: string
-  ssl_key:
-    description: Path to your TLS/SSL key to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt) this will be at `/ssl/privkey.pem`.
-    required: false
-    type: string
-  ssl_profile:
-    description: The [Mozilla SSL profile](https://wiki.mozilla.org/Security/Server_Side_TLS) to use. Only lower if you are experiencing integrations causing SSL handshake errors.
-    required: false
-    type: string
-    default: modern
+  keys:
+    server_host:
+      description: "Only listen to incoming requests on specific IP/host. By default the `http` integration auto-detects IPv4/IPv6 and listens on all connections. Use `server_host: 0.0.0.0` if you want to only listen to IPv4 addresses. The default listed assumes support for IPv4 and IPv6."
+      required: false
+      type: [list, string]
+      default: "0.0.0.0, ::"
+    server_port:
+      description: Let you set a port to use.
+      required: false
+      type: integer
+      default: 8123
+    ssl_certificate:
+      description: Path to your TLS/SSL certificate to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt) this will be at `/ssl/fullchain.pem`. We recommend to use the [NGINX add-on](https://github.com/home-assistant/addons/tree/master/nginx_proxy) instead of using this option.
+      required: false
+      type: string
+    ssl_peer_certificate:
+      description: Path to the client/peer TLS/SSL certificate to accept secure connections from.
+      required: false
+      type: string
+    ssl_key:
+      description: Path to your TLS/SSL key to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt) this will be at `/ssl/privkey.pem`.
+      required: false
+      type: string
+    ssl_profile:
+      description: The [Mozilla SSL profile](https://wiki.mozilla.org/Security/Server_Side_TLS) to use. Only lower if you are experiencing integrations causing SSL handshake errors.
+      required: false
+      type: string
+      default: modern
 cors_allowed_origins:
   description: "A list of origin domain names to allow [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) requests from. Enabling this will set the `Access-Control-Allow-Origin` header to the Origin header if it is found in the list, and the `Access-Control-Allow-Headers` header to `Origin, Accept, X-Requested-With, Content-type, Authorization`. You must provide the exact Origin, i.e., `https://www.home-assistant.io` will allow requests from `https://www.home-assistant.io` but __not__ `http://www.home-assistant.io`."
   required: false

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -51,7 +51,7 @@ servers:
       required: false
       type: string
     ssl_peer_certificate:
-      description: Path to the client/peer TLS/SSL certificate to accept secure connections from.
+      description: Path to the client/peer TLS/SSL certificate from which you want to accept secure connections.
       required: false
       type: string
     ssl_key:

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -32,6 +32,9 @@ http:
 
 {% configuration %}
 servers:
+  description: "List of servers"
+  required: false
+  type: list
   server_host:
     description: "Only listen to incoming requests on specific IP/host. By default the `http` integration auto-detects IPv4/IPv6 and listens on all connections. Use `server_host: 0.0.0.0` if you want to only listen to IPv4 addresses. The default listed assumes support for IPv4 and IPv6."
     required: false

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -59,7 +59,7 @@ servers:
       required: false
       type: string
     ssl_profile:
-      description: The [Mozilla SSL profile](https://wiki.mozilla.org/Security/Server_Side_TLS) to use. Only lower if you are experiencing integrations causing SSL handshake errors.
+      description: The [Mozilla SSL profile](https://wiki.mozilla.org/Security/Server_Side_TLS) to use. Only lower the configuration (options: modern, intermediate, old), if integrations cause SSL handshake errors.
       required: false
       type: string
       default: modern

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -42,7 +42,7 @@ servers:
       type: [list, string]
       default: "0.0.0.0, ::"
     server_port:
-      description: Let's you set a port to use.
+      description: "Let's you set a port to use."
       required: false
       type: integer
       default: 8123

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -12,7 +12,12 @@ ha_domain: http
 ha_integration_type: system
 ---
 
-The `http` integration serves all files and data required for the Home Assistant frontend. You only need to add this to your configuration file if you want to change any of the default settings.
+
+The `http` integration serves all files and data required for the Home Assistant frontend. 
+
+## Configuration
+
+You only need to add this to your configuration file if you want to change any of the default settings.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -115,9 +115,9 @@ The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-us
 
 The below sample will listen on multiple ports which can be useful for devices that use webhooks that do no work with SSL or use an older TLS/SSL standard. 
 
-8123 - TLS with the modern TLS/SSL profile
-8124 - TLS with the intermediate TLS/SSL profile
-8125 - No TLS/SSL
+- 8123 - TLS with the modern TLS/SSL profile
+- 8124 - TLS with the intermediate TLS/SSL profile
+- 8125 - No TLS/SSL
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -113,9 +113,9 @@ The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-us
 
 ## TLS/SSL Configuration per port
 
-The below sample will listen on multiple ports which can be useful for devices that use webhooks that do no work with SSL or use an older TLS/SSL standard.
+For most use case, configure the first one with the most secure settings when using multiple servers, as it will be used by default when determining the external URL.
 
-Configuring the first one with the most secure settings when using multiple servers, as it will be used by default when determining the external URL.
+The below sample will listen on multiple ports which can be useful for devices that use webhooks that do no work with SSL or use an older TLS/SSL standard.
 
 - 8123 - TLS with the modern TLS/SSL profile
 - 8124 - TLS with the intermediate TLS/SSL profile

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -14,17 +14,6 @@ ha_integration_type: system
 
 The `http` integration serves all files and data required for the Home Assistant frontend. You only need to add this to your configuration file if you want to change any of the default settings.
 
-There is currently support for the following device types within Home Assistant:
-
-- [Binary Sensor](#binary-sensor)
-- [Sensor](#sensor)
-
-<div class='note'>
-
-The option `server_host` should only be used on a Home Assistant Core installation!
-
-</div>
-
 ```yaml
 # Example configuration.yaml entry
 http:
@@ -87,6 +76,12 @@ login_attempts_threshold:
   type: integer
   default: -1
 {% endconfiguration %}
+
+<div class='note'>
+
+The option `server_host` should only be used on a Home Assistant Core installation!
+
+</div>
 
 The sample below shows a configuration entry with possible values:
 

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -115,7 +115,7 @@ The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-us
 
 For most use cases, configure the first server with the most secure settings when using multiple servers. This is the server that will be used by default when determining the external URL.
 
-The sample below will listen on multiple ports, which can be helpful for devices that use webhooks that do not work with SSL or use an older TLS/SSL standard.
+The example below shows a configuration that allows listening on multiple ports. This can be helpful for devices that use webhooks that do not work with SSL or use an older TLS/SSL standard.
 
 - 8123 - TLS with the modern TLS/SSL profile
 - 8124 - TLS with the intermediate TLS/SSL profile

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -37,7 +37,7 @@ servers:
   type: list
   keys:
     server_host:
-      description: "Only listen to incoming requests on specific IP/host. By default the `http` integration auto-detects IPv4/IPv6 and listens on all connections. Use `server_host: 0.0.0.0` if you want to only listen to IPv4 addresses. The default listed assumes support for IPv4 and IPv6."
+      description: "Only listen to incoming requests on specific IP/host. By default, the `http` integration auto-detects IPv4/IPv6 and listens on all connections. Use `server_host: 0.0.0.0` if you want to only listen to IPv4 addresses. The default listed assumes support for IPv4 and IPv6."
       required: false
       type: [list, string]
       default: "0.0.0.0, ::"

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -189,7 +189,14 @@ If you want to use Home Assistant to host or serve static files then create a di
 
 </div>
 
-## Binary Sensor
+## States API
+
+There is currently support for the following device types within Home Assistant:
+
+- [Binary Sensor](#binary-sensor)
+- [Sensor](#sensor)
+
+### Binary Sensor
 
 The HTTP binary sensor is dynamically created with the first request that is made to its URL. You don't have to define it in the configuration first.
 
@@ -237,11 +244,11 @@ $ curl -X GET -H "Authorization: Bearer LONG_LIVED_ACCESS_TOKEN" \
 }
 ```
 
-### Examples
+#### Examples
 
 In this section you'll find some real-life examples of how to use this sensor, besides `curl`, which was shown earlier.
 
-#### Using Python request module
+##### Using Python request module
 
 As already shown on the [API](/developers/rest_api/) page, it's very simple to use Python and the [Requests](https://requests.kennethreitz.org/en/latest/) module for the interaction with Home Assistant.
 
@@ -257,7 +264,7 @@ response = requests.post(
 print(response.text)
 ```
 
-#### Using `httpie`
+##### Using `httpie`
 
 [`httpie`](https://github.com/httpie/httpie) is a user-friendly CLI HTTP client.
 
@@ -267,7 +274,7 @@ $ http -v POST http://localhost:8123/api/states/binary_sensor.radio \
       attributes:='{"friendly_name": "Radio"}'
 ```
 
-## Sensor
+### Sensor
 
 The HTTP sensor is dynamically created with the first request that is made to its URL. You don't have to define it in the configuration first.
 

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -113,9 +113,9 @@ The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-us
 
 ## Multiple Servers (TLS/SSL Configuration per port)
 
-For most use cases, configure the first one with the most secure settings when using multiple servers, as it will be used by default when determining the external URL.
+For most use cases, configure the first server with the most secure settings when using multiple servers, as it will be used by default when determining the external URL.
 
-The below sample will listen on multiple ports which can be useful for devices that use webhooks that do no work with SSL or use an older TLS/SSL standard.
+The sample below will listen on multiple ports, which can be helpful for devices that use webhooks that do not work with SSL or use an older TLS/SSL standard.
 
 - 8123 - TLS with the modern TLS/SSL profile
 - 8124 - TLS with the intermediate TLS/SSL profile

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -111,7 +111,7 @@ http:
 
 The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-using-lets-encrypt/) blog post gives you details about the encryption of your traffic using free certificates from [Let's Encrypt](https://letsencrypt.org/).
 
-## TLS/SSL Configuration per port
+## Multiple Servers (TLS/SSL Configuration per port)
 
 For most use case, configure the first one with the most secure settings when using multiple servers, as it will be used by default when determining the external URL.
 

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -113,7 +113,7 @@ The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-us
 
 ## Multiple Servers (TLS/SSL Configuration per port)
 
-For most use cases, configure the first server with the most secure settings when using multiple servers, as it will be used by default when determining the external URL.
+For most use cases, configure the first server with the most secure settings when using multiple servers. This is the server that will be used by default when determining the external URL.
 
 The sample below will listen on multiple ports, which can be helpful for devices that use webhooks that do not work with SSL or use an older TLS/SSL standard.
 

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -31,28 +31,34 @@ http:
 ```
 
 {% configuration %}
-server_host:
-  description: "Only listen to incoming requests on specific IP/host. By default the `http` integration auto-detects IPv4/IPv6 and listens on all connections. Use `server_host: 0.0.0.0` if you want to only listen to IPv4 addresses. The default listed assumes support for IPv4 and IPv6."
-  required: false
-  type: [list, string]
-  default: "0.0.0.0, ::"
-server_port:
-  description: Let you set a port to use.
-  required: false
-  type: integer
-  default: 8123
-ssl_certificate:
-  description: Path to your TLS/SSL certificate to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt) this will be at `/ssl/fullchain.pem`. We recommend to use the [NGINX add-on](https://github.com/home-assistant/addons/tree/master/nginx_proxy) instead of using this option.
-  required: false
-  type: string
-ssl_peer_certificate:
-  description: Path to the client/peer TLS/SSL certificate to accept secure connections from.
-  required: false
-  type: string
-ssl_key:
-  description: Path to your TLS/SSL key to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt) this will be at `/ssl/privkey.pem`.
-  required: false
-  type: string
+servers:
+  server_host:
+    description: "Only listen to incoming requests on specific IP/host. By default the `http` integration auto-detects IPv4/IPv6 and listens on all connections. Use `server_host: 0.0.0.0` if you want to only listen to IPv4 addresses. The default listed assumes support for IPv4 and IPv6."
+    required: false
+    type: [list, string]
+    default: "0.0.0.0, ::"
+  server_port:
+    description: Let you set a port to use.
+    required: false
+    type: integer
+    default: 8123
+  ssl_certificate:
+    description: Path to your TLS/SSL certificate to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt) this will be at `/ssl/fullchain.pem`. We recommend to use the [NGINX add-on](https://github.com/home-assistant/addons/tree/master/nginx_proxy) instead of using this option.
+    required: false
+    type: string
+  ssl_peer_certificate:
+    description: Path to the client/peer TLS/SSL certificate to accept secure connections from.
+    required: false
+    type: string
+  ssl_key:
+    description: Path to your TLS/SSL key to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt) this will be at `/ssl/privkey.pem`.
+    required: false
+    type: string
+  ssl_profile:
+    description: The [Mozilla SSL profile](https://wiki.mozilla.org/Security/Server_Side_TLS) to use. Only lower if you are experiencing integrations causing SSL handshake errors.
+    required: false
+    type: string
+    default: modern
 cors_allowed_origins:
   description: "A list of origin domain names to allow [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) requests from. Enabling this will set the `Access-Control-Allow-Origin` header to the Origin header if it is found in the list, and the `Access-Control-Allow-Headers` header to `Origin, Accept, X-Requested-With, Content-type, Authorization`. You must provide the exact Origin, i.e., `https://www.home-assistant.io` will allow requests from `https://www.home-assistant.io` but __not__ `http://www.home-assistant.io`."
   required: false
@@ -76,11 +82,6 @@ login_attempts_threshold:
   required: false
   type: integer
   default: -1
-ssl_profile:
-  description: The [Mozilla SSL profile](https://wiki.mozilla.org/Security/Server_Side_TLS) to use. Only lower if you are experiencing integrations causing SSL handshake errors.
-  required: false
-  type: string
-  default: modern
 {% endconfiguration %}
 
 The sample below shows a configuration entry with possible values:
@@ -88,9 +89,11 @@ The sample below shows a configuration entry with possible values:
 ```yaml
 # Example configuration.yaml entry
 http:
-  server_port: 12345
-  ssl_certificate: /etc/letsencrypt/live/hass.example.com/fullchain.pem
-  ssl_key: /etc/letsencrypt/live/hass.example.com/privkey.pem
+  servers:
+    - server_port: 12345
+      ssl_certificate: /etc/letsencrypt/live/hass.example.com/fullchain.pem
+      ssl_key: /etc/letsencrypt/live/hass.example.com/privkey.pem
+      ssl_profile: modern
   cors_allowed_origins:
     - https://google.com
     - https://www.home-assistant.io
@@ -103,6 +106,29 @@ http:
 ```
 
 The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-using-lets-encrypt/) blog post gives you details about the encryption of your traffic using free certificates from [Let's Encrypt](https://letsencrypt.org/).
+
+## TLS/SSL Configuration per port
+
+The below sample will listen on multiple ports which can be useful for devices that use webhooks that do no work with SSL or use an older TLS/SSL standard. 
+
+8123 - TLS with the modern TLS/SSL profile
+8124 - TLS with the intermediate TLS/SSL profile
+8125 - No TLS/SSL
+
+```yaml
+# Example configuration.yaml entry
+http:
+  servers:
+    - server_port: 8123
+      ssl_certificate: /etc/letsencrypt/live/hass.example.com/fullchain.pem
+      ssl_key: /etc/letsencrypt/live/hass.example.com/privkey.pem
+      ssl_profile: modern
+    - server_port: 8124
+      ssl_certificate: /etc/letsencrypt/live/hass.example.com/fullchain.pem
+      ssl_key: /etc/letsencrypt/live/hass.example.com/privkey.pem
+      ssl_profile: intermediate
+    - server_port: 8125
+```
 
 ## Reverse proxies
 

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -47,7 +47,7 @@ servers:
       type: integer
       default: 8123
     ssl_certificate:
-      description: Path to your TLS/SSL certificate to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt) this will be at `/ssl/fullchain.pem`. We recommend to use the [NGINX add-on](https://github.com/home-assistant/addons/tree/master/nginx_proxy) instead of using this option.
+      description: Path to your TLS/SSL certificate to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt), this will be at `/ssl/fullchain.pem`. We recommend to use the [NGINX add-on](https://github.com/home-assistant/addons/tree/master/nginx_proxy) instead of using this option.
       required: false
       type: string
     ssl_peer_certificate:

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -113,7 +113,7 @@ The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-us
 
 ## Multiple Servers (TLS/SSL Configuration per port)
 
-For most use case, configure the first one with the most secure settings when using multiple servers, as it will be used by default when determining the external URL.
+For most use cases, configure the first one with the most secure settings when using multiple servers, as it will be used by default when determining the external URL.
 
 The below sample will listen on multiple ports which can be useful for devices that use webhooks that do no work with SSL or use an older TLS/SSL standard.
 

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -55,7 +55,7 @@ servers:
       required: false
       type: string
     ssl_key:
-      description: Path to your TLS/SSL key to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt) this will be at `/ssl/privkey.pem`.
+      description: Path to your TLS/SSL key to serve Home Assistant over a secure connection. If using the [Let's Encrypt add-on](https://github.com/home-assistant/addons/tree/master/letsencrypt), this will be at `/ssl/privkey.pem`.
       required: false
       type: string
     ssl_profile:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
aiohttp already supports multiple `TCPSite`s for a single server

This allows Home Assistant to listen on multiple ports with different ssl configuration per port so that devices that need a less secure configuration can be isolated to a single port.

Motivation:
 - No need downgrade entire ssl configuration for a single device that needs a less secure configuration
 - Make external access require a client certificate but internal access allowed without it
 - Support an ONVIF camera that does not do SSL
 - Webhooks that do not work with SSL (ie Reolink)
 - Enable TLS/SSL on another so assist works without breaking no ssl on the primary port
 - Makes setups that use a TLS/SSL external url and a non-TLS/SSL internal url possible which seems to keep coming up over and over and over again for ONVIF / Reolink / Doorbird / anything using webhooks / etc users



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/93284
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
