### PR TITLE
Add documentation for calendar list events services

### DIFF
--- a/source/_integrations/calendar.markdown
+++ b/source/_integrations/calendar.markdown
@@ -194,3 +194,62 @@ data:
   end_date_time: "{{ now() + timedelta(minutes=1) }}"
 ```
 {% endraw %}
+
+
+### Service `calendar.list_events`
+
+This service populates [Response Data](/docs/scripts/service-calls#use-templates-to-handle-response-data)
+with calendar events within a date range.
+
+| Service data attribute | Optional | Description | Example |
+| ---------------------- | -------- | ----------- | --------|
+| `start_date_time` | yes | Return active events after this time (exclusive). When not set, defaults to now. | 2019-03-10 20:00:00
+| `end_date_time` | yes | Return active events before this time (exclusive). Cannot be used with 'duration'. | 2019-03-10 23:00:00
+| `duration` | yes | Return active events from start_date_time until the specified duration. | `days: 2`
+
+<div class='note'>
+
+Use only one of `end_date_time` or `duration`.
+
+</div>
+
+
+{% raw %}
+```yaml
+service: calendar.list_events
+target:
+  entity_id: calendar.school
+data:
+  duration:
+    hours: 24
+response_variable: agenda
+```
+{% endraw %}
+
+The response data field `events` is a list of events with these fields:
+
+| Response data | Description | Example |
+| ---------------------- | ----------- | -------- |
+| `summary` | The title of the event. | Bowling
+| `description` | The description of the event. | Birthday bowling
+| `start` | The date or date time the event starts. | 2019-03-10 20:00:00
+| `end` | The date or date time the event ends (exclusive). | 2019-03-10 23:00:00
+| `location` | The location of the event. | Bowling center
+
+This example uses a template with response data in another service call:
+
+{% raw %}
+```yaml
+service: notify.gmail_com
+data:
+  target: gduser1@workspacesamples.dev
+  title: Daily agenda for {{ now().date() }}
+  message: >-
+    Your agenda for today:
+    <p>
+    {% for event in agenda.events %}
+    {{ event.start}}: {{ event.summary }}<br>
+    {% endfor %}
+    </p>
+```
+{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add calendar integration documentation for details on service calls with response data. This duplicates the example in https://github.com/home-assistant/home-assistant.io/pull/27863 (to make it easier for users to follow a full example) which I think is OK. Gives details on service response data fields

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/94759/
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
