### PR TITLE
Update discovery examples to include device creation and script

### DIFF
--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -587,7 +587,7 @@ Delete the sensor by sending an empty message:
 mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/binary_sensor/garden/config" -m ''
 ```
 
-Note: the Configuration topic prefix must be 'homeassistant' (or another if you changed the default). However, the State topic prefix does not need to be 'homeassistant'. It is common for the State topic prefix to indicate which device or script sent the MQTT message, for example 'my_esp_device', 'rtl_433', or 'my_python_script'.
+Note: the Configuration topic prefix must be `homeassistant` (or another if you changed the default). However, the State topic prefix does not need to be `homeassistant`. It is common for the State topic prefix to indicate which device or script sent the MQTT message, for example 'my_esp_device', 'rtl_433', or 'my_python_script'.
 
 #### Creating a device with two sensor entities (temperature and humidity sensor)
 
@@ -639,13 +639,13 @@ Notes:
 - Don't forget to publish configuration messages with 'retain' set to true.
 - If publishing the configuration payload via the Home Assistant MQTT integration (Settings > Devices and Services > core-mosquitto > Configure), be sure to tick 'Allow template'.
 
-#### Using a script to create a device with multiple sensor entities (rtl_433 and door/window sensors)
+#### Using a script to create a device with multiple sensor entities (door/window sensors)
 
 With a [`script`](/integrations/script/) the user can automate sending multiple configuration messages to create a device with multiple entities. 
 
 In the following example, a device will be created to represent the state of a Honeywell Security Model 5816 Door and window Contact Sensor. A separate application called RTL_433 has been configured to receive 345MHz RF transmissions from the physical device, decode, and transmit an MQTT message with state payload.
 
-The following command will run rtl_433 and publish mqtt payload messages:
+The following command will run rtl_433 and publish MQTT messages:
 `rtl_433 -f 345M -F "mqtt://MY_HA_SERVER_IP:1883,user=MY_MQTT_USER,pass=MY_MQTT_PASSWORD,events=rtl_433[/model][/id]"`
 
 The state topic for sensor 181554 would be: `rtl_433/Honeywell-Security/181554`
@@ -674,7 +674,7 @@ Create the scripts.yaml file, and paste in the following script:
 
 {% details "Script" %}
 
-```
+```yaml
 create_sensors:
   alias: "Create sensors via MQTT Discovery"
   sequence:

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -593,7 +593,7 @@ Note: the Configuration topic prefix must be `homeassistant` (or another if you 
 
 In the following example, a device will be created with two sensor entities representing temperature and humidity measurements. Sensor entities can be represented by an [MQTT Sensor](/integrations/sensor.mqtt/).
 
-To set up a any device with multiple entities, a Configuration topic must be published for each entity. Each entity must include a 'unique_id' property qhich is unique entity, and a 'device' property which includes a device 'identifiers' property which is unique to the device.
+To set up a any device with multiple entities, a Configuration topic must be published for each entity. Each Configuration topic must include a "unique_id" property which is unique to the entity being created, and a "device" property which includes a device "identifiers" property which is unique to the device.
 
 A user, script, or device would send its configuration as JSON payload to the Configuration topic. After the first message to `config`, then the device may send MQTT messages with new sensor measurements in the form of a JSON payload.
 
@@ -638,6 +638,14 @@ Notes:
 - The configuration topic must be unique for each entity. In this example the configuration topic 'object_id' combines the device name, serial number, and sensor id to form a unique topic.
 - Don't forget to publish configuration messages with 'retain' set to true.
 - If publishing the configuration payload via the Home Assistant MQTT integration (Settings > Devices and Services > core-mosquitto > Configure), be sure to tick 'Allow template'.
+
+Delete this example device and entities:
+- Configuration topic 1: `homeassistant/sensor/my_custom_sensor_001_temperature/config`
+- Configuration payload 1: (empty)
+- Configuration topic 2: `homeassistant/sensor/my_custom_sensor_001_humidity/config`
+- Configuration payload 2: (empty)
+- The messages must be published 'retain' set to true. Do not tick 'Allow template'.
+- If using mosquitto_pub, see previous example.
 
 #### Using a script to create a device with multiple sensor entities (door/window sensors)
 


### PR DESCRIPTION
## Proposed change
Currently, [this example](https://www.home-assistant.io/integrations/mqtt/#sensors) does not produce the intended results.

This change will update the discovery examples section to use correct Home Assistant terminology for sensors, entities, and devices. Examples have been extended to include a useful script for automating device creation.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #27989

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
