### PR TITLE
Update ecovacs.markdown

### DIFF
--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -79,11 +79,11 @@ logger:
 
 The `ecovacs` vacuum platform allows you to monitor and control your Ecovacs Deebot vacuums.
 
-### Vacuum services
+### Vacuum services historical note
 
-The `ecovacs` vacuum platform does not support eithor of the services `vacuum.pause` or `vacuum.start`, it supports the following services instead.
+The `ecovacs` vacuum platform previously did not support either of the services `vacuum.pause` or `vacuum.start`, it supported the `vacuum.turn_on` and `vacuum.turn_off` instead. This functionality was replaced with standardized `vacuum.start` and `vacuum.stop` by 2023.8.
 
-#### Service `vacuum.turn_on`
+#### Service `vacuum.start`
 
 Start a new cleaning task.
 
@@ -91,7 +91,7 @@ Start a new cleaning task.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
-#### Service `vacuum.turn_off`
+#### Service `vacuum.stop`
 
 Stop the current cleaning task and return to the dock.
 

--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -126,7 +126,7 @@ Pause a cleaning task.
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-| `fan_speed`               |      no  | Fan speed. Values are `normal` or `high`.                                |
+| `fan_speed`               |      no  | Fan speed. Values are `normal` or `high`.                               |
 
 #### Service `vacuum.return_to_base`
 

--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -130,7 +130,7 @@ Pause a cleaning task.
 
 #### Service `vacuum.return_to_base`
 
-Pause a cleaning task.
+Return to charging base/dock immediately.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|

--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -126,7 +126,7 @@ Pause a cleaning task.
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-| `fan_speed`               |      no  | Fan speed. Values are `medium` or `high`.                                |
+| `fan_speed`               |      no  | Fan speed. Values are `normal` or `high`.                                |
 
 #### Service `vacuum.return_to_base`
 

--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -79,10 +79,6 @@ logger:
 
 The `ecovacs` vacuum platform allows you to monitor and control your Ecovacs Deebot vacuums.
 
-### Vacuum services historical note
-
-The `ecovacs` vacuum platform previously did not support either of the services `vacuum.pause` or `vacuum.start`, it supported the `vacuum.turn_on` and `vacuum.turn_off` instead. This functionality was replaced with standardized `vacuum.start` and `vacuum.stop` by 2023.8.
-
 #### Service `vacuum.start`
 
 Start a new cleaning task.
@@ -99,9 +95,42 @@ Stop the current cleaning task and return to the dock.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
-#### Service `vacuum.start_pause`
+#### Service `vacuum.pause`
 
-Start, pause or resume a cleaning task.
+Pause a cleaning task.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+
+#### Service `vacuum.clean_spot`
+
+Begin a spot cleaning operation.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+
+#### Service `vacuum.locate`
+
+Locate the vacuum.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+
+#### Service `vacuum.set_fan_speed`
+
+Pause a cleaning task.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `fan_speed`               |      no  | Fan speed. Values are `medium` or `high`.                                |
+
+#### Service `vacuum.return_to_base`
+
+Pause a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|

--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -79,7 +79,7 @@ logger:
 
 The `ecovacs` vacuum platform allows you to monitor and control your Ecovacs Deebot vacuums.
 
-#### Service `vacuum.start`
+### Service `vacuum.start`
 
 Start a new cleaning task.
 
@@ -87,7 +87,7 @@ Start a new cleaning task.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
-#### Service `vacuum.stop`
+### Service `vacuum.stop`
 
 Stop the current cleaning task and return to the dock.
 
@@ -95,7 +95,7 @@ Stop the current cleaning task and return to the dock.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
-#### Service `vacuum.pause`
+### Service `vacuum.pause`
 
 Pause a cleaning task.
 
@@ -103,7 +103,7 @@ Pause a cleaning task.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
-#### Service `vacuum.clean_spot`
+### Service `vacuum.clean_spot`
 
 Begin a spot cleaning operation.
 
@@ -111,7 +111,7 @@ Begin a spot cleaning operation.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
-#### Service `vacuum.locate`
+### Service `vacuum.locate`
 
 Locate the vacuum.
 
@@ -119,7 +119,7 @@ Locate the vacuum.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
-#### Service `vacuum.set_fan_speed`
+### Service `vacuum.set_fan_speed`
 
 Pause a cleaning task.
 
@@ -128,7 +128,7 @@ Pause a cleaning task.
 | `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 | `fan_speed`               |      no  | Fan speed. Values are `normal` or `high`.                               |
 
-#### Service `vacuum.return_to_base`
+### Service `vacuum.return_to_base`
 
 Return to charging base/dock immediately.
 


### PR DESCRIPTION
Updating documentation. Previous docs did not lead to a working state based on current releases.

## Proposed change
Update Ecovacs integration docs for HA to reflect current state of integration


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
I'm not so great at reading code, but I think the changes in behavior are linked to this PR. I just know as a user that something changed sometime in the last 1.5 months that broke my existing automation and I had to switch from vacuum.turn_on to vacuum.start.
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/96200
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
