### PR TITLE
Update dsmr.markdown to add Kaifa MA304C

### DIFF
--- a/source/_integrations/dsmr.markdown
+++ b/source/_integrations/dsmr.markdown
@@ -58,6 +58,7 @@ This integration is known to work for:
 - Landis+Gyr E350 (DMSR 4)
 - Landis+Gyr ZCF110 / ZM F110 (DSMR 4.2)
 - Kaifa E0026
+- Kaifa MA304C (DSMR 4.2)
 - Kamstrup 382JxC (DSMR 2.2)
 - Sagemcom XS210 ESMR5
 - Sagemcom T211 


### PR DESCRIPTION
I have a working instance with the Kaifa MA304C using DSMR version 4.2

## Proposed change
Added Kaifa MA304C using DSMR version 4.2 to the list of known to be working meters


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  x I made a change to the existing documentation and used the `current` branch.
  n/a I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
