### PR TITLE
Add update platform to devolo Home Control

### DIFF
--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -7,6 +7,7 @@ ha_category:
   - Presence Detection
   - Sensor
   - Switch
+  - Update
 ha_release: '2021.12'
 ha_iot_class: Local Polling
 ha_config_flow: true
@@ -22,6 +23,7 @@ ha_platforms:
   - diagnostics
   - sensor
   - switch
+  - update
 ha_zeroconf: true
 ha_integration_type: device
 ---
@@ -71,6 +73,11 @@ Currently the following device types within Home Assistant are supported.
   - Is enabled by default
 - Turn on/off the device LEDs
   - Is enabled by default
+
+## Update
+
+- Update the firmware of a device
+  - Is enabled by default, but will only give a result, if regular checks are enabled on the device
 
 ## Supported devolo Devices
 

--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -76,8 +76,8 @@ Currently the following device types within Home Assistant are supported.
 
 ## Update
 
-- Update the firmware of a device
-  - Is enabled by default, but will only give a result, if regular checks are enabled on the device
+- Update the firmware of a device.
+  - Is enabled by default but will only give a result if regular checks are enabled on the device.
 
 ## Supported devolo Devices
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I accidentally removed the base for #25784. This MR restores it.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/86003
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
