### PR TITLE
Update Lutron integration docs with Lutron RadioRA2 software changes

### DIFF
--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -60,6 +60,12 @@ It is recommended to assign a static IP address to your main repeater. This ensu
 
 </div>
 
+<div class='note'>
+
+If you are using RadioRA2 software version 12 or later, the default `lutron` user with password `integration` is not configured by default.  To configure a new telnet user, go to Settings > Integration in your project and add a new telnet login.  The username and password you set in the RadioRA2 software are what need to be entered in the YAML configuration above.
+
+</div>
+
 ## Keypad buttons
 
 Individual buttons on keypads are not represented as entities. Instead, they fire events called `lutron_event` whose payloads include `id` and `action` attributes.

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -62,7 +62,7 @@ It is recommended to assign a static IP address to your main repeater. This ensu
 
 <div class='note'>
 
-If you are using RadioRA2 software version 12 or later, the default `lutron` user with password `integration` is not configured by default. To configure a new telnet user, go to Settings > Integration in your project and add a new telnet login. Once configured, use the transfer tab to push your changes to the RadioRA2 main repeater(s).
+If you are using RadioRA2 software version 12 or later, the default `lutron` user with password `integration` is not configured by default. To configure a new telnet user, go to **Settings** > **Integration** in your project and add a new telnet login. Once configured, use the transfer tab to push your changes to the RadioRA2 main repeater(s).
 
 </div>
 

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -62,7 +62,7 @@ It is recommended to assign a static IP address to your main repeater. This ensu
 
 <div class='note'>
 
-If you are using RadioRA2 software version 12 or later, the default `lutron` user with password `integration` is not configured by default.  To configure a new telnet user, go to Settings > Integration in your project and add a new telnet login.  The username and password you set in the RadioRA2 software are what need to be entered in the YAML configuration above.
+If you are using RadioRA2 software version 12 or later, the default `lutron` user with password `integration` is not configured by default.  To configure a new telnet user, go to Settings > Integration in your project and add a new telnet login.  Once configured, use the transfer tab to push your changes to the RadioRA2 main repeater(s).
 
 </div>
 

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -62,7 +62,7 @@ It is recommended to assign a static IP address to your main repeater. This ensu
 
 <div class='note'>
 
-If you are using RadioRA2 software version 12 or later, the default `lutron` user with password `integration` is not configured by default.  To configure a new telnet user, go to Settings > Integration in your project and add a new telnet login.  Once configured, use the transfer tab to push your changes to the RadioRA2 main repeater(s).
+If you are using RadioRA2 software version 12 or later, the default `lutron` user with password `integration` is not configured by default. To configure a new telnet user, go to Settings > Integration in your project and add a new telnet login. Once configured, use the transfer tab to push your changes to the RadioRA2 main repeater(s).
 
 </div>
 


### PR DESCRIPTION
## Proposed change
Update Lutron integration documentation to note changes to setting up a login on the Lutron RadioRa2 main repeater.



## Type of change
In the current doc page, it mentions that all Lutron RadioRa2 controllers have a default / ever present login of lutron/integration but as of version 12.X of RadioRA2 software, this is not the case and users must go in and create telnet logins so Home Assistant can communicate with the main repeater.  This is not clear in the current docs and caused my hours of headache as many other forums online say just use lutron/integration to login.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue: fixes #27662 

## Checklist
- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


### URL

https://www.home-assistant.io/integrations/lutron/

### Version

All