### PR TITLE
Added documentation for new replace boolean

### DIFF
--- a/source/dashboards/actions.markdown
+++ b/source/dashboards/actions.markdown
@@ -41,6 +41,11 @@ tap_action:
       description: "Path to navigate to (e.g., `/lovelace/0/`) when the `action` is defined as `navigate`"
       type: string
       default: none
+    navigation_replace:
+      required: false
+      description: "Whether to replace the current page in the the history with the new URL when the `action` is defined as `navigate`"
+      type: boolean
+      default: none
     url_path:
       required: false
       description: "Path to navigate to (e.g., `https://www.home-assistant.io`) when the `action` is defined as `url`"
@@ -98,6 +103,11 @@ hold_action:
       description: "Path to navigate to (e.g., `/lovelace/0/`) when the `action` is defined as `navigate`"
       type: string
       default: none
+    navigation_replace:
+      required: false
+      description: "Whether to replace the current page in the the history with the new URL when the `action` is defined as `navigate`"
+      type: boolean
+      default: none
     url_path:
       required: false
       description: "Path to navigate to (e.g., `https://www.home-assistant.io`) when the `action` is defined as `url`"
@@ -154,6 +164,11 @@ double_tap_action:
       required: false
       description: "Path to navigate to (e.g., `/lovelace/0/`) when the `action` is defined as `navigate`"
       type: string
+      default: none
+    navigation_replace:
+      required: false
+      description: "Whether to replace the current page in the the history with the new URL when the `action` is defined as `navigate`"
+      type: boolean
       default: none
     url_path:
       required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds documentation for a newly-exposed feature in the front-end related to `navigate` actions. Previously, the front-end didn't allow navigation events to overwrite the existing page in the history stack (only push new pages). The related codebase change exposes built-in `navigate` functionality that wasn't previously available from the UI.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/17740

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
