### PR TITLE
Logger integration: replace term component by integration

### DIFF
--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -25,7 +25,7 @@ logger:
 The log severity level is `warning` if the logger integration is not enabled in `configuration.yaml`.
 
 To log all messages and ignore events lower than critical for specified
-components:
+integrations:
 
 ```yaml
 # Example configuration.yaml entry
@@ -37,7 +37,7 @@ logger:
 ```
 
 To ignore all messages lower than critical and log event for specified
-components:
+integrations:
 
 ```yaml
 # Example configuration.yaml entry
@@ -59,7 +59,7 @@ logger:
     # log level for SmartThings lights
     homeassistant.components.smartthings.light: info
 
-    # log level for a custom component
+    # log level for a custom integration
     custom_components.my_integration: debug
 
     # log level for the `aiohttp` Python package
@@ -85,7 +85,7 @@ where **namespace** is the *<component_namespace>* currently logging.
     type: map
     keys:
       '&lt;component_namespace&gt;':
-        description: Logger namespace of the component. See [log_level](#log-levels).
+        description: Logger namespace of the integration. See [log_level](#log-levels).
         type: string
   filters:
     description: Regular Expression logging filters.
@@ -93,7 +93,7 @@ where **namespace** is the *<component_namespace>* currently logging.
     type: map
     keys:
       '&lt;component_namespace&gt;':
-        description: Logger namespace of the component and a list of Regular Expressions. See [Log Filters](#log-filters).
+        description: Logger namespace of the integration and a list of Regular Expressions. See [Log Filters](#log-filters).
         type: list
 {% endconfiguration %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Logger integration:
-  Replace term _component_ by _integration_
- as it has been renamed



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
