### PR TITLE
Tweak wording of assistant setup process

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -58,7 +58,7 @@ To use Google Assistant, your Home Assistant configuration has to be [externally
         3. Authorization URL: `https://[YOUR HOME ASSISTANT URL:PORT]/auth/authorize`. (Replace `[YOUR HOME ASSISTANT URL:PORT]` with your values.)
         4. Token URL (replace with your actual URL): `https://[YOUR HOME ASSISTANT URL:PORT]/auth/token`. (Replace `[YOUR HOME ASSISTANT URL:PORT]` with your values.)
            Select **Next**, then **Next** again.
-    6. In the **Configure your client** **Scopes** textbox, type `email` and select **Add scope**, then type **name** and select **Add scope** again.
+    6. In the **Configure your client** **Scopes** textbox, type `email` and select **Add scope**, then type `name` and select **Add scope** again.
     7. Do **NOT** check **Google to transmit clientID and secret via HTTP basic auth header**.
     8. Select **Next**, then select **Save**.
 
@@ -72,7 +72,7 @@ To use Google Assistant, your Home Assistant configuration has to be [externally
     3. Go to the menu and select **APIs and Services** and next **Credentials**.
     4. In the **Credentials** view, select **Create credentials** and next **Service account**.
         1. **Service account name**: Give your account a self-selected name.
-        2. Select **Create**.
+        2. Select **Create and Continue**.
         3. **Select a role**: **Service Accounts** and **Service Account Token Creator**.
         4. Select **Continue**.
         5. Select **Done**.
@@ -106,7 +106,7 @@ If you want to allow other household users to control the devices:
 1. Open the project you created in the [Actions on Google console](https://console.actions.google.com/).
 2. Select **Test** on the top of the page, then select **Simulator** located to the page left, then click the three little dots (more) icon in the upper right corner of the console.
 3. Select **Manage user access**. This redirects you to the Google Cloud Platform IAM permissions page.
-4. Select **ADD** at the top of the page.
+4. Select **GRANT ACCESS** at the top of the page.
     1. Enter the email address of the user you want to add.
     2. Select **Select a role** and choose **Project** > **Viewer**.
     3. Select **SAVE**.


### PR DESCRIPTION
## Proposed change
I went through home assistant setup this afternoon, and noticed a small formatting error and some language in the Google console that had changed. Now that I've finished a successful setup and verified that clicking the buttons with slightly different wording did indeed work, I'm updating the docs to keep in sync with the new wording.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
