### PR TITLE
Adds loss, jitter, and bandwidth docs to iperf3 integration page

### DIFF
--- a/source/_integrations/iperf3.markdown
+++ b/source/_integrations/iperf3.markdown
@@ -14,7 +14,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `iperf3` sensor integration allows you to measure network bandwidth performance against a private or public [Iperf3](https://software.es.net/iperf/index.html) server.
+The `iperf3` sensor integration allows you to measure network bandwidth performance, loss, and jitter against a private or public [Iperf3](https://software.es.net/iperf/index.html) server.
 
 Enabling this integration will automatically create the Iperf3 sensors for the monitored conditions (below). By default, it will run every hour. The user can change the update frequency in the configuration by defining the `scan_interval` for a Iperf3 test to run.
 
@@ -45,6 +45,10 @@ iperf3:
         description: The download speed (Mbit/s).
       upload:
         description: The upload speed (Mbit/s).
+      loss:
+        description: The percentage of packets lost. Only available if protocol is UDP.
+      jitter:
+        description: The jitter in milliseconds. Only available if protocol is UDP.
   hosts:
     description: A list of Iperf3 servers to perform the test against.
     required: true
@@ -87,6 +91,11 @@ Configuration variables (host):
     required: false
     default: tcp
     type: string
+  bandwidth:
+    description: The target bandwidth in bits/sec. If 0 is provided, the default (1 Mbit/sec for UDP, unlimited for TCP) iperf3 bandwidth will be used.
+    required: false
+    default: 0
+    type: integer
 {% endconfiguration %}
 
 #### Time period dictionary example


### PR DESCRIPTION
Add the loss, jitter, and bandwidth configuration documentation to the iperf3 integration page.
Good to review once https://github.com/home-assistant/core/pull/93298 is approved.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
