### PR TITLE
S-integrations, 02: replace term component by integration

### DIFF
--- a/source/_integrations/simulated.markdown
+++ b/source/_integrations/simulated.markdown
@@ -1,6 +1,6 @@
 ---
 title: Simulated
-description: Component for simulating a numerical sensor.
+description: Integration for simulating a numerical sensor.
 ha_category:
   - Sensor
   - Utility

--- a/source/_integrations/sisyphus.markdown
+++ b/source/_integrations/sisyphus.markdown
@@ -25,7 +25,7 @@ There is currently support for the following device types within Home Assistant:
 
 The Light and Media players will be automatically added for each of your Sisyphus tables, if the Sisyphus integration is configured.
 
-There are two ways to configure this component. For the automatic discovery of your table(s), simply add the following to your `configuration.yaml`:
+There are two ways to configure this integration. For the automatic discovery of your table(s), add the following to your `configuration.yaml`:
 
 ```yaml
 # This will auto-detect all Sisyphus tables on your local network.

--- a/source/_integrations/snapcast.markdown
+++ b/source/_integrations/snapcast.markdown
@@ -20,7 +20,7 @@ The Snapcast integration allows you to control [Snapcast](https://github.com/bad
 
 ## Services
 
-The snapcast components provides a few services registered under the media_player component.
+The snapcast integration provides a few services registered under the media_player integration.
 
 ### Service `snapcast.snapshot`
 

--- a/source/_integrations/snips.markdown
+++ b/source/_integrations/snips.markdown
@@ -141,7 +141,7 @@ Alternatively, MQTT can be configured to bridge messages between servers if usin
 
 ### Triggering actions
 
-In Home Assistant, we trigger actions based on intents produced by Snips using the [`intent_script`](/integrations/intent_script) component. For instance, the following block handles a `ActivateLightColor` intent to change light colors:
+In Home Assistant, we trigger actions based on intents produced by Snips using the [`intent_script`](/integrations/intent_script) integration. For instance, the following block handles a `ActivateLightColor` intent to change light colors:
 
 Note: If your Snips action is prefixed with a username (e.g., `john:playmusic` or `john__playmusic`), the Snips integration in Home Assistant will try and strip off the username. Bear this in mind if you get the error `Received unknown intent` even when what you see on the MQTT bus looks correct. Internally the Snips integration is trying to match the non-username version of the intent (i.e., just `playmusic`).
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -15,7 +15,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `solaredge_local` platform uses the local API available on some SolarEdge Inverters to allow you to get details from your SolarEdge solar power setup and integrate these into your Home Assistant installation.
+The `solaredge_local` integration uses the local API available on some SolarEdge Inverters to allow you to get details from your SolarEdge solar power setup and integrate these into your Home Assistant installation.
 
 Only specific models support the local API. The local API is available on inverters that do not have an LCD character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection". These inverters also have a part number that ends with a 4. For example: SEXXK-XXXXXBXX4 or SEXXXXH-XXXXXBXX4
 
@@ -23,7 +23,7 @@ You can check if the local API works by finding the IP address of your inverter 
 
 <div class='note'>
 
-Recent firmware updates have disabled the local API on many inverters. Please enter the IP address of your inverter in a browser before attempting to use this component. If the local API is enabled, you'll see a web page with the SolarEdge logo and a "Commissioning" menu. See [this issue](https://github.com/jbuehl/solaredge/issues/124) and [this issue](https://github.com/drobtravels/solaredge-local/issues/24) for additional details.
+Recent firmware updates have disabled the local API on many inverters. Please enter the IP address of your inverter in a browser before attempting to use this integration. If the local API is enabled, you'll see a web page with the SolarEdge logo and a "Commissioning" menu. See [this issue](https://github.com/jbuehl/solaredge/issues/124) and [this issue](https://github.com/drobtravels/solaredge-local/issues/24) for additional details.
   
 If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
 

--- a/source/_integrations/spaceapi.markdown
+++ b/source/_integrations/spaceapi.markdown
@@ -264,7 +264,7 @@ The list of sensors can be any sensor, not just temperature or humidity.
 
 ## Examples
 
-In this section you find some real-life examples of how to use this component.
+In this section you find some real-life examples of how to use this integration.
 
 ### Eastermundigen
 

--- a/source/_integrations/speedtestdotnet.markdown
+++ b/source/_integrations/speedtestdotnet.markdown
@@ -39,7 +39,7 @@ Please be aware of the potential [inconsistencies](https://github.com/sivel/spee
 
 ## Examples
 
-In this section you will find some real-life examples of how to use this component.
+In this section you will find some real-life examples of how to use this integration.
 ### Using as a trigger in an automation
 
 {% raw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Integrations starting with s (2nd batch):

Replace term component by integration
- as it has been renamed


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
