### PR TITLE
Fixed indentation on  tile.markdown example block

### DIFF
--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -93,9 +93,9 @@ type: tile
 entity: vacuum.ground_floor
 features:
   - type: vacuum-commands
-      commands:
-        - start_pause
-        - return_home
+    commands:
+      - start_pause
+      - return_home
 ```
 
 ## Available color tokens


### PR DESCRIPTION
## Proposed change
One of the examples has extra indentations resulting in invalid yaml. This fixes that.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

