### PR TITLE
Add HDMI-CEC documentation on HAOS setup

### DIFF
--- a/source/_integrations/hdmi_cec.markdown
+++ b/source/_integrations/hdmi_cec.markdown
@@ -18,6 +18,12 @@ The `hdmi_cec` integration provides services that allow selecting the active dev
 
 ## CEC Setup
 
+### Home Assistant OS
+
+To test if hdmi-CEC will work on your Home Assistant OS installation you can use the official "CEC Scanner" Add-on. Run this add-on to discover if your hardware has HDMI-CEC capabilities and which devices are connected. Do not have this add-on `Start on boot` as it will interfere with the integration. 
+
+Once you've run the add-on you can use the resulting scan information to configure the integration.
+
 ### Adapter
 
 The computer running Home Assistant must support CEC, and of course be connected via HDMI to a device also supporting CEC. You can purchase a [USB CEC adapter](https://www.pulse-eight.com/p/104/usb-hdmi-cec-adapter) to add support if necessary. Note that all Raspberry Pi models support CEC natively.

--- a/source/_integrations/hdmi_cec.markdown
+++ b/source/_integrations/hdmi_cec.markdown
@@ -20,9 +20,9 @@ The `hdmi_cec` integration provides services that allow selecting the active dev
 
 ### Home Assistant OS
 
-To test if hdmi-CEC will work on your Home Assistant OS installation you can use the official "CEC Scanner" Add-on. Run this add-on to discover if your hardware has HDMI-CEC capabilities and which devices are connected. Do not have this add-on `Start on boot` as it will interfere with the integration. 
+To test if HDMI-CEC will work on your Home Assistant OS installation, you can use the official **CEC Scanner** add-on. Run this add-on to see if your hardware has HDMI-CEC capabilities and which devices are connected. Do not have this add-on **Start on boot** as it will interfere with the integration. 
 
-Once you've run the add-on you can use the resulting scan information to configure the integration.
+Once you've run the add-on, you can use the resulting scan information to configure the integration.
 
 ### Adapter
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds documentation on how to setup the HDMI-CEC integration when using Home Assistant OS. It adds a small paragraph on using the "CEC Scanner" Add-on to find the HDMI-CEC devices connected to your system.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28066

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
