### PR TITLE
Document sentence trigger wildcards

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -100,7 +100,8 @@ These are the properties available for a [Sentence trigger](/docs/automation/tri
 | ---- | ---- |
 | `trigger.platform` | Hardcoded: `conversation`
 | `trigger.sentence` | Text of the sentence that was matched
-| `trigger.entities` | Object with matched entities by name, such as [wildcards](/docs/automation/trigger/#sentence-wildcards). Each entity contains: <ul><li>`name` - name of the entity</li><li>`text` - matched text</li><li>`value` - output value (see [lists](https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax/#lists))</li></ul>
+| `trigger.slots`    | Object with matched slot values
+| `trigger.entities` | Object with matched entity info by name, such as [wildcards](/docs/automation/trigger/#sentence-wildcards). Each entity contains: <ul><li>`name` - name of the entity</li><li>`text` - matched text</li><li>`value` - output value (see [lists](https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax/#lists))</li></ul>
 
 ### State
 

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -100,7 +100,7 @@ These are the properties available for a [Sentence trigger](/docs/automation/tri
 | ---- | ---- |
 | `trigger.platform` | Hardcoded: `conversation`
 | `trigger.sentence` | Text of the sentence that was matched
-| `trigger.wildcards` | Object with names and values of all [wildcards](/docs/automation/trigger/#sentence-wildcards)
+| `trigger.entities` | Object with matched entities by name, such as [wildcards](/docs/automation/trigger/#sentence-wildcards). Each entity contains: <ul><li>`name` - name of the entity</li><li>`text` - matched text</li><li>`value` - output value (see [lists](https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax/#lists))</li></ul>
 
 ### State
 

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -92,6 +92,16 @@ These are the properties available for a [Numeric State trigger](/docs/automatio
 | `trigger.to_state` | The new [state object] that triggered trigger.
 | `trigger.for` | Timedelta object how long state has met above/below criteria, if any.
 
+### Sentence
+
+These are the properties available for a [Sentence trigger](/docs/automation/trigger/#sentence-trigger).
+
+| Template variable | Data |
+| ---- | ---- |
+| `trigger.platform` | Hardcoded: `conversation`
+| `trigger.sentence` | Text of the sentence that was matched
+| `trigger.wildcards` | Object with names and values of all [wildcards](/docs/automation/trigger/#sentence-wildcards)
+
 ### State
 
 These are the properties available for a [State trigger](/docs/automation/trigger/#state-trigger).

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -101,7 +101,7 @@ These are the properties available for a [Sentence trigger](/docs/automation/tri
 | `trigger.platform` | Hardcoded: `conversation`
 | `trigger.sentence` | Text of the sentence that was matched
 | `trigger.slots`    | Object with matched slot values
-| `trigger.entities` | Object with matched entity info by name, such as [wildcards](/docs/automation/trigger/#sentence-wildcards). Each entity contains: <ul><li>`name` - name of the entity</li><li>`text` - matched text</li><li>`value` - output value (see [lists](https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax/#lists))</li></ul>
+| `trigger.details` | Object with matched slot details by name, such as [wildcards](/docs/automation/trigger/#sentence-wildcards). Each detail contains: <ul><li>`name` - name of the slot</li><li>`text` - matched text</li><li>`value` - output value (see [lists](https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax/#lists))</li></ul>
 
 ### State
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -948,8 +948,8 @@ For example, the sentence `play {album} by {artist}` will match "play the white 
 
 {% raw %}
 
-* `{{ trigger.wildcards.album }}` - "the white album"
-* `{{ trigger.wildcards.artist }}` - "the beatles"
+- `{{ trigger.wildcards.album }}` - "the white album"
+- `{{ trigger.wildcards.artist }}` - "the beatles"
 
 {% endraw %}
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -939,6 +939,20 @@ The sentences matched by this trigger will be:
 
 Punctuation and casing are ignored, so "It's PARTY TIME!!!" will also match.
 
+### Sentence Wildcards
+
+Adding one or more `{lists}` to your trigger sentences will capture any text at that point in the sentence and copy it into a `wildcards` object in the trigger data.
+This allows you to match sentences with variable parts, such as album/artist names or a description of a picture.
+
+For example, the sentence `play {album} by {artist}` will match "play the white album by the beatles" and have the following variables available in the action templates:
+
+{% raw %}
+
+* `{{ trigger.wildcards.album }}` - "the white album"
+* `{{ trigger.wildcards.artist }}` - "the beatles"
+
+{% endraw %}
+
 ## Multiple triggers
 
 It is possible to specify multiple triggers for the same rule. To do so just prefix the first line of each trigger with a dash (-) and indent the next lines accordingly. Whenever one of the triggers fires, processing of your automation rule begins.

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -941,15 +941,15 @@ Punctuation and casing are ignored, so "It's PARTY TIME!!!" will also match.
 
 ### Sentence Wildcards
 
-Adding one or more `{lists}` to your trigger sentences will capture any text at that point in the sentence and copy it into a `wildcards` object in the trigger data.
+Adding one or more `{lists}` to your trigger sentences will capture any text at that point in the sentence. An `entities` object will be [availble in the trigger data](/docs/automation/templating#sentence).
 This allows you to match sentences with variable parts, such as album/artist names or a description of a picture.
 
 For example, the sentence `play {album} by {artist}` will match "play the white album by the beatles" and have the following variables available in the action templates:
 
 {% raw %}
 
-- `{{ trigger.wildcards.album }}` - "the white album"
-- `{{ trigger.wildcards.artist }}` - "the beatles"
+- `{{ trigger.entities.album.text }}` - "the white album"
+- `{{ trigger.entities.artist.text }}` - "the beatles"
 
 {% endraw %}
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -941,7 +941,7 @@ Punctuation and casing are ignored, so "It's PARTY TIME!!!" will also match.
 
 ### Sentence Wildcards
 
-Adding one or more `{lists}` to your trigger sentences will capture any text at that point in the sentence. An `entities` object will be [availble in the trigger data](/docs/automation/templating#sentence).
+Adding one or more `{lists}` to your trigger sentences will capture any text at that point in the sentence. An `entities` object will be [available in the trigger data](/docs/automation/templating#sentence).
 This allows you to match sentences with variable parts, such as album/artist names or a description of a picture.
 
 For example, the sentence `play {album} by {artist}` will match "play the white album by the beatles" and have the following variables available in the action templates:

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -953,6 +953,9 @@ For example, the sentence `play {album} by {artist}` will match "play the white 
 
 {% endraw %}
 
+Wildcards will match as much text as possible, which may lead to surprises: "play day by day by taken by trees" will match `album` as "day by day by taken" and `artist` as "trees".
+Including extra words in your template can help: `play {album} by artist {artist}` can now correctly match "play day by day by artist taken by trees".
+
 ## Multiple triggers
 
 It is possible to specify multiple triggers for the same rule. To do so just prefix the first line of each trigger with a dash (-) and indent the next lines accordingly. Whenever one of the triggers fires, processing of your automation rule begins.

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -941,19 +941,19 @@ Punctuation and casing are ignored, so "It's PARTY TIME!!!" will also match.
 
 ### Sentence Wildcards
 
-Adding one or more `{lists}` to your trigger sentences will capture any text at that point in the sentence. An `entities` object will be [available in the trigger data](/docs/automation/templating#sentence).
+Adding one or more `{lists}` to your trigger sentences will capture any text at that point in the sentence. A `slots` object will be [available in the trigger data](/docs/automation/templating#sentence).
 This allows you to match sentences with variable parts, such as album/artist names or a description of a picture.
 
 For example, the sentence `play {album} by {artist}` will match "play the white album by the beatles" and have the following variables available in the action templates:
 
 {% raw %}
 
-- `{{ trigger.entities.album.text }}` - "the white album"
-- `{{ trigger.entities.artist.text }}` - "the beatles"
+- `{{ trigger.slots.album }}` - "the white album"
+- `{{ trigger.slots.artist }}` - "the beatles"
 
 {% endraw %}
 
-Wildcards will match as much text as possible, which may lead to surprises: "play day by day by taken by trees" will match `album` as "day by day by taken" and `artist` as "trees".
+Wildcards will match as much text as possible, which may lead to surprises: "play day by day by taken by trees" will match `album` as "day" and `artist` as "day by taken by trees".
 Including extra words in your template can help: `play {album} by artist {artist}` can now correctly match "play day by day by artist taken by trees".
 
 ## Multiple triggers


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document wildcards in sentence triggers


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/97236
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
