### PR TITLE
L-integrations: replace term component by integration

### DIFF
--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -205,9 +205,9 @@ In this section you will find some real-life examples of how to use this light.
 ### Theater Volume Control
 
 This example shows a light that is actually a home theater's volume. This
-component gives you the flexibility to provide whatever you'd like to send as
+integration gives you the flexibility to provide whatever you'd like to send as
 the payload to the consumer including any scale conversions you may need to
-make; the [Media Player component](/integrations/media_player/) needs a floating
+make; the [Media Player integration](/integrations/media_player/) needs a floating
 point percentage value from `0.0` to `1.0`.
 
 {% raw %}

--- a/source/_integrations/logbook.markdown
+++ b/source/_integrations/logbook.markdown
@@ -154,7 +154,7 @@ exclude them in `recorder` instead.
 ### Custom Entries
 
 It is possible to add custom entries to the logbook by using the script
-component to fire an event.
+integration to fire an event.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/logi_circle.markdown
+++ b/source/_integrations/logi_circle.markdown
@@ -98,7 +98,7 @@ logi_circle:
       - streaming
 ```
 
-By default, all sensors available from your Logi Circle devices will be monitored. Leave `monitored_conditions` blank to disable all sensors for the Logi Circle component. Devices without an internal battery will not expose a `battery_level` sensor.
+By default, all sensors available from your Logi Circle devices will be monitored. Leave `monitored_conditions` blank to disable all sensors for the Logi Circle integration. Devices without an internal battery will not expose a `battery_level` sensor.
 
 {% configuration %}
 sensor:

--- a/source/_integrations/lutron_caseta.markdown
+++ b/source/_integrations/lutron_caseta.markdown
@@ -45,7 +45,7 @@ Supports Bridges:
 - QSX Processor (HQP7)
 - RadioRA 3 All-in-One Processor (RR-PROC3)
  
-For the RadioRA 2 and HomeWorks QS product lines, see the [Lutron component](/integrations/lutron/).
+For the RadioRA 2 and HomeWorks QS product lines, see the [Lutron integration](/integrations/lutron/).
 
 The currently supported devices are:
 
@@ -118,7 +118,7 @@ To get Lutron Caseta roller, honeycomb shades, lights, scene and switch working 
 
 After setup, shades will appear in Home Assistant using an `entity_id` based on the name used in the Lutron mobile app. For example, a shade called 'Living Room Window' will appear in Home Assistant as `cover.living_room_window`.
 
-For more information on working with shades in Home Assistant, see the [Covers component](/integrations/cover/).
+For more information on working with shades in Home Assistant, see the [Covers integration](/integrations/cover/).
 
 Available services: `cover.open_cover`, `cover.close_cover`, `cover.stop_cover` and `cover.set_cover_position`. Cover `position` ranges from `0` for fully closed to `100` for fully open.
 
@@ -128,7 +128,7 @@ After setup, dimmable lights including wall and plug-in dimmers will appear in H
 
 For non-dimmable lights or switched loads, see the switch section on this page.
 
-For more information on working with lights in Home Assistant, see the [Lights component](/integrations/light/).
+For more information on working with lights in Home Assistant, see the [Lights integration](/integrations/light/).
 
 ## Scene
 
@@ -136,7 +136,7 @@ The Lutron Caseta scene platform allows you to control your Smart Bridge Scenes 
 
 After setup, scenes will appear in Home Assistant using an `entity_id` based on the name used in the Lutron mobile app. For example, a scene called 'Entertain' will appear in Home Assistant as `scene.entertain`.
 
-For more information on working with scenes in Home Assistant, see the [Scenes component](/integrations/scene/).
+For more information on working with scenes in Home Assistant, see the [Scenes integration](/integrations/scene/).
 
 Scenes are not directly supported on RA3 and QSX models, however the button platform (see below) can be used to activate scenes for these systems.
 
@@ -146,13 +146,13 @@ After setup, switches will appear in Home Assistant using an `entity_id` based o
 
 For dimmable lights including wall and plug-in dimmers, see the light section on this page.
 
-For more information on working with switches in Home Assistant, see the [Switches component](/integrations/switch/).
+For more information on working with switches in Home Assistant, see the [Switches integration](/integrations/switch/).
 
 ## Fan
 
 After setup, fans will appear in Home Assistant using an `entity_id` based on the name used in the Lutron mobile app. For example, a light switch called 'Master Bedroom Ceiling Fan' will appear in Home Assistant as `fan.master_bedroom_ceiling_fan`.
 
-For more information on working with fans in Home Assistant, see the [Fans component](/components/fan/).
+For more information on working with fans in Home Assistant, see the [Fans integration](/integrations/fan/).
 
 ## Sensor
 
@@ -166,7 +166,7 @@ Lutron Caseta occupancy sensors support 4 different timeouts and 3 different sen
 
 Because Lutron Caseta devices automatically report state to Home Assistant (rather than relying on polling), occupancy status updates occur almost instantaneously.
 
-For more information on working with binary sensors in Home Assistant, see the [Binary Sensors Component](/components/binary_sensor/)
+For more information on working with binary sensors in Home Assistant, see the [Binary Sensors integration](/integrations/binary_sensor/)
 
 ## Button
 

--- a/source/_integrations/lyric.markdown
+++ b/source/_integrations/lyric.markdown
@@ -22,7 +22,7 @@ The Honeywell Lyric integration integrates the Lyric thermostat platform into Ho
 
 ## Setup
 
-To set up this component, you first **must** set up a developer account with Honeywell:
+To set up this integration, you first **must** set up a developer account with Honeywell:
 
 1. Go to the [developer site](https://developer.honeywellhome.com) and register with an account.
 1. Next, create a [new app](https://developer.honeywellhome.com/user/me/apps/add) via the `My Apps` section.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Integrations starting with L:
-  Replace term _component_ by _integration_
- as it has been renamed


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
