### PR TITLE
Refactor SQL with ManualTriggerEntity

### DIFF
--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -73,7 +73,7 @@ sql:
     name:
       description: The name of the sensor.
       required: true
-      type: string
+      type: template
     query:
       description: An SQL QUERY string, should return 1 result at most.
       required: true
@@ -102,6 +102,18 @@ sql:
       description: "Provide [state class](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes) for this sensor."
       required: false
       type: string
+    icon:
+      description: "Defines a template for the icon of the entity."
+      required: false
+      type: template
+    picture:
+      description: "Defines a template for the entity picture of the entity."
+      required: false
+      type: template
+    availability:
+      description: "Defines a template if the entity state is available or not."
+      required: false
+      type: template
 {% endconfiguration %}
 
 ## Information


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Refactoring SQL with ManualTriggerEntity
Enables templates with (yaml only)
- `name`
- `icon`
- `picture`
- `available`

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/95116
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
