### PR TITLE
Flux config flow documentation update

### DIFF
--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -24,7 +24,7 @@ To use the Flux integration in your installation, navigate to the "Integrations"
 
 ## Configuration
 
-Flux allows you to configure how your lights behave throughout the day. By default, Flux sets the timings (such as `start_time`, `sunset_time` and `stop_time`) based on your geographical location. However, these can be manually adjusted in the configuration panel for finer control.
+Flux allows you to configure how your lights behave throughout the day. By default, Flux sets the timings (such as `start_time`, `sunset_time` and `stop_time`) based on your geographical location. However, these (except `sunset_time`) can be manually adjusted in the configuration panel for finer control.
 
 During the day (in between `start_time` and `sunset_time`), the lights transition from a cool, daylight temperature to a warm, sunset color. After sunset (between `sunset_time` and `stop_time`), the lights continue to warm, mimicking the natural transition from daylight to nighttime.
 

--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -14,18 +14,18 @@ ha_integration_type: integration
 
 The `flux` switch platform enables you to control the temperature of your lights, using a model that resembles the human circadian rhythm. Your lights will be bright during the day, and gradually fade to a warmer hue at night. The `flux` switch restores its last state after startup.
 
-This integration changes your lights based on the time of day. It only affects lights that are turned on and configured in the flux switch.
+This integration changes your lights based on the time of day. It only affects lights that are turned on and configured in the Flux integration.
 
-## Installation and Configuration
+## Installation
 
-The Flux integration can now be installed and configured directly from the Home Assistant user interface, which simplifies the setup process and reduces the need for manual YAML configuration. 
+The Flux integration can now be installed directly from the Home Assistant user interface.
 
 To use the Flux integration in your installation, navigate to the "Integrations" page in the configuration panel. Click on the "+" button, search for "Flux", and fill in the form to set up the integration.
 
-During the day (in between the set `start_time` and the adjusted `sunset_time`), the lights will transition from the `start_colortemp` to the `sunset_colortemp`. After sunset (between `sunset_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. The fade effect is created by updating the lights periodically.
+## Configuration
 
-The value of `sunset_time` can be set based on your preference within the Flux integration configuration.
+Flux allows you to configure how your lights behave throughout the day. By default, Flux sets the timings (such as `start_time`, `sunset_time` and `stop_time`) based on your geographical location. However, these can be manually adjusted in the configuration panel for finer control.
 
-The color temperature is specified in kelvin, and accepted values are between 1000 and 40000 kelvin. Lower values will seem more red, while higher will look more white.
+During the day (in between `start_time` and `sunset_time`), the lights transition from a cool, daylight temperature to a warm, sunset color. After sunset (between `sunset_time` and `stop_time`), the lights continue to warm, mimicking the natural transition from daylight to nighttime.
 
-If you want to update at variable intervals, you can leave the switch turned off and use automation rules that call the service `switch.<name>_update` whenever you want the lights updated, where `<name>` equals the name you set in the switch configuration.
+The color temperature can be adjusted to your liking, with lower values giving a warmer, redder hue and higher values creating a cooler, whiter light.

--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -12,106 +12,20 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `flux` switch platform will change the temperature of your lights similar to the way flux works on your computer, using circadian rhythm. They will be bright during the day, and gradually fade to a red/orange at night. The `flux` switch restores its last state after startup.
+The `flux` switch platform enables you to control the temperature of your lights, using a model that resembles the human circadian rhythm. Your lights will be bright during the day, and gradually fade to a warmer hue at night. The `flux` switch restores its last state after startup.
 
-The integration will update your lights based on the time of day. It will only affect lights that are turned on and listed in the flux configuration.
+This integration changes your lights based on the time of day. It only affects lights that are turned on and configured in the flux switch.
 
-During the day (in between `start_time` and `sunset_time`), it will fade the lights from the `start_colortemp` to the `sunset_colortemp`. After sunset (between `sunset_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. If the lights are still on after the `stop_time` it will continue to change the light to the `stop_colortemp` until the light is turned off. The fade effect is created by updating the lights periodically.
+## Installation and Configuration
 
-The value of `sunset_time` is automatically calculated based on the location specified in your [Home Assistant configuration](/docs/configuration/basic).
+The Flux integration can now be installed and configured directly from the Home Assistant user interface, which simplifies the setup process and reduces the need for manual YAML configuration. 
+
+To use the Flux integration in your installation, navigate to the "Integrations" page in the configuration panel. Click on the "+" button, search for "Flux", and fill in the form to set up the integration.
+
+During the day (in between the set `start_time` and the adjusted `sunset_time`), the lights will transition from the `start_colortemp` to the `sunset_colortemp`. After sunset (between `sunset_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. The fade effect is created by updating the lights periodically.
+
+The value of `sunset_time` can be set based on your preference within the Flux integration configuration.
 
 The color temperature is specified in kelvin, and accepted values are between 1000 and 40000 kelvin. Lower values will seem more red, while higher will look more white.
 
-If you want to update at variable intervals, you can leave the switch turned off and use automation rules that call the service `switch.<name>_update` whenever you want the lights updated, where `<name>` equals the `name:` property in the switch configuration.
-
-To use the Flux switch in your installation, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-switch:
-  - platform: flux
-    lights:
-      - light.desk
-      - light.lamp
-```
-
-{% configuration %}
-lights:
-  description: array list of light entities.
-  required: true
-  type: list
-name:
-  description: The name to use when displaying this switch.
-  required: false
-  default: Flux
-  type: string
-start_time:
-  description: The start time.
-  required: false
-  type: time
-stop_time:
-  description: The stop time.
-  required: false
-  type: time
-start_colortemp:
-  description: The color temperature at the start.
-  required: false
-  default: 4000
-  type: integer
-sunset_colortemp:
-  description: The sun set color temperature.
-  required: false
-  default: 3000
-  type: integer
-stop_colortemp:
-  description: The color temperature at the end.
-  required: false
-  default: 1900
-  type: integer
-brightness:
-  description: Constant brightness of the lights. Besides color temperature, brightness is also adjusted unless a value is specified here.
-  required: false
-  type: integer
-disable_brightness_adjust:
-  description: If true, brightness will not be adjusted, only color temperature.
-  required: false
-  type: boolean
-  default: false
-mode:
-  description: Select how color temperature is passed to lights. Valid values are `xy`, `mired` and `rgb`.
-  required: false
-  default: xy
-  type: string
-transition:
-  description: Transition time in seconds for the light changes (high values may not be supported by all light models).
-  required: false
-  default: 30
-  type: integer
-interval:
-  description: Frequency in seconds at which the lights should be updated.
-  required: false
-  default: 30
-  type: integer
-{% endconfiguration %}
-
-Full example:
-
-```yaml
-# Example configuration.yaml entry
-switch:
-  - platform: flux
-    lights:
-      - light.desk
-      - light.lamp
-    name: Fluxer
-    start_time: "7:00"
-    stop_time: "23:00"
-    start_colortemp: 4000
-    sunset_colortemp: 3000
-    stop_colortemp: 1900
-    brightness: 200
-    disable_brightness_adjust: true
-    mode: xy
-    transition: 30
-    interval: 60
-```
+If you want to update at variable intervals, you can leave the switch turned off and use automation rules that call the service `switch.<name>_update` whenever you want the lights updated, where `<name>` equals the name you set in the switch configuration.

--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -12,7 +12,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `flux` switch platform enables you to control the temperature of your lights, using a model that resembles the human circadian rhythm. Your lights will be bright during the day, and gradually fade to a warmer hue at night. The `flux` switch restores its last state after startup.
+The `flux` switch platform enables you to control the temperature of your lights, adapting to natural day-night cycles. Your lights will be bright during the day, and gradually fade to a warmer hue at night. The `flux` switch restores its last state after startup.
 
 This integration changes your lights based on the time of day. It only affects lights that are turned on and configured in the Flux integration.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The Flux integration now supports user interface (UI) installation and configuration, reducing reliance on YAML. Additionally, it consolidates `brightness` and `disable_brightness_adjust` into a single UI option.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/94394

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
