### PR TITLE
Remove YAML setup option for EDL21

### DIFF
--- a/source/_integrations/edl21.markdown
+++ b/source/_integrations/edl21.markdown
@@ -31,26 +31,7 @@ Tested smart meters:
 - efr SGM-C4 (enable InF as described in manual to retrieve full data)
 - easymeter Q3 ([Link](https://www.easymeter.com/products/zaehler/q3a))
 
-## Configuration
-
-To set it up, add the following information to your `configuration.yaml` file:
-
-```yaml
-sensor:
-  - platform: edl21
-    serial_port: /dev/ttyUSB0
-```
-
-{% configuration %}
-name:
-  description: The friendly name of the smart meter.
-  required: false
-  type: string
-serial_port:
-  description: The device to communicate with. When using ser2net, use socket://host:port.
-  required: true
-  type: string
-{% endconfiguration %}
+{% include integrations/config_flow.md %}
 
 ## InF Mode
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove YAML setup option for EDL21. I can't find any references to the hass config in the code and config flow is there, so the YAML isn't imported anymore.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
