### PR TITLE
Enforce Markdown header style in linter

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -12,6 +12,7 @@ var remarkrc = {
     ["frontmatter"],
     ["lint-fenced-code-flag"],
     ["lint-no-shell-dollars"],
+    ["remark-lint-heading-style", "atx"],
     [
       "remark-lint-prohibited-strings",
       [

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "remark-frontmatter": "^4.0.1",
         "remark-lint": "^9.1.2",
         "remark-lint-fenced-code-flag": "^3.1.2",
+        "remark-lint-heading-style": "^3.1.2",
         "remark-lint-no-shell-dollars": "^3.1.2",
         "remark-lint-prohibited-strings": "^3.1.0",
         "remark-stringify": "^10.0.3",
@@ -2157,6 +2158,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/mdast-util-heading-style": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-heading-style/-/mdast-util-heading-style-2.0.1.tgz",
+      "integrity": "sha512-0L5rthU4xKDVbw+UQ7D8Y8xOEsX4JXZvemWoEAsL+WAaeSH+TvVVwFnTb3G/OrjyP4VYQULoNWU+PdZfkmNu4A==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-1.3.2.tgz",
@@ -3515,6 +3529,24 @@
         "unified-lint-rule": "^2.0.0",
         "unist-util-generated": "^2.0.0",
         "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-heading-style": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-heading-style/-/remark-lint-heading-style-3.1.2.tgz",
+      "integrity": "sha512-0RkcRPV/H2bPFgeInzBkK1cWUwtFTm83I+Db/Z5tDY02GzKOosHLvxtJyj/1391/opAH1LYbHtHWffir99IUgw==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-heading-style": "^2.0.0",
+        "unified": "^10.0.0",
+        "unified-lint-rule": "^2.0.0",
+        "unist-util-generated": "^2.0.0",
         "unist-util-visit": "^4.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "remark-frontmatter": "^4.0.1",
     "remark-lint": "^9.1.2",
     "remark-lint-fenced-code-flag": "^3.1.2",
+    "remark-lint-heading-style": "^3.1.2",
     "remark-lint-no-shell-dollars": "^3.1.2",
     "remark-lint-prohibited-strings": "^3.1.0",
     "remark-stringify": "^10.0.3",

--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -15,7 +15,7 @@ The debugging screen is split into four features, the first being the Step Detai
 
 Automations created in YAML must have an [`id`](/docs/automation/yaml/#migrating-your-yaml-automations-to-automationsyaml) assigned in order for debugging traces to be stored.
 
-#### Traces ####
+#### Traces
 
 The last 5 traces are recorded for all automations. It is possible to change this by adding the following code to your automation.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR enables a rule in our remark Markdown linter to check for the used header style.
One violation has been found and fixed.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
