### PR TITLE
Constant selector update to match schema

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -383,12 +383,12 @@ is that the constant selector has no value when it's not enabled.
 The selector's value must be configured, and optionally, a label.
 
 ```yaml
-boolean:
+constant:
   value: true
   label: Enabled
 ```
 
-The output of this selector is the configured value when the toggle is on, it has not output otherwise.
+The output of this selector is the configured value when the toggle is on, it has no output otherwise.
 
 ## Conversation agent selector
 


### PR DESCRIPTION
Updating blueprint selector documentation to match schema, as found at line ~500 (class ConstantSelector registers "constant").

Source: 
https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/selector.py

## Proposed change
Documentation update to update selector documentation to match source schema.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

Source schema: https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/selector.py

- Link to parent pull request in the codebase: none
- Link to parent pull request in the Brands repository: none
- This PR fixes or closes issue: fixes # n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
