### PR TITLE
Add ConEd and ORU virtual integrations (opower)

### DIFF
--- a/source/_integrations/coned.markdown
+++ b/source/_integrations/coned.markdown
@@ -1,0 +1,20 @@
+---
+title: Consolidated Edison (ConEd)
+description: Get energy usage from Consolidated Edison (ConEd) using the Opower integration
+ha_category:
+  - Energy
+  - Sensor
+ha_release: 2023.9
+ha_domain: coned
+ha_integration_type: virtual
+ha_supporting_domain: opower
+ha_supporting_integration: Opower
+ha_codeowners:
+  - '@tronikos'
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_iot_class: Cloud Polling
+---
+
+{% include integrations/supported_brand.md %}

--- a/source/_integrations/oru_opower.markdown
+++ b/source/_integrations/oru_opower.markdown
@@ -1,0 +1,20 @@
+---
+title: Orange and Rockland Utilities (ORU) Opower
+description: Get energy usage from Orange and Rockland Utilities using the Opower integration
+ha_category:
+  - Energy
+  - Sensor
+ha_release: 2023.9
+ha_domain: oru_opower
+ha_integration_type: virtual
+ha_supporting_domain: opower
+ha_supporting_integration: Opower
+ha_codeowners:
+  - '@tronikos'
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_iot_class: Cloud Polling
+---
+
+{% include integrations/supported_brand.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add doc pages for two new Opower-based virtual integrations for ConEd and Orange and Rockland Utilities.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/99230
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/4625
- This PR fixes or closes issue: fixes #


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
