### PR TITLE
Matter: remove Google Home requirement for Android commissioning

### DIFF
--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -253,7 +253,7 @@ Tasmota supports Matter over IP on all ESP32 based devices (in experimental phas
 This button will only be visible within the Home Assistant Companion App (so not in the browser) and your device meets all requirements for Matter support.
 
 - For iOS, minimum version is iOS 16 (minimal 16.3 is preferred) and the most recent version of the HA companion app.
-- For Android, minimum version is 8.1 and the most recent version of the (full) HA Companion app, downloaded from the app store.
+- For Android, minimum version is 8.1 and the most recent version of the (full) HA Companion app, downloaded from the Play Store.
 
 ### When I'm trying to commission using the Android app, I get an error stating "Matter is currently unavailable"
 

--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -253,11 +253,11 @@ Tasmota supports Matter over IP on all ESP32 based devices (in experimental phas
 This button will only be visible within the Home Assistant Companion App (so not in the browser) and your device meets all requirements for Matter support.
 
 - For iOS, minimum version is iOS 16 (minimal 16.3 is preferred) and the most recent version of the HA companion app.
-- For Android, minimum version is 8.1 and the most recent version of both the Google Home app and the (full) HA Companion app, downloaded from the app store.
+- For Android, minimum version is 8.1 and the most recent version of the (full) HA Companion app, downloaded from the app store.
 
 ### When I'm trying to commission using the Android app, I get an error stating "Matter is currently unavailable"
 
-See above, make sure your device meets all requirements to support Matter. Update Android to the latest version and the Google Home and Home Assistant Companion app. To quickly verify if your device meets all requirements to support Matter, on your Android device, go to **Settings** > **Google** > **Devices & Sharing**. There should be an entry there for **Matter devices**.
+See above, make sure your device meets all requirements to support Matter. Update Android to the latest version and the Home Assistant Companion app. To quickly verify if your device meets all requirements to support Matter, on your Android device, go to **Settings** > **Google** > **Devices & Sharing**. There should be an entry there for **Matter devices**.
 
 Some users have reported that uninstalling and reinstalling the Google Home app fixed this issue for them.
 Also see this [extended troubleshooting guide](https://developers.home.google.com/matter/verify-services) from Google.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The 2023.6 release of the Android app, released yesterday, [includes a change](https://github.com/home-assistant/android/pull/3427) that ensures the Play Store installs Matter support on the device when installing the Home Assistant app, removing the requirement to install the Google Home app for commissioning:

![Play Store screenshot for the Home Assistant app with a message 'Google Play Services will install additional components (5.3 MB) needed to use this app' highlighted](https://github.com/home-assistant/home-assistant.io/assets/8148535/7859eb48-a1c2-4ebc-b5db-f6e2ddef63cd)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
