### PR TITLE
group: Document preserve_relative_brightness option for lights

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -60,6 +60,8 @@ Binary sensor, light, and switch groups allow you set the "All entities" option.
 - Otherwise, the group state is `off` if at least one group member is `off`.
 - Otherwise, the group state is `on`.
 
+Light groups additionally allow you to set the "Preserve relative brightness" option. When this option is disabled (the default), the current brightness of the group is the average brightness of all group members, and changing the brightness of the group results in setting all group members to the new brightness level. When the option is enabled, the current brightness of the group is the brightness of the brightest member, and changing the brightness preserves the ratio of brightness between that brightest member and other group members.
+
 ### Cover groups
 In short, when any group member entity is `open`, the group will also be `open`. A complete overview of how cover groups behave:
 
@@ -237,6 +239,11 @@ unique_id:
   type: string
 all:
   description: Only available for `binary_sensor`, `light` and `switch` groups. Set this to `true` if the group state should only turn *on* if **all** grouped entities are *on*.
+  required: false
+  type: boolean
+  default: false
+preserve_relative_brightness:
+  description: Only available for `light` switch groups. Set this to `true` if changing the brightness of the group should preserve the ratio of brightness between different members of the group, rather than setting all members to the new brightness level.
   required: false
   type: boolean
   default: false


### PR DESCRIPTION
## Proposed change

Corresponding documentation change for home-assistant/core#97811. From that PR:

> This introduces a new option on light groups: `preserve_relative_brightness`. When enabled, the brightness of the group is the brightness of the brightest member entity (rather than the average), and adjusting the brightness of the group scales the brightness of each entity relative to that maximum. This is, of course, rough and potentially subject to rounding errors. You can see the new behavior here:
> 
> https://github.com/home-assistant/core/assets/28167/5ef0b1d3-263c-4e7f-a00b-3afa79c6978d
> 
> If `preserve_relative_brightness` is disabled (the default), the old behavior is preserved: brightness of the group is the average brightness of its members, and setting the brightness of the group sets all members of that group to that brightness level. This is also the behavior if the group is off.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/97811
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
