### PR TITLE
Add missing remote commands to Apple TV docs

### DIFF
--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -36,25 +36,32 @@ This entity will display the active app and playback controls.
 ## Remote
 
 The Apple TV remote platform will automatically create a Remote entity for each Apple TV
-configured on to your Home Assistant instance.
+configured on your Home Assistant instance.
 These entities allow you to turn the device on/off and to send control commands.
 
 The following commands are currently available:
 
 - `wakeup`
+- `suspend`
 - `home`
 - `home_hold`
 - `top_menu`
 - `menu`
 - `select`
+- `play`
+- `pause`
 - `up`
 - `down`
 - `left`
 - `right`
 - `volume_up`
 - `volume_down`
+- `previous`
+- `next`
+- `skip_backward`
+- `skip_forward`
 
-**NOTE:** Not all commands are supported by all Apple TV versions
+**NOTE:** Not all commands are supported by all Apple TV versions.
 
 ### Service `send_command`
 


### PR DESCRIPTION
## Proposed change

Add missing remote commands to Apple TV docs based on this list https://pyatv.dev/api/interface#pyatv.interface.RemoteControl as recommended by https://community.home-assistant.io/t/apple-tv-remote-implementation/194317/43.

Fix a couple minor typos.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

I tested the added commands on my Apple TV and they worked, but they were not listed in the documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
