### PR TITLE
Remove documentation of deprecated vacuum services

### DIFF
--- a/source/_integrations/vacuum.markdown
+++ b/source/_integrations/vacuum.markdown
@@ -1,6 +1,6 @@
 ---
 title: Vacuum
-description: Instructions on how to setup and use vacuum's in Home Assistant.
+description: Instructions on how to setup and use vacuums in Home Assistant.
 ha_release: 0.51
 ha_domain: vacuum
 ha_quality_scale: internal
@@ -12,47 +12,11 @@ ha_integration_type: entity
 
 The `vacuum` integration enables the ability to control home cleaning robots within Home Assistant.
 
-## Configuration
+## Services
 
-To use this integration in your installation, add a `vacuum` platform to your `configuration.yaml` file, like the [Xiaomi](/integrations/xiaomi_miio#xiaomi-mi-robot-vacuum).
-
-```yaml
-# Example configuration.yaml entry
-vacuum:
-  - platform: xiaomi_miio
-    name: Living room
-    host: 192.168.1.2
-```
-
-### Integration services
-
-Available services: `turn_on`, `turn_off`, `start_pause`, `start`, `pause`, `stop`, `return_to_base`, `locate`, `clean_spot`, `set_fan_speed` and `send_command`.
+Available services: `start`, `pause`, `stop`, `return_to_base`, `locate`, `clean_spot`, `set_fan_speed` and `send_command`.
 
 Before calling one of these services, make sure your vacuum platform supports it.
-
-#### Service `vacuum.turn_on`
-
-Start a new cleaning task. For the Xiaomi Vacuum, Roomba, and Neato use `vacuum.start` instead.
-
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-
-#### Service `vacuum.turn_off`
-
-Stop the current cleaning task and return to the dock. For the Xiaomi Vacuum, Roomba, and Neato use `vacuum.stop` instead.
-
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-
-#### Service `vacuum.start_pause`
-
-Start, pause or resume a cleaning task. For the Xiaomi Vacuum, Roomba, and Neato use `vacuum.start` and `vacuum.pause` instead.
-
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.start`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove documentation of vacuum services only supported by the deprecated `VacuumEntity` base class.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
