### PR TITLE
Includes template: update path to reflect new integration design

### DIFF
--- a/source/_includes/integrations/option_flow.md
+++ b/source/_includes/integrations/option_flow.md
@@ -5,7 +5,6 @@
 Options for {{ name }} can be set via the user interface, by taking the following steps:
 
 - Browse to your Home Assistant instance.
-- In the sidebar click on _**{% my config icon %}**_.
-- From the configuration menu select: _**{% my integrations %}**_.
+- Go to **{% my integrations title="Settings > Devices & Services" %}**.
 - If multiple instances of {{ name }} are configured, choose the instance you want to configure.
-- Click on _**"Options"**_.
+- Select the cogwheel, then select **Configure**.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Includes template for text reuse: 
- update path to reflect new integration design


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration others are adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/16640
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
