### PR TITLE
Add wake_word integration docs

### DIFF
--- a/source/_integrations/wake_word.markdown
+++ b/source/_integrations/wake_word.markdown
@@ -1,0 +1,19 @@
+---
+title: Wake-word-detection
+description: Detect a wake word in streaming audio.
+ha_category:
+  - Voice
+ha_release: '2023.8'
+ha_codeowners:
+  - '@balloob'
+  - '@synesthesiam'
+ha_domain: wake_word
+ha_integration_type: entity
+---
+
+A wake-word-detection entity allows other integrations or applications to detect wake words in streaming audio.
+
+The wake-word-detection entities cannot be implemented manually, but can be provided by integrations such as [Wyoming](/integrations/wyoming). The API in [Assist Pipelines](https://developers.home-assistant.io/docs/voice/pipelines/) enables wake-word-detection as part of [Assist](/voice_control/).
+
+
+{% include integrations/config_flow.md %}

--- a/source/_integrations/wake_word.markdown
+++ b/source/_integrations/wake_word.markdown
@@ -16,4 +16,5 @@ A wake-word-detection entity allows other integrations or applications to detect
 The wake-word-detection entities cannot be implemented manually, but can be provided by integrations such as [Wyoming](/integrations/wyoming). The API in [Assist Pipelines](https://developers.home-assistant.io/docs/voice/pipelines/) enables wake-word-detection as part of [Assist](/voice_control/).
 
 
-{% include integrations/config_flow.md %}
+
+{% include integrations/building_block_integration.md %}

--- a/source/_integrations/wake_word.markdown
+++ b/source/_integrations/wake_word.markdown
@@ -3,7 +3,7 @@ title: Wake-word-detection
 description: Detect a wake word in streaming audio.
 ha_category:
   - Voice
-ha_release: '2023.8'
+ha_release: '2023.9'
 ha_codeowners:
   - '@balloob'
   - '@synesthesiam'

--- a/source/_integrations/wyoming.markdown
+++ b/source/_integrations/wyoming.markdown
@@ -13,6 +13,7 @@ ha_integration_type: integration
 ha_platforms:
   - stt
   - tts
+  - wake_word
 ha_config_flow: true
 ---
 

--- a/source/_integrations/wyoming.markdown
+++ b/source/_integrations/wyoming.markdown
@@ -17,9 +17,10 @@ ha_platforms:
 ha_config_flow: true
 ---
 
-The Wyoming integration connects external voice services to Home Assistant using a [small protocol](https://github.com/rhasspy/rhasspy3/blob/master/docs/wyoming.md). This enables [Assist](/voice_control/) to use a variety of local [speech-to-text](/integrations/stt/) and [text-to-speech](/integrations/tts/) systems, such as:
+The Wyoming integration connects external voice services to Home Assistant using a [small protocol](https://github.com/rhasspy/rhasspy3/blob/master/docs/wyoming.md). This enables [Assist](/voice_control/) to use a variety of local [speech-to-text](/integrations/stt/), [text-to-speech](/integrations/tts/), and [wake-word-detection](/integrations/wake_word/) systems, such as:
 
 - Whisper {% my supervisor_addon badge addon="core_whisper" %}
 - Piper {% my supervisor_addon badge addon="core_piper" %}
+- openWakeWord {% my supervisor_addon badge addon="core_openwakeword" %}
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document new `wake_word` integration: https://github.com/home-assistant/core/pull/96380
- can be merged once text fragment is merged: #29129


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
