### PR TITLE
Update SmartThings cover capabilities

### DIFF
--- a/source/_integrations/smartthings.markdown
+++ b/source/_integrations/smartthings.markdown
@@ -192,6 +192,7 @@ The SmartThings Cover platform lets you control devices that have open/close rel
 | [`garageDoorControl`](https://developer-preview.smartthings.com/docs/devices/capabilities/deprecated#garageDoorControl) (seb a) | `open` and `close`                |
 | [`windowShade`](https://developer-preview.smartthings.com/docs/devices/capabilities/capabilities-reference#windowShade) (set a)              | `open` and `close`                |
 | [`switchLevel`](https://developer-preview.smartthings.com/docs/devices/capabilities/capabilities-reference#switchLevel)                      | `position`                        |
+| [`windowShadeLevel`](https://developer.smartthings.com/docs/devices/capabilities/capabilities-reference/#windowShadeLevel)                   | `position`                        |
 | [`battery`](https://developer-preview.smartthings.com/docs/devices/capabilities/capabilities-reference#battery)                               | `battery_level` (state attribute) |
 
 ### Fan


### PR DESCRIPTION
## Proposed change
Updates the documented capabilities supported for the SmartThings cover entity to now include `windowShadeLevel`.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/96612
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
