### PR TITLE
Add missing breaking change in 2023.6 release notes

### DIFF
--- a/source/_posts/2023-06-07-release-20236.markdown
+++ b/source/_posts/2023-06-07-release-20236.markdown
@@ -938,6 +938,18 @@ be safely deleted.
 [@raman325]: https://github.com/raman325
 [#93946]: https://github.com/home-assistant/core/pull/93946
 
+---
+
+If you have zwave_js cover entities already and your device supports Window 
+Covering CC, you may see newly created cover entities. The old cover entities
+can safely be deleted but all customizations will need to be reapplied to the
+new entities.
+
+([@raman325] - [#93314]) ([documentation](/integrations/zwave_js))
+
+[@raman325]: https://github.com/raman325
+[#93314]: https://github.com/home-assistant/core/pull/93314
+
 {% enddetails %}
 
 If you are a custom integration developer and want to learn about breaking

--- a/source/_posts/2023-06-07-release-20236.markdown
+++ b/source/_posts/2023-06-07-release-20236.markdown
@@ -942,7 +942,7 @@ be safely deleted.
 
 If you have zwave_js cover entities already and your device supports Window 
 Covering CC, you may see newly created cover entities. The old cover entities
-can safely be deleted but all customizations will need to be reapplied to the
+can safely be deleted, but all customizations must be reapplied to the
 new entities.
 
 ([@raman325] - [#93314]) ([documentation](/integrations/zwave_js))


### PR DESCRIPTION
## Proposed change
I missed tagging a breaking change PR that was introduced in 2023.6. I have updated the PR (https://github.com/home-assistant/core/pull/93314) and am updating the release notes so it is included



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
