### PR TITLE
Make clearer that all automation conditions must pass

### DIFF
--- a/source/_docs/automation/condition.markdown
+++ b/source/_docs/automation/condition.markdown
@@ -3,7 +3,7 @@ title: "Automation Conditions"
 description: "Automations can test conditions when invoked."
 ---
 
-Conditions are an optional part of an automation rule, and can be used to prevent the automation's actions from being run. After an automation has been triggered, all conditions will be checked, and if any of them do not return true, the automation will stop executing. Conditions look very similar to triggers but are very different - a trigger will look at events happening in the system while a condition only looks at how the system looks right now. A trigger can observe that a switch is being turned on. A condition can only see if a switch is currently on or off.
+Conditions are an optional part of an automation rule. They can be used to prevent the automation's actions from being run. After an automation has been triggered, all conditions will be checked. If any of them do not return true, the automation will stop executing. Conditions look very similar to triggers, but they are very different &mdash; a trigger will look at events happening in the system, while a condition only looks at how the system looks right now. A trigger can observe that a switch is being turned on. A condition can only see if a switch is currently on or off.
 
 The available conditions for an automation are the same as for the script syntax so see that page for a [full list of available conditions](/docs/scripts/conditions/).
 

--- a/source/_docs/automation/condition.markdown
+++ b/source/_docs/automation/condition.markdown
@@ -3,7 +3,7 @@ title: "Automation Conditions"
 description: "Automations can test conditions when invoked."
 ---
 
-Conditions are an optional part of an automation rule and can be used to prevent an action from happening when triggered. When a condition does not return true, the automation will stop executing. Conditions look very similar to triggers but are very different. A trigger will look at events happening in the system while a condition only looks at how the system looks right now. A trigger can observe that a switch is being turned on. A condition can only see if a switch is currently on or off.
+Conditions are an optional part of an automation rule, and can be used to prevent the automation's actions from being run. After an automation has been triggered, all conditions will be checked, and if any of them do not return true, the automation will stop executing. Conditions look very similar to triggers but are very different - a trigger will look at events happening in the system while a condition only looks at how the system looks right now. A trigger can observe that a switch is being turned on. A condition can only see if a switch is currently on or off.
 
 The available conditions for an automation are the same as for the script syntax so see that page for a [full list of available conditions](/docs/scripts/conditions/).
 


### PR DESCRIPTION
Clarify that if any automation conditions fail, the automation actions will not be executed.

## Proposed change
Improves docs for automation conditions to make clearer that all conditions must pass (as opposed to one or more must pass).
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
