### PR TITLE
Assist on Android: add shortcut, access from lock screen

### DIFF
--- a/source/voice_control/android.markdown
+++ b/source/voice_control/android.markdown
@@ -56,7 +56,7 @@ Once Assist has been defined as the default digital assistant on your phone, you
 3. Long tap the **Assist** icon and drag it onto your home screen.
 4. Select the server and the assistant.
 5. If you want to be able to use voice control, enable the **Start listening** toggle.
-6. Repeat this procedure for each server you want to connect to, for example if you support someone elses home.
+6. Repeat this procedure for each server you want to connect to, for example, if you support someone else's home.
 
 ## Assist on Wear OS
 

--- a/source/voice_control/android.markdown
+++ b/source/voice_control/android.markdown
@@ -49,27 +49,14 @@ Once Assist has been defined as the default digital assistant on your phone, you
 5. Select the assistant from the instance you want to speak to.
    - Speak your command.
 
-### Using Assist via shortcuts
+### Using Assist via shortcut
 
-You can create up to 5 shortcuts on your phone. The shortcut can point to any Home Assistant server you choose.
-
-1. Create a new dashboard which only contains an [Assist button](/voice_control/start_assist_from_dashboard/).
-   - Call it **assist**.
-2. On the Android phone, go to **Settings** > **Companion app** and select **Manage shortcuts**.
-3. Define the shortcut.
-   - Select an icon, such as `message`.
-   - Add a shortcut label and description.
-   - Select the server (the Home Assistant instance you want to use).
-   - Under **Shortcut type**, select **Dashboard**.
-   - Under **Dashboard view**, enter the path to the Assist button. For example, `/lovelace/assist/`.
-   - Select **Add shortcut**.
-4. If you want to access multiple servers via Assist, repeat step 2 and step 3 for each server.
-   - Make sure to use a different icon for each.
-5. Place the shortcut.
-   - On your home screen, long-tap the Home Assistant app.
-   - The shortcuts should be listed.
-   - Drag and drop the shortcuts to your home screen.
-
+1. On your phone, open the **Widgets** panel.
+2. From the list, select **Home Assistant**.
+3. Long tap the **Assist** icon and drag it onto your home screen.
+4. Select the server and the assistant.
+5. If you want to be able to use voice control, enable the **Start listening** toggle.
+6. Repeat this procedure for each server you want to connect to, for example if you support someone elses home.
 
 ## Assist on Wear OS
 

--- a/source/voice_control/android.markdown
+++ b/source/voice_control/android.markdown
@@ -27,6 +27,8 @@ To define Home Assistant Assist as default assistant app, follow these steps:
    - Swipe from the bottom left corner.
    - Long press the power button.
    - Hold the home button (square button at the bottom).
+7. You can now also start Assist from your lock screen.
+   <lite-youtube videoid="8TsutVHj7LQ" videotitle="Use Home Assistant from anywhere on Android"></lite-youtube>
 
 ### Using Assist with multiple Home Assistant servers
 
@@ -46,6 +48,27 @@ Once Assist has been defined as the default digital assistant on your phone, you
 
 5. Select the assistant from the instance you want to speak to.
    - Speak your command.
+
+### Using Assist via shortcuts
+
+You can create up to 5 shortcuts on your phone. The shortcut can point to any Home Assistant server you choose.
+
+1. Create a new dashboard which only contains an [Assist button](/voice_control/start_assist_from_dashboard/).
+   - Call it **assist**.
+2. On the Android phone, go to **Settings** > **Companion app** and select **Manage shortcuts**.
+3. Define the shortcut.
+   - Select an icon, such as `message`.
+   - Add a shortcut label and description.
+   - Select the server (the Home Assistant instance you want to use).
+   - Under **Shortcut type**, select **Dashboard**.
+   - Under **Dashboard view**, enter the path to the Assist button. For example, `/lovelace/assist/`.
+   - Select **Add shortcut**.
+4. If you want to access multiple servers via Assist, repeat step 2 and step 3 for each server.
+   - Make sure to use a different icon for each.
+5. Place the shortcut.
+   - On your home screen, long-tap the Home Assistant app.
+   - The shortcuts should be listed.
+   - Drag and drop the shortcuts to your home screen.
 
 
 ## Assist on Wear OS


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Assist on Android: 
- add procedure on adding Assist shortcuts
- add step on starting Assist from the lock screen


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
