### PR TITLE
Setting fan speed is also supported

### DIFF
--- a/source/_integrations/sharkiq.markdown
+++ b/source/_integrations/sharkiq.markdown
@@ -28,5 +28,6 @@ Currently supported services are:
 - `stop`
 - `return_to_base`
 - `locate`
+- `set_fan_speed`
 
 If `pause` does not work for you, then it is not supported by your vacuum. The `stop` service will provide similar functionality.


### PR DESCRIPTION
## Proposed change
<!-- 
Setting of fan speed is also supported
https://github.com/home-assistant/core/blob/dev/homeassistant/components/sharkiq/vacuum.py#L202-L209
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/blob/dev/homeassistant/components/sharkiq/vacuum.py#L202-L209
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
