### PR TITLE
Roon: update path to reflect new integration design

### DIFF
--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -20,12 +20,12 @@ This integration uses Roon Core, a Roon application that runs on a machine on yo
 
 ## Configuration
 
-1. From the Home Assistant front-end, navigate to **Settings** -> **Devices & Services**. Under **Set up a new integration** locate 'Roon' and click **Configure**.
-2. Home Assistant will then try to find your Roon Core - if it is successful it will display `Authorize HomeAssistant in Roon`. Click **Submit** and skip to step 4
-3. If your Roon Core is not automatically found you can enter the `Hostname` or `IP address` for the Roon Core machine when requested and click **Submit**.
-4. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to **Settings** and then **Extensions**, there you will see an entry for Home Assistant with a button next to it. Click **Enable**.
-5. Roon core will then provide Home Assistant with the details of your media players.
-6. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.
+1. From the Home Assistant front-end, go to {% my integrations title="**Settings** > **Devices & Services**" %}. On the **Roon** integration, select the cogwheel. Then, select **Configure**.
+1. Home Assistant will then try to find your Roon Core - if it is successful it will display `Authorize HomeAssistant in Roon`. Select **Submit** and skip to step 4.
+1. If your Roon Core is not automatically found, enter the `Hostname` or `IP address` for the Roon Core machine when requested and select **Submit**.
+1. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to **Settings** and then **Extensions**. There, you will see an entry for Home Assistant with a button next to it. Select **Enable**.
+1. Roon core will then provide Home Assistant with the details of your media players.
+1. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Roon integration:
- update paths to reflect new integration design


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/16640
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
