### PR TITLE
Add clarification about apple_tv integration volume behaviour

### DIFF
--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -146,6 +146,16 @@ Remote app in iOS. If that is the case, please write a bug in
 [pyatv](https://github.com/postlund/pyatv/issues/new?assignees=&labels=bug&template=bug_report.yml)
 and include logs (see Debugging below).
 
+### Setting volume doesn't work on my Apple TV
+
+Volume control functionality depends on how the Apple TV is set up. If the
+Apple TV is connected to a HomePod or HomePod stereo pair, all volume controls
+should work. If the Apple TV is connected to TV speakers and with volume control
+over HDMI CEC (Settings -> Remotes and Devices -> Volume Control) only volume
+up/down controls will work. If volume control is over IR then volume cannot be
+controlled remotely through the Apple TV, but you may be able to integrate your
+TV or soundbar directly.
+
 ### I'm trying to play a stream via AirPlay, but it doesn't work
 
 The Apple TV is quite picky when it comes to which formats it plays. The best bet is MP4. If it doesn't

--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -148,12 +148,13 @@ and include logs (see Debugging below).
 
 ### Setting volume doesn't work on my Apple TV
 
-Volume control functionality depends on how the Apple TV is set up. If the
-Apple TV is connected to a HomePod or HomePod stereo pair, all volume controls
-should work. If the Apple TV is connected to TV speakers and with volume control
+Volume control functionality depends on how the Apple TV is set up. 
+All volume controls should work if the Apple TV is connected to a 
+HomePod or HomePod stereo pair. If the Apple TV is connected to 
+TV speakers and with volume control
 over HDMI CEC (Settings -> Remotes and Devices -> Volume Control) only volume
 up/down controls will work. If volume control is over IR then volume cannot be
-controlled remotely through the Apple TV, but you may be able to integrate your
+controlled remotely through the Apple TV, but you can integrate your
 TV or soundbar directly.
 
 ### I'm trying to play a stream via AirPlay, but it doesn't work


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds a section to the apple_tv integration FAQ section clarifying volume support to help users understand why volume may not work despite recent bug fixes in the pyatv library.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/94683
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
