### PR TITLE
U-V-integrations: replace term component by integration

### DIFF
--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -13,7 +13,7 @@ ha_integration_type: integration
 
 This is a presence detection scanner for [OpenWrt](https://openwrt.org/) using [ubus](https://wiki.openwrt.org/doc/techref/ubus). It scans for changes in `hostapd.*`, which will detect and report changes in devices connected to the access point on the router.
 
-Before this scanner can be used you have to install the ubus RPC packages on OpenWrt (versions older than 18.06.x do not require the `uhttpd-mod-ubus` package):
+Before this scanner can be used, you have to install the ubus RPC packages on OpenWrt (versions older than 18.06.x do not require the `uhttpd-mod-ubus` package):
 
 ```bash
 opkg update
@@ -90,7 +90,7 @@ If you find that this never creates `known_devices.yaml`, or if you need more in
 ### Increase Log Level
 
 1. On your Home Assistant device, stop Home Assistant
-2. Adjust `configuration.yaml` to log more detail for the `device_tracker` component
+2. Adjust `configuration.yaml` to log more detail for the `device_tracker` integration.
 
     ```yaml
     logger:

--- a/source/_integrations/vacuum.markdown
+++ b/source/_integrations/vacuum.markdown
@@ -24,7 +24,7 @@ vacuum:
     host: 192.168.1.2
 ```
 
-### Component services
+### Integration services
 
 Available services: `turn_on`, `turn_off`, `start_pause`, `start`, `pause`, `stop`, `return_to_base`, `locate`, `clean_spot`, `set_fan_speed` and `send_command`.
 

--- a/source/_integrations/vacuum.template.markdown
+++ b/source/_integrations/vacuum.template.markdown
@@ -111,7 +111,7 @@ State-based template entities have the special template variable `this` availabl
 
 ### Control vacuum with Harmony Hub
 
-This example shows how you can use a Template Vacuum to control an IR vacuum cleaner using the [Harmony Hub Remote component](/integrations/harmony).
+This example shows how you can use a Template Vacuum to control an IR vacuum cleaner using the [Harmony Hub Remote integration](/integrations/harmony).
 
 ```yaml
 vacuum:

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -61,7 +61,7 @@ A note about the current temperature attribute: Viessmann devices with room temp
 
 ### Supported services `climate.vicare_heating`
 
-The following services of the [Climate component](/integrations/climate/) are provided by the ViCare integration: `set_temperature`, `set_hvac_mode`, `set_preset_mode` 
+The following services of the [Climate integration](/integrations/climate/) are provided by the ViCare integration: `set_temperature`, `set_hvac_mode`, `set_preset_mode` 
 
 #### Service `set_temperature`
 
@@ -78,7 +78,7 @@ Note that `set_temperature` will always affect the current normal temperature or
 
 Set HVAC mode for the climate device. The following modes are supported:
 
-The `climate.vicare_heating` component has the following mapping of HVAC modes to Viessmann operation modes:
+The `climate.vicare_heating` integration has the following mapping of HVAC modes to Viessmann operation modes:
 
 | HVAC mode | Viessmann mode | Description |
 | ---------------------- | -------- | ----------- |
@@ -112,11 +112,11 @@ Eco mode reduces the target temperature by 3°C, whereas Comfort mode sets the t
 
 ## Water Heater
 
-It is not possible to turn on/off water heating via the Water Heater component since this would conflict with the operation modes of the heating component. Therefore the operation mode of that component is just available as an attribute and cannot be modified.
+It is not possible to turn on/off water heating via the Water Heater integration since this would conflict with the operation modes of the heating integration. Therefore the operation mode of that integration is just available as an attribute and cannot be modified.
 
 ### Supported services `water_heater.vicare_water`
 
-The following services of the [Water Heater component](/integrations/water_heater/) are provided by the ViCare integration: `set_temperature`
+The following services of the [Water Heater integration](/integrations/water_heater/) are provided by the ViCare integration: `set_temperature`
 
 #### Service `set_temperature`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Integrations starting with u or v:
-  Replace term _component_ by _integration_
- as it has been renamed



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
