### PR TITLE
Add Reolink sensor platform

### DIFF
--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -54,9 +54,16 @@ Depending on the supported features of the camera, binary sensors are added for:
 - AI pet detection
 - AI face detection
 
-These sensors are polled every 60 seconds and receive ONVIF push events for immediate updates.
+These sensors receive events using 3 methods in order: ONVIF push, ONVIF long polling or fast polling (every 5 seconds).
+The latency for receiving the events is the best for ONVIF push and the worst for fast polling, the fastest available method that is detected to work will be used, and slower methods will not be used. The `Event Connection` sensor shows the current method beeing used.
+As a extra redundancy these sensors are polled every 60 seconds together with the update of all other entities.
 Not all camera models generate ONVIF push events for all event types, some binary sensors might, therefore, only be polled.
 For list of Reolink products that support ONVIF see the [Reolink Support Site](https://support.reolink.com/hc/en-us/articles/900000617826).
+If the `Event Connection` sensor does not show `ONVIF push` and you wish to reduce the latency, see the troubleshooting section.
+
+## General notes for all entities
+
+Entities listed below that have a * behind their name are disabled by default. To enable them go to settings->devices->reolink->device->+x enties not shown, click the entity you want to enable, settings (gear) -> enable.
 
 ## Number entities
 
@@ -154,6 +161,13 @@ Depending on the supported features of the camera, light entities are added for:
 When the floodlight entity is ON always ON, when OFF controlled based on the internal camera floodlight mode (Off, Auto, Schedule), see the "Floodlight mode" select entity.
 
 When IR light entity is OFF always OFF, when ON IR LEDs will be on when the camera is in night vision mode, see the "Day night mode" select entity.
+
+## Sensor entities
+
+Depending on the supported features of the camera, sensor entities are added for:
+
+- WiFi signal*
+- Event Connection (ONVIF push, ONVIF long poll, Fast poll)*
 
 ## Update entity
 

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -55,7 +55,7 @@ Depending on the supported features of the camera, binary sensors are added for:
 - AI face detection
 
 These sensors receive events using 3 methods in order: ONVIF push, ONVIF long polling or fast polling (every 5 seconds).
-The latency for receiving the events is the best for ONVIF push and the worst for fast polling, the fastest available method that is detected to work will be used, and slower methods will not be used. The `Event Connection` sensor shows the current method beeing used.
+The latency for receiving the events is the best for ONVIF push and the worst for fast polling, the fastest available method that is detected to work will be used, and slower methods will not be used. The `Event Connection` sensor shows the current method being used.
 As a extra redundancy these sensors are polled every 60 seconds together with the update of all other entities.
 Not all camera models generate ONVIF push events for all event types, some binary sensors might, therefore, only be polled.
 For list of Reolink products that support ONVIF see the [Reolink Support Site](https://support.reolink.com/hc/en-us/articles/900000617826).
@@ -166,7 +166,7 @@ When IR light entity is OFF always OFF, when ON IR LEDs will be on when the came
 
 Depending on the supported features of the camera, sensor entities are added for:
 
-- WiFi signal*
+- Wi-Fi signal*
 - Event Connection (ONVIF push, ONVIF long poll, Fast poll)*
 
 ## Update entity

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -55,11 +55,10 @@ Depending on the supported features of the camera, binary sensors are added for:
 - AI face detection
 
 These sensors receive events using 3 methods in order: ONVIF push, ONVIF long polling or fast polling (every 5 seconds).
-The latency for receiving the events is the best for ONVIF push and the worst for fast polling, the fastest available method that is detected to work will be used, and slower methods will not be used. The `Event Connection` sensor shows the current method being used.
+The latency for receiving the events is the best for ONVIF push and the worst for fast polling, the fastest available method that is detected to work will be used, and slower methods will not be used.
 For redundancy, these sensors are polled every 60 seconds together with the update of all other entities.
 Not all camera models generate ONVIF push events for all event types, some binary sensors might, therefore, only be polled.
 For list of Reolink products that support ONVIF see the [Reolink Support Site](https://support.reolink.com/hc/en-us/articles/900000617826).
-If the `Event Connection` sensor does not show `ONVIF push` and you wish to reduce the latency, refer to the [troubleshooting](#troubleshooting) section.
 
 ## Number entities
 
@@ -163,7 +162,6 @@ When IR light entity is OFF always OFF, when ON IR LEDs will be on when the came
 Depending on the supported features of the camera, the following sensor entities are added:
 
 - Wi-Fi signal*
-- Event Connection (ONVIF push, ONVIF long poll, Fast poll)*
 
 ## Update entity
 

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -56,14 +56,10 @@ Depending on the supported features of the camera, binary sensors are added for:
 
 These sensors receive events using 3 methods in order: ONVIF push, ONVIF long polling or fast polling (every 5 seconds).
 The latency for receiving the events is the best for ONVIF push and the worst for fast polling, the fastest available method that is detected to work will be used, and slower methods will not be used. The `Event Connection` sensor shows the current method being used.
-As a extra redundancy these sensors are polled every 60 seconds together with the update of all other entities.
+For redundancy, these sensors are polled every 60 seconds together with the update of all other entities.
 Not all camera models generate ONVIF push events for all event types, some binary sensors might, therefore, only be polled.
 For list of Reolink products that support ONVIF see the [Reolink Support Site](https://support.reolink.com/hc/en-us/articles/900000617826).
-If the `Event Connection` sensor does not show `ONVIF push` and you wish to reduce the latency, see the troubleshooting section.
-
-## General notes for all entities
-
-Entities listed below that have a * behind their name are disabled by default. To enable them go to settings->devices->reolink->device->+x enties not shown, click the entity you want to enable, settings (gear) -> enable.
+If the `Event Connection` sensor does not show `ONVIF push` and you wish to reduce the latency, refer to the [troubleshooting](#troubleshooting) section.
 
 ## Number entities
 
@@ -164,7 +160,7 @@ When IR light entity is OFF always OFF, when ON IR LEDs will be on when the came
 
 ## Sensor entities
 
-Depending on the supported features of the camera, sensor entities are added for:
+Depending on the supported features of the camera, the following sensor entities are added:
 
 - Wi-Fi signal*
 - Event Connection (ONVIF push, ONVIF long poll, Fast poll)*


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Reolink sensor platform, see https://github.com/home-assistant/core/pull/96323

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/96323
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
