### PR TITLE
Document that some august entities are slower to update

### DIFF
--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -73,7 +73,8 @@ Other August locks expect to be powered by AA alkaline (non-rechargeable) batter
 While most entities are able to be updated via the push API, August/Yale does not offer a push API for for some data which means these entities will update slower:
 
 - Doorbell ding sensor (Doorman models only)
-- Operator sensor
+- Lock Battery sensor
+- Lock Operation sensor
 
 ## Binary Sensor
 

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -68,6 +68,13 @@ The August Wi-Fi Smart Lock (Gen 4) uses different battery technology (lithium-i
 		
 Other August locks expect to be powered by AA alkaline (non-rechargeable) batteries. Rechargeable batteries in these locks will result in incorrect reporting of battery charge.
 
+## Push updates not available for some entities
+
+While most entities are able to be updated via the push API, August/Yale does not offer a push API for for some data which means these entities will update slower:
+
+- Doorbell ding sensor (Doorman models only)
+- Operator sensor
+
 ## Binary Sensor
 
 If you have an August Doorbell, once you have enabled the August integration, you should see following sensors:

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -70,7 +70,7 @@ Other August locks expect to be powered by AA alkaline (non-rechargeable) batter
 
 ## Push updates not available for some entities
 
-While most entities are able to be updated via the push API, August/Yale does not offer a push API for for some data which means these entities will update slower:
+While most entities can be updated via the push API, August/Yale does not offer a push API for some data, which means these entities will update slower:
 
 - Doorbell ding sensor (Doorman models only)
 - Lock Battery sensor


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document that some august entities are slower to update


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/97940
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
