### PR TITLE
Add supported_features to the MQTT Alarm Control Panel

### DIFF
--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -263,6 +263,24 @@ value_template:
 
 In this section you find some real-life examples of how to use this alarm control panel.
 
+### Configuration with partial feature support
+
+The example below shows a full configuration with an alarm panel that only supports the `arm_home` and `arm_away` features.
+
+{% raw %}
+
+```yaml
+# Example with partial feature support
+mqtt:
+  - alarm_control_panel:
+      name: "Alarm Panel"
+      supported_features: ["arm_home", "arm_away"]
+      state_topic: "alarmdecoder/panel"
+      command_topic: "alarmdecoder/panel/set"
+```
+
+{% endraw %}
+
 ### Configuration with local code validation
 
 The example below shows a full configuration with local code validation.

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -244,6 +244,11 @@ state_topic:
   description: The MQTT topic subscribed to receive state updates.
   required: true
   type: string
+supported_features
+  description: A list of features that the alarm control panel supports. The available options are "arm_home", "arm_away", "arm_night", "arm_vacation", "arm_custom_bypass", and "trigger".
+  required: true
+  type: [list, string]
+  default: ["arm_home", "arm_away", "arm_night", "arm_vacation", "arm_custom_bypass", "trigger"]
 unique_id:
    description: An ID that uniquely identifies this alarm panel. If two alarm panels have the same unique ID, Home Assistant will raise an exception.
    required: false

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -244,10 +244,10 @@ state_topic:
   description: The MQTT topic subscribed to receive state updates.
   required: true
   type: string
-supported_features
-  description: A list of features that the alarm control panel supports. The available options are "arm_home", "arm_away", "arm_night", "arm_vacation", "arm_custom_bypass", and "trigger".
-  required: true
-  type: [list, string]
+supported_features:
+  description: A list of features that the alarm control panel supports. The available list options are `arm_home`, `arm_away`, `arm_night`, `arm_vacation`, `arm_custom_bypass`, and `trigger`.
+  required: false
+  type: list
   default: ["arm_home", "arm_away", "arm_night", "arm_vacation", "arm_custom_bypass", "trigger"]
 unique_id:
    description: An ID that uniquely identifies this alarm panel. If two alarm panels have the same unique ID, Home Assistant will raise an exception.

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -274,7 +274,9 @@ The example below shows a full configuration with an alarm panel that only suppo
 mqtt:
   - alarm_control_panel:
       name: "Alarm Panel"
-      supported_features: ["arm_home", "arm_away"]
+      supported_features:
+        - arm_home
+        - arm_away
       state_topic: "alarmdecoder/panel"
       command_topic: "alarmdecoder/panel/set"
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This adds support for the new `supported_features` option of the MQTT Alarm Control Panel that I'm working on. https://github.com/home-assistant/core/pull/98363 has the full context of the change.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/98363
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: fixes N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
