### PR TITLE
Update light.markdown to include flash in turn_off options

### DIFF
--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -113,6 +113,7 @@ Turns one or multiple lights off.
 | ---------------------- | -------- | ----------- |
 | `entity_id`  | no  | String or list of strings that point at `entity_id`s of lights. To target all lights, set `entity_id` to `all`.
 | `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds.
+| `flash`      | yes | Tell light to flash, can be either value `short` or `long`.
 
 ### Service `light.toggle`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Following a tweak to the in code doc strings on core found in the following merged PR: https://github.com/home-assistant/core/pull/98252#event-10105313268 it became apparent that the documentation for `light.turn_off` on the website was missing the `flash` option.

I've simply copied the line from the `turn_on` part of the page to the `turn_off` one to keep consistency here and in the core doc strings :)



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
  - More related than parent: https://github.com/home-assistant/core/pull/98252#event-10105313268
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].
  - I hope 😅

[standards]: https://developers.home-assistant.io/docs/documenting/standards
