### PR TITLE
Enforce Markdown ordered list marker style

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -15,6 +15,7 @@ var remarkrc = {
     ["remark-lint-heading-increment"],
     ["remark-lint-heading-style", "atx"],
     ["remark-lint-unordered-list-marker-style", "-"],
+    ["remark-lint-ordered-list-marker-style", "."],
     [
       "remark-lint-prohibited-strings",
       [

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "remark-lint-heading-increment": "^3.1.2",
         "remark-lint-heading-style": "^3.1.2",
         "remark-lint-no-shell-dollars": "^3.1.2",
+        "remark-lint-ordered-list-marker-style": "^3.1.2",
         "remark-lint-prohibited-strings": "^3.1.0",
         "remark-lint-unordered-list-marker-style": "^3.1.2",
         "remark-stringify": "^10.0.3",
@@ -3583,6 +3584,24 @@
         "unified": "^10.0.0",
         "unified-lint-rule": "^2.0.0",
         "unist-util-generated": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-ordered-list-marker-style": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-style/-/remark-lint-ordered-list-marker-style-3.1.2.tgz",
+      "integrity": "sha512-62iVE/YQsA0Azaqt8yAJWPplWLS47kDLjXeC2PlRIAzCqbNt9qH3HId8vZ15QTSrp8rHmJwrCMdcqV6AZUi7gQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "unified": "^10.0.0",
+        "unified-lint-rule": "^2.0.0",
+        "unist-util-generated": "^2.0.0",
+        "unist-util-position": "^4.0.0",
         "unist-util-visit": "^4.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "remark-lint-heading-increment": "^3.1.2",
     "remark-lint-heading-style": "^3.1.2",
     "remark-lint-no-shell-dollars": "^3.1.2",
+    "remark-lint-ordered-list-marker-style": "^3.1.2",
     "remark-lint-prohibited-strings": "^3.1.0",
     "remark-lint-unordered-list-marker-style": "^3.1.2",
     "remark-stringify": "^10.0.3",

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -52,14 +52,14 @@ We are working on adding a lot of features to the core integration. We have reve
 
 ### How can I clean a specific room?
 We plan to make the process simpler in the future, but for now, it is a multi-step process.
-1) Make sure to first name the rooms in the Roborock app; otherwise, they won't appear in the debug log.
-2) [Enable debug logging](/docs/configuration/troubleshooting/#enabling-debug-logging) for this integration and reload it.
-3) Search your logs for 'Got home data' and find the attribute rooms.
-4) Write the rooms down; they have a name and 6 digit ID.
-5) Go to {% my developer_call_service service="vacuum.send_command" title="**Developer Tools** > **Services** > **Vacuum: Send Command**" %}. Select your vacuum as the entity and `get_room_mapping` as the command.
-6) Go back to your logs and look at the response to `get_room_mapping`. This is a list of the 6-digit IDs you saw earlier to 2-digit IDs. In your original list of room names and 6-digit IDs, replace the 6-digit ID with its pairing 2-digit ID.
-7) Now, you have the 2-digit ID that your vacuum uses to describe a room.
-8) Go back to {% my developer_call_service service="vacuum.send_command" title="**Developer Tools** > **Services** > **Vacuum: Send Command**" %} then type `app_segment_clean` as your command and `segments` with a list of the 2-digit IDs you want to clean. Then, add `repeat` with a number (ranging from 1 to 3) to determine how many times you want to clean these areas.
+1. Make sure to first name the rooms in the Roborock app; otherwise, they won't appear in the debug log.
+2. [Enable debug logging](/docs/configuration/troubleshooting/#enabling-debug-logging) for this integration and reload it.
+3. Search your logs for 'Got home data' and find the attribute rooms.
+4. Write the rooms down; they have a name and 6 digit ID.
+5. Go to {% my developer_call_service service="vacuum.send_command" title="**Developer Tools** > **Services** > **Vacuum: Send Command**" %}. Select your vacuum as the entity and `get_room_mapping` as the command.
+6. Go back to your logs and look at the response to `get_room_mapping`. This is a list of the 6-digit IDs you saw earlier to 2-digit IDs. In your original list of room names and 6-digit IDs, replace the 6-digit ID with its pairing 2-digit ID.
+7. Now, you have the 2-digit ID that your vacuum uses to describe a room.
+8. Go back to {% my developer_call_service service="vacuum.send_command" title="**Developer Tools** > **Services** > **Vacuum: Send Command**" %} then type `app_segment_clean` as your command and `segments` with a list of the 2-digit IDs you want to clean. Then, add `repeat` with a number (ranging from 1 to 3) to determine how many times you want to clean these areas.
 
 Example:
 ```yaml


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Set the order-list Markdown style in our linters/CI to `.`.

Example:

```Markdown
# Good

1. Foo

# Bad

1) Bar
```


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
