### PR TITLE
t-integrations: replace term component by integration

### DIFF
--- a/source/_integrations/tank_utility.markdown
+++ b/source/_integrations/tank_utility.markdown
@@ -54,7 +54,7 @@ The device item value is the last segment of the URL path, e.g., the URL
 
 ## Configuration
 
-To enable the component, add the following lines to your `configuration.yaml` file:
+To enable the integration, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -415,7 +415,7 @@ template:
 
 ### State based sensor modifying another sensor's output
 
-If you don't like the wording of a sensor output, then the Template Sensor can help too. Let's rename the output of the [Sun component](/integrations/sun/) as a simple example:
+If you don't like the wording of a sensor output, then the Template Sensor can help too. Let's rename the output of the [Sun integration](/integrations/sun/) as a simple example:
 
 {% raw %}
 
@@ -790,7 +790,7 @@ sensor:
             required: true
             type: template
       availability_template:
-        description: Defines a template to get the `available` state of the component. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`.
+        description: Defines a template to get the `available` state of the integration. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the integration will always be `available`.
         required: false
         type: template
         default: true

--- a/source/_integrations/thethingsnetwork.markdown
+++ b/source/_integrations/thethingsnetwork.markdown
@@ -52,7 +52,7 @@ Access keys
 
 ## Configuration
 
-To enable this component, add the following lines to your `configuration.yaml`:
+To enable this integration, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry
@@ -76,7 +76,7 @@ access_key:
 
 The `thethingsnetwork` sensor platform allows you to get data from a [The Things Network Storage Integration](https://www.thethingsnetwork.org/docs/applications/storage/).
 
-This platform requires that the [The Things Network component](#configuration) is set up and the [The Things Network Storage Integration](https://www.thethingsnetwork.org/docs/applications/storage/) as well.
+This platform requires that the [The Things Network integration](#configuration) is set up and the [The Things Network Storage Integration](https://www.thethingsnetwork.org/docs/applications/storage/) as well.
 
 ### Prerequisites
 

--- a/source/_integrations/thingspeak.markdown
+++ b/source/_integrations/thingspeak.markdown
@@ -10,7 +10,7 @@ ha_integration_type: integration
 ---
 
 The `thingspeak` integrations makes Home Assistant communicate with the [ThingSpeak API](https://thingspeak.com/).
-For now, it records exactly one entity at once, which is great for testing purposes. For long-time storage you should rely on the [InfluxDB component](/integrations/influxdb/).
+For now, it records exactly one entity at once, which is great for testing purposes. For long-time storage you should rely on the [InfluxDB integration](/integrations/influxdb/).
 
 ## Configuration
 

--- a/source/_integrations/toon.markdown
+++ b/source/_integrations/toon.markdown
@@ -46,7 +46,7 @@ There is currently support for the following device types within Home Assistant:
 
 ## Setting up a developer account
 
-In order to be able to use this component, you'll need to sign up for a free Toon API developer account.
+In order to be able to use this integration, you'll need to sign up for a free Toon API developer account.
 
 1. Visit the [Toon API developers website](https://developer.toon.eu/), and [sign in](https://developer.toon.eu/user/login). [Create an account](https://developer.toon.eu/user/register) if you don’t have one already.
 2. Open the "[My Apps](https://developer.toon.eu/user/me/apps)" page and click on "Add a new App" button on the top right.

--- a/source/_integrations/totalconnect.markdown
+++ b/source/_integrations/totalconnect.markdown
@@ -68,7 +68,7 @@ automation:
 
 {% details "Notes for Home Assistant Core Installations" %}
 
-If you have issues running this component, you may require `libxml2-dev` and `libxmlsec1-dev` packages. To install these on Raspbian, run the command:
+If you have issues running this integration, you may require `libxml2-dev` and `libxmlsec1-dev` packages. To install these on Raspbian, run the command:
 
 ```bash
 sudo apt install libxml2-dev libxmlsec1-dev

--- a/source/_integrations/tplink_lte.markdown
+++ b/source/_integrations/tplink_lte.markdown
@@ -18,7 +18,7 @@ The integration provides a notification service that will send an SMS.
 
 ## Configuration
 
-To enable the component, add the following lines to your `configuration.yaml` file:
+To enable the integration, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/tradfri.markdown
+++ b/source/_integrations/tradfri.markdown
@@ -23,7 +23,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `tradfri` integration allows you to connect your IKEA Trådfri Gateway to Home Assistant. The gateway can control compatible Zigbee-based lights (certified Zigbee Light Link products) connected to it. Home Assistant will automatically discover the gateway's presence on your local network if `discovery:` is present in your `configuration.yaml` file.
+The IKEA TRÅDFRI integration allows you to connect your IKEA Trådfri Gateway to Home Assistant. The gateway can control compatible Zigbee-based lights (certified Zigbee Light Link products) connected to it. Home Assistant will automatically discover the gateway's presence on your local network if `discovery:` is present in your `configuration.yaml` file.
 
 {% include integrations/config_flow.md %}
 
@@ -57,7 +57,7 @@ Then restart Home Assistant. When prompted, enter the security key and click *co
   This does not apply to Home Assistant running in Docker Containers, including the default Home Assistant install.
 </div>
 
-Please make sure you have `autoconf` installed (`$ sudo apt-get install autoconf`) if you want to use this component. Also, installing some dependencies might take considerable time (more than one hour) on slow devices.
+Please make sure you have `autoconf` installed (`$ sudo apt-get install autoconf`) if you want to use this integration. Also, installing some dependencies might take considerable time (more than one hour) on slow devices.
 
 ## Known limitations
 

--- a/source/_integrations/twilio.markdown
+++ b/source/_integrations/twilio.markdown
@@ -39,7 +39,7 @@ auth_token:
 
 ### Usage
 
-After configuring the base Twilio component, add and configure either or both of the [Twilio SMS](/integrations/twilio_sms) and [Twilio Phone](/integrations/twilio_call) integrations to utilize the notification functionality.
+After configuring the base Twilio integration, add and configure either or both of the [Twilio SMS](/integrations/twilio_sms) and [Twilio Phone](/integrations/twilio_call) integrations to utilize the notification functionality.
 
 To be able to receive events from Twilio, your Home Assistant instance needs to be accessible from the web and you need to have the external URL [configured](/docs/configuration/basic) in Home Assistant.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Integrations starting with t:
-  Replace term _component_ by _integration_
- as it has been renamed


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
