### PR TITLE
Use action response in intent_script speech template

### DIFF
--- a/source/_integrations/intent_script.markdown
+++ b/source/_integrations/intent_script.markdown
@@ -77,3 +77,33 @@ intent:
           required: true
           type: template
 {% endconfiguration %}
+
+## Using the action response
+
+When using a `speech` template, data returned from the executed action are
+available in the `action_response` variable.
+
+{% raw %}
+
+```yaml
+conversation:
+    EventCountToday:
+      - "How many meetings do I have today?"
+
+intent_script:
+  EventCountToday:
+    action:
+      - service: calendar.list_events
+        target:
+          entity_id: calendar.my_calendar
+        data_template:
+          start_date_time: "{{ today_at('00:00') }}"
+          duration: { "hours": 24 }
+        response_variable: result                     # get service response
+      - stop: ""
+        response_variable: result                     # and return it
+    speech:
+      text: "{{ action_response.events | length }}"   # use the action's response
+```
+
+{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR documents the ability to use service responses in `intent_script` (see the [parent PR](https://github.com/home-assistant/core/pull/96256) for more details).




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/96256
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
