### PR TITLE
Followup on rework modbus

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -372,6 +372,8 @@ modbus entities are grouped below each modbus communication entry.
 
 All modbus entities have the following parameters:
 
+Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
+
 {% configuration %}
 address:
   description: "Address of coil/register."
@@ -460,7 +462,7 @@ For that reason, many devices (especially older ones) do not share the coil addr
 and this `input` would read from a different address space than `coil`. The problem is present in devices with
 shared address space and are a frequent cause of problems when configuring entities.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
+Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 binary_sensors:
@@ -552,7 +554,7 @@ The master configuration like device_class are automatically copied to the slave
 
 The Modbus climate platform allows you to monitor a thermostat or heaters as well as set a target temperature.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
+Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 climates:
@@ -776,7 +778,7 @@ Cover that uses `input_type: coil` is not able to determine intermediary states 
 
 If your cover uses `input_type: holding` (default) to send commands, it can also read the intermediary states. To adjust which value represents what state, you can fine-tune the optional state attributes, like `state_open`. These optional state values are also used for specifying values written into the register. If you specify an optional status_register attribute, cover states will be read from status_register instead of the register used for sending commands.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
+Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 covers:
@@ -963,7 +965,7 @@ modbus:
 
 The `modbus` fan platform allows you to control [Modbus](http://www.modbus.org/) coils or registers.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
+Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 fans:
@@ -1070,7 +1072,7 @@ modbus:
 
 The `modbus` light platform allows you to control [Modbus](http://www.modbus.org/) coils or registers.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
+Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 lights:
@@ -1178,7 +1180,7 @@ modbus:
 
 The `modbus` sensor allows you to gather data from [Modbus](http://www.modbus.org/) registers.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
+Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 sensors:
@@ -1368,7 +1370,7 @@ modbus:
 
 The `modbus` switch platform allows you to control [Modbus](http://www.modbus.org/) coils or registers.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
+Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 switches:

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -372,7 +372,7 @@ modbus entities are grouped below each modbus communication entry.
 
 All modbus entities have the following parameters:
 
-Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
+Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 address:
@@ -462,7 +462,7 @@ For that reason, many devices (especially older ones) do not share the coil addr
 and this `input` would read from a different address space than `coil`. The problem is present in devices with
 shared address space and are a frequent cause of problems when configuring entities.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
+Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 binary_sensors:
@@ -554,7 +554,7 @@ The master configuration like device_class are automatically copied to the slave
 
 The Modbus climate platform allows you to monitor a thermostat or heaters as well as set a target temperature.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
+Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 climates:
@@ -778,7 +778,7 @@ Cover that uses `input_type: coil` is not able to determine intermediary states 
 
 If your cover uses `input_type: holding` (default) to send commands, it can also read the intermediary states. To adjust which value represents what state, you can fine-tune the optional state attributes, like `state_open`. These optional state values are also used for specifying values written into the register. If you specify an optional status_register attribute, cover states will be read from status_register instead of the register used for sending commands.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
+Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 covers:
@@ -965,7 +965,7 @@ modbus:
 
 The `modbus` fan platform allows you to control [Modbus](http://www.modbus.org/) coils or registers.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
+Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 fans:
@@ -1072,7 +1072,7 @@ modbus:
 
 The `modbus` light platform allows you to control [Modbus](http://www.modbus.org/) coils or registers.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
+Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 lights:
@@ -1180,7 +1180,7 @@ modbus:
 
 The `modbus` sensor allows you to gather data from [Modbus](http://www.modbus.org/) registers.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
+Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 sensors:
@@ -1370,7 +1370,7 @@ modbus:
 
 The `modbus` switch platform allows you to control [Modbus](http://www.modbus.org/) coils or registers.
 
-Please refer to [Parameter usage](##Parameters-usage-matrix) for conflicting parameters.
+Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
 {% configuration %}
 switches:

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -460,6 +460,7 @@ For that reason, many devices (especially older ones) do not share the coil addr
 and this `input` would read from a different address space than `coil`. The problem is present in devices with
 shared address space and are a frequent cause of problems when configuring entities.
 
+Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
 
 {% configuration %}
 binary_sensors:
@@ -550,6 +551,8 @@ The master configuration like device_class are automatically copied to the slave
 ## Configuring climate entities
 
 The Modbus climate platform allows you to monitor a thermostat or heaters as well as set a target temperature.
+
+Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
 
 {% configuration %}
 climates:
@@ -773,6 +776,8 @@ Cover that uses `input_type: coil` is not able to determine intermediary states 
 
 If your cover uses `input_type: holding` (default) to send commands, it can also read the intermediary states. To adjust which value represents what state, you can fine-tune the optional state attributes, like `state_open`. These optional state values are also used for specifying values written into the register. If you specify an optional status_register attribute, cover states will be read from status_register instead of the register used for sending commands.
 
+Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
+
 {% configuration %}
 covers:
   description: "A list of all cover entities configured for this connection."
@@ -958,6 +963,7 @@ modbus:
 
 The `modbus` fan platform allows you to control [Modbus](http://www.modbus.org/) coils or registers.
 
+Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
 
 {% configuration %}
 fans:
@@ -1063,6 +1069,8 @@ modbus:
 ## Configuring light entities
 
 The `modbus` light platform allows you to control [Modbus](http://www.modbus.org/) coils or registers.
+
+Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
 
 {% configuration %}
 lights:
@@ -1170,6 +1178,7 @@ modbus:
 
 The `modbus` sensor allows you to gather data from [Modbus](http://www.modbus.org/) registers.
 
+Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
 
 {% configuration %}
 sensors:
@@ -1359,6 +1368,8 @@ modbus:
 
 The `modbus` switch platform allows you to control [Modbus](http://www.modbus.org/) coils or registers.
 
+Please refer to [Parameter usage](##Parameters-usage-matrix] for conflicting parameters.
+
 {% configuration %}
 switches:
   description: "A list of all switches in this modbus instance."
@@ -1490,19 +1501,19 @@ modbus:
             state_off: 1
 ```
 
-## Parameters usage matrix:
+## Parameters usage matrix
 
 Some parameters exclude other parameters, the following tables show what can be combined:
 
-| Datatype:       | custom | string | <type>16 | <type>32 | <type>64 |
-| --------------- | ------ | ------ | -------- | -------- | -------- |
-| count           | Yes    | Yes    | No       | No       | No       |
-| structure       | Yes    | No     | No       | No       | No       |
-| slave_count     | No     | No     | Yes      | Yes      | Yes      |
-| swap: none      | Yes    | Yes    | Yes      | Yes      | Yes      |
-| swap: byte      | No     | No     | Yes      | Yes      | Yes      |
-| swap: word      | No     | No     | No       | Yes      | Yes      |
-| swap: word_byte | No     | No     | No       | Yes      | Yes      |
+| Datatype:       | custom | string | *16 | *32 | *64 |
+| --------------- | ------ | ------ | --- | --- | --- |
+| count           | Yes    | Yes    | No  | No  | No  |
+| structure       | Yes    | No     | No  | No  | No  |
+| slave_count     | No     | No     | Yes | Yes | Yes |
+| swap: none      | Yes    | Yes    | Yes | Yes | Yes |
+| swap: byte      | No     | No     | Yes | Yes | Yes |
+| swap: word      | No     | No     | No  | Yes | Yes |
+| swap: word_byte | No     | No     | No  | Yes | Yes |
 
 
 # modbus services


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added a link to the parameter usage in each entity section, so there are no excuse :-)

Removed "int" "uint", which have been deprecated for a year or more.

Remove "int8", "uint8" which have been allowed but never worked since Modbus uses 16 bit as minimum.

Both are still in the code, but will be removed, when the documentation have a been published a while.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
