### PR TITLE
Add Netgear troubleshooting

### DIFF
--- a/source/_integrations/netgear.markdown
+++ b/source/_integrations/netgear.markdown
@@ -112,4 +112,4 @@ Displays the current link type: wired, 2.4GHz or 5GHz.
 
 ## Troubleshooting
 
-- If you get a "Connection or login error" when trying to setup the Netgear integration, please try using the IP address of the router (often "192.168.1.1") as host instead of the default "routerlogin.net".
+- If you get a "Connection or login error" when trying to setup the NETGEAR integration, please try using the IP address of the router (often "192.168.1.1") as host instead of the default "routerlogin.net".

--- a/source/_integrations/netgear.markdown
+++ b/source/_integrations/netgear.markdown
@@ -109,3 +109,7 @@ Displays the current link rate of the device indicating the maximum possible dat
 ### Link type
 
 Displays the current link type: wired, 2.4GHz or 5GHz.
+
+## Troubleshooting
+
+- If you get a "Connection or login error" when trying to setup the Netgear integration, please try using the IP address of the router (often "192.168.1.1") as host instead of the default "routerlogin.net".


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Netgear troubleshooting section.
based on issue: https://github.com/home-assistant/core/issues/93263


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/93263

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
