### PR TITLE
freebox: add raid array health binary sensor (#95242)

### DIFF
--- a/source/_integrations/freebox.markdown
+++ b/source/_integrations/freebox.markdown
@@ -19,6 +19,7 @@ ha_platforms:
   - camera
   - device_tracker
   - sensor
+  - binary_sensor
   - switch
 ha_zeroconf: true
 ha_integration_type: integration
@@ -29,6 +30,7 @@ The `freebox` integration allows you to observe and control [Freebox router](htt
 There is currently support for the following device types within Home Assistant:
 
 * [Sensor](#sensor) with metrics for connection speed, internal temperature, free partition space and missed calls
+* [Binary sensor](#binary-sensor) for monitoring Raid arrays health
 * [Device tracker](#presence-detection) for connected devices
 * [Switch](#switch) to control Wi-Fi
 * [Camera](#camera)
@@ -117,7 +119,12 @@ The monitored metrics are:
 * Free partition space of used disks
 * Number of missed calls
 
+## Binary sensor
+
+The health status of each RAID array can be monitored with a diagnostics binary sensor reflecting the `degraded` state (OK means not degraded, PROBLEM means degraded).
+
 ## Camera
+
 Cameras are only available in Freebox V7 (also known as Freebox Delta).
 
 ## Service


### PR DESCRIPTION
## Proposed change

Mention new sensor added by PR #95242 to freebox documentation.


## Type of change

- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/95242

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
