### PR TITLE
Update systemmonitor docs for #93861

### DIFF
--- a/source/_integrations/systemmonitor.markdown
+++ b/source/_integrations/systemmonitor.markdown
@@ -52,6 +52,7 @@ file.
 | disk_use_percent       | Path, e.g., `/`           | no                        |
 | disk_use               | Path, e.g., `/`           | no                        |
 | disk_free              | Path, e.g., `/`           | no                        |
+| disk_await             | Device, e.g., `mmcblk0`   | no                        |
 | memory_use_percent     |                           |                           |
 | memory_use             |                           |                           |
 | memory_free            |                           |                           |
@@ -101,6 +102,12 @@ sensor:
       - type: disk_use
         arg: /dev/shm
 ```
+
+## Disk await
+
+Disk await provides a measure of disk I/O latency - specifically, the average time to service an I/O request. The value will be displayed in the system's native time unit (seconds).
+
+Unlike disk usage, which is concerned with mount points, disk await is concerned with block devices. The `lsblk` command provides a list of block devices and their mount points. If no device is provided via the optional argument, the system-wide average await time is reported.
 
 ## Processor temperature
 
@@ -157,6 +164,8 @@ sensor:
         arg: /config
       - type: disk_use
       - type: disk_free
+      - type: disk_await
+        arg: mmcblk0
       - type: memory_use_percent
       - type: memory_use
       - type: memory_free


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Doc changes accompanying core [PR 93861](https://github.com/home-assistant/core/pull/93861), which adds `disk_await` entity to the `systemmonitor` integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/93861


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
