### PR TITLE
Fix grammatical issue with services change in release notes

### DIFF
--- a/source/_posts/2023-08-02-release-20238.markdown
+++ b/source/_posts/2023-08-02-release-20238.markdown
@@ -91,7 +91,7 @@ Services are the actions you can call, like turning on a light. This was one of
 the bigger things in Home Assistant, that still was only available in English.
 
 Starting this release, we are adding translations to these services. Hoping to
-drasticly improve the experience when English is not main language.
+drasticly improve the experience when English is not your main language.
 
 <p class='img'>
 <img src='https://cdn.discordapp.com/attachments/427516175237382144/1133776797583015957/CleanShot_2023-07-26_at_17.01.53.png'></a>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Not sure if you guys are typically open to PR's for beta notes, but I noticed this and I figured I would at the very least point it out. Could also be "the main language" opposed to "your main language".


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
