### PR TITLE
Default mqtt climate initial, min_temp, max_temp

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -181,10 +181,9 @@ fan_modes:
   default: ['auto', 'low', 'medium', 'high']
   type: list
 initial:
-  description: Set the initial target temperature. The default value depends un the temperature unit.
+  description: Set the initial target temperature. The default value depends on the temperature unit and will be 21° or 69.8°F.
   required: false
   type: integer
-  default: 21° or 69.8°F
 icon:
   description: "[Icon](/docs/configuration/customizing-devices/#icon) for the entity."
   required: false
@@ -203,19 +202,18 @@ max_humidity:
   type: integer
   default: 99
 max_temp:
-  description: Maximum set point available. The default value depends un the temperature unit.
+  description: Maximum set point available. The default value depends on the temperature unit, and will be 35°C or 95°F.
   type: float
-  required: 35°C or 95°F
+  required: false
 min_humidity:
   description: The maximum target humidity percentage that can be set.
   required: false
   type: integer
   default: 30
 min_temp:
-  description: Minimum set point available. The default value depends un the temperature unit.
+  description: Minimum set point available. The default value depends on the temperature unit, and will be 7°C or 44.6°F.
   type: float
   required: false
-  default: 7°C or 44.6°F
 mode_command_template:
   description: A template to render the value sent to the `mode_command_topic` with.
   required: false

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -181,10 +181,10 @@ fan_modes:
   default: ['auto', 'low', 'medium', 'high']
   type: list
 initial:
-  description: Set the initial target temperature.
+  description: Set the initial target temperature. The default value depends un the temperature unit.
   required: false
   type: integer
-  default: 21
+  default: 21° or 69.8°F
 icon:
   description: "[Icon](/docs/configuration/customizing-devices/#icon) for the entity."
   required: false
@@ -203,18 +203,19 @@ max_humidity:
   type: integer
   default: 99
 max_temp:
-  description: Maximum set point available.
+  description: Maximum set point available. The default value depends un the temperature unit.
   type: float
-  required: false
+  required: 35°C or 95°F
 min_humidity:
   description: The maximum target humidity percentage that can be set.
   required: false
   type: integer
   default: 30
 min_temp:
-  description: Minimum set point available.
+  description: Minimum set point available. The default value depends un the temperature unit.
   type: float
   required: false
+  default: 7°C or 44.6°F
 mode_command_template:
   description: A template to render the value sent to the `mode_command_topic` with.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Default mqtt climate initial, min_temp, max_temp will depend on the temperature unit set.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/93965
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
