### PR TITLE
Add unsupported model section for TP-Link Kasa integration

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -100,7 +100,7 @@ Other bulbs may also work, but with limited color temperature range (2700-5000).
 
 ### Plugs
 
-- KP125M (supported via [Matter](/integrations/matter/), but without energy monitoring features)
+- KP125M (supported via [Matter](/integrations/matter/#tp-link-tapo-p125m-power-plug), but without energy monitoring features)
 
 ### Random Effect - Service `tplink.random_effect`
 

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -96,6 +96,12 @@ See [Supported Devices in python-kasa](https://github.com/python-kasa/python-kas
 
 Other bulbs may also work, but with limited color temperature range (2700-5000). If you find a bulb isn't reaching the full-color temperature boundaries, submit a bug report to [python-kasa](https://github.com/python-kasa/python-kasa).
 
+## Unsupported devices
+
+### Plugs
+
+- KP125M (supported via [Matter](/integrations/matter/), but without energy monitoring features)
+
 ### Random Effect - Service `tplink.random_effect`
 
 The light strips allow setting a random effect.


### PR DESCRIPTION
## Proposed change
Some newer models of TP-Link Kasa devices are incompatible with the integration. Creating an "Unsupported" section for them and adding one known model. Additionally, cross link to the Matter integration where said model has limited support.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a (I think?), but related to https://github.com/home-assistant/core/issues/94947

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
