### PR TITLE
r-integrations: replace term component by integration

### DIFF
--- a/source/_integrations/raincloud.markdown
+++ b/source/_integrations/raincloud.markdown
@@ -73,7 +73,7 @@ monitored_conditions:
 
 ## Sensor
 
-Once you have enabled the [Raincloud component](#configuration), add the following to your `configuration.yaml` file:
+Once you have enabled the [Raincloud integration](#configuration), add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -100,7 +100,7 @@ monitored_conditions:
 
 ## Switch
 
-Once you have enabled the [Raincloud component](#configuration), add the following to your `configuration.yaml` file:
+Once you have enabled the [Raincloud integration](#configuration), add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -122,5 +122,5 @@ monitored_conditions:
     auto_watering:
       description: Toggle the watering scheduled per zone.
     manual_watering:
-      description: Toggle manually the watering per zone. It will inherent the value in minutes specified on the RainCloud hub component.
+      description: Toggle manually the watering per zone. It will inherent the value in minutes specified on the RainCloud hub integration.
 {% endconfiguration %}

--- a/source/_integrations/rest_command.markdown
+++ b/source/_integrations/rest_command.markdown
@@ -14,7 +14,7 @@ This integration can expose regular REST commands as services. Services can be c
 [script]: /integrations/script/
 [automation]: /getting-started/automation/
 
-To use this component, add the following lines to your `configuration.yaml` file:
+To use this integration, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -138,7 +138,7 @@ To add the device, enter the value unaltered in the Event Code field, and click 
 
 #### Convert switch event to dimming event
 
-To convert a standard switch to a light, use the [Light Switch](/integrations/light.switch/) component.
+To convert a standard switch to a light, use the [Light Switch](/integrations/light.switch/) integration.
 
 To convert a switch to a dimmable light, make sure the event contains a dimming command. You can usually convert a command by changing one byte.
 

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -23,7 +23,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `ring` implementation allows you to integrate your [Ring.com](https://ring.com/) devices in Home Assistant. Due to recent authentication changes of Ring, you will need to run at least Home Assistant 0.104.
+The Ring integration allows you to integrate your [Ring.com](https://ring.com/) devices in Home Assistant. Due to recent authentication changes of Ring, you will need to run at least Home Assistant 0.104.
 
 There is currently support for the following device types within Home Assistant:
 
@@ -33,7 +33,7 @@ There is currently support for the following device types within Home Assistant:
 - [Switch](#switch)
 
 <p class='note'>
-This component does NOT allow for live viewing of your Ring camera within Home Assistant.
+This integration does NOT allow for live viewing of your Ring camera within Home Assistant.
 </p>
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Integrations starting with r:
-  Replace term _component_ by _integration_
- as it has been renamed



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
