### PR TITLE
Update Zodiac documentation for config flow

### DIFF
--- a/source/_integrations/zodiac.markdown
+++ b/source/_integrations/zodiac.markdown
@@ -14,7 +14,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `zodiac` integration tracks the current zodiac sign.
+The Zodiac integration tracks the current zodiac sign.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/zodiac.markdown
+++ b/source/_integrations/zodiac.markdown
@@ -3,7 +3,7 @@ title: Zodiac
 description: Instructions on how to setup the zodiac integration within Home Assistant.
 ha_category:
   - Environment
-ha_iot_class: Local Polling
+ha_iot_class: Calculated
 ha_release: 0.116
 ha_quality_scale: silver
 ha_codeowners:
@@ -16,14 +16,7 @@ ha_integration_type: integration
 
 The `zodiac` integration tracks the current zodiac sign.
 
-## Configuration
-
-To enable the zodiac integration, add the following lines to your `configuration.yaml`:
-
-```yaml
-# Example configuration.yaml entry
-zodiac:
-```
+{% include integrations/config_flow.md %}
 
 ## Sensor
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update documentation to add config flow instructions.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/95447
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
