### PR TITLE
Add LC-80LE632U to the list of supported Aquos TVs

### DIFF
--- a/source/_integrations/aquostv.markdown
+++ b/source/_integrations/aquostv.markdown
@@ -82,5 +82,6 @@ Also, with **power_on_enabled** as True, the Aquos logo on your TV will stay on 
 - LC-70LE650U
 - LC-70LE747E (no volume control)
 - LC-60LE650U
+- LC-80LE632U
 
 If your model is not on the list, give it a test. If everything works correctly, then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.io/blob/current/source/_integrations/aquostv.markdown).


### PR DESCRIPTION
## Proposed change
Adding LC-80LE632U to the list of supported Sharp Aquos TVs



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
