### PR TITLE
Add persistent_notification automation trigger to docs

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -146,7 +146,7 @@ These are the properties available for a [Time Pattern trigger](/docs/automation
 
 ### Persistent Notification
 
-These are the properties available for a [Persistent Notification trigger](/docs/automation/trigger/#persistent-notification-trigger).
+These properties are available for a [Persistent Notification trigger](/docs/automation/trigger/#persistent-notification-trigger).
 
 | Template variable | Data |
 | ---- | ---- |

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -151,7 +151,7 @@ These are the properties available for a [Persistent Notification trigger](/docs
 | Template variable | Data |
 | ---- | ---- |
 | `trigger.platform` | Hardcoded: `persistent_notification`
-| `trigger.update_type` | Type of persistent notification update `added` or `removed`.
+| `trigger.update_type` | Type of persistent notification update `added`, `removed`, `current` or `updated`.
 | `trigger.notification` | Notification object that triggered the persistent_notification trigger.
 | `trigger.notification.notification_id` | The notification ID
 | `trigger.notification.title` | Title of the notification

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -144,6 +144,20 @@ These are the properties available for a [Time Pattern trigger](/docs/automation
 | `trigger.platform` | Hardcoded: `time_pattern`
 | `trigger.now` | DateTime object that triggered the time_pattern trigger.
 
+### Persistent Notification
+
+These are the properties available for a [Persistent Notification trigger](/docs/automation/trigger/#persistent-notification-trigger).
+
+| Template variable | Data |
+| ---- | ---- |
+| `trigger.platform` | Hardcoded: `persistent_notification`
+| `trigger.update_type` | Type of persistent notification update `added` or `removed`.
+| `trigger.notification` | Notification object that triggered the persistent_notification trigger.
+| `trigger.notification.notification_id` | The notification ID
+| `trigger.notification.title` | Title of the notification
+| `trigger.notification.message` | Message of the notification
+| `trigger.notification.created_ad` | DateTime object indicating when the notification was created.
+
 ### Webhook
 
 These are the properties available for a [Webhook trigger](/docs/automation/trigger/#webhook-trigger).

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -152,7 +152,7 @@ These properties are available for a [Persistent Notification trigger](/docs/aut
 | ---- | ---- |
 | `trigger.platform` | Hardcoded: `persistent_notification`
 | `trigger.update_type` | Type of persistent notification update `added`, `removed`, `current` or `updated`.
-| `trigger.notification` | Notification object that triggered the persistent_notification trigger.
+| `trigger.notification` | Notification object that triggered the persistent notification trigger.
 | `trigger.notification.notification_id` | The notification ID
 | `trigger.notification.title` | Title of the notification
 | `trigger.notification.message` | Message of the notification

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -151,7 +151,7 @@ These properties are available for a [Persistent Notification trigger](/docs/aut
 | Template variable | Data |
 | ---- | ---- |
 | `trigger.platform` | Hardcoded: `persistent_notification`
-| `trigger.update_type` | Type of persistent notification update `added`, `removed`, `current` or `updated`.
+| `trigger.update_type` | Type of persistent notification update `added`, `removed`, `current`, or `updated`.
 | `trigger.notification` | Notification object that triggered the persistent notification trigger.
 | `trigger.notification.notification_id` | The notification ID
 | `trigger.notification.title` | Title of the notification

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -156,7 +156,7 @@ These are the properties available for a [Persistent Notification trigger](/docs
 | `trigger.notification.notification_id` | The notification ID
 | `trigger.notification.title` | Title of the notification
 | `trigger.notification.message` | Message of the notification
-| `trigger.notification.created_ad` | DateTime object indicating when the notification was created.
+| `trigger.notification.created_at` | DateTime object indicating when the notification was created.
 
 ### Webhook
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -19,7 +19,7 @@ An automation can be triggered by an event, a certain entity state, at a given t
 - [Template trigger](#template-trigger)
 - [Time trigger](#time-trigger)
 - [Time pattern trigger](#time-pattern-trigger)
-- [Persistent Notification trigger](#persistent-notification-trigger)
+- [Persistent notification trigger](#persistent-notification-trigger)
 - [Webhook trigger](#webhook-trigger)
 - [Zone trigger](#zone-trigger)
 - [Geolocation trigger](#geolocation-trigger)
@@ -778,7 +778,7 @@ Do not prefix numbers with a zero - using `'01'` instead of `'1'` for example wi
 
 </div>
 
-## Persistent Notification trigger
+## Persistent notification trigger
 
 Persistent notification triggers are fired when a `persistent_notification` is `added` or `removed` that matches the configuration options.
 
@@ -786,7 +786,7 @@ Persistent notification triggers are fired when a `persistent_notification` is `
 automation:
   trigger:
     - platform: persistent_notification
-      update_type: 
+      update_type:
         - added
         - removed
       notification_id: invalid_config

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -19,6 +19,7 @@ An automation can be triggered by an event, a certain entity state, at a given t
 - [Template trigger](#template-trigger)
 - [Time trigger](#time-trigger)
 - [Time pattern trigger](#time-pattern-trigger)
+- [Persistent Notification trigger](#persistent-notification-trigger)
 - [Webhook trigger](#webhook-trigger)
 - [Zone trigger](#zone-trigger)
 - [Geolocation trigger](#geolocation-trigger)
@@ -776,6 +777,20 @@ automation 3:
 Do not prefix numbers with a zero - using `'01'` instead of `'1'` for example will result in errors.
 
 </div>
+
+## Persistent Notification trigger
+
+Persistent notification triggers are fired when a `persistent_notification` is `added` or `removed` that matches the configuration options.
+
+```yaml
+automation:
+  trigger:
+    - platform: persistent_notification
+      update_type: added
+      notification_id: invalid_config
+```
+
+See the [Persistent Notification](/integrations/persistent_notification/) integration for more details on event triggers and the additional event data available for use by an automation.
 
 ## Webhook trigger
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -786,7 +786,9 @@ Persistent notification triggers are fired when a `persistent_notification` is `
 automation:
   trigger:
     - platform: persistent_notification
-      update_type: added
+      update_type: 
+        - added
+        - removed
       notification_id: invalid_config
 ```
 

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -33,12 +33,15 @@ An example of a persistent_notification trigger in YAML:
 ```yaml
 automation:
   - trigger:
-    - platform: persistent_notification
-      # Optional. Possible values: added, removed
-      update_type: added
-      # Optional.
-      notification_id: invalid_config
+      - platform: persistent_notification
+        # Optional. Possible values: added, removed, updated, current
+        update_type:
+          - added
+          - removed
+        # Optional.
+        notification_id: invalid_config
 ```
+
 See [Automation Trigger Variables: Persistent Notification](/docs/automation/templating/#persistent-notification) 
 for additional trigger data available for conditions or actions.
 

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -21,7 +21,7 @@ The `persistent_notification` integration can be used to show a notification on 
 ## Automation
 
 Persistent Notification [Triggers](/docs/automation/trigger) enable automations to be
-triggered when `persistent_notification`s are `added` or `removed`.
+triggered when `persistent_notification`s are updated. This can be limited to a specific notification by providing an ID for `notification_id`, or when this value is omitted the automation will trigger for any notification ID. If no `update_type` is provided, the automation will trigger for any of the following update types: `added`, `removed`, `updated`, `current`. By providing one or more of these values to the `update_type` option, the automation triggers only on these events.
 Review the [Automating Home Assistant](/getting-started/automation/)
 getting started guide on automations or the [Automation](/docs/automation/)
 documentation for full details.

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -20,11 +20,9 @@ The `persistent_notification` integration can be used to show a notification on 
 
 ## Automation
 
-Persistent Notification [Triggers](/docs/automation/trigger) enable automations to be
-triggered when `persistent_notification`s are updated. This can be limited to a specific notification by providing an ID for `notification_id`, or when this value is omitted the automation will trigger for any notification ID. If no `update_type` is provided, the automation will trigger for any of the following update types: `added`, `removed`, `updated`, `current`. By providing one or more of these values to the `update_type` option, the automation triggers only on these events.
-Review the [Automating Home Assistant](/getting-started/automation/)
-getting started guide on automations or the [Automation](/docs/automation/)
-documentation for full details.
+Persistent Notification [Triggers](/docs/automation/trigger) enable automations to be triggered when persistent notifications are updated. Triggers can be limited to a specific notification by providing an ID for `notification_id`, or when this value is omitted the automation will trigger for any notification ID. If no `update_type` is provided, the automation will trigger for the following update types: `added`, `removed`, `updated`, `current`. By providing one or more of these values to the `update_type` option, the automation triggers only on these `update_type` events.
+
+Review the [Automating Home Assistant](/getting-started/automation/) getting started guide on automations or the [Automation](/docs/automation/) documentation for full details.
 
 {% my automations badge %}
 

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -20,13 +20,13 @@ The `persistent_notification` integration can be used to show a notification on 
 
 ## Automation
 
-Persistent Notification [Triggers](/docs/automation/trigger) enable automations to be triggered when persistent notifications are updated. Triggers can be limited to a specific notification by providing an ID for `notification_id`, or when this value is omitted the automation will trigger for any notification ID. If no `update_type` is provided, the automation will trigger for the following update types: `added`, `removed`, `updated`, `current`. By providing one or more of these values to the `update_type` option, the automation triggers only on these `update_type` events.
+Persistent notification [triggers](/docs/automation/trigger) enable automations to be triggered when persistent notifications are updated. Triggers can be limited to a specific notification by providing an ID for `notification_id`, or when this value is omitted the automation will trigger for any notification ID. If no `update_type` is provided, the automation will trigger for the following update types: `added`, `removed`, `updated`, or `current`. By providing one or more of these values to the `update_type` option, the automation triggers only on these `update_type` events.
 
 Review the [Automating Home Assistant](/getting-started/automation/) getting started guide on automations or the [Automation](/docs/automation/) documentation for full details.
 
 {% my automations badge %}
 
-An example of a persistent_notification trigger in YAML:
+An example of a persistent notification trigger in YAML:
 
 ```yaml
 automation:

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -18,6 +18,30 @@ The `persistent_notification` integration can be used to show a notification on 
   <img src='/images/screenshots/persistent-notification.png' />
 </p>
 
+## Automation
+
+Persistent Notification [Triggers](/docs/automation/trigger) enable automations to be
+triggered when `persistent_notification`s are `added` or `removed`.
+Review the [Automating Home Assistant](/getting-started/automation/)
+getting started guide on automations or the [Automation](/docs/automation/)
+documentation for full details.
+
+{% my automations badge %}
+
+An example of a persistent_notification trigger in YAML:
+
+```yaml
+automation:
+  - trigger:
+    - platform: persistent_notification
+      # Optional. Possible values: added, removed
+      update_type: added
+      # Optional.
+      notification_id: invalid_config
+```
+See [Automation Trigger Variables: Persistent Notification](/docs/automation/templating/#persistent-notification) 
+for additional trigger data available for conditions or actions.
+
 ### Service
 
 The service `persistent_notification.create` takes in `message`, `title`, and `notification_id`.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updated docs for `persistent_notification` automation triggers.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#94809
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
