### PR TITLE
Add documentation for new `tag_scanned` event data 

### DIFF
--- a/source/_integrations/tag.markdown
+++ b/source/_integrations/tag.markdown
@@ -113,5 +113,5 @@ When a tag is scanned, the `tag_scanned` event is fired. This event contains the
 | Value | Description |
 | - | - |
 | `tag_id` | Identifier of the tag. Use this to decide what to do.
-| `name` | Name of the tag.
+| `name` | Name of the tag. The name is not unique. Multiple tags can have the same name.
 | `device_id` | Device registry identifier of the device that scanned the tag. Use this to decide where to do it.

--- a/source/_integrations/tag.markdown
+++ b/source/_integrations/tag.markdown
@@ -113,4 +113,5 @@ When a tag is scanned, the `tag_scanned` event is fired. This event contains the
 | Value | Description |
 | - | - |
 | `tag_id` | Identifier of the tag. Use this to decide what to do.
+| `name` | Name of the tag.
 | `device_id` | Device registry identifier of the device that scanned the tag. Use this to decide where to do it.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This adds the necessary changes to the documentation of the `tag` integration for https://github.com/home-assistant/core/pull/97553.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/97553

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
