### PR TITLE
Update 2023.7 release blog with hyperion breaking change

### DIFF
--- a/source/_posts/2023-07-05-release-20237.markdown
+++ b/source/_posts/2023-07-05-release-20237.markdown
@@ -648,7 +648,9 @@ the backup was initiated (`%Y-%m-%d %H:%M:%S`, for example,
 
 The behavior of Hyperion lights has changed:
 
-Turning off the light entity will only clear the priority you have configured during the integration setup. Other HA-independent light sources in Hyperion might still be active and cause light to be emitted. To turn the light output off entirely regardless of active light sources, you can enable the `switch.[instance]_led_device` entity that acts as a global switch. Subsequently, external effects unrelated to the Hyperion light source (such as USB capture) have been removed from the light entity. To control them, enable the respective disabled-by-default switch entity.
+Turning off the light entity will only clear the priority you have configured during the integration setup. Other Home Assistant independent light sources in Hyperion might still be active and cause light to be emitted. If you want to turn the light off entirely, regardless of active light sources, you can enable the `switch.[instance]_led_device` entity that acts as a global switch. 
+
+External effects that are unrelated to the Hyperion light source (such as USB capture) have been removed from the light entity. To control them, enable the respective disabled-by-default switch entity.
 
 ([@Sab44 ] - [#80478]) ([documentation](/integrations/hyperion))
 

--- a/source/_posts/2023-07-05-release-20237.markdown
+++ b/source/_posts/2023-07-05-release-20237.markdown
@@ -648,7 +648,7 @@ the backup was initiated (`%Y-%m-%d %H:%M:%S`, for example,
 
 The behavior of hyperion lights has changed:
 
-Turning off the light entity will only clear the priority you have configured during integration setup. Other HA-independent light sources in Hyperion might still be active and cause light to be emitted. In order to turn the light output off entirely regardless of active light sources, you can enable the `switch.[instance]_led_device` entity that acts as a global switch. Subsequently, external effects that are unrelated to the Hyperion light source (such as USB capture) have been removed from the light entity. To control them, enable the respective disabled-by-default switch entity.
+Turning off the light entity will only clear the priority you have configured during the integration setup. Other HA-independent light sources in Hyperion might still be active and cause light to be emitted. To turn the light output off entirely regardless of active light sources, you can enable the `switch.[instance]_led_device` entity that acts as a global switch. Subsequently, external effects unrelated to the Hyperion light source (such as USB capture) have been removed from the light entity. To control them, enable the respective disabled-by-default switch entity.
 
 ([@Sab44 ] - [#80478]) ([documentation](/integrations/hyperion))
 

--- a/source/_posts/2023-07-05-release-20237.markdown
+++ b/source/_posts/2023-07-05-release-20237.markdown
@@ -646,7 +646,7 @@ the backup was initiated (`%Y-%m-%d %H:%M:%S`, for example,
 
 {% details "Hyperion" %}
 
-The behavior of hyperion lights has changed:
+The behavior of Hyperion lights has changed:
 
 Turning off the light entity will only clear the priority you have configured during the integration setup. Other HA-independent light sources in Hyperion might still be active and cause light to be emitted. To turn the light output off entirely regardless of active light sources, you can enable the `switch.[instance]_led_device` entity that acts as a global switch. Subsequently, external effects unrelated to the Hyperion light source (such as USB capture) have been removed from the light entity. To control them, enable the respective disabled-by-default switch entity.
 

--- a/source/_posts/2023-07-05-release-20237.markdown
+++ b/source/_posts/2023-07-05-release-20237.markdown
@@ -644,6 +644,19 @@ the backup was initiated (`%Y-%m-%d %H:%M:%S`, for example,
 
 {% enddetails %}
 
+{% details "Hyperion" %}
+
+The behavior of hyperion lights has changed:
+
+Turning off the light entity will only clear the priority you have configured during integration setup. Other HA-independent light sources in Hyperion might still be active and cause light to be emitted. In order to turn the light output off entirely regardless of active light sources, you can enable the `switch.[instance]_led_device` entity that acts as a global switch. Subsequently, external effects that are unrelated to the Hyperion light source (such as USB capture) have been removed from the light entity. To control them, enable the respective disabled-by-default switch entity.
+
+([@Sab44 ] - [#80478]) ([documentation](/integrations/hyperion))
+
+[@Sab44]: https://github.com/Sab44
+[#80478]: https://github.com/home-assistant/core/pull/80478
+
+{% enddetails %}
+
 {% details "MQTT" %}
 
 If the `initial` temperature, `min_temp`, or `max_temp` is not set, the default


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update 2023.7 release blog with hyperion breaking change from PR https://github.com/home-assistant/core/pull/80478


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
