### PR TITLE
Add information for Opensky config flow

### DIFF
--- a/source/_integrations/opensky.markdown
+++ b/source/_integrations/opensky.markdown
@@ -13,7 +13,7 @@ ha_codeowners:
   - '@joostlek'
 ---
 
-The `opensky` sensor allows one to track overhead flights in a given region. It uses crowd-sourced data from the [OpenSky Network](https://opensky-network.org/) public API. It will also fire Home Assistant events when flights enter and exit the defined region.
+The OpenSky integration allows one to track overhead flights in a given region. It uses crowd-sourced data from the [OpenSky Network](https://opensky-network.org/) public API. It will also fire Home Assistant events when flights enter and exit the defined region.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/opensky.markdown
+++ b/source/_integrations/opensky.markdown
@@ -15,23 +15,7 @@ ha_codeowners:
 
 The `opensky` sensor allows one to track overhead flights in a given region. It uses crowd-sourced data from the [OpenSky Network](https://opensky-network.org/) public API. It will also fire Home Assistant events when flights enter and exit the defined region.
 
-## Configuration
-
-To enable this sensor, add the following lines to your `configuration.yaml` file:
-
-```yaml
-sensor:
-  - platform: opensky
-    radius: 10
-```
-
-Configuration options for the OpenSky Network sensor:
-
-- **radius** (*Required*): Radius of region to monitor, in kilometers.
-- **latitude** (*Optional*): Region latitude. Defaults to home zone latitude.
-- **longitude** (*Optional*): Region longitude. Defaults to home zone longitude.
-- **altitude** (*Optional*): The maximum altitude (in meters) for planes to be detected in, 0 sets it to unlimited. Defaults to 0).
-- **name** (*Optional*): Sensor name. Defaults to opensky.
+{% include integrations/config_flow.md %}
 
 ## Events
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add information for Opensky config flow, introduced in 2023.8


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/96912
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
