### PR TITLE
Integrations page update paths to reflect current UI

### DIFF
--- a/source/_includes/integrations/option_flow.md
+++ b/source/_includes/integrations/option_flow.md
@@ -7,4 +7,4 @@ Options for {{ name }} can be set via the user interface, by taking the followin
 - Browse to your Home Assistant instance.
 - Go to **{% my integrations title="Settings > Devices & Services" %}**.
 - If multiple instances of {{ name }} are configured, choose the instance you want to configure.
-- Select the cogwheel, then select **Configure**.
+- Select the integration, then select **Configure**.

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -83,7 +83,7 @@ api_key:
   <img src='/images/screenshots/ecobee-thermostat-card.png' />
 </p>
 
-You must [restart Home Assistant](/docs/configuration/#reloading-changes) for the changes to take effect. After restarting, go to {% my integrations title="**Settings** > **Devices & Services**" %} and select the cogwheel. Then, select **Configure** and continue to authorize the app according to the above **Automatic Configuration**, starting at step 2.
+You must [restart Home Assistant](/docs/configuration/#reloading-changes) for the changes to take effect. After restarting, go to {% my integrations title="**Settings** > **Devices & Services**" %} and select the integration. Then, select **Configure** and continue to authorize the app according to the above **Automatic Configuration**, starting at step 2.
 
 ## Notifications
 

--- a/source/_integrations/forecast_solar.markdown
+++ b/source/_integrations/forecast_solar.markdown
@@ -101,7 +101,7 @@ updates (based on a higher data resolution), you could [sign up for one
 of their plans](https://doc.forecast.solar/doku.php?id=account_models#compare_plans).
 
 To enable the use of the API key with this integration, go to {% my integrations %}. 
-On the Forecast.Solar integration, select the cogwheel, then select **Configure**. Enter the
+Select the Forecast.Solar integration, then select **Configure**. Enter the
 API key for your account.
 
 ## Tweaking the estimations
@@ -134,5 +134,4 @@ instance:
 1. Browse to your Home Assistant instance.
 1. Go to **{% my integrations title="Settings > Devices & Services" %}**.
 1. If multiple instances of {{ name }} are configured, choose the instance you want to configure.
-1. Select the cogwheel.
 1. Select **Configure**.

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -82,7 +82,7 @@ If no password is given, it will be auto-generated.
 ## Integration options
 
 It is possible to change some behaviors through the integration options.
-To change the settings, go to {% my integrations title="**Settings** > **Devices & Services**" %}. On the **AVM FRITZ!Box Tools** integration, select the cogwheel. Then select **Configure**.
+To change the settings, go to {% my integrations title="**Settings** > **Devices & Services**" %}. Select the **AVM FRITZ!Box Tools** integration, then select **Configure**.
 
 - **Consider home**: Number of seconds that must elapse before considering a disconnected device "not at home".
 - **Enable old discovery method**: Needed on some scenarios like no mesh support (fw <= 6.x), mixed brands network devices or LAN switches.

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -73,8 +73,8 @@ MQTT broker settings are configured when the MQTT integration is first set up an
 Add the MQTT integration, then provide your broker's hostname (or IP address) and port and (if required) the username and password that Home Assistant should use. To change the settings later, follow these steps:
 
 1. Go to **{% my integrations title="Settings > Devices & Services" %}**.
-2. Select the MQTT integration.
-3. Select **Configure**, then **Re-configure MQTT**.
+1. Select the MQTT integration.
+1. Select **Configure**, then **Re-configure MQTT**.
 
 <div class='note'>
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -73,8 +73,8 @@ MQTT broker settings are configured when the MQTT integration is first set up an
 Add the MQTT integration, then provide your broker's hostname (or IP address) and port and (if required) the username and password that Home Assistant should use. To change the settings later, follow these steps:
 
 1. Go to **{% my integrations title="Settings > Devices & Services" %}**.
-1. On the MQTT integration, select the cogwheel. 
-1. Select **Configure**, then **Re-configure MQTT**.
+2. Select the MQTT integration.
+3. Select **Configure**, then **Re-configure MQTT**.
 
 <div class='note'>
 
@@ -129,7 +129,7 @@ A configured client certificate will only be active if broker certificate valida
 To change the settings, follow these steps:
 
 1. Go to **{% my integrations title="Settings > Devices & Services" %}**.
-1. On the MQTT integration, select the cogwheel. 
+1. Select the MQTT integration.
 1. Select **Configure**, then **Re-configure MQTT**.
 1. To open the MQTT options page, select **Next**.
 
@@ -157,7 +157,7 @@ mosquitto_pub -h 127.0.0.1 -t homeassistant/switch/1/on -m "Switch is ON"
 Another way to send MQTT messages manually is to use the **MQTT** integration in the frontend. Choose "Settings" on the left menu, click "Devices & Services", and choose "Configure" in the "Mosquitto broker" tile. Enter something similar to the example below into the "topic" field under "Publish a packet" and press "PUBLISH" .
 
 1. Go to **{% my integrations title="Settings > Devices & Services" %}**.
-1. On the Mosquitto broker integration, select the cogwheel, then select **Configure**.
+1. Select the Mosquitto broker integration, then select **Configure**.
 1. Enter something similar to the example below into the **topic** field under **Publish a packet**. Select **Publish**.
 
 ```bash

--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -20,12 +20,12 @@ This integration uses Roon Core, a Roon application that runs on a machine on yo
 
 ## Configuration
 
-1. From the Home Assistant front-end, go to {% my integrations title="**Settings** > **Devices & Services**" %}. On the **Roon** integration, select the cogwheel. Then, select **Configure**.
+1. From the Home Assistant front-end, go to {% my integrations title="**Settings** > **Devices & Services**" %}. Select the **Roon** integration. Then, select **Configure**.
 1. Home Assistant will then try to find your Roon Core - if it is successful it will display `Authorize HomeAssistant in Roon`. Select **Submit** and skip to step 4.
-1. If your Roon Core is not automatically found, enter the `Hostname` or `IP address` for the Roon Core machine when requested and select **Submit**.
-1. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to **Settings** and then **Extensions**. There, you will see an entry for Home Assistant with a button next to it. Select **Enable**.
-1. Roon core will then provide Home Assistant with the details of your media players.
-1. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.
+2. If your Roon Core is not automatically found, enter the `Hostname` or `IP address` for the Roon Core machine when requested and select **Submit**.
+3. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to **Settings** and then **Extensions**. There, you will see an entry for Home Assistant with a button next to it. Select **Enable**.
+4. Roon core will then provide Home Assistant with the details of your media players.
+5. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.
 
 ## Services
 

--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -22,10 +22,10 @@ This integration uses Roon Core, a Roon application that runs on a machine on yo
 
 1. From the Home Assistant front-end, go to {% my integrations title="**Settings** > **Devices & Services**" %}. Select the **Roon** integration. Then, select **Configure**.
 1. Home Assistant will then try to find your Roon Core - if it is successful it will display `Authorize HomeAssistant in Roon`. Select **Submit** and skip to step 4.
-2. If your Roon Core is not automatically found, enter the `Hostname` or `IP address` for the Roon Core machine when requested and select **Submit**.
-3. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to **Settings** and then **Extensions**. There, you will see an entry for Home Assistant with a button next to it. Select **Enable**.
-4. Roon core will then provide Home Assistant with the details of your media players.
-5. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.
+1. If your Roon Core is not automatically found, enter the `Hostname` or `IP address` for the Roon Core machine when requested and select **Submit**.
+1. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to **Settings** and then **Extensions**. There, you will see an entry for Home Assistant with a button next to it. Select **Enable**.
+1. Roon core will then provide Home Assistant with the details of your media players.
+1. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.
 
 ## Services
 

--- a/source/_integrations/sentry.markdown
+++ b/source/_integrations/sentry.markdown
@@ -46,6 +46,6 @@ The Sentry integration provides settings to:
 - Ability to send out events originating from third-party Python packages.
 - Enable performance tracing and tune the tracing sample rate used.
 
-To change the settings, go to {% my integrations title="**Settings** > **Devices & Services**" %}. On the already installed **Sentry** integration, select the cogwheel and select **Options**.
+To change the settings, go to {% my integrations title="**Settings** > **Devices & Services**" %}. Select the **Sentry** integration. Then, select **Options**.
 
 After changing the Sentry settings, you'll need to restart Home Assistant in order to make them effective.

--- a/source/_integrations/waze_travel_time.markdown
+++ b/source/_integrations/waze_travel_time.markdown
@@ -27,7 +27,7 @@ Notes:
 
 ## Manual Polling
 
-Some users want more control over polling intervals. To use more granular polling, you can disable automated polling. Go to {% my integrations title="**Settings** > **Devices & Services**" %}, and on the **Waze Travel Time** integration, select the cogwheel. On the integration entry, select the three dots. Then, select **System options** and toggle the button to disable polling. To manually trigger a polling request, call the [`homeassistant.update_entity` service](/integrations/homeassistant/#service-homeassistantupdate_entity) as needed, either manually or via automations.
+Some users want more control over polling intervals. To use more granular polling, you can disable automated polling. Go to {% my integrations title="**Settings** > **Devices & Services**" %}, and select the **Waze Travel Time** integration. On the integration entry, select the three dots. Then, select **System options** and toggle the button to disable polling. To manually trigger a polling request, call the [`homeassistant.update_entity` service](/integrations/homeassistant/#service-homeassistantupdate_entity) as needed, either manually or via automations.
 
 ## Example using dynamic destination
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -387,7 +387,7 @@ Tip! It is highly recommended that you read through the two segments under the t
 **To add a new Zigbee device:**
 
 1. Go to {% my integrations title="**Settings** > **Devices & Services**" %}.
-1. On the **Zigbee Home Automation** integration select the cogwheel, the select **Configure**.
+1. Select the **Zigbee Home Automation** integration. Then, select **Configure**.
 1. To start a scan for new devices, on the bottom right corner of the screen, select **Add device**.
 1. Reset your Zigbee devices to factory default settings according to the device instructions provided by the manufacturer (e.g., turn on/off lights up to 10 times; switches usually have a reset button/pin). It might take a few seconds for the devices to appear. You can click on **Show logs** for more verbose output.
 1. Once the device is found, it will appear on that page and will be automatically added to your devices. You can optionally change its name and add it to an area (you can change this later). You can search again to add another device, or you can go back to the list of added devices.
@@ -550,7 +550,7 @@ When reporting issues, please provide the following information in addition to i
 1. Debug logs for the issue, see [debug logging](#debug-logging)
 2. Model of Zigbee radio being used
 3. If the issue is related to a specific Zigbee device, provide both the **Zigbee Device Signature** and the **Diagnostics** information.
-  * Both the **Zigbee Device Signature** and the **Diagnostics** information can be found under {% my integrations title="**Settings** > **Devices & Services**" %}. On the **Zigbee Home Automation** integration, select the cogwheel. Then, select **Configure** > **Devices** (pick your device). Select **Zigbee Device Signature** and **Download Diagnostics**, respectively.
+  * Both the **Zigbee Device Signature** and the **Diagnostics** information can be found under {% my integrations title="**Settings** > **Devices & Services**" %}. Select the **Zigbee Home Automation** integration. Then, select **Configure** > **Devices** (pick your device). Select **Zigbee Device Signature** and **Download Diagnostics**, respectively.
 
 ### Debug logging
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -99,7 +99,7 @@ While your Z-Wave mesh is permanently stored on your dongle, the additional meta
 ### Adding a new device to the Z-Wave network
 
 1. In Home Assistant, go to {% my integrations title="**Settings** > **Devices & Services**" %}.
-1. In the Z-Wave integration, select the cogwheel, then select **Configure**.
+1. Select the Z-Wave integration. Then select **Configure**.
 1. Select **Add device**.
    * The Z-Wave controller is now in inclusion mode.
 1. If your device supports SmartStart (700 series controller), select **Scan QR code** and scan the QR code on your device.
@@ -118,7 +118,7 @@ While your Z-Wave mesh is permanently stored on your dongle, the additional meta
 ### Removing a device from the Z-Wave network
 
 1. In Home Assistant, go to {% my integrations title="**Settings** > **Devices & Services**" %}.
-1. In the Z-Wave integration, select the cogwheel, then select **Configure**.
+1. Select the **Z-Wave** integration. Then, select **Configure**.
 1. Select **Remove device**, then **Start exclusion**.
    * The Z-Wave controller is now in exclusion mode.
 1. Put the device you want to remove in exclusion mode. Refer to its manual how this is done.
@@ -131,8 +131,8 @@ The Z-Wave integration provides several special entities, some of which are avai
 ### Entities available for every Z-Wave device
 
 1. **Node status** sensor: This sensor shows the node status for a given Z-Wave device.  The sensor is disabled by default.  The available node statuses are explained in the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/node?id=status). They can be used in state change automations. For example to ping a device when it is dead, or refresh values when it wakes up.
-2. **Ping** button: This button can be pressed to ping a device. It is an alternative to the `zwave_js.ping` service.
-3. **Controller/node statistics** sensors: Z-Wave JS collects statistics about communications between [nodes](https://zwave-js.github.io/node-zwave-js/#/api/node?id=quotstatistics-updatedquot) and the [controller](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=quotstatistics-updatedquot). The statistics can be used to troubleshoot RF issues in your environment. These statistics are available in the network configuration and device info panels. But they are also available as sensors which are disabled by default.
+1. **Ping** button: This button can be pressed to ping a device. It is an alternative to the `zwave_js.ping` service.
+1. **Controller/node statistics** sensors: Z-Wave JS collects statistics about communications between [nodes](https://zwave-js.github.io/node-zwave-js/#/api/node?id=quotstatistics-updatedquot) and the [controller](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=quotstatistics-updatedquot). The statistics can be used to troubleshoot RF issues in your environment. These statistics are available in the network configuration and device info panels. But they are also available as sensors which are disabled by default.
 
 ### Conditional entities
 
@@ -861,7 +861,7 @@ If the interview is complete, then the device does not yet have a device file fo
 When trying to determine why something isn't working as you expect, or when reporting an issue with the integration, it is helpful to know what Z-Wave JS sees as the current state of your Z-Wave network. To get a dump of your current network state, follow these steps:
 
 1. Go to {% my integrations title="**Settings** > **Devices & Services**" %}.
-1. On the **Z-Wave** integration, select the cogwheel, then select the three dots.
+1. Select the **Z-Wave** integration. Then, select the three dots.
 1. From he dropdown menu, select **Download diagnostics**.
 
 ### Interference issues
@@ -873,7 +873,7 @@ Many users have reported issues with interference when the USB stick was directl
 Z-Wave JS writes details to its logs. To access these logs, follow these steps:
 
 1. Go to {% my integrations title="**Settings** > **Devices & Services**" %}.
-1. On the **Z-Wave** integration, select the cogwheel, then select **Configure**.
+1. Select the **Z-Wave** integration. Then, select **Configure**.
 1. Open the **Logs** tab.
 1. Make sure to keep this browser tab open. Otherwise the logging is not active.
 

--- a/source/voice_control/thirteen-usd-voice-remote.markdown
+++ b/source/voice_control/thirteen-usd-voice-remote.markdown
@@ -57,7 +57,7 @@ Before you can use this device with Home Assistant, you need to install a bit of
    * Add your ATOM Echo to a room and select **Finish**. 
 1. You should now see the **ESPHome** integration.
    ![New ESPHome device discovered](/images/assist/m5stack-atom-echo-discovered-33.png)
-1. Select the cogwheel. Under **Devices**, you should see the **M5Stack Atom Echo** listed.
+1. Select the **ESPHome** integration. Under **Devices**, you should see the **M5Stack Atom Echo** listed.
    ![ATOM Echo discovered](/images/assist/m5stack-atom-echo-discovered-new-03.png)
    * Your ATOM Echo is connected to Home Assistant over Wi-Fi. You can now move it to any place in your home with a USB power supply. 
 1. Congratulations! You can now voice control Home Assistant using a button with a built-in microphone. Now give some commands.


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Integrations page: update paths to reflect current UI
- The cogwheel on the integration card was removed with 2023.7

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
