### PR TITLE
W-Z-integrations: replace term component by integration

### DIFF
--- a/source/_integrations/wake_on_lan.markdown
+++ b/source/_integrations/wake_on_lan.markdown
@@ -29,7 +29,7 @@ To use this integration in your installation, add the following to your `configu
 wake_on_lan:
 ```
 
-### Component services
+### Integration services
 
 Available services: `send_magic_packet`.
 

--- a/source/_integrations/water_heater.markdown
+++ b/source/_integrations/water_heater.markdown
@@ -12,7 +12,7 @@ ha_integration_type: entity
 
 The `water_heater` integration is built for the controlling and monitoring of hot water heaters.
 
-To enable this component, pick one of the platforms, and add it to your `configuration.yaml`:
+To enable this integration, pick one of the platforms, and add it to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/watson_iot.markdown
+++ b/source/_integrations/watson_iot.markdown
@@ -14,7 +14,7 @@ with an [IBM Watson IoT Platform instance](https://www.ibm.com/us-en/marketplace
 
 ## Configuration
 
-To use this component, you first need to register a gateway device type and then
+To use this integration, you first need to register a gateway device type and then
 a gateway device in your IoT platform instance. For instructions on how to do
 this check the [official documentation](https://cloud.ibm.com/docs/services/IoT?topic=iot-platform-getting-started#IoT_connectGateway)
 which provides the details on doing this. After you register the gateway device
@@ -25,7 +25,7 @@ for your Home Assistant instance you'll need four pieces of information:
 - Gateway device ID
 - Authentication Token
 
-With this basic information you can configure the component:
+With this basic information you can configure the integration:
 
 ```yaml
 # Example configuration.yaml entry:

--- a/source/_integrations/wemo.markdown
+++ b/source/_integrations/wemo.markdown
@@ -47,7 +47,7 @@ There is currently support for the following device types within Home Assistant:
     type: list
 {% endconfiguration %}
 
-Supported devices will be automatically discovered if the optional `discovery` configuration item is omitted or set to true or if the `discovery` integration is enabled. If the `discovery` configuration item is set to false, then automatic discovery of WeMo devices is disabled both for the `wemo` integration and for the `discovery` component. Loading the `wemo` integration with the `discovery` configuration item omitted or set to true will scan the local network for WeMo devices, even if you are not using the `discovery` component.
+Supported devices will be automatically discovered if the optional `discovery` configuration item is omitted or set to true or if the `discovery` integration is enabled. If the `discovery` configuration item is set to false, then automatic discovery of WeMo devices is disabled both for the `wemo` integration and for the `discovery` integration. Loading the `wemo` integration with the `discovery` configuration item omitted or set to true will scan the local network for WeMo devices, even if you are not using the `discovery` integration.
 
 ```yaml
 # Example configuration.yaml entry with automatic discovery enabled (by omitting the discovery configuration item)

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1689,7 +1689,7 @@ Water Shortage**:
 
 ### Attributes
 
-The vacuums from the `xiaomi` platform does not expose additional attributes other the ones provided by [the `vacuum` component](/integrations/vacuum/#attributes),
+The vacuums from the `xiaomi` platform does not expose additional attributes other the ones provided by [the `vacuum` integration](/integrations/vacuum/#attributes),
 
 ### Example on how to clean a specific room
 

--- a/source/_integrations/xs1.markdown
+++ b/source/_integrations/xs1.markdown
@@ -86,7 +86,7 @@ Home Assistant can combine temperature sensors and climate actuators into a sing
 
 ## Examples
 
-In this section, you find some real-life examples of how to use this component.
+In this section, you find some real-life examples of how to use this integration.
 
 ### Full configuration
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -232,7 +232,7 @@ custom_quirks_path:
 
 ### OTA firmware updates
 
-ZHA component has the ability to automatically download and perform OTA (Over-The-Air) firmware updates of Zigbee devices if the OTA firmware provider source URL for updates is available. OTA firmware updating is set to disabled (`false`) in the configuration by default.
+The ZHA integration has the ability to automatically download and perform OTA (Over-The-Air) firmware updates of Zigbee devices if the OTA firmware provider source URL for updates is available. OTA firmware updating is set to disabled (`false`) in the configuration by default.
 
 Online OTA providers for firmware updates are currently only available for IKEA, LEDVANCE/OSRAM, SALUS/Computime, and INOVELLI devices. Support for OTA updates from other manufacturers could be supported in the future if they publish their firmware images publicly.
 
@@ -554,7 +554,7 @@ When reporting issues, please provide the following information in addition to i
 
 ### Debug logging
 
-To enable debug logging for ZHA component and radio libraries, add the following [logger](/integrations/logger/) configuration to `configuration.yaml`:
+To enable debug logging for the ZHA integration and radio libraries, add the following [logger](/integrations/logger/) configuration to `configuration.yaml`:
 
 ```yaml
 logger:

--- a/source/_integrations/zoneminder.markdown
+++ b/source/_integrations/zoneminder.markdown
@@ -109,7 +109,7 @@ action:
 
 The `zoneminder` binary sensor platform lets you monitor the availability of your [ZoneMinder](https://www.zoneminder.com) install.
 
-Each binary_sensor created will be named after the hostname used when configuring the [ZoneMinder component](/integrations/zoneminder/).
+Each binary_sensor created will be named after the hostname used when configuring the [ZoneMinder integration](/integrations/zoneminder/).
 
 ## Camera
 
@@ -167,7 +167,7 @@ The `zoneminder` switch platform allows you to toggle the current function of al
 
 <div class='note'>
 
-You must have the [ZoneMinder component](/integrations/zoneminder/) configured to use this and if ZoneMinder authentication is enabled the account specified in the integration configuration must have "Edit" permission for "System".
+You must have the [ZoneMinder integration](/integrations/zoneminder/) configured to use this and if ZoneMinder authentication is enabled the account specified in the integration configuration must have "Edit" permission for "System".
 
 </div>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Integrations starting with w, x, or z:
-  Replace term _component_ by _integration_
- as it has been renamed



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
