### PR TITLE
Add missing info for scene integration

### DIFF
--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -20,7 +20,7 @@ The scene entity is stateless, as in, it cannot have a state like the `on` or
 `off` state that, for example, a normal switch entity has.
 
 Every scene entity does keep track of the timestamp of when the last time
-the scene entity was called the Home Assistant UI or called via
+the scene entity was called via the Home Assistant UI or called via
 a service call.
 
 ## Scenes created by integrations

--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -1,5 +1,5 @@
 ---
-title: Scenes
+title: Scene
 description: Instructions on how to setup scenes within Home Assistant.
 ha_category:
   - Organization
@@ -10,6 +10,24 @@ ha_codeowners:
 ha_domain: scene
 ha_integration_type: entity
 ---
+
+A scene entity is an entity that can restore the state of a group of entities.
+Scenes can be user defined or can be provided through an integration.
+
+## The state of a scene
+
+The scene entity is stateless, as in, it cannot have a state like the `on` or
+`off` state that, for example, a normal switch entity has.
+
+Every scene entity does keep track of the timestamp of when the last time
+the scene entity was called the Home Assistant UI or called via
+a service call.
+
+## Scenes created by integrations
+
+Some integrations like `hue`, `mqtt`, and `knx` provide scenes. You can activate them from the Home Assistant UI or via as service calls. In this case the integration provides the preferred states to restore.
+
+## Creating a scene
 
 You can create scenes that capture the states you want certain entities to be. For example, a scene can specify that light A should be turned on and light B should be bright red.
 

--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -12,7 +12,7 @@ ha_integration_type: entity
 ---
 
 A scene entity is an entity that can restore the state of a group of entities.
-Scenes can be user defined or can be provided through an integration.
+Scenes can be user-defined or can be provided through an integration.
 
 ## The state of a scene
 

--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -25,7 +25,7 @@ a service call.
 
 ## Scenes created by integrations
 
-Some integrations like `hue`, `mqtt`, and `knx` provide scenes. You can activate them from the Home Assistant UI or via as service calls. In this case the integration provides the preferred states to restore.
+Some integrations like [Philips Hue](/integrations/hue), [MQTT](/integrations/mqtt), and [KNX](/integrations/knx) provide scenes. You can activate them from the Home Assistant UI or via as service calls. In this case, the integration provides the preferred states to restore.
 
 ## Creating a scene
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Scenes in Home Assistant allow users to restore a wanted state for a group of entities. The documentation lacks to mention that integrations can supply scene entities as well.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
