### PR TITLE
Remove show_icon option for state-label badge.

### DIFF
--- a/source/dashboards/badges.markdown
+++ b/source/dashboards/badges.markdown
@@ -42,11 +42,6 @@ show_name:
   description: Show name.
   type: boolean
   default: "true"
-show_icon:
-  required: false
-  description: Show icon.
-  type: boolean
-  default: "true"
 {% endconfiguration %}
 
 ## Entity Filter Badge


### PR DESCRIPTION
## Proposed change

show_icon option does not currently exist in frontend. 

Even if we wanted to add it, it's not clear to me what the behavior could/should be. We already make a domain-based determination on whether or not to show an icon representation of the state. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
