### PR TITLE
Add imap ssl verify option

### DIFF
--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -50,14 +50,16 @@ Below is an example for setting up the integration to connect to your Microsoft 
   - Password: Your password
   - Charset: `US-ASCII`
 
-### Selecting an alternate SSL cipher list (advanced mode)
+### Selecting an alternate SSL cipher list or disable SSL verification (advanced mode)
 
 If the default IMAP server settings do not work, you might try to set an alternate SLL cipher list.
 The SSL cipher list option allows to select the list of SSL ciphers to be accepted from this endpoint. `default` (_system default_), `modern` or `intermediate` (_inspired by [Mozilla Security/Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS)_)
 
+If you are using self signed certificates can can turn of SSL verification.
+
 <div class='note info'>
 
-The SSL cipher list is an advanced setting. The option is available only when advanced mode is enabled (see user settings).
+The SSL cipher list and verify SSL are advanced settings. The options are available only when advanced mode is enabled (see user settings).
 
 </div>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Mention ssl verify option as alternative when using self signed certificates.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/93811
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #27576

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
