### PR TITLE
Add documentation for microBees integration

### DIFF
--- a/source/_integrations/microbees.markdown
+++ b/source/_integrations/microbees.markdown
@@ -5,7 +5,7 @@ ha_category:
   - Hub
   - Light
   - Switch
-ha_release: 0.44
+ha_release: 0.1.0
 ha_codeowners:
   - '@microBeesTech'
 ha_config_flow: true

--- a/source/_integrations/microbees.markdown
+++ b/source/_integrations/microbees.markdown
@@ -1,0 +1,30 @@
+---
+title: microBees
+description: Instructions on how to integrate microBees devices into Home Assistant.
+ha_category:
+  - Hub
+  - Light
+  - Switch
+ha_release: 0.44
+ha_codeowners:
+  - '@microBeesTech'
+ha_config_flow: true
+ha_domain: microbees
+ha_iot_class: Cloud Polling
+ha_platforms:
+  - light
+  - switch
+ha_integration_type: integration
+---
+
+The `microbees` integration allows you to control your [microBees devices](https://www.microbees.com/) such as plugs, wall switches and bulbs.
+To use this integration you need OAuth2 Client ID and Client Secret and your user credentials.
+
+To retrieve the OAuth2 Client ID and Client Secret go to [microBees Developer Dashboard](https://developers.microbees.com/dashboard), login with your microBees account and [create a new app](https://developers.microbees.com/dashboard/?p=wizard).
+
+There is currently support for the following device types within Home Assistant:
+
+- **Light**
+- **Switch**
+
+{% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add microBees documentation


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [X] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/99573
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/4645
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
