### PR TITLE
Add new section for PhilipsTV binary_sensor

### DIFF
--- a/source/_integrations/philips_js.markdown
+++ b/source/_integrations/philips_js.markdown
@@ -5,7 +5,7 @@ ha_category:
   - Light
   - Media Player
   - Remote
-  - Binary Sensor
+  - Binary sensor
 ha_iot_class: Local Polling
 ha_release: 0.34
 ha_codeowners:
@@ -145,10 +145,10 @@ Some TV's allow you to sync the processed ambilight color data to your Philips H
 The integration exposes a "Ambilight+Hue" switch entity when your TV supports it which enables you to toggle this.
 
 
-## Binary Sensor
+## Binary sensor
 
-Some newer OS version support live TV recording functions via the API.\
-For those TV'S this integration supports two entities:
+Some newer OS versions support live TV recording functions via the API.
+For those TVs, this integration supports two entities:
 
 - New recording available
 - Recording ongoing

--- a/source/_integrations/philips_js.markdown
+++ b/source/_integrations/philips_js.markdown
@@ -25,7 +25,6 @@ ha_integration_type: integration
 The `philips_js` platform allows you to control Philips TVs which expose the [jointSPACE](http://jointspace.sourceforge.net/) JSON-API.
 
 If your TV responds to `http://IP_ADDRESS_OF_TV:1925/system` then this integration can be used. In the response, you should also be able to see the version of the API the TV uses (`"api_version":{"Major":6...`).
-
 For older TVs follow instructions on how to activate the API and if your model is supported [here](http://jointspace.sourceforge.net/download.html). Note that not all listed, jointSPACE-enabled devices will have JSON-interface running on port 1925. This is true at least for some models before year 2011.
 
 Also, note that version 6 of the API needs to be authenticated by a PIN code displayed on your TV.
@@ -136,9 +135,9 @@ The integration exposes a single light entity to control the mode of the ambilig
 When the light entity is turned on, it is controlling the ambilights, when it is turned off the TV is in control of the ambilight in its standard video-based fashion.
 
 Limits:
-- The integration does not expose current ambilight measured values since it would
+ - The integration does not expose current ambilight measured values since it would
 overload the event bus in Home Assistant.
-- There is no support to control the standard, non-expert, styles of the TV.
+ - There is no support to control the standard, non-expert, styles of the TV.
 
 #### Ambilight+Hue
 

--- a/source/_integrations/philips_js.markdown
+++ b/source/_integrations/philips_js.markdown
@@ -5,7 +5,6 @@ ha_category:
   - Light
   - Media Player
   - Remote
-  - Sensor
   - Binary Sensor
 ha_iot_class: Local Polling
 ha_release: 0.34
@@ -19,14 +18,13 @@ ha_platforms:
   - media_player
   - remote
   - switch
-  - sensor
   - binary_sensor
 ha_integration_type: integration
 ---
 
 The `philips_js` platform allows you to control Philips TVs which expose the [jointSPACE](http://jointspace.sourceforge.net/) JSON-API.
 
-If your TV responds to `http://IP_ADDRESS_OF_TV:1925/system` then this integration can be used. In the response, you should also be able to see the version of the API the TV uses (`"api_version":{"Major":6...`). Note that newer OS might be fixed to secured communication only. To check those, use `https://IP_ADDRESS_OF_TV:1926/system` instead.
+If your TV responds to `http://IP_ADDRESS_OF_TV:1925/system` then this integration can be used. In the response, you should also be able to see the version of the API the TV uses (`"api_version":{"Major":6...`).
 
 For older TVs follow instructions on how to activate the API and if your model is supported [here](http://jointspace.sourceforge.net/download.html). Note that not all listed, jointSPACE-enabled devices will have JSON-interface running on port 1925. This is true at least for some models before year 2011.
 
@@ -54,6 +52,7 @@ Also, note that version 6 of the API needs to be authenticated by a PIN code dis
 | Ambilight Control  | Yes              | ?   | Yes                | ?                |
 | Ambilight Styles   | No               | ?   | Yes                | Yes              |
 | Ambilight Measure  | No               | No  | No                 | No               |
+
 
 ### Turn on device
 
@@ -130,27 +129,22 @@ The integration provides a remote entity for sending remote key presses directly
 | SmartTV          |                                           |
 | PhilipsMenu      |                                           |
 
-## Ambilight
+### Ambilight
 
 The integration exposes a single light entity to control the mode of the ambilight on the TV. It allows setting a fixed background color or switching the TV to one of the lounge modes supported by the TV.
 
 When the light entity is turned on, it is controlling the ambilights, when it is turned off the TV is in control of the ambilight in its standard video-based fashion.
 
 Limits:
-
 - The integration does not expose current ambilight measured values since it would
 overload the event bus in Home Assistant.
 - There is no support to control the standard, non-expert, styles of the TV.
 
-### Ambilight+Hue
+#### Ambilight+Hue
 
 Some TV's allow you to sync the processed ambilight color data to your Philips Hue bridge. This will make your Hue lights sync with the TV ambilight without the need to purchase a Hue Play HDMI Sync Box.
 The integration exposes a "Ambilight+Hue" switch entity when your TV supports it which enables you to toggle this.
 
-## Sensor
-
-Some newer OS version support live TV recording functions via the API.\
-For those TV's this integration supports the time of the next scheduled recording.
 
 ## Binary Sensor
 

--- a/source/_integrations/philips_js.markdown
+++ b/source/_integrations/philips_js.markdown
@@ -5,6 +5,8 @@ ha_category:
   - Light
   - Media Player
   - Remote
+  - Sensor
+  - Binary Sensor
 ha_iot_class: Local Polling
 ha_release: 0.34
 ha_codeowners:
@@ -17,12 +19,15 @@ ha_platforms:
   - media_player
   - remote
   - switch
+  - sensor
+  - binary_sensor
 ha_integration_type: integration
 ---
 
 The `philips_js` platform allows you to control Philips TVs which expose the [jointSPACE](http://jointspace.sourceforge.net/) JSON-API.
 
-If your TV responds to `http://IP_ADDRESS_OF_TV:1925/system` then this integration can be used. In the response, you should also be able to see the version of the API the TV uses (`"api_version":{"Major":6...`).
+If your TV responds to `http://IP_ADDRESS_OF_TV:1925/system` then this integration can be used. In the response, you should also be able to see the version of the API the TV uses (`"api_version":{"Major":6...`). Note that newer OS might be fixed to secured communication only. To check those, use `https://IP_ADDRESS_OF_TV:1926/system` instead.
+
 For older TVs follow instructions on how to activate the API and if your model is supported [here](http://jointspace.sourceforge.net/download.html). Note that not all listed, jointSPACE-enabled devices will have JSON-interface running on port 1925. This is true at least for some models before year 2011.
 
 Also, note that version 6 of the API needs to be authenticated by a PIN code displayed on your TV.
@@ -49,7 +54,6 @@ Also, note that version 6 of the API needs to be authenticated by a PIN code dis
 | Ambilight Control  | Yes              | ?   | Yes                | ?                |
 | Ambilight Styles   | No               | ?   | Yes                | Yes              |
 | Ambilight Measure  | No               | No  | No                 | No               |
-
 
 ### Turn on device
 
@@ -126,18 +130,32 @@ The integration provides a remote entity for sending remote key presses directly
 | SmartTV          |                                           |
 | PhilipsMenu      |                                           |
 
-### Ambilight
+## Ambilight
 
 The integration exposes a single light entity to control the mode of the ambilight on the TV. It allows setting a fixed background color or switching the TV to one of the lounge modes supported by the TV.
 
 When the light entity is turned on, it is controlling the ambilights, when it is turned off the TV is in control of the ambilight in its standard video-based fashion.
 
 Limits:
- - The integration does not expose current ambilight measured values since it would
-overload the event bus in Home Assistant.
- - There is no support to control the standard, non-expert, styles of the TV.
 
-#### Ambilight+Hue
+- The integration does not expose current ambilight measured values since it would
+overload the event bus in Home Assistant.
+- There is no support to control the standard, non-expert, styles of the TV.
+
+### Ambilight+Hue
 
 Some TV's allow you to sync the processed ambilight color data to your Philips Hue bridge. This will make your Hue lights sync with the TV ambilight without the need to purchase a Hue Play HDMI Sync Box.
 The integration exposes a "Ambilight+Hue" switch entity when your TV supports it which enables you to toggle this.
+
+## Sensor
+
+Some newer OS version support live TV recording functions via the API.\
+For those TV's this integration supports the time of the next scheduled recording.
+
+## Binary Sensor
+
+Some newer OS version support live TV recording functions via the API.\
+For those TV'S this integration supports two entities:
+
+- New recording available
+- Recording ongoing


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
A new feature within the PhilipsTV integration requires some little explanation or at least the listing of those new functionality.
This PR will add those new featured binary_sensor.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/94691

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - ~~I made a change to the existing documentation and used the `current` branch.~~
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
