### PR TITLE
Remove negative letter-spacing for paragraphs

### DIFF
--- a/source/_styles/custom/content.css
+++ b/source/_styles/custom/content.css
@@ -77,7 +77,6 @@
 }
 .content p {
     color: rgb(87 87 87);
-    letter-spacing: -0.02em;
     font-weight: 400;
     font-size: 1rem;
     line-height: 1.5rem;
@@ -283,7 +282,7 @@
     margin-left: -20px;
     scroll-margin-top: 100px;
 }
-  
+
 .content .config-vars  .config-vars-label:hover a.title-link::before {
     position: absolute;
     top: 50%;
@@ -299,7 +298,7 @@
     height: 15px;
     width: 15px;
 }
-  
+
 .content .config-vars .config-vars-default {
     padding-top: 8px;
 }
@@ -308,7 +307,7 @@
     margin: 0;
     display: inline;
 }
-  
+
 .content .config-vars .config-vars-default .nested {
     margin-left: 48px;
 }
@@ -339,5 +338,5 @@
     .content table th,
     .content table td {
         padding: 6px;
-    } 
+    }
 }

--- a/source/_styles/custom/guide.css
+++ b/source/_styles/custom/guide.css
@@ -68,7 +68,6 @@
 .guide-content p {
     --tw-text-opacity: 1;
     color: rgb(87 87 87 / var(--tw-text-opacity));
-    letter-spacing: -0.02em;
     font-weight: 400;
     font-size: 1rem;
     line-height: 1.5rem;


### PR DESCRIPTION
## Proposed change
This PR removes the negative `letter-spacing` for content paragraphs to improve readability for the new site redesign.

Before:
![image](https://github.com/home-assistant/home-assistant.io/assets/7545841/20d2be8b-ef5d-466f-92f9-53f996bfc463)

After:
![image](https://github.com/home-assistant/home-assistant.io/assets/7545841/8828fed2-b344-4970-bd60-dde81d0c6288)

