### PR TITLE
Update energy.markdown with a troubleshooting section for missing entities

### DIFF
--- a/source/_docs/energy.markdown
+++ b/source/_docs/energy.markdown
@@ -21,3 +21,17 @@ Home Assistant is an open platform and so home energy management is not restrict
 If you have a sensor that returns instantaneous power readings (W or kW), then to add a sensor that returns energy usage or generation (kWh) refer to [Riemann sum integral integration](/integrations/integration/#energy)
 
 <img src='/images/docs/energy/energy-overview.png' alt='Visual representation of how all different energy forms relate.' style='border: 0;box-shadow: none;'>
+
+## Troubleshooting Missing Entities 
+
+If you have a sensor you are trying to add to the energy dashboard, and it does not appear in the selection list, please check the following points to see why it may be missing:
+
+- The sensor must have the appropriate attributes. Check your entity attributes in `Developer Tools -> States` to confirm the following:
+  - `device_class` must be `energy` for electricity grid, solar, or battery categories. It must be `gas` for gas, or `water` for water.
+  - `state_class` must be `total` or `total_increasing`.
+  - The sensor must have an appropriate `unit_of_measurement`. See the help text for each category to see which units are accepted. Units containg an exponent must match superscript characters exactly as defined, e.g. `m³` is accepted, `m3` is not.
+  
+  If any of the attributes are not correct, you can take it up with the integration developer that provides your sensor, or override missing attributes with [customize](/docs/configuration/customizing-devices/).
+ 
+- The entity must be a `sensor`. If you are trying to add something from another domain (e.g. like an `input_number`), then you must first create a template sensor from it.
+- The entity must not have any statistics errors. Go to `Developer Tools -> Statistics` to check your specific entity. If your unit has a listed issue here, you must fix the issue before it can be added to the dashboard. 

--- a/source/_docs/energy.markdown
+++ b/source/_docs/energy.markdown
@@ -28,7 +28,7 @@ If you have a sensor that returns instantaneous power readings (W or kW), then t
 
 You are trying to add a sensor to the energy dashboard, but it does not appear in the selection list. 
 
-### Remedy
+### Resolution
 
 To find out why the sensor is not showing, check the following points:
 - The sensor must have the appropriate attributes. Check your entity attributes in {% my developer_states title="**Developer Tools** > **States**" %} to confirm the following:

--- a/source/_docs/energy.markdown
+++ b/source/_docs/energy.markdown
@@ -36,7 +36,7 @@ To find out why the sensor is not showing, check the following points:
   - `state_class` must be `total` or `total_increasing`.
   - The sensor must have an appropriate `unit_of_measurement`. See the help text for each category to see which units are accepted. Units containing an exponent must match superscript characters exactly as defined, e.g. `m³` is accepted, `m3` is not.
   
-  If any of the attributes are not correct, you can take it up with the integration developer that provides your sensor, or override missing attributes with [customize](/docs/configuration/customizing-devices/).
+  If any of the attributes are not correct, please open an issue against the integration that provides your sensor, or if you are developing custom template sensors, make sure the templates have the correct settings.
  
 - The entity must be a `sensor`. If you are trying to add something from another domain (for example an `input_number`), then you must first create a template sensor from it.
-- The entity must not have any statistics errors. Go to **{% my developer_statistics title="Developer tools > Statistics" %}** to check your specific entity. If your unit has a listed issue here, you must fix the issue before it can be added to the dashboard. 
+- The entity must not have any statistics errors. Go to **{% my developer_statistics title="Developer tools > Statistics" %}** to check your specific entity. If your unit has a listed issue here, you must fix the issue before it can be added to the dashboard.

--- a/source/_docs/energy.markdown
+++ b/source/_docs/energy.markdown
@@ -31,7 +31,7 @@ You are trying to add a sensor to the energy dashboard, but it does not appear i
 ### Remedy
 
 To find out why the sensor is not showing, check the following points:
-- The sensor must have the appropriate attributes. Check your entity attributes in **{% my developer_states title="Developer Tools > States" %}** to confirm the following:
+- The sensor must have the appropriate attributes. Check your entity attributes in {% my developer_states title="**Developer Tools** > **States**" %} to confirm the following:
   - `device_class` must be `energy` for electricity grid, solar, or battery categories. It must be `gas` for gas, or `water` for water.
   - `state_class` must be `total` or `total_increasing`.
   - The sensor must have an appropriate `unit_of_measurement`. See the help text for each category to see which units are accepted. Units containing an exponent must match superscript characters exactly as defined, e.g. `m³` is accepted, `m3` is not.
@@ -39,4 +39,4 @@ To find out why the sensor is not showing, check the following points:
   If any of the attributes are not correct, please open an issue against the integration that provides your sensor, or if you are developing custom template sensors, make sure the templates have the correct settings.
  
 - The entity must be a `sensor`. If you are trying to add something from another domain (for example an `input_number`), then you must first create a template sensor from it.
-- The entity must not have any statistics errors. Go to **{% my developer_statistics title="Developer tools > Statistics" %}** to check your specific entity. If your unit has a listed issue here, you must fix the issue before it can be added to the dashboard.
+- The entity must not have any statistics errors. Go to {% my developer_statistics title="**Developer Tools** > **Statistics**" %} to check your specific entity. If your unit has a listed issue here, you must fix the issue before it can be added to the dashboard.

--- a/source/_docs/energy.markdown
+++ b/source/_docs/energy.markdown
@@ -22,16 +22,21 @@ If you have a sensor that returns instantaneous power readings (W or kW), then t
 
 <img src='/images/docs/energy/energy-overview.png' alt='Visual representation of how all different energy forms relate.' style='border: 0;box-shadow: none;'>
 
-## Troubleshooting Missing Entities 
+## Troubleshooting missing entities 
 
-If you have a sensor you are trying to add to the energy dashboard, and it does not appear in the selection list, please check the following points to see why it may be missing:
+### Condition
 
-- The sensor must have the appropriate attributes. Check your entity attributes in `Developer Tools -> States` to confirm the following:
+You are trying to add a sensor to the energy dashboard, but it does not appear in the selection list. 
+
+### Remedy
+
+To find out why the sensor is not showing, check the following points:
+- The sensor must have the appropriate attributes. Check your entity attributes in **{% my developer_states title="Developer Tools > States" %}** to confirm the following:
   - `device_class` must be `energy` for electricity grid, solar, or battery categories. It must be `gas` for gas, or `water` for water.
   - `state_class` must be `total` or `total_increasing`.
-  - The sensor must have an appropriate `unit_of_measurement`. See the help text for each category to see which units are accepted. Units containg an exponent must match superscript characters exactly as defined, e.g. `m³` is accepted, `m3` is not.
+  - The sensor must have an appropriate `unit_of_measurement`. See the help text for each category to see which units are accepted. Units containing an exponent must match superscript characters exactly as defined, e.g. `m³` is accepted, `m3` is not.
   
   If any of the attributes are not correct, you can take it up with the integration developer that provides your sensor, or override missing attributes with [customize](/docs/configuration/customizing-devices/).
  
-- The entity must be a `sensor`. If you are trying to add something from another domain (e.g. like an `input_number`), then you must first create a template sensor from it.
-- The entity must not have any statistics errors. Go to `Developer Tools -> Statistics` to check your specific entity. If your unit has a listed issue here, you must fix the issue before it can be added to the dashboard. 
+- The entity must be a `sensor`. If you are trying to add something from another domain (for example an `input_number`), then you must first create a template sensor from it.
+- The entity must not have any statistics errors. Go to **{% my developer_statistics title="Developer tools > Statistics" %}** to check your specific entity. If your unit has a listed issue here, you must fix the issue before it can be added to the dashboard. 


### PR DESCRIPTION

## Proposed change

Add a troubleshooting description for the reasons why an entity may not be selectable in the energy dashboard. This question seems to come up multiple times per day in support channels. 

Ultimately I would like to change the help link in the statistics picker in the energy dashboard configuration to point to this section.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
