### PR TITLE
Revert "Add Alarm Control Panel category for Alarm Control Panel, Alarm Control Panel Template and Manual Alarm"

### DIFF
--- a/source/_integrations/alarm_control_panel.markdown
+++ b/source/_integrations/alarm_control_panel.markdown
@@ -3,7 +3,6 @@ title: Alarm Control Panel
 description: Instructions on how to integrate Alarm Control Panels into Home Assistant.
 ha_category:
   - Alarm
-  - Alarm Control Panel
 ha_release: 0.7.3
 ha_quality_scale: internal
 ha_domain: alarm_control_panel

--- a/source/_integrations/alarm_control_panel.template.markdown
+++ b/source/_integrations/alarm_control_panel.template.markdown
@@ -3,7 +3,6 @@ title: "Template Alarm Control Panel"
 description: "Instructions on how to integrate Template Alarm Control Panels into Home Assistant."
 ha_category: 
   - Alarm
-  - Alarm Control Panel
 ha_release: 0.105
 ha_iot_class: "Local Push"
 ha_qa_scale: internal

--- a/source/_integrations/manual.markdown
+++ b/source/_integrations/manual.markdown
@@ -3,7 +3,6 @@ title: Manual Alarm Control Panel
 description: Instructions on how to integrate manual alarms into Home Assistant.
 ha_category:
   - Alarm
-  - Alarm Control Panel
 ha_release: 0.7.6
 ha_quality_scale: internal
 ha_domain: manual


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#28112

I'm suggesting to revert this PR.

This PR adds more integrations to the "Alarm Control Panel" category, which makes no sense to me, as we already have an "Alarm" category. It adds no value and only adds more confusion.

If anything, we should try to get rid of the "Alarm Control Panel" category.

../Frenck

/CC @c0ffeeca7 @dougiteixeira 