### PR TITLE
Changes in naming of MQTT entities

### DIFF
--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -177,7 +177,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the alarm. Can be set to `None` if only the device name is relevant.
+  description: The name of the alarm. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Alarm

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -177,7 +177,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the alarm.
+  description: The name of the alarm. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Alarm

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -155,7 +155,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the binary sensor.
+  description: The name of the binary sensor. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Binary Sensor

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -155,7 +155,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the binary sensor. Can be set to `None` if only the device name is relevant.
+  description: The name of the binary sensor. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Binary Sensor

--- a/source/_integrations/button.mqtt.markdown
+++ b/source/_integrations/button.mqtt.markdown
@@ -145,7 +145,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name to use when displaying this button.
+  description: The name to use when displaying this button. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Button

--- a/source/_integrations/button.mqtt.markdown
+++ b/source/_integrations/button.mqtt.markdown
@@ -145,7 +145,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name to use when displaying this button. Can be set to `None` if only the device name is relevant.
+  description: The name to use when displaying this button. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Button

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -146,7 +146,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the camera. Can be set to `None` if only the device name is relevant.
+  description: The name of the camera. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
 object_id:

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -146,7 +146,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the camera.
+  description: The name of the camera. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
 object_id:

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -236,7 +236,7 @@ modes:
   default: ['auto', 'off', 'cool', 'heat', 'dry', 'fan_only']
   type: list
 name:
-  description: The name of the HVAC.
+  description: The name of the HVAC. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT HVAC

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -236,7 +236,7 @@ modes:
   default: ['auto', 'off', 'cool', 'heat', 'dry', 'fan_only']
   type: list
 name:
-  description: The name of the HVAC. Can be set to `None` if only the device name is relevant.
+  description: The name of the HVAC. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT HVAC

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -157,7 +157,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the cover. Can be set to `None` if only the device name is relevant.
+  description: The name of the cover. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Cover

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -157,7 +157,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the cover.
+  description: The name of the cover. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Cover

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -147,7 +147,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the fan. Can be set to `None` if only the device name is relevant.
+  description: The name of the fan. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Fan

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -147,7 +147,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the fan.
+  description: The name of the fan. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Fan

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -181,7 +181,7 @@ min_humidity:
   type: integer
   default: 0
 name:
-  description: The name of the humidifier.
+  description: The name of the humidifier. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT humidifier

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -181,7 +181,7 @@ min_humidity:
   type: integer
   default: 0
 name:
-  description: The name of the humidifier. Can be set to `None` if only the device name is relevant.
+  description: The name of the humidifier. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT humidifier

--- a/source/_integrations/image.mqtt.markdown
+++ b/source/_integrations/image.mqtt.markdown
@@ -159,7 +159,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the image.
+  description: The name of the image. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
 object_id:

--- a/source/_integrations/image.mqtt.markdown
+++ b/source/_integrations/image.mqtt.markdown
@@ -159,7 +159,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the image. Can be set to `None` if only the device name is relevant.
+  description: The name of the image. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
 object_id:

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -257,7 +257,7 @@ min_mireds:
   required: false
   type: integer
 name:
-  description: The name of the light.
+  description: The name of the light. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Light

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -257,7 +257,7 @@ min_mireds:
   required: false
   type: integer
 name:
-  description: The name of the light. Can be set to `None` if only the device name is relevant.
+  description: The name of the light. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Light

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -154,7 +154,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the lock.
+  description: The name of the lock. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Lock

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -154,7 +154,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the lock. Can be set to `None` if only the device name is relevant.
+  description: The name of the lock. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Lock

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -254,7 +254,7 @@ mqtt:
           - dev001
 ```
 
-So when an MQTT entity configuration has a `device` mapping, `has_entity_name` will be set to `True` and the entity's `friendly_name` and `entity_id` will constructed from the device `name` and entity `name`, in other cases `has_entity_name` will be set to False and the  friendly name will be set to the entity `name`.
+So when an MQTT entity configuration has a `device` mapping, `has_entity_name` will be set to `True` and the entity's `friendly_name` and `entity_id` will constructed from the device `name` and entity `name`, in other cases `has_entity_name` will be set to `False` and the friendly name will be set to the entity `name`.
 
 The entity `name` option can also be set to `null`. This will set the entity name to `None` and `has_entity_name` to `True`. The entity `friendly_name` will only inherit the device name.
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -199,8 +199,8 @@ Example:
 ```yaml
 # Example configuration.yaml entry
 mqtt:
-  sensor:
-    - state_topic: "home/bedroom/temperature"
+  - sensor:
+      state_topic: "home/bedroom/temperature"
       unique_id: "brtemp01"
       name: "temperature"
       object_id: "test"
@@ -214,8 +214,8 @@ Example:
 ```yaml
 # Example configuration.yaml entry
 mqtt:
-  sensor:
-    - state_topic: "home/bedroom/humidity"
+  - sensor:
+      state_topic: "home/bedroom/humidity"
       unique_id: "brhum01"
       name: "humidity"
       device:
@@ -229,8 +229,8 @@ If the `device_class` option is set, it is not needed to set the entity's `name`
 ```yaml
 # Example configuration.yaml entry
 mqtt:
-  sensor:
-    - state_topic: "home/bedroom/temperature"
+  - sensor:
+      state_topic: "home/bedroom/temperature"
       unique_id: "brtemp01"
       device_class: temperature
       device:
@@ -244,8 +244,8 @@ In the following example without a `device_class` the entity `name` will become 
 ```yaml
 # Example configuration.yaml entry
 mqtt:
-  sensor:
-    - state_topic: "home/bedroom/sensor"
+  - sensor:
+      state_topic: "home/bedroom/sensor"
       unique_id: "brsensor01"
       name: "some sensor"
       device:

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -188,18 +188,23 @@ For reading all messages sent on the topic `homeassistant` to a broker running o
 mosquitto_sub -h 127.0.0.1 -v -t "homeassistant/#"
 ```
 
-## MQTT Entities and the `entity_id` generated
+## MQTT Entities and their entity_id
 
-Every MQTT entity is assigned a unique `entity_id`. If `unique_id` is configured, you can change the entity_id and store the changes in the Entity Registry. The `entity_id` is generated when an item is loaded the first time, if the entity has a `unique_id` set, then the `entity_id` will be stored.
+For every configured MQTT entity Home Assistant automatically assigns a unique `entity_id`. If the `unique_id` option is configured, you can change the `entity_id` after creation, and the changes are stored in the Entity Registry. The `entity_id` is generated when an item is loaded the first time.
 
-If `object_id` is set, then this will be used to generate the `entity_id`.
+If the `object_id` option is set, then this will be used to generate the `entity_id`.
 If for example we have configured a `sensor`, and we have set `object_id` to `test` then Home Assistant will try to assign `sensor.test` as `entity_id`, but if this `entity_id` already exits it will a append it with a suffix to make it unique, for example `sensor.test_2`.
 
-If `object_id` is not set, then the `entity_id` will be based on the name, the device name or both. If for example the MQTT items `name` is set to `attic` and the `name` under the `device` key is set `temperature`, the default `entity_id` becomes `sensor.attic_temperature`. In case both `name` and device `name` are set to `test`, the default `entity_id` will be `sensor.test`.
+If `object_id` is not set, then the default `entity_id` will be based on the `name` option, the `name` option under the `device` key or both.
+If for example the MQTT items `name` is set to `temperature` and the `name` under the `device` key is set `attic`, the default `entity_id` becomes `sensor.attic_temperature`.
 
 <div class='note'>
 
-When the `name` is set under the device key, the entity's default name will not be assigned, bit it will inherit the device name instead.
+When an MQTT entity configuration has a `device` mapping and the `name` option is set, `has_entity_name` will be set to `True`.
+
+When the `name` is set under the device key, the entity's default name will not be be used, because the device name is used instead.
+
+More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#entity-naming).
 
 </div>
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -215,8 +215,8 @@ Example:
 # Example configuration.yaml entry
 mqtt:
   sensor:
-    - state_topic: "home/bedroom/temperature"
-      unique_id: "brtemp01"
+    - state_topic: "home/bedroom/humidity"
+      unique_id: "brhum01"
       name: "humidity"
       device:
         name: "Attic"
@@ -239,15 +239,15 @@ mqtt:
           - dev001
 ```
 
-In the following example without a `device_class` the entity `name` will become `Bedroom temperature`:
+In the following example without a `device_class` the entity `name` will become `Bedroom some sensor`:
 
 ```yaml
 # Example configuration.yaml entry
 mqtt:
   sensor:
-    - state_topic: "home/bedroom/temperature"
-      unique_id: "brtemp01"
-      name: "temperature"
+    - state_topic: "home/bedroom/sensor"
+      unique_id: "brsensor01"
+      name: "some sensor"
       device:
         name: "Bedroom"
         identifiers:
@@ -256,9 +256,7 @@ mqtt:
 
 <div class='note'>
 
-When an MQTT entity configuration has a `device` mapping and the `name` option is set, `has_entity_name` will be set to `True`.
-
-When the `name` is set under the device key, the entity's default name will not be be used, because the device name is used instead.
+So when an MQTT entity configuration has a `device` mapping, `has_entity_name` will be set to `True` and the entity's `friendly_name` and `entity_id` will constructed from the device `name` and entity `name`, in other cases `has_entity_name` will be set to False and the  friendly name will be set to the entity `name`.
 
 More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#entity-naming).
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -188,7 +188,12 @@ For reading all messages sent on the topic `homeassistant` to a broker running o
 mosquitto_sub -h 127.0.0.1 -v -t "homeassistant/#"
 ```
 
-## MQTT Entities and their entity_id and name
+## Sharing of device configuration
+
+MQTT entities can share device configuration, meaning one entity can include the full device configuration and other entities can link to that device by only setting mandatory fields.
+The mandatory fields were previously limited to at least one of `connection` and `identifiers`, but has now been extended to at least one of `connection` and `identifiers` as well as the `name`.
+
+## Naming of MQTT Entities
 
 For every configured MQTT entity Home Assistant automatically assigns a unique `entity_id`. If the `unique_id` option is configured, you can change the `entity_id` after creation, and the changes are stored in the Entity Registry. The `entity_id` is generated when an item is loaded the first time.
 
@@ -254,9 +259,9 @@ mqtt:
           - dev001
 ```
 
-So when an MQTT entity configuration has a `device` mapping, `has_entity_name` will be set to `True` and the entity's `friendly_name` and `entity_id` will constructed from the device `name` and entity `name`, in other cases `has_entity_name` will be set to `False` and the friendly name will be set to the entity `name`.
+So when an MQTT entity configuration has a `device` mapping, and the entity's `friendly_name` and `entity_id` will constructed from the device `name` and entity `name.
 
-The entity `name` option can also be set to `null`. This will set the entity name to `None` and `has_entity_name` to `True`. The entity `friendly_name` will only inherit the device name.
+The entity `name` option can also be set to `null`. This will set the entity name to `None`. The entity `friendly_name` will only inherit the device name.
 
 In the example below the default `entity_id` will be `sensor.bedroom` and the `friendly_name` will be "Bedroom":
 
@@ -273,7 +278,7 @@ mqtt:
           - dev001
 ```
 
-More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#entity-naming).
+Note that on each MQTT entity the `has_entity_name` attribute will be set to `True`. More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#entity-naming).
 
 ## MQTT Discovery
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -188,6 +188,21 @@ For reading all messages sent on the topic `homeassistant` to a broker running o
 mosquitto_sub -h 127.0.0.1 -v -t "homeassistant/#"
 ```
 
+## MQTT Entities and the `entity_id` generated
+
+Every MQTT entity is assigned a unique `entity_id`. If `unique_id` is configured, you can change the entity_id and store the changes in the Entity Registry. The `entity_id` is generated when an item is loaded the first time, if the entity has a `unique_id` set, then the `entity_id` will be stored.
+
+If `object_id` is set, then this will be used to generate the `entity_id`.
+If for example we have configured a `sensor`, and we have set `object_id` to `test` then Home Assistant will try to assign `sensor.test` as `entity_id`, but if this `entity_id` already exits it will a append it with a suffix to make it unique, for example `sensor.test_2`.
+
+If `object_id` is not set, then the `entity_id` will be based on the name, the device name or both. If for example the MQTT items `name` is set to `attic` and the `name` under the `device` key is set `temperature`, the default `entity_id` becomes `sensor.attic_temperature`. In case both `name` and device `name` are set to `test`, the default `entity_id` will be `sensor.test`.
+
+<div class='note'>
+
+When the `name` is set under the device key, the entity's default name will not be assigned, bit it will inherit the device name instead.
+
+</div>
+
 ## MQTT Discovery
 
 The discovery of MQTT devices will enable one to use MQTT devices with only minimal configuration effort on the side of Home Assistant. The configuration is done on the device itself and the topic used by the device. Similar to the [HTTP binary sensor](/integrations/http/#binary-sensor) and the [HTTP sensor](/integrations/http/#sensor). To prevent multiple identical entries if a device reconnects, a unique identifier is necessary. Two parts are required on the device side: The configuration topic which contains the necessary device type and unique identifier, and the remaining device configuration without the device type.

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -188,17 +188,71 @@ For reading all messages sent on the topic `homeassistant` to a broker running o
 mosquitto_sub -h 127.0.0.1 -v -t "homeassistant/#"
 ```
 
-## MQTT Entities and their entity_id
+## MQTT Entities and their entity_id and name
 
 For every configured MQTT entity Home Assistant automatically assigns a unique `entity_id`. If the `unique_id` option is configured, you can change the `entity_id` after creation, and the changes are stored in the Entity Registry. The `entity_id` is generated when an item is loaded the first time.
 
 If the `object_id` option is set, then this will be used to generate the `entity_id`.
 If for example we have configured a `sensor`, and we have set `object_id` to `test` then Home Assistant will try to assign `sensor.test` as `entity_id`, but if this `entity_id` already exits it will a append it with a suffix to make it unique, for example `sensor.test_2`.
+Example:
+
+```yaml
+# Example configuration.yaml entry
+mqtt:
+  sensor:
+    - state_topic: "home/bedroom/temperature"
+      unique_id: "brtemp01"
+      name: "temperature"
+      object_id: "test"
+```
 
 If `object_id` is not set, then the default `entity_id` will be based on the `name` option, the `name` option under the `device` key or on the `device_class` of the entity.
-If for example the MQTT items `name` is set to `humidity` and the `name` under the `device` key is set `attic`, the default `entity_id` becomes `sensor.attic_humidity`.
+If for example the MQTT items `name` is set to `humidity` and the `name` under the `device` key is set `Attic`, the default `entity_id` becomes `sensor.attic_humidity`.
 
-If the `device_class` option is set, it is not needed to set the entity's `name`, in that case the entity name follows the name of the `device_class`.
+Example:
+
+```yaml
+# Example configuration.yaml entry
+mqtt:
+  sensor:
+    - state_topic: "home/bedroom/temperature"
+      unique_id: "brtemp01"
+      name: "humidity"
+      device:
+        - name: "Attic"
+          identifiers:
+            - dev001
+```
+
+If the `device_class` option is set, it is not needed to set the entity's `name`, in that case the entity name follows the name of the `device_class`, this name supports translations. In the following example the entity `name` becomes `Bedroom Temperature`:
+
+```yaml
+# Example configuration.yaml entry
+mqtt:
+  sensor:
+    - state_topic: "home/bedroom/temperature"
+      unique_id: "brtemp01"
+      device_class: temperature
+      device:
+        - name: "Bedroom"
+          identifiers:
+            - dev001
+```
+
+In the following example without a `device_class` the entity `name` will become `Bedroom temperature`:
+
+```yaml
+# Example configuration.yaml entry
+mqtt:
+  sensor:
+    - state_topic: "home/bedroom/temperature"
+      unique_id: "brtemp01"
+      name: "temperature"
+      device:
+        - name: "Bedroom"
+          identifiers:
+            - dev001
+```
 
 <div class='note'>
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -219,9 +219,9 @@ mqtt:
       unique_id: "brtemp01"
       name: "humidity"
       device:
-        - name: "Attic"
-          identifiers:
-            - dev001
+        name: "Attic"
+        identifiers:
+          - dev001
 ```
 
 If the `device_class` option is set, it is not needed to set the entity's `name`, in that case the entity name follows the name of the `device_class`, this name supports translations. In the following example the entity `name` becomes `Bedroom Temperature`:
@@ -234,9 +234,9 @@ mqtt:
       unique_id: "brtemp01"
       device_class: temperature
       device:
-        - name: "Bedroom"
-          identifiers:
-            - dev001
+        name: "Bedroom"
+        identifiers:
+          - dev001
 ```
 
 In the following example without a `device_class` the entity `name` will become `Bedroom temperature`:
@@ -249,9 +249,9 @@ mqtt:
       unique_id: "brtemp01"
       name: "temperature"
       device:
-        - name: "Bedroom"
-          identifiers:
-            - dev001
+        name: "Bedroom"
+        identifiers:
+          - dev001
 ```
 
 <div class='note'>

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -191,21 +191,21 @@ mosquitto_sub -h 127.0.0.1 -v -t "homeassistant/#"
 ## Sharing of device configuration
 
 MQTT entities can share device configuration, meaning one entity can include the full device configuration and other entities can link to that device by only setting mandatory fields.
-The mandatory fields were previously limited to at least one of `connection` and `identifiers`, but has now been extended to at least one of `connection` and `identifiers` as well as the `name`.
+The mandatory fields were previously limited to at least one of `connection` and `identifiers`, but have now been extended to at least one of `connection` and `identifiers` as well as the `name`.
 
 ## Naming of MQTT Entities
 
 For every configured MQTT entity Home Assistant automatically assigns a unique `entity_id`. If the `unique_id` option is configured, you can change the `entity_id` after creation, and the changes are stored in the Entity Registry. The `entity_id` is generated when an item is loaded the first time.
 
 If the `object_id` option is set, then this will be used to generate the `entity_id`.
-If for example we have configured a `sensor`, and we have set `object_id` to `test` then Home Assistant will try to assign `sensor.test` as `entity_id`, but if this `entity_id` already exits it will a append it with a suffix to make it unique, for example `sensor.test_2`.
+If, for example, we have configured a `sensor`, and we have set `object_id` to `test`, then Home Assistant will try to assign `sensor.test` as `entity_id`, but if this `entity_id` already exits it will append it with a suffix to make it unique, for example, `sensor.test_2`.
 
 This means any MQTT entity which is part of a device will [automatically have it's `friendly_name` attribute prefixed with the device name](https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations)
 
 Unnamed `binary_sensor`, `button`, `number` and `sensor` entities will now be named by their device class instead of being named "MQTT binary sensor" etc.
-It's allowed to set an MQTT entity's name to `None` (use `null` in YAML) to mark it as the main feature of a device
+It's allowed to set an MQTT entity's name to `None` (use `null` in YAML) to mark it as the main feature of a device.
 
-Note that on each MQTT entity the `has_entity_name` attribute will be set to `True`. More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations).
+Note that on each MQTT entity, the `has_entity_name` attribute will be set to `True`. More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations).
 
 ## MQTT Discovery
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -224,7 +224,7 @@ mqtt:
           - dev001
 ```
 
-If the `device_class` option is set, it is not needed to set the entity's `name`, in that case the entity name follows the name of the `device_class`, this name supports translations. In the following example the entity `name` becomes `Bedroom Temperature`:
+If the `device_class` option is set, it is not needed to set the entity's `name`, in that case the entity name follows the name of the `device_class`, this name supports translations. In the following example the entity `friendly_name` becomes `Bedroom Temperature`:
 
 ```yaml
 # Example configuration.yaml entry
@@ -239,7 +239,7 @@ mqtt:
           - dev001
 ```
 
-In the following example without a `device_class` the entity `name` will become `Bedroom some sensor`:
+In the following example without a `device_class` the entity `friendly_name` will become `Bedroom some sensor`:
 
 ```yaml
 # Example configuration.yaml entry
@@ -254,13 +254,26 @@ mqtt:
           - dev001
 ```
 
-<div class='note'>
-
 So when an MQTT entity configuration has a `device` mapping, `has_entity_name` will be set to `True` and the entity's `friendly_name` and `entity_id` will constructed from the device `name` and entity `name`, in other cases `has_entity_name` will be set to False and the  friendly name will be set to the entity `name`.
 
-More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#entity-naming).
+The entity `name` option can also be set to `null`. This will set the entity name to `None` and `has_entity_name` to `True`. The entity `friendly_name` will only inherit the device name.
 
-</div>
+In the example below the default `entity_id` will be `sensor.bedroom` and the `friendly_name` will be "Bedroom":
+
+```yaml
+# Example configuration.yaml entry
+mqtt:
+  - sensor:
+      state_topic: "home/bedroom/sensor"
+      unique_id: "brsensor01"
+      name: null
+      device:
+        name: "Bedroom"
+        identifiers:
+          - dev001
+```
+
+More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#entity-naming).
 
 ## MQTT Discovery
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -199,86 +199,13 @@ For every configured MQTT entity Home Assistant automatically assigns a unique `
 
 If the `object_id` option is set, then this will be used to generate the `entity_id`.
 If for example we have configured a `sensor`, and we have set `object_id` to `test` then Home Assistant will try to assign `sensor.test` as `entity_id`, but if this `entity_id` already exits it will a append it with a suffix to make it unique, for example `sensor.test_2`.
-Example:
 
-```yaml
-# Example configuration.yaml entry
-mqtt:
-  - sensor:
-      state_topic: "home/bedroom/temperature"
-      unique_id: "brtemp01"
-      name: "temperature"
-      object_id: "test"
-```
+This means any MQTT entity which is part of a device will [automatically have it's `friendly_name` attribute prefixed with the device name](https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations)
 
-If `object_id` is not set, then the default `entity_id` will be based on the `name` option, the `name` option under the `device` key or on the `device_class` of the entity.
-If for example the MQTT items `name` is set to `humidity` and the `name` under the `device` key is set `Attic`, the default `entity_id` becomes `sensor.attic_humidity`.
+Unnamed `binary_sensor`, `button`, `number` and `sensor` entities will now be named by their device class instead of being named "MQTT binary sensor" etc.
+It's allowed to set an MQTT entity's name to `None` (use `null` in YAML) to mark it as the main feature of a device
 
-Example:
-
-```yaml
-# Example configuration.yaml entry
-mqtt:
-  - sensor:
-      state_topic: "home/bedroom/humidity"
-      unique_id: "brhum01"
-      name: "humidity"
-      device:
-        name: "Attic"
-        identifiers:
-          - dev001
-```
-
-If the `device_class` option is set, it is not needed to set the entity's `name`, in that case the entity name follows the name of the `device_class`, this name supports translations. In the following example the entity `friendly_name` becomes `Bedroom Temperature`:
-
-```yaml
-# Example configuration.yaml entry
-mqtt:
-  - sensor:
-      state_topic: "home/bedroom/temperature"
-      unique_id: "brtemp01"
-      device_class: temperature
-      device:
-        name: "Bedroom"
-        identifiers:
-          - dev001
-```
-
-In the following example without a `device_class` the entity `friendly_name` will become `Bedroom some sensor`:
-
-```yaml
-# Example configuration.yaml entry
-mqtt:
-  - sensor:
-      state_topic: "home/bedroom/sensor"
-      unique_id: "brsensor01"
-      name: "some sensor"
-      device:
-        name: "Bedroom"
-        identifiers:
-          - dev001
-```
-
-So when an MQTT entity configuration has a `device` mapping, and the entity's `friendly_name` and `entity_id` will constructed from the device `name` and entity `name.
-
-The entity `name` option can also be set to `null`. This will set the entity name to `None`. The entity `friendly_name` will only inherit the device name.
-
-In the example below the default `entity_id` will be `sensor.bedroom` and the `friendly_name` will be "Bedroom":
-
-```yaml
-# Example configuration.yaml entry
-mqtt:
-  - sensor:
-      state_topic: "home/bedroom/sensor"
-      unique_id: "brsensor01"
-      name: null
-      device:
-        name: "Bedroom"
-        identifiers:
-          - dev001
-```
-
-Note that on each MQTT entity the `has_entity_name` attribute will be set to `True`. More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#entity-naming).
+Note that on each MQTT entity the `has_entity_name` attribute will be set to `True`. More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations).
 
 ## MQTT Discovery
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -195,8 +195,10 @@ For every configured MQTT entity Home Assistant automatically assigns a unique `
 If the `object_id` option is set, then this will be used to generate the `entity_id`.
 If for example we have configured a `sensor`, and we have set `object_id` to `test` then Home Assistant will try to assign `sensor.test` as `entity_id`, but if this `entity_id` already exits it will a append it with a suffix to make it unique, for example `sensor.test_2`.
 
-If `object_id` is not set, then the default `entity_id` will be based on the `name` option, the `name` option under the `device` key or both.
-If for example the MQTT items `name` is set to `temperature` and the `name` under the `device` key is set `attic`, the default `entity_id` becomes `sensor.attic_temperature`.
+If `object_id` is not set, then the default `entity_id` will be based on the `name` option, the `name` option under the `device` key or on the `device_class` of the entity.
+If for example the MQTT items `name` is set to `humidity` and the `name` under the `device` key is set `attic`, the default `entity_id` becomes `sensor.attic_humidity`.
+
+If the `device_class` option is set, it is not needed to set the entity's `name`, in that case the entity name follows the name of the `device_class`.
 
 <div class='note'>
 

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -154,7 +154,7 @@ mode:
   type: string
   default: '"auto"'
 name:
-  description: The name of the Number. Can be set to `None` if only the device name is relevant.
+  description: The name of the Number. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
 object_id:

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -154,7 +154,7 @@ mode:
   type: string
   default: '"auto"'
 name:
-  description: The name of the Number.
+  description: The name of the Number. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
 object_id:

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -145,7 +145,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the Select. Can be set to `None` if only the device name is relevant.
+  description: The name of the Select. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
 object_id:

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -145,7 +145,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the Select.
+  description: The name of the Select. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
 object_id:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -153,7 +153,7 @@ last_reset_value_template:
   required: false
   type: template
 name:
-  description: The name of the MQTT sensor. Can be set to `None` if only the device name is relevant.
+  description: The name of the MQTT sensor. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Sensor

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -153,7 +153,7 @@ last_reset_value_template:
   required: false
   type: template
 name:
-  description: The name of the MQTT sensor.
+  description: The name of the MQTT sensor. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Sensor

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -156,7 +156,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name to use when displaying this siren. Can be set to `None` if only the device name is relevant.
+  description: The name to use when displaying this siren. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Siren

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -156,7 +156,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name to use when displaying this siren.
+  description: The name to use when displaying this siren. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Siren

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -147,8 +147,8 @@ json_attributes_topic:
   description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor attributes. Usage example can be found in [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-topic-configuration) documentation.
   required: false
   type: string
-name: Can be set to `None` if only the device name is relevant.
-  description: The name to use when displaying this switch.
+name:
+  description: The name to use when displaying this switch. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Switch

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -147,7 +147,7 @@ json_attributes_topic:
   description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor attributes. Usage example can be found in [MQTT sensor](/integrations/sensor.mqtt/#json-attributes-topic-configuration) documentation.
   required: false
   type: string
-name:
+name: Can be set to `None` if only the device name is relevant.
   description: The name to use when displaying this switch.
   required: false
   type: string

--- a/source/_integrations/text.mqtt.markdown
+++ b/source/_integrations/text.mqtt.markdown
@@ -150,7 +150,7 @@ mode:
   type: string
   default: text
 name:
-  description: The name of the text entity. Can be set to `None` if only the device name is relevant.
+  description: The name of the text entity. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: "MQTT Text"

--- a/source/_integrations/text.mqtt.markdown
+++ b/source/_integrations/text.mqtt.markdown
@@ -150,7 +150,7 @@ mode:
   type: string
   default: text
 name:
-  description: The name of the text entity.
+  description: The name of the text entity. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: "MQTT Text"

--- a/source/_integrations/update.mqtt.markdown
+++ b/source/_integrations/update.mqtt.markdown
@@ -154,7 +154,7 @@ latest_version_topic:
   required: false
   type: string
 name:
-  description: The name of the Update.
+  description: The name of the Update. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
 object_id:

--- a/source/_integrations/update.mqtt.markdown
+++ b/source/_integrations/update.mqtt.markdown
@@ -154,7 +154,7 @@ latest_version_topic:
   required: false
   type: string
 name:
-  description: The name of the Update. Can be set to `None` if only the device name is relevant.
+  description: The name of the Update. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
 object_id:

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -153,7 +153,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the vacuum. Can be set to `None` if only the device name is relevant.
+  description: The name of the vacuum. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Vacuum
@@ -429,7 +429,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the vacuum. Can be set to `None` if only the device name is relevant.
+  description: The name of the vacuum. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Vacuum

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -153,7 +153,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the vacuum.
+  description: The name of the vacuum. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Vacuum
@@ -429,7 +429,7 @@ json_attributes_topic:
   required: false
   type: string
 name:
-  description: The name of the vacuum.
+  description: The name of the vacuum. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Vacuum

--- a/source/_integrations/water_heater.mqtt.markdown
+++ b/source/_integrations/water_heater.mqtt.markdown
@@ -175,7 +175,7 @@ modes:
   default: ['off', 'eco', 'electric', 'gas', 'heat_pump', 'high_demand', 'performance']
   type: list
 name:
-  description: The name of the Water Heater.
+  description: The name of the Water Heater. Can be set to `None` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Water Heater

--- a/source/_integrations/water_heater.mqtt.markdown
+++ b/source/_integrations/water_heater.mqtt.markdown
@@ -175,7 +175,7 @@ modes:
   default: ['off', 'eco', 'electric', 'gas', 'heat_pump', 'high_demand', 'performance']
   type: list
 name:
-  description: The name of the Water Heater. Can be set to `None` if only the device name is relevant.
+  description: The name of the Water Heater. Can be set to `null` if only the device name is relevant.
   required: false
   type: string
   default: MQTT Water Heater


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documents how the friendly name default entity_id is generated for MQTT items and that `has_entity_name` is set to `True`.
The linked PR changes this behavior when both entity and and device name are set.
Also the default name will not be set if the the device `name` is set.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/95159
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
