### PR TITLE
Disambiguate weekday from workday

### DIFF
--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -21,7 +21,7 @@ The `workday` binary sensor indicates whether the current day is a workday or no
 
 It allows specifying which days of the week will count as workdays and also uses the Python module [holidays](https://pypi.org/project/holidays/) to incorporate information about region-specific public holidays. 
 
-This can be used to make daily automations that act differently wether it is a working day or not. For example, you could make your bedroom lights turn on (gently) at 7 in the morning if it is a workday, but wait until 11 if it is a non working day.
+This can be used to make daily automations that act differently on workdays than non-workdays. For example, you could make your bedroom lights turn on (gently) at 7 in the morning if it is a workday but wait until 11 if it is a non-working day.
 
 ## Setup
 
@@ -34,7 +34,7 @@ The keyword `holiday` is used for public holidays identified by the holidays mod
 
 <div class='note warning'>
 
-Watch out how the `holiday` keyword is used. Your first instinct might be adding it to the `exclude` configuration, thinking it means skipping the holidays. But it is meant to exclude the days in the holiday list from the workdays. So, when you exclude `holiday` and a workday falls on that day, that workday is excluded and thus the sensor will be **off**. If you want every workday flagged with no regard to holidays, ensure that there is something in your `Excludes` configuration _other_ than `holiday`.
+Take note of the `holiday` keyword. Your first instinct might be to add it to the `exclude` configuration, thinking it means skipping the holidays. But it is meant to exclude the days in the holiday list from the workdays. So, when you exclude `holiday` and a workday falls on that day, that workday is excluded, and the sensor will be **off**. If you want every workday flagged with no regard to holidays, ensure that there is something in your `Excludes` configuration _other_ than `holiday`.
 
 </div>
 

--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -17,10 +17,11 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `workday` binary sensor indicates whether the current day is a workday or not. It allows specifying which days of the week will count as workdays and also
-uses the Python module [holidays](https://pypi.org/project/holidays/) to incorporate information about region-specific public holidays. 
+The `workday` binary sensor indicates whether the current day is a workday or not.
 
-This can be used to make automations that act differently on weekdays vs weekends. For example, you could make your bedroom lights turn on (gently) at 7 in the morning if it is a weekday, but wait until 11 if it is a weekend day.
+It allows specifying which days of the week will count as workdays and also uses the Python module [holidays](https://pypi.org/project/holidays/) to incorporate information about region-specific public holidays. 
+
+This can be used to make daily automations that act differently wether it is a working day or not. For example, you could make your bedroom lights turn on (gently) at 7 in the morning if it is a workday, but wait until 11 if it is a non working day.
 
 ## Setup
 
@@ -33,7 +34,7 @@ The keyword `holiday` is used for public holidays identified by the holidays mod
 
 <div class='note warning'>
 
-Watch how the `holiday` keyword is used. Your first instinct might be adding it to the `exclude` configuration, thinking it means skipping the holidays. It means to exclude the days in the holiday list from the workdays. So, when you exclude `holiday` and a workday falls on that day, that workday is excluded, and the sensor will be **off**. If you want every workday flagged with no regard to holidays, ensure that there is something in your `Excludes` configuration _other_ than `holiday`.
+Watch out how the `holiday` keyword is used. Your first instinct might be adding it to the `exclude` configuration, thinking it means skipping the holidays. But it is meant to exclude the days in the holiday list from the workdays. So, when you exclude `holiday` and a workday falls on that day, that workday is excluded and thus the sensor will be **off**. If you want every workday flagged with no regard to holidays, ensure that there is something in your `Excludes` configuration _other_ than `holiday`.
 
 </div>
 


### PR DESCRIPTION
## Proposed change
Weekdays are always from monday to sunday.
The difference beeing, wether someone works on that given day. And in other cultures, the workweek can span from sunday to friday. Hence, we should always use the term "workday" to explain this integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
none

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
