### PR TITLE
Add Victron BLE documentation

### DIFF
--- a/source/_integrations/victron_ble.markdown
+++ b/source/_integrations/victron_ble.markdown
@@ -1,0 +1,28 @@
+---
+title: Victron BLE
+description: Instructions on how to integrate Victron BLE devices into Home Assistant.
+ha_category:
+  - Sensor
+ha_bluetooth: true
+ha_release: '2023.7'
+ha_iot_class: Local Push
+ha_codeowners:
+  - '@rajlaud'
+ha_domain: victron_ble
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_integration_type: integration
+---
+
+Integrates Victron Energy devices that support the BLE protocol into Home Assistant.
+
+{% include integrations/config_flow.md %}
+
+The Victron BLE integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
+
+To configure a discovered device, you will need to supply the per-device encryption key, which you can retrieve using these [instructions](https://github.com/keshavdv/victron-ble/tree/main#fetching-keys).
+
+## Supported devices
+
+- [Sensirion MyCO2 Gadget](https://sensirion.com/products/catalog/SCD4x-CO2-Gadget/)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the new Victron BLE integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [X] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands). 
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/94994/files
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/4485
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
