### PR TITLE
Update alert.markdown with companion app examples

### DIFF
--- a/source/_integrations/alert.markdown
+++ b/source/_integrations/alert.markdown
@@ -292,10 +292,7 @@ but you will still receive the done message.
         entity_id: alert.garage_door
 ```
 
-Notifications sent to Home Assistant companion apps support [replacing](https://companion.home-assistant.io/docs/notifications/notifications-basic/#replacing)
-and [clearing](https://companion.home-assistant.io/docs/notifications/notifications-basic/#replacing) notifications.
-To use these functions with alerts, set a `tag` in the message data, send
-`clear_notification` as the `done_message`, and use `mobile_app_*` as the notifier:
+Notifications sent to Home Assistant Companion apps support [replacing](https://companion.home-assistant.io/docs/notifications/notifications-basic/#replacing) and [clearing](https://companion.home-assistant.io/docs/notifications/notifications-basic/#replacing) notifications. To use these functions with alerts, set a `tag` in the message data, send `clear_notification` as the `done_message`, and use `mobile_app_*` as the notifier:
 
 ```yaml
 alert:

--- a/source/_integrations/alert.markdown
+++ b/source/_integrations/alert.markdown
@@ -292,4 +292,26 @@ but you will still receive the done message.
         entity_id: alert.garage_door
 ```
 
+Notifications sent to Home Assistant companion apps support [replacing](https://companion.home-assistant.io/docs/notifications/notifications-basic/#replacing)
+and [clearing](https://companion.home-assistant.io/docs/notifications/notifications-basic/#replacing) notifications.
+To use these functions with alerts, set a `tag` in the message data, send
+`clear_notification` as the `done_message`, and use `mobile_app_*` as the notifier:
+
+```yaml
+alert:
+  garage_door:
+    name: Garage is open
+    done_message: clear_notification
+    entity_id: input_boolean.garage_door
+    state: "on"
+    repeat: 30
+    can_acknowledge: true
+    skip_first: true
+    notifiers:
+      - mobile_app_ryan
+      - mobile_app_kristen
+    data:
+      tag: garage-door
+```
+
 [template]: /docs/configuration/templating/


### PR DESCRIPTION
## Proposed change

Add examples for how to send and clear alerts to the Home Assistant companion app.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

Sending alerts to the companion app is probably the most common use case, but the existing documentation for it is scattered or non-existent. I'm not even sure what's the intended use case for the "basic example" targeting notifiers like "ryans_phone". AFAIK, the unique id for a mobile app notifier is always `mobile_app_*`. If it's documented how to transform the mobile app ID to a unique id like `mobile_app_*`, we should also note that here (I couldn't find any such documentation; it seems like you just make the human-readable name lowercase and remove punctuation).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
