### PR TITLE
Add zwave_js breaking change to 2023.6 release notes

### DIFF
--- a/source/_posts/2023-06-07-release-20236.markdown
+++ b/source/_posts/2023-06-07-release-20236.markdown
@@ -882,16 +882,14 @@ get created as a `select` entity.
 
 ---
 
-For devices with the `Entry control` generic device class, the `Door lock mode`
-config parameter no longer gets created as a `sensor` entity and will instead
-get created as a `select` entity.
+The Nice IBT4ZWAVE module was previously discovered as a light, but now it is
+discovered as a cover. The light entity will be permanently unavailable and can
+be safely deleted.
 
-- Add zwave config parameter entities ([@raman325] - [#92223]) ([zwave_js docs]) (breaking-change)
-
-([@raman325] - [#92223]) ([documentation](/integrations/zwave_js))
+([@raman325] - [#93946]) ([documentation](/integrations/zwave_js))
 
 [@raman325]: https://github.com/raman325
-[#92223]: https://github.com/home-assistant/core/pull/92223
+[#93946]: https://github.com/home-assistant/core/pull/93946
 
 {% enddetails %}
 


### PR DESCRIPTION
Forgot to add a breaking change note for a PR that was merged in b3. It also looks like you duplicated the same breaking change twice

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
