### PR TITLE
Add last-used and preferred keyword for pipeline id parameter

### DIFF
--- a/source/dashboards/actions.markdown
+++ b/source/dashboards/actions.markdown
@@ -63,7 +63,7 @@ tap_action:
       default: "false"
     pipeline_id:
       required: false
-      description: "Assist pipeline to use when the `action` is defined as `assist`. It can be either `last_used`, `preferred` or a pipeline id."
+      description: "Assist pipeline to use when the `action` is defined as `assist`. It can be either `last_used`, `preferred`, or a pipeline id."
       type: string
       default: "`last_used`"
     start_listening:

--- a/source/dashboards/actions.markdown
+++ b/source/dashboards/actions.markdown
@@ -63,9 +63,9 @@ tap_action:
       default: "false"
     pipeline_id:
       required: false
-      description: "Assist pipeline id to use when the `action` is defined as `assist`"
+      description: "Assist pipeline to use when the `action` is defined as `assist`. It can be either `last_used`, `preferred` or a pipeline id."
       type: string
-      default: none
+      default: "`last_used`"
     start_listening:
       required: false
       description: "If supported, listen for voice commands when opening the assist dialog and the `action` is defined as `assist`"


### PR DESCRIPTION
## Proposed change

Add last-used and preferred keyword for pipeline id parameter

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/17329
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
