### PR TITLE
Add Reolink reboot button

### DIFF
--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -58,6 +58,10 @@ These sensors are polled every 60 seconds and receive ONVIF push events for imme
 Not all camera models generate ONVIF push events for all event types, some binary sensors might, therefore, only be polled.
 For list of Reolink products that support ONVIF see the [Reolink Support Site](https://support.reolink.com/hc/en-us/articles/900000617826).
 
+## General notes for all entities
+
+Entities listed below that have a * behind their name are disabled by default. To enable them go to settings->devices->reolink->device->+x enties not shown, click the entity you want to enable, settings (gear) -> enable.
+
 ## Number entities
 
 Depending on the supported features of the camera, number entities are added for:
@@ -98,6 +102,7 @@ Depending on the supported features of the camera, button entities are added for
 - PTZ calibrate
 - Guard go to
 - Guard set current position
+- Reboot*
 
 PTZ left, right, up and down will continually move the camera in the respective position until the PTZ stop is called or the hardware limit is reached.
 

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -60,7 +60,7 @@ For list of Reolink products that support ONVIF see the [Reolink Support Site](h
 
 ## General notes for all entities
 
-Entities listed below that have a * behind their name are disabled by default. To enable them go to settings->devices->reolink->device->+x enties not shown, click the entity you want to enable, settings (gear) -> enable.
+Entities listed below that have a * behind their name are disabled by default. To enable them go to settings->devices->select the reolink device->+x enties not shown, click the entity you want to enable, settings (gear) -> enable.
 
 ## Number entities
 

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -102,7 +102,7 @@ Depending on the supported features of the camera, button entities are added for
 - PTZ calibrate
 - Guard go to
 - Guard set current position
-- Reboot*
+- Restart*
 
 PTZ left, right, up and down will continually move the camera in the respective position until the PTZ stop is called or the hardware limit is reached.
 

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -58,9 +58,9 @@ These sensors are polled every 60 seconds and receive ONVIF push events for imme
 Not all camera models generate ONVIF push events for all event types, some binary sensors might, therefore, only be polled.
 For list of Reolink products that support ONVIF see the [Reolink Support Site](https://support.reolink.com/hc/en-us/articles/900000617826).
 
-## General notes for all entities
+## Asterisk (*) next to entities listed in this documentation
 
-Entities listed below that have a * behind their name are disabled by default. To enable them go to settings->devices->select the reolink device->+x enties not shown, click the entity you want to enable, settings (gear) -> enable.
+If an entity listed below has an asterisk (*) next to its name, it means it is disabled by default. To use such an entity, you must [enable the entity](/common-tasks/general/#enabling-entities) first.
 
 ## Number entities
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Reolink reboot button, see https://github.com/home-assistant/core/pull/96311


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/96311
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
