### PR TITLE
Reolink integration: Added device to docs

### DIFF
--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -171,7 +171,7 @@ The following models have been tested and confirmed to work:
 - C2 Pro
 - E1 Zoom
 - E1 Outdoor
-- E1 Outdoor Pro (Wi-Fi)
+- E1 Outdoor Pro
 - RLC-410
 - RLC-410W
 - RLC-411

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -171,6 +171,7 @@ The following models have been tested and confirmed to work:
 - C2 Pro
 - E1 Zoom
 - E1 Outdoor
+- E1 Outdoor Pro (Wi-Fi)
 - RLC-410
 - RLC-410W
 - RLC-411


### PR DESCRIPTION
## Proposed change
Added the Reolink E1 Outdoor Pro to the list of supported devices. I bought one myself and integrated it. I have tested all the functionalities and everything works as expected.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
One thing I did noticed was that the device was not recognized through the integrations page.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
