### PR TITLE
Move Yale Doorman to the known working devices for August

### DIFF
--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -43,6 +43,7 @@ The `august` integration allows you to integrate your [August](https://august.co
 | Yale Assure Lock 2 | yes |
 | Yale Conexis L1 | yes |
 | Yale Conexis L2 | yes |
+| Yale Doorman L3 | yes |
 | Yale Linus | yes |
 | Yale Smart Safe | yes |
 
@@ -66,8 +67,6 @@ The August Wi-Fi Smart Lock (Gen 4) uses different battery technology (lithium-i
 Other August locks expect to be powered by AA alkaline (non-rechargeable) batteries. Rechargeable batteries in these locks will result in incorrect reporting of battery charge.
 
 ## Known Unsupported Devices
-
-- The Yale Doorman L3
 
 Other devices not listed above have not been tested and may not function as expected.
 

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -66,10 +66,6 @@ The August Wi-Fi Smart Lock (Gen 4) uses different battery technology (lithium-i
 		
 Other August locks expect to be powered by AA alkaline (non-rechargeable) batteries. Rechargeable batteries in these locks will result in incorrect reporting of battery charge.
 
-## Known Unsupported Devices
-
-Other devices not listed above have not been tested and may not function as expected.
-
 ## Binary Sensor
 
 If you have an August Doorbell, once you have enabled the August integration, you should see following sensors:

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -47,6 +47,8 @@ The `august` integration allows you to integrate your [August](https://august.co
 | Yale Linus | yes |
 | Yale Smart Safe | yes |
 
+Other devices not listed above have not been tested and may not function as expected.
+
 There is currently support for the following device types within Home Assistant:
 
 - Doorbell


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Move Yale Doorman to the known working devices for August

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/97997

- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
