### PR TITLE
Make `state_topic` optional for MQTT device_tracker and improve examples

### DIFF
--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -168,7 +168,7 @@ source_type:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive device tracker state changes, or to reset the state override when a message configured with `payload_reset` is received. Can only be omitted if only `json_attributes_topic` is used.
+  description: The MQTT topic subscribed to receive device tracker state changes. The states defined in `state_topic` override the location states defined by the `json_attributes_topic`. This state override is turned inactive if the `state_topic` receives a message containing `payload_reset`. The `state_topic` can only be omitted if `json_attributes_topic` is used.
   required: false
   type: string
 unique_id:

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -118,7 +118,11 @@ json_attributes_template:
   required: false
   type: template
 json_attributes_topic:
-  description: "The MQTT topic subscribed to receive a JSON dictionary message and then set as device_tracker attributes. If the attributes in the JSON message include `longitude`, `latitude` and optional `gps_accuracy` and if the device tracker is within a configured [zone](/integrations/zone/), they can be used to set the location of the device tracker, then configuring `state_topic` is not required. Be aware that any location message received at `state_topic` will override the location received via `json_attributes_topic` until a message configured with `payload_reset` is received at `state_topic`. A more generic usage example for the use of `json_attributes_topic` can be found in [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-topic-configuration) documentation."
+  description: "The MQTT topic subscribed to receive a JSON dictionary message containing device tracker attributes. 
+  This topic can be used to set the location of the device tracker under the following conditions: 
+    * If the attributes in the JSON message include `longitude`, `latitude`, and `gps_accuracy` (optional).
+    * If the device tracker is within a configured [zone](/integrations/zone/). 
+    If these conditions are met, it is not required to configure `state_topic`. Be aware that any location message received at `state_topic`  overrides the location received via `json_attributes_topic` until a message configured with `payload_reset` is received at `state_topic`. For a more generic usage example of the `json_attributes_topic`, refer to the [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-topic-configuration) documentation."
   required: false
   type: string
 name:

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -118,7 +118,7 @@ json_attributes_template:
   required: false
   type: template
 json_attributes_topic:
-  description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as device_tracker attributes. Usage example can be found in [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-topic-configuration) documentation.
+  description: "The MQTT topic subscribed to receive a JSON dictionary message and then set as device_tracker attributes. If the attributes in the JSON message include `longitude`, `latitude` and optional `gps_accuracy` and if the device tracker is within a configured [zone](/integrations/zone/), they can be used to set the location of the device tracker, then configuring `state_topic` is not required. Be aware that any location message received at `state_topic` will override the location received via `json_attributes_topic` until a message configured with `payload_reset` is received at `state_topic`. A more generic usage example for the use of `json_attributes_topic` can be found in [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-topic-configuration) documentation."
   required: false
   type: string
 name:
@@ -164,8 +164,8 @@ source_type:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive device tracker state changes.
-  required: true
+  description: The MQTT topic subscribed to receive device tracker state changes, or to reset the state override when a message configured with `payload_reset` is received. Can only be omitted if only `json_attributes_topic` is used.
+  required: false
   type: string
 unique_id:
   description: "An ID that uniquely identifies this device_tracker. If two device_trackers have the same unique ID, Home Assistant will raise an exception."
@@ -208,6 +208,8 @@ If the device supports GPS coordinates then they can be sent to Home Assistant b
 - Attributes topic: `a4567d663eaf/attributes`
 - Example attributes payload:
 
+Example message to be received at topic `a4567d663eaf/attributes`:
+
 ```json
 {
   "latitude": 32.87336,
@@ -219,8 +221,14 @@ If the device supports GPS coordinates then they can be sent to Home Assistant b
 To create the device_tracker with GPS coordinates support:
 
 ```bash
-mosquitto_pub -h 127.0.0.1 -t homeassistant/device_tracker/a4567d663eaf/config -m '{"state_topic": "a4567d663eaf/state", "name": "My Tracker", "payload_home": "home", "payload_not_home": "not_home", "json_attributes_topic": "a4567d663eaf/attributes"}'
+mosquitto_pub -h 127.0.0.1 -t homeassistant/device_tracker/a4567d663eaf/config -m '{"json_attributes_topic": "a4567d663eaf/attributes", "name": "My Tracker"}'
 ```
+
+<div class='note info'>
+
+Using `state_topic` is optional when using `json_attributes_topic` to determine the state of the device tracker.
+
+</div>
 
 To set the state of the device tracker to specific coordinates:
 

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -118,11 +118,14 @@ json_attributes_template:
   required: false
   type: template
 json_attributes_topic:
-  description: "The MQTT topic subscribed to receive a JSON dictionary message containing device tracker attributes. 
-  This topic can be used to set the location of the device tracker under the following conditions: 
-    * If the attributes in the JSON message include `longitude`, `latitude`, and `gps_accuracy` (optional).
-    * If the device tracker is within a configured [zone](/integrations/zone/). 
-    If these conditions are met, it is not required to configure `state_topic`. Be aware that any location message received at `state_topic`  overrides the location received via `json_attributes_topic` until a message configured with `payload_reset` is received at `state_topic`. For a more generic usage example of the `json_attributes_topic`, refer to the [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-topic-configuration) documentation."
+  description: "The MQTT topic subscribed to receive a JSON dictionary message containing device tracker attributes.
+  This topic can be used to set the location of the device tracker under the following conditions:
+
+* If the attributes in the JSON message include `longitude`, `latitude`, and `gps_accuracy` (optional).\n
+* If the device tracker is within a configured [zone](/integrations/zone/).\n
+
+  If these conditions are met, it is not required to configure `state_topic`.\n\n
+  Be aware that any location message received at `state_topic`  overrides the location received via `json_attributes_topic` until a message configured with `payload_reset` is received at `state_topic`. For a more generic usage example of the `json_attributes_topic`, refer to the [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-topic-configuration) documentation."
   required: false
   type: string
 name:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Make `state_topic` optional for MQTT device_tracker and improve examples that use `json_attribute_topic` to receive GPS messages to determine the device tracker location.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/93322
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #27468

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
