### PR TITLE
Conversation: align service attribute description

### DIFF
--- a/source/_integrations/conversation.markdown
+++ b/source/_integrations/conversation.markdown
@@ -161,11 +161,11 @@ It's now possible to say "engage all lights in the bedroom", which will turn on 
 
 Send a message to a conversation agent for processing.
 
-| Service data attribute | Optional | Description      |
-|------------------------|----------|------------------|
-| `text`                 | no      | Transcribed text |
-| `language`                 | yes      | Language of the text |
-| `agent_id`                 | yes      | ID of conversation agent to use |
+| Service data attribute | Optional | Description                                                                                                               |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `text`                 | no       | Transcribed text input                                                                                                    |
+| `language`             | yes      | Language of the text                                                                                                      |
+| `agent_id`             | yes      | ID of conversation agent. The conversation agent is the brains of the assistant. It processes the incoming text commands. |
 
 This service is able to return [response data](/docs/scripts/service-calls/#use-templates-to-handle-response-data). The response is the same response as for the
 [`/api/conversation/process` API](https://developers.home-assistant.io/docs/intent_conversation_api#conversation-response).


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Conversation: align service attribute description
- with the description provided in core strings
- this PR is related to https://github.com/home-assistant/core/pull/96365
  - But the content applies to the _current_ branch

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
