### PR TITLE
Update anel_pwrctrl.markdown

### DIFF
--- a/source/_integrations/anel_pwrctrl.markdown
+++ b/source/_integrations/anel_pwrctrl.markdown
@@ -38,11 +38,11 @@ host:
   required: false
   type: string
 port_recv:
-  description: The port the device receives data to.
+  description: The port on which the device receives data.
   required: true
   type: integer
 port_send:
-  description: The port the device sends data from.
+  description: The port from which the device sends data.
   required: true
   type: integer
 username:

--- a/source/_integrations/anel_pwrctrl.markdown
+++ b/source/_integrations/anel_pwrctrl.markdown
@@ -11,23 +11,25 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `anel_pwrctrl` switch platform allows you to control [ANEL PwrCtrl](https://en.anel.eu/index.htm?src=/produkte/produkte.htm) devices.
+The `anel_pwrctrl` switch platform allows you to control [ANEL PwrCtrl](https://en.anel.eu/index.htm?src=/produkte/produkte.htm) devices on firmware 6.x and older. [ANEL PwrCtrl](https://en.anel.eu/index.htm?src=/produkte/produkte.htm) devices on firmware 7.x are not supported.
 
 Supported devices (tested):
 
 - PwrCtrl HUT
+- PwrCtrl Advanced
+- PwrCtrl Advanced Power
 
 To add this platform to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 switch:
-  platform: anel_pwrctrl
-  host: IP_ADDRESS
-  port_recv: PORT
-  port_send: PORT
-  username: USERNAME
-  password: PASSWORD
+  - platform: anel_pwrctrl
+    host: IP_ADDRESS
+    port_recv: PORT
+    port_send: PORT
+    username: USERNAME
+    password: PASSWORD
 ```
 
 {% configuration %}
@@ -36,11 +38,11 @@ host:
   required: false
   type: string
 port_recv:
-  description: The port to receive data from the device.
+  description: The port the device receives data to.
   required: true
   type: integer
 port_send:
-  description: The port to send data to the device.
+  description: The port the device sends data from.
   required: true
   type: integer
 username:


### PR DESCRIPTION
Added notes about supported firmware, tested devices and fixed port descriptions.

## Proposed change
    - The Anel Pwr-Ctrl integration only supports firmware 6.x (and below). Firmware 7.x does not work with this.
    - I also added two devices I tested this integration with.
    - the ports were described incorrectly, not from the view of the device but from HA
    - AFAICT the yaml example needed a little fix to make `platform` a block




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.



## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
