### PR TITLE
Assist sentence trigger: add hardware to prerequisites

### DIFF
--- a/source/voice_control/custom_sentences.markdown
+++ b/source/voice_control/custom_sentences.markdown
@@ -12,8 +12,10 @@ This is the easiest method to get started with custom sentences for automations.
 
 If you have not set up voice control yet, set up the hardware first. For instructions, refer to one of the following tutorials:
 
-- [World's most private voice assistant](/voice_control/worlds-most-private-voice-assistant/): Using a phone.
-- [$13 voice remote for Home Assistant](/voice_control/thirteen-usd-voice-remote/): Using a button with speaker and mic.
+- [World's most private voice assistant](/voice_control/worlds-most-private-voice-assistant/): Using a classic landline phone
+- [$13 voice remote for Home Assistant](/voice_control/thirteen-usd-voice-remote/): Using a button with speaker and mic
+- [Assist for Apple](/voice_control/apple/): Using your iPhone, Mac, or Apple watch
+- [Assist for Android](/voice_control/android/): Using your Android phone, tablet, or a Wear OS watch
 
 ### To add a custom sentence to trigger an automation
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Assist sentence trigger: add hardware to prerequisites
- add Android and Apple devices as HW options to use with Assist

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
