### PR TITLE
sensirion-ble: note SHT4x and SHT3x are supported too in 2023.7

### DIFF
--- a/source/_integrations/sensirion_ble.markdown
+++ b/source/_integrations/sensirion_ble.markdown
@@ -24,3 +24,5 @@ The Sensirion BLE integration will automatically discover devices once the [Blue
 ## Supported devices
 
 - [Sensirion MyCO2 Gadget](https://sensirion.com/products/catalog/SCD4x-CO2-Gadget/)
+- [Sensirion SHT4x Smart Gadget](https://www.sensirion.com/products/catalog/SHT4x-Smart-Gadget)
+- [Sensirion SHT31 Gadget](https://developer.sensirion.com/archive/platforms/sht31-smart-gadget-development-kit/) (untested)


### PR DESCRIPTION
## Proposed change

Adds the SHT3x and SHT4x gadgets to supported devices.

See discussion in https://github.com/home-assistant/core/issues/93678#issuecomment-1621062553

Enabled by https://github.com/home-assistant/core/pull/94352

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/94352

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
