### PR TITLE
Update modes.markdown

### DIFF
--- a/source/_docs/automation/modes.markdown
+++ b/source/_docs/automation/modes.markdown
@@ -10,7 +10,7 @@ The automation's `mode` configuration option controls what happens when the auto
 Mode | Description
 -|-
 `single` | (Default) Do not start a new run. Issue a warning.
-`restart` | Start a new run after first stopping previous run.
+`restart` | Start a new run after first stopping previous run. The automation only restarts, if the **Conditions** are met. 
 `queued` | Start a new run after all previous runs complete. Runs are guaranteed to execute in the order they were queued. Note that subsequent queued automations will only join the queue if any conditions it may have are met at the time it is triggered.
 `parallel` | Start a new, independent run in parallel with previous runs.
 

--- a/source/_docs/automation/modes.markdown
+++ b/source/_docs/automation/modes.markdown
@@ -10,7 +10,7 @@ The automation's `mode` configuration option controls what happens when the auto
 Mode | Description
 -|-
 `single` | (Default) Do not start a new run. Issue a warning.
-`restart` | Start a new run after first stopping previous run. The automation only restarts, if the **Conditions** are met. 
+`restart` | Start a new run after first stopping the previous run. The automation only restarts if the conditions are met. 
 `queued` | Start a new run after all previous runs complete. Runs are guaranteed to execute in the order they were queued. Note that subsequent queued automations will only join the queue if any conditions it may have are met at the time it is triggered.
 `parallel` | Start a new, independent run in parallel with previous runs.
 


### PR DESCRIPTION
Add information about restart behavior

## Proposed change
Add missing information about the behavior of the automation restart mode. 
https://github.com/home-assistant/home-assistant.io/issues/27602 

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #27602 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
