### PR TITLE
Update Synology "Docker" package name to "Container Manager"

### DIFF
--- a/source/_includes/installation/container/alternative.md
+++ b/source/_includes/installation/container/alternative.md
@@ -8,7 +8,7 @@ The steps would be:
 - Launch Container Manager-app and move to "Registry"-section
 - Find "homeassistant/home-assistant" within registry and click on "Download". Choose the "stable" tag.
 - Wait for some time until your NAS has pulled the image
-- Move to the "Image"-section of the Docker-app
+- Move to the "Image"-section of the "Container Manager"-app
 - Click on "Launch"
 - Within "Network" select "Use same network as Docker Host" and click Next
 - Choose a container-name you want (e.g., "homeassistant")
@@ -48,8 +48,8 @@ Complete the remainder of the Z-Wave configuration by [following the instruction
 
 Remark: to update your Home Assistant on your Docker within Synology NAS, you just have to do the following:
 
-- Go to the Docker-app and move to "Registry"-section
-- Find "homeassistant/home-assistant" within registry and click on "Download". Choose the "stable" tag.
+- Go to the "Container Manager"-app and move to "Image"-section
+- Find "homeassistant/home-assistant" within Image and click on "Update".
 - Wait until the system-message/-notification comes up, that the download is finished (there is no progress bar)
 - Move to "Container"-section
 - Stop your container if it's running
@@ -58,7 +58,7 @@ Remark: to update your Home Assistant on your Docker within Synology NAS, you ju
 
 Remark: to restart your Home Assistant within Synology NAS, you just have to do the following:
 
-- Go to the Docker-app and move to "Container"-section
+- Go to the "Container Manager"-app and move to "Container"-section
 - Right-click on it and select "Action"->"Restart".
 
 <div class='note'>

--- a/source/_includes/installation/container/alternative.md
+++ b/source/_includes/installation/container/alternative.md
@@ -4,8 +4,8 @@ As Synology within DSM now supports Docker (with a neat UI), you can simply inst
 
 The steps would be:
 
-- Install "Docker" package on your Synology NAS
-- Launch Docker-app and move to "Registry"-section
+- Install Docker "Container Manager" package on your Synology NAS
+- Launch Container Manager-app and move to "Registry"-section
 - Find "homeassistant/home-assistant" within registry and click on "Download". Choose the "stable" tag.
 - Wait for some time until your NAS has pulled the image
 - Move to the "Image"-section of the Docker-app


### PR DESCRIPTION
Package name for Synology Docker app is now called "Container manager". See also https://www.synology.com/en-global/releaseNote/ContainerManager, version 20.10.23-1405

## Proposed change
Changed manual to reflect Synology DSM package name changes starting with DSM 7.2.


## Type of change
Documentation only.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
n/a


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
