### PR TITLE
S-integrations: replace term component by integration

### DIFF
--- a/source/_integrations/shiftr.markdown
+++ b/source/_integrations/shiftr.markdown
@@ -13,7 +13,7 @@ The `shiftr` integration makes it possible to transfer details collected with Ho
 
 ## Configuration
 
-Create a new [namespace](https://shiftr.io/new) and generate a new token. You will need to use `Key (Username)` and `Secret (Password)` to setup the component.
+Create a new [namespace](https://shiftr.io/new) and generate a new token. You will need to use `Key (Username)` and `Secret (Password)` to setup the integration.
 
 To use the `shiftr` integration in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_integrations/stiebel_eltron.markdown
+++ b/source/_integrations/stiebel_eltron.markdown
@@ -48,7 +48,7 @@ The following preset modes are supported. The STIEBEL ELTRON modes are mapped an
 
 ## Configuration
 
-To enable this component, add the following lines to your `configuration.yaml` file:
+To enable this integration, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/stream.markdown
+++ b/source/_integrations/stream.markdown
@@ -16,7 +16,7 @@ ha_platforms:
 ha_integration_type: system
 ---
 
-The stream integration provides a way to proxy live streams through Home Assistant. Most users should not need to configure anything or interface with the component directly since it is an internal component used by the [camera integration](/integrations/camera).
+The stream integration provides a way to proxy live streams through Home Assistant. Most users should not need to configure anything or interface with the integration directly since it is an internal integration used by the [camera integration](/integrations/camera).
 
 ## Configuration
 

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -19,7 +19,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `surepetcare` component allows you to get information on your Sure Petcare Connect Pet or Cat Flap.
+The Sure Petcare integration allows you to get information on your Sure Petcare Connect Pet or Cat Flap.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/system_log.markdown
+++ b/source/_integrations/system_log.markdown
@@ -59,7 +59,7 @@ Errors and warnings are posted as the event `system_log_event`, so it is possibl
 | `source`    | File that triggered the error, e.g., `core.py` or `media_player/yamaha.py`. |
 | `exception` | Full stack trace if available, an empty string otherwise.                   |
 | `message`   | Descriptive message of the error, e.g., "Error handling request".           |
-| `name`      | Name of the component, e.g., `homeassistant.components.device_tracker`      |
+| `name`      | Name of the integration, e.g., `homeassistant.components.device_tracker`      |
 | `timestamp` | Unix timestamp with as a double, e.g., 1517241010.237416.                   |
 
 Live examples of these events can be found in the Home Assistant log file (`home-assistant.log`) or by just looking in the system log. An example could, for instance, look like this:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Integrations starting with S:
-  Replace term _component_ by _integration_
- as it has been renamed



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
