### PR TITLE
Event: Terminology tweak on button long-press

### DIFF
--- a/source/_integrations/event.markdown
+++ b/source/_integrations/event.markdown
@@ -43,7 +43,7 @@ Besides the timestamp of the last event, the event entity also keeps track of th
 
 This allows you, for example, to trigger a different action when the button on a remote control is pressed once or twice, if your remote control is capable of emitting these different types of events.
 
-When combining that with the [choose action](/docs/scripts/#choose-a-group-of-actions) script, you can assign multiple different actions to a single event entity. In the following example, pressing the button on the remote short or long will trigger a different scene:
+When combining that with the [choose action](/docs/scripts/#choose-a-group-of-actions) script, you can assign multiple different actions to a single event entity. In the following example, short- or long-pressing the button on the remote will trigger a different scene:
 
 ```yaml
 trigger:
@@ -53,7 +53,7 @@ action:
   - alias: "Choose an action based on the type of event"
     choose:
       - conditions:
-        - alias: "Normal evening scene if the button was pressed shortly"
+        - alias: "Normal evening scene if the button was pressed"
           condition: state
           entity_id: event.hue_remote_control_on_button
           attribute: "event_type"
@@ -61,7 +61,7 @@ action:
         sequence:
           - scene: scene.living_room_evening
       - conditions:
-        - alias: "Scene for watching a movie if the button was pressed long"
+        - alias: "Scene for watching a movie if the button was long-pressed"
           condition: state
           entity_id: event.hue_remote_control_on_button
           attribute: "event_type"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Event: Terminology tweak on button press

- use long-press instead of press.... long
- uses Apple SG in this case to fit in with Hue examples (as opposed to MS SG witch uses press and hold)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
