### PR TITLE
Kodi keypress events

### DIFF
--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -440,14 +440,14 @@ action:
   - choose:
       - conditions:
           - condition: template
-            value_template: '''{{trigger.event.data.data.key == 'volume_up'}}'''
+            value_template: {{trigger.event.data.data.key == "volume_up"}}
         sequence:
           - service: media_player.volume_up
             target:
               entity_id: media_player.receiver
       - conditions:
           - condition: template
-            value_template: '''{{trigger.event.data.data.key == 'volume_down'}}'''
+            value_template: {{trigger.event.data.data.key == "volume_down"}}
         sequence:
           - service: media_player.volume_down
             target:

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -440,14 +440,14 @@ action:
   - choose:
       - conditions:
           - condition: template
-            value_template: "{{trigger.event.data.data.key == 'volume_up'}}"
+            value_template: '''{{trigger.event.data.data.key == 'volume_up'}}'''
         sequence:
           - service: media_player.volume_up
             target:
               entity_id: media_player.receiver
       - conditions:
           - condition: template
-            value_template: "{{trigger.event.data.data.key == 'volume_down'}}"
+            value_template: '''{{trigger.event.data.data.key == 'volume_down'}}'''
         sequence:
           - service: media_player.volume_down
             target:

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -394,10 +394,10 @@ To use notifications, please see the [getting started with automation page](/get
 ## Keypress device triggers
 key presses of keyboards/remotes can be overwritten in Kodi and configured to send a event to Home Assistant, which can then be used in automations to for instance turn up/down the volume of a TV/receiver.
 
-A keypress can be overwritten in Kodi by using the [kodi keymap XML](https://kodi.wiki/view/Keymap) or from within the Kodi GUI using the [Keymap Editor add-on](https://kodi.wiki/view/Add-on:Keymap_Editor).
+A keypress can be overwritten in Kodi by using the [Kodi keymap XML](https://kodi.wiki/view/Keymap) or from within the Kodi GUI using the [Keymap Editor add-on](https://kodi.wiki/view/Add-on:Keymap_Editor).
 
 A example of the Kodi keymap configuration using XML which will overwrite the volume_up/volume_down buttons and instead send a event to HomeAssistant:
-```
+```xml
 <keymap>
   <global>
     <keyboard>
@@ -408,14 +408,14 @@ A example of the Kodi keymap configuration using XML which will overwrite the vo
 </keymap>
 ```
 The `"KodiLivingroom"` can be set to any value and will be present in the event data as the `"sender"`
-The `"OnKeyPress"` is needed to identify the event in HomeAssistant, do not change this.
-The `{"key":"volume_up"}` can contain any json which will be present in the event data under the `"data"` key, normally this is used to identitfy which key was pressed.
+The `"OnKeyPress"` is needed to identify the event in Home Assistant, do not change this.
+The `{"key":"volume_up"}` can contain any JSON which will be present in the event data under the `"data"` key, normally this is used to identitfy which key was pressed.
 
 For possible keyboard key names see: https://kodi.wiki/view/List_of_keynames
 For other actions see: https://kodi.wiki/view/Keymap#Keynames
 
 For the example abbove, when the volume up key is pressed, a event in Home Assistant will be fired that looks like:
-```
+```yaml
 event_type: kodi_keypress
 data:
   type: keypress
@@ -426,7 +426,7 @@ data:
 ```
 
 A example of a automation to turn up/down the volume of a receiver using the device trigger:
-```
+```yaml
 alias: Kodi keypress
 mode: parallel
 max: 10

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -392,11 +392,13 @@ data:
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
 
 ## Keypress events
-key presses of keyboards/remotes can be overwritten in Kodi and configured to send a event to Home Assistant, which can then be used in automations to for instance turn up/down the volume of a TV/receiver.
+
+key presses of keyboards/remotes can be overwritten in Kodi and configured to send an event to Home Assistant, which can then be used in automations to, for instance, turn up/down the volume of a TV/receiver.
 
 A keypress can be overwritten in Kodi by using the [Kodi keymap XML](https://kodi.wiki/view/Keymap) or from within the Kodi GUI using the [Keymap Editor add-on](https://kodi.wiki/view/Add-on:Keymap_Editor).
 
-A example of the Kodi keymap configuration using XML which will overwrite the volume_up/volume_down buttons and instead send a event to HomeAssistant:
+An example of the Kodi keymap configuration using XML, which will overwrite the volume_up/volume_down buttons and instead send an event to HomeAssistant:
+
 ```xml
 <keymap>
   <global>
@@ -407,14 +409,15 @@ A example of the Kodi keymap configuration using XML which will overwrite the vo
   </global>
 </keymap>
 ```
+
 The `"KodiLivingroom"` can be set to any value and will be present in the event data as the `"sender"`
 The `"OnKeyPress"` is needed to identify the event in Home Assistant, do not change this.
-The `{"key":"volume_up"}` can contain any JSON which will be present in the event data under the `"data"` key, normally this is used to identitfy which key was pressed.
+The `{"key":"volume_up"}` can contain any JSON which will be present in the event data under the `"data"` key, normally this is used to identify which key was pressed.
 
-For possible keyboard key names see: https://kodi.wiki/view/List_of_keynames
-For other actions see: https://kodi.wiki/view/Keymap#Keynames
+For possible keyboard key names, see: https://kodi.wiki/view/List_of_keynames
+For other actions, see: https://kodi.wiki/view/Keymap#Keynames
 
-For the example abbove, when the volume up key is pressed, a event in Home Assistant will be fired that looks like:
+For the example above, when the volume up key is pressed, an event in Home Assistant will be fired that looks like this:
 ```yaml
 event_type: kodi_keypress
 data:

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -440,14 +440,14 @@ action:
   - choose:
       - conditions:
           - condition: template
-            value_template: "{{trigger.event.data.data.key == 'volume_up'}}"
+            value_template: "{{trigger.event.data.data.key=='volume_up'}}"
         sequence:
           - service: media_player.volume_up
             target:
               entity_id: media_player.receiver
       - conditions:
           - condition: template
-            value_template: "{{trigger.event.data.data.key == 'volume_down'}}"
+            value_template: "{{trigger.event.data.data.key=='volume_down'}}"
         sequence:
           - service: media_player.volume_down
             target:

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -456,3 +456,5 @@ action:
             target:
               entity_id: media_player.receiver
 ```
+
+{% endraw %}

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -440,14 +440,14 @@ action:
   - choose:
       - conditions:
           - condition: template
-            value_template: {{trigger.event.data.data.key == "volume_up"}}
+            value_template: "{{trigger.event.data.data.key == 'volume_up'}}"
         sequence:
           - service: media_player.volume_up
             target:
               entity_id: media_player.receiver
       - conditions:
           - condition: template
-            value_template: {{trigger.event.data.data.key == "volume_down"}}
+            value_template: "{{trigger.event.data.data.key == 'volume_down'}}"
         sequence:
           - service: media_player.volume_down
             target:

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -427,6 +427,9 @@ data:
 ```
 
 A example of a automation to turn up/down the volume of a receiver using the event:
+
+{% raw %}
+
 ```yaml
 alias: Kodi keypress
 mode: parallel

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -391,7 +391,7 @@ data:
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
 
-## Keypress device triggers
+## Keypress events
 key presses of keyboards/remotes can be overwritten in Kodi and configured to send a event to Home Assistant, which can then be used in automations to for instance turn up/down the volume of a TV/receiver.
 
 A keypress can be overwritten in Kodi by using the [Kodi keymap XML](https://kodi.wiki/view/Keymap) or from within the Kodi GUI using the [Keymap Editor add-on](https://kodi.wiki/view/Add-on:Keymap_Editor).
@@ -420,22 +420,22 @@ event_type: kodi_keypress
 data:
   type: keypress
   device_id: 72e5g0ay5621f5d719qd8cydj943421a
+  entity_id: media_player.kodi_livingroom
   sender: KodiLivingroom
   data:
     key: volume_up
 ```
 
-A example of a automation to turn up/down the volume of a receiver using the device trigger:
+A example of a automation to turn up/down the volume of a receiver using the event:
 ```yaml
 alias: Kodi keypress
 mode: parallel
 max: 10
 trigger:
-  - platform: device
-    device_id: 72e5g0ay5621f5d719qd8cydj943421a
-    domain: kodi
-    entity_id: media_player.kodi_livingroom
-    type: keypress
+  - platform: event
+    event_type: kodi_keypress
+    event_data:
+      entity_id: media_player.kodi_livingroom
 action:
   - choose:
       - conditions:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documetation for Kodi keypress events, see PR: https://github.com/home-assistant/core/pull/93321


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/93321
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
