### PR TITLE
Add Nexia Number entity documentation

### DIFF
--- a/source/_integrations/nexia.markdown
+++ b/source/_integrations/nexia.markdown
@@ -71,6 +71,10 @@ The following thermostats are not supported: `XL624`, `XL950`, `AZONE950`, `AZEM
 
 Other thermostats may work, but they have not been tested.
 
+### Number
+
+The number platform lets you adjust the fan speed on systems with variable-speed fan support.
+
 ### Scene
 
 The scene platform lets you activate a nexia automation.

--- a/source/_integrations/nexia.markdown
+++ b/source/_integrations/nexia.markdown
@@ -101,12 +101,3 @@ Sets the humidify setpoint. This setting will affect all zones on the same therm
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings that point at `entity_id`'s of climate devices to control.
 | `humidity` | no | Humidify setpoint level, from 35 to 65.
-
-### Service `nexia.set_fan_speed`
-
-Sets the blower fan speed. This setting will affect all zones on the same thermostat.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`'s of climate devices to control.
-| `fan_speed` | no | Fan speed setpoint, from 35 to 100.

--- a/source/_integrations/nexia.markdown
+++ b/source/_integrations/nexia.markdown
@@ -97,3 +97,12 @@ Sets the humidify setpoint. This setting will affect all zones on the same therm
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings that point at `entity_id`'s of climate devices to control.
 | `humidity` | no | Humidify setpoint level, from 35 to 65.
+
+### Service `nexia.set_fan_speed`
+
+Sets the blower fan speed. This setting will affect all zones on the same thermostat.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String or list of strings that point at `entity_id`'s of climate devices to control.
+| `fan_speed` | no | Fan speed setpoint, from 35 to 100.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation to Nexia integration for new Fan Speed number entity. This entity allows for changing the air-handler / blower fan speed on Nexia systems with variable-speed fan support.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/98642
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
