### PR TITLE
Add Shutter Contact II to supported devices for Bosch SHC 

### DIFF
--- a/source/_integrations/bosch_shc.markdown
+++ b/source/_integrations/bosch_shc.markdown
@@ -38,6 +38,7 @@ There is currently support for the following device types within Home Assistant:
 The binary sensor platform allows you to monitor the states of your shutter contact and battery sensors. Binary sensor devices are added for each of the following devices:
 
 - Shutter Contact
+- Shutter Contact II
 - Battery powered devices
 
 ### Cover


### PR DESCRIPTION
The component has been updated to shutter contact II binary sensor and the documentation should be updated accordingly.

Resolves: #86295

## Proposed change

Add shutter contact II to the list of supported binary sensors in Bosch SHC.

## Type of change
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/98331
- This PR fixes or closes issue: fixes #86295

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
