### PR TITLE
Add default operation mode for mqtt climate

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -99,6 +99,14 @@ current_temperature_topic:
   description: The MQTT topic on which to listen for the current temperature. A `"None"` value received will reset the current temperature. Empty values (`'''`) will be ignored.
   required: false
   type: string
+default_mode_state_template:
+  description: A template with which the value received on `default_mode_state_topic` will be rendered.
+  required: false
+  type: template
+default_mode_state_topic:
+  description: The MQTT topic to subscribe for changes of the default HVAC operation mode. If this is not set, the last mode received at `mode_state_topic` will be considered the default mode. The received mode must be one of the `modes` configured, mode `off` excluded.
+  required: false
+  type: string
 device:
   description: 'Information about the device this HVAC device is a part of to tie it into the [device registry](https://developers.home-assistant.io/docs/en/device_registry_index.html). Only works through [MQTT discovery](/integrations/mqtt/#mqtt-discovery) and when [`unique_id`](#unique_id) is set. At least one of identifiers or connections must be present to identify the device.'
   required: false
@@ -219,7 +227,7 @@ mode_command_template:
   required: false
   type: template
 mode_command_topic:
-  description: The MQTT topic to publish commands to change the HVAC operation mode. Use with `mode_command_template` if you only want to publish the power state.
+  description: The MQTT topic to publish commands to change the HVAC operation mode. Use with `mode_command_template` if you only want to publish the power state. When optimistic mode applies, this will set default operation mode unless `default_mode_state_topic` is configured. 
   required: false
   type: string
 mode_state_template:
@@ -413,9 +421,9 @@ value_template:
 
 If a property works in *optimistic mode* (when the corresponding state topic is not set), Home Assistant will assume that any state changes published to the command topics did work and change the internal state of the entity immediately after publishing to the command topic. If it does not work in optimistic mode, the internal state of the entity is only updated when the requested update is confirmed by the device through the state topic. You can enforce optimistic mode by setting the `optimistic` option to `true`. When set, the internal state will always be updated, even when a state topic is defined.
 
-## Last active operation mode
+## Default operation mode
 
-Home Assistant remembers the last active operation mode for a MQTT HVAC device. When the device is turned using the `climate.turn_on` service the last known active operation mode will be set to turn on the device. The last active operation mode is also exposed via state attribute `last_active_mode`.
+The default operation mode is the mode that is set when the climate is turned on using the `climate.turn_on` service. In that case no operation mode is massed to the service. This functionality relies on the climate reporting this mode on `default_state_topic`. If this is not set, in pessimistic mode the fist supported mode (configured in `modes`) in in `['heat_cool', 'heat', 'cool']` will be used. In optimistic mode, if `default_state_topic` is not set, the default operation mode is the last active mode set.
 
 ## Using Templates
 

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -413,6 +413,10 @@ value_template:
 
 If a property works in *optimistic mode* (when the corresponding state topic is not set), Home Assistant will assume that any state changes published to the command topics did work and change the internal state of the entity immediately after publishing to the command topic. If it does not work in optimistic mode, the internal state of the entity is only updated when the requested update is confirmed by the device through the state topic. You can enforce optimistic mode by setting the `optimistic` option to `true`. When set, the internal state will always be updated, even when a state topic is defined.
 
+## Last active operation mode
+
+Home Assistant remembers the last active operation mode for a MQTT HVAC device. When the device is turned using the `climate.turn_on` service the last known active operation mode will be set to turn on the device.
+
 ## Using Templates
 
 For all `*_state_topic`s, a template can be specified that will be used to render the incoming payloads on these topics. Also, a default template that applies to all state topics can be specified as `value_template`. This can be useful if you received payloads are e.g., in JSON format. Since in JSON, a quoted string (e.g., `"foo"`) is just a string, this can also be used for unquoting.

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -423,7 +423,7 @@ If a property works in *optimistic mode* (when the corresponding state topic is 
 
 ## Default operation mode
 
-The default operation mode is the mode that is set when the climate is turned on using the `climate.turn_on` service. In that case no operation mode is massed to the service. This functionality relies on the climate reporting this mode on `default_state_topic`. If this is not set, in pessimistic mode the fist supported mode (configured in `modes`) in in `['heat_cool', 'heat', 'cool']` will be used. In optimistic mode, if `default_state_topic` is not set, the default operation mode is the last active mode set.
+The default operation mode is the mode that is set when the climate is turned on using the `climate.turn_on` service. In that case, no operation mode is passed to the service. This functionality relies on the climate reporting this mode on `default_state_topic`. If this is not set, in pessimistic mode, the first supported mode (configured in `modes`) in in `['heat_cool', 'heat', 'cool']` will be used. If `default_state_topic` is not set in optimistic mode, the default operation mode is the last active mode set.
 
 ## Using Templates
 

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -415,7 +415,7 @@ If a property works in *optimistic mode* (when the corresponding state topic is 
 
 ## Last active operation mode
 
-Home Assistant remembers the last active operation mode for a MQTT HVAC device. When the device is turned using the `climate.turn_on` service the last known active operation mode will be set to turn on the device.
+Home Assistant remembers the last active operation mode for a MQTT HVAC device. When the device is turned using the `climate.turn_on` service the last known active operation mode will be set to turn on the device. The last active operation mode is also exposed via state attribute `last_active_mode`.
 
 ## Using Templates
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document the new default operation mode state and template options for MQTT climate.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/94257
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
