### PR TITLE
Update Apprise example to include name

### DIFF
--- a/source/_integrations/apprise.markdown
+++ b/source/_integrations/apprise.markdown
@@ -22,7 +22,8 @@ To use Apprise supported notifications, add the following to your `configuration
 ```yaml
 # Example configuration.yaml entry using URLs
 notify:
-  - platform: apprise
+  - name: apprise
+    platform: apprise
     url: YOUR_APPRISE_URLS
 ```
 
@@ -32,7 +33,8 @@ You can also pre-define your own configuration files while storing them either r
 # Example configuration.yaml entry using externally located Apprise
 # Configuration Files/Sites:
 notify:
-  - platform: apprise
+  - name: apprise
+    platform: apprise
     config: YOUR_APPRISE_CONFIG_URLS
 ```
 
@@ -41,7 +43,8 @@ There is no restriction on the number of URLs or Apprise Configuration locations
 ```yaml
 # Example configuration.yaml entry using all options
 notify:
-  - platform: apprise
+  - name: apprise
+    platform: apprise
     config: YOUR_APPRISE_CONFIG_URLS
     url: YOUR_APPRISE_URLS
 ```

--- a/source/_integrations/apprise.markdown
+++ b/source/_integrations/apprise.markdown
@@ -22,7 +22,7 @@ To use Apprise supported notifications, add the following to your `configuration
 ```yaml
 # Example configuration.yaml entry using URLs
 notify:
-  - name: apprise
+  - name: NOTIFIER_NAME
     platform: apprise
     url: YOUR_APPRISE_URLS
 ```
@@ -33,7 +33,7 @@ You can also pre-define your own configuration files while storing them either r
 # Example configuration.yaml entry using externally located Apprise
 # Configuration Files/Sites:
 notify:
-  - name: apprise
+  - name: NOTIFIER_NAME
     platform: apprise
     config: YOUR_APPRISE_CONFIG_URLS
 ```
@@ -43,7 +43,7 @@ There is no restriction on the number of URLs or Apprise Configuration locations
 ```yaml
 # Example configuration.yaml entry using all options
 notify:
-  - name: apprise
+  - name: NOTIFIER_NAME
     platform: apprise
     config: YOUR_APPRISE_CONFIG_URLS
     url: YOUR_APPRISE_URLS
@@ -68,7 +68,7 @@ config:
 ## Example service call
 
 ```yaml
-- service: notify.apprise
+- service: notify.NOTIFIER_NAME
   data:
     message: "A message from Home Assistant"
 ```
@@ -76,7 +76,7 @@ config:
 If you're using configuration files to store your Apprise URLs in, then you have the added bonus of associating tags with them. By default, Apprise in Home Assistant will only notify the elements that have no tags associated with them. You can optionally focus on only notifying a specific service based on the tag(s) you assigned them like so:
 
 ```yaml
-- service: notify.apprise
+- service: notify.NOTIFIER_NAME
   data:
     message: "A message from Home Assistant"
     target: [


### PR DESCRIPTION
## Proposed change
Minor update to documentation, clarifies use of Apprise notification service
- add name, as defined in https://github.com/home-assistant/core/blob/6be47b1fbde48d810cc1d5cfd9824f41513805fd/homeassistant/components/notify/__init__.py#L37

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
The Apprise integration is meant to be called as a service. To register this service, the configuration needs to have the "name" parameter configured. Copying the examples as-is will not currently work because they are calling the `notify.apprise` service, which was not registered because the "name" parameter was not used. I added this parameter so the example will work.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
