### PR TITLE
Add docs for fully_kiosk set_config service

### DIFF
--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -96,7 +96,6 @@ You can use the service `fully_kiosk.set_config` to change the many configuratio
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `device_id` | no | Device ID (or list of device IDs) to load the URL on.
-| `config_type` | no | The type of configuration parameter, either 'string' or 'bool'.
 | `key` | no | The configuration parameter key. The list of available keys can be found in the Fully Kiosk Browser remote admin panel by clicking the 'Show keys' button.
 | `value` | no | The value to set the configuration parameter to.
 

--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -96,7 +96,7 @@ You can use the service `fully_kiosk.set_config` to change the many configuratio
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `device_id` | no | Device ID (or list of device IDs) to load the URL on.
-| `key` | no | The configuration parameter key. The list of available keys can be found in the Fully Kiosk Browser remote admin panel by clicking the 'Show keys' button.
+| `key` | no | The configuration parameter key. The list of available keys can be found in the Fully Kiosk Browser remote admin panel by clicking the **Show keys** button.
 | `value` | no | The value to set the configuration parameter to.
 
 Example:

--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -89,6 +89,29 @@ target:
   device_id: a674c90eca95eca91f6020415de07713
 ```
 
+**Service `set_config`**
+
+You can use the service `fully_kiosk.set_config` to change the many configuration parameters of Fully Kiosk Browser.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `device_id` | no | Device ID (or list of device IDs) to load the URL on.
+| `config_type` | no | The type of configuration parameter, either 'string' or 'bool'.
+| `key` | no | The configuration parameter key. The list of available keys can be found in the Fully Kiosk Browser remote admin panel by clicking the 'Show keys' button.
+| `value` | no | The value to set the configuration parameter to.
+
+Example:
+
+```yaml
+service: fully_kiosk.set_config
+data:
+  config_type: "string"
+  key: "startURL"
+  value: "https://home-assistant.io"
+target:
+  device_id: a674c90eca95eca91f6020415de07713
+```
+
 **Service `start_application`**
 
 You can use the service `fully_kiosk.start_application` to have the tablet launch the specified app.


### PR DESCRIPTION
## Proposed change
Adds documentation for the Fully Kiosk Browser `set_config` service.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/95318
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
