### PR TITLE
Authentication, events: replace component by integration

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -197,7 +197,7 @@ For now, meta variables are only respected the first time a particular user is a
 This is a legacy feature for backwards compatibility and will be dropped in a future release. You should move to one of the other auth providers.
 </div>
 
-Activating this auth provider will allow you to authenticate with the API password set in the HTTP component.
+Activating this auth provider will allow you to authenticate with the API password set in the HTTP integration.
 
 ```yaml
 homeassistant:

--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -98,7 +98,7 @@ This event is fired when a new service has been registered within Home Assistant
 
 | Field     | Description                                                             |
 | --------- | ----------------------------------------------------------------------- |
-| `domain`  | The domain of the component that offers this service. Example: `light`. |
+| `domain`  | The domain of the integration that offers this service. Example: `light`. |
 | `service` | The name of the service. Example: `turn_on`                             |
 
 ### `service_removed`
@@ -107,7 +107,7 @@ This event is fired when a service has been removed from Home Assistant.
 
 | Field     | Description                                                             |
 | --------- | ----------------------------------------------------------------------- |
-| `domain`  | The domain of the component that offers this service. Example: `light`. |
+| `domain`  | The domain of the integration that offers this service. Example: `light`. |
 | `service` | The name of the service. Example: `turn_on`                             |
 
 ### `state_changed`


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Authentication and events: 
 - replace term _component_ by _integration_ 
 - as it has been renamed


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
