### PR TITLE
Add Aprilaire integration

### DIFF
--- a/source/_integrations/aprilaire.markdown
+++ b/source/_integrations/aprilaire.markdown
@@ -22,10 +22,10 @@ This integration supports Aprilaire [8800-series Home Automation Wi-Fi Thermosta
 
 ## Prerequisites
 
-In order to connect to the thermostat, you will need to enable automation mode. This involves going into the Contractor Menu on your thermostat and changing the Connection Type to Automation. Please look up the instructions for your model, as this can vary between models.
+In order to connect to the thermostat, you will need to enable automation mode. This involves going into the Contractor Menu on your thermostat and changing the Connection Type to Automation. As the specific instructions can vary per model, consult the manual for your specific model.
 
 {% include integrations/config_flow.md %}
 
 ## Caution regarding device limitations
 
-Due to limitations of the thermostats, only one home automation connection to a device is permitted at one time (the Aprilaire app is not included in this limitation as it uses a separate protocol). Attempting to connect multiple times to the same thermostat simultaneously can cause various issues, including the thermostat becoming unresponsive and shutting down. If this does occur, power cycling the thermostat should restore functionality.
+Due to limitations of the thermostats, only one automation connection to a device is permitted at one time (the Aprilaire app is not included in this limitation as it uses a separate protocol). Attempting to connect multiple times to the same thermostat simultaneously can cause various issues, including the thermostat becoming unresponsive and shutting down. If this does occur, power cycling the thermostat should restore functionality.

--- a/source/_integrations/aprilaire.markdown
+++ b/source/_integrations/aprilaire.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate Aprilaire devices into Home Assist
 ha_category:
   - Climate
 ha_iot_class: Local Push
-ha_release: 2023.8
+ha_release: 2024.3
 ha_domain: aprilaire
 ha_codeowners:
   - '@chamberlain2007'

--- a/source/_integrations/aprilaire.markdown
+++ b/source/_integrations/aprilaire.markdown
@@ -1,0 +1,31 @@
+---
+title: Aprilaire
+description: Instructions on how to integrate Aprilaire devices into Home Assistant.
+ha_category:
+  - Climate
+ha_iot_class: Local Push
+ha_release: 2023.8
+ha_domain: aprilaire
+ha_codeowners:
+  - '@chamberlain2007'
+ha_config_flow: true
+ha_platforms:
+  - climate
+ha_integration_type: integration
+---
+
+The Aprilaire integration allows you to control an Aprilaire thermostat.
+
+## Supported Models
+
+This integration supports Aprilaire [8800-series Home Automation Wi-Fi Thermostats](https://www.aprilaire.com/whole-house-products/thermostats/home-automation) and [6000-series Wi-Fi Zone Control devices](https://www.aprilaire.com/whole-house-products/zone-control) which support setting the thermostat to automation mode. It is known that there are some models which are marketed as home automation capable that do not support automation mode, and are therefore not supported.
+
+## Prerequisites
+
+In order to connect to the thermostat, you will need to enable automation mode. This involves going into the Contractor Menu on your thermostat and changing the Connection Type to Automation. Please look up the instructions for your model, as this can vary between models.
+
+{% include integrations/config_flow.md %}
+
+## Caution regarding device limitations
+
+Due to limitations of the thermostats, only one home automation connection to a device is permitted at one time (the Aprilaire app is not included in this limitation as it uses a separate protocol). Attempting to connect multiple times to the same thermostat simultaneously can cause various issues, including the thermostat becoming unresponsive and shutting down. If this does occur, power cycling the thermostat should restore functionality.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds documentation for the new Aprilaire integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/95093
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/4051
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
