### PR TITLE
Update input_select.markdown

### DIFF
--- a/source/_integrations/input_select.markdown
+++ b/source/_integrations/input_select.markdown
@@ -213,3 +213,53 @@ input_select:
 ```
 
 {% endraw %}
+
+Example of `input_select` being used to display the name associated to a numeric state.
+For example, the wallbox *DomBusEVSE* outputs the entity `sensor.evstate` with the following numeric values:
+
+1 -> Car disconnected  
+2 -> Car connected  
+3 -> Charging   
+4 -> Charging + Ventilation req.  
+....  
+
+The following example shows how to create an `input_selector` helper and an automation that updates it when `sensor.evstate` changes: the automation create a list/array *slist* within all options of the input_selector, the variable *item* corresponding to the evse state, and set the input_selector option to *slist[item]*.
+
+{% raw %}
+```yaml
+# define the input_select helper that shows the status name associated to sensor.evstate numeric status
+# the following lines go into configuration.yaml file
+input_select:
+  evstatename:
+    name: EVStateName
+    options:
+    - Off
+    - Disconnected
+    - Connected
+    - Charging
+    - Charging+Vent
+    - Alarm EV
+    - Alarm Power Outage
+    - Alarm Welded
+    initial: Disconnected
+
+# define an automation that update evstatename when sensor.evstate changes
+# the following lines go into automations.yaml file
+# in action, it creates a list variable within all options of the input_select.evstatename
+# and a variable corresponding to the sensor.evstate, then set the proper option for input_select.evstatename
+# it's really simple and works perfect.
+- id: "evstatenameautomation"
+  alias: "Automation that updates EVStateName entity/helper when EVState changes"
+  trigger:
+  - platform: state
+    entity_id: sensor.evstate
+  action:
+    - service: input_select.select_option
+      data_template:
+        entity_id: input_select.evstatename
+        option: >
+          {% set slist = state_attr('input_select.evstatename','options') %}
+          {% set item = states.sensor.evstate.state|int %}
+          {{slist[item]}}
+```
+{% endraw %}


### PR DESCRIPTION
Added an automation example that uses a list to update an input_select helper with the status name corresponding to a status numeric value (contained in a sensor entity).

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
