### PR TITLE
Add switchbot cloud integration

### DIFF
--- a/source/_integrations/switchbot_cloud.markdown
+++ b/source/_integrations/switchbot_cloud.markdown
@@ -11,7 +11,6 @@ ha_iot_class: Cloud Polling
 ha_codeowners:
   - '@SeraphicRav'
 ha_domain: switchbot_cloud
-ha_bluetooth: false
 ha_platforms:
   - switch
 ha_config_flow: true

--- a/source/_integrations/switchbot_cloud.markdown
+++ b/source/_integrations/switchbot_cloud.markdown
@@ -2,6 +2,9 @@
 title: SwitchBot Cloud
 description: Instructions on how to set up SwitchBot Devices.
 ha_category:
+  - Hub
+  - Plug
+  - Remote
   - Switch
 ha_release: '2023.10'
 ha_iot_class: Cloud Polling

--- a/source/_integrations/switchbot_cloud.markdown
+++ b/source/_integrations/switchbot_cloud.markdown
@@ -1,0 +1,39 @@
+---
+title: SwitchBot Cloud
+description: Instructions on how to set up SwitchBot Devices.
+ha_category:
+  - Switch
+ha_release: '2023.10'
+ha_iot_class: Cloud Polling
+ha_codeowners:
+  - '@SeraphicRav'
+ha_domain: switchbot_cloud
+ha_bluetooth: false
+ha_platforms:
+  - switch
+ha_config_flow: true
+ha_integration_type: integration
+---
+
+The SwitchBot integration allows you to control SwitchBot [devices](https://www.switch-bot.com/).
+
+## Prerequisites
+
+In order to use this integration, you will need to get a token and secret key from the SwitchBot mobile app in Profiles>Preferences>Developer Options.
+
+Please note, device names configured in the SwitchBot app are transferred into Home Assistant.
+
+{% include integrations/config_flow.md %}
+
+## Supported Devices
+
+- Plug (Wi-Fi only), Plug Mini, both the original (model W1901400) and HomeKit-enabled (model W1901401)
+- Remotes exposed through the different hubs excepted "Others" (State is inferred from previous commands in Home Assistant and might not reflect reality if you use other ways to control the device)
+
+<div class='note warning'>
+Only the switch platform is currently supported.
+</div>
+
+## Error codes and troubleshooting
+
+The SwitchBot integration will automatically discover devices using the SwitchBot API.

--- a/source/_integrations/switchbot_cloud.markdown
+++ b/source/_integrations/switchbot_cloud.markdown
@@ -18,7 +18,7 @@ ha_config_flow: true
 ha_integration_type: integration
 ---
 
-The SwitchBot Cloud integration allows you to control SwitchBot [devices](https://www.switch-bot.com/) connected through the SwitchBot hub. It will automatically discover devices accessible by the hub and remotes configured in the hub using the SwitchBot API.
+The SwitchBot Cloud integration allows you to control SwitchBot [devices](https://www.switch-bot.com/) connected through the SwitchBot hub.
 
 ## Prerequisites
 

--- a/source/_integrations/switchbot_cloud.markdown
+++ b/source/_integrations/switchbot_cloud.markdown
@@ -15,25 +15,22 @@ ha_config_flow: true
 ha_integration_type: integration
 ---
 
-The SwitchBot integration allows you to control SwitchBot [devices](https://www.switch-bot.com/).
+The SwitchBot Cloud integration allows you to control SwitchBot [devices](https://www.switch-bot.com/). It will automatically discover devices accessible by the hub and remotes configured in the hub using the SwitchBot API.
 
 ## Prerequisites
 
-In order to use this integration, you will need to get a token and secret key from the SwitchBot mobile app in Profiles>Preferences>Developer Options.
+In order to use this integration, you will need at least a SwitchBot Hub and a SwitchBot account to get a token and secret key from the SwitchBot mobile app in Profiles>Preferences>Developer Options.
 
 Please note, device names configured in the SwitchBot app are transferred into Home Assistant.
 
 {% include integrations/config_flow.md %}
 
-## Supported Devices
+## Supported devices
 
-- Plug (Wi-Fi only), Plug Mini, both the original (model W1901400) and HomeKit-enabled (model W1901401)
+- Plug (Wi-Fi only, only available in Japan)
+- Plug Mini, both the original and HomeKit-enabled
 - Remotes exposed through the different hubs excepted "Others" (State is inferred from previous commands in Home Assistant and might not reflect reality if you use other ways to control the device)
 
 <div class='note warning'>
 Only the switch platform is currently supported.
 </div>
-
-## Error codes and troubleshooting
-
-The SwitchBot integration will automatically discover devices using the SwitchBot API.

--- a/source/_integrations/switchbot_cloud.markdown
+++ b/source/_integrations/switchbot_cloud.markdown
@@ -15,7 +15,7 @@ ha_config_flow: true
 ha_integration_type: integration
 ---
 
-The SwitchBot Cloud integration allows you to control SwitchBot [devices](https://www.switch-bot.com/). It will automatically discover devices accessible by the hub and remotes configured in the hub using the SwitchBot API.
+The SwitchBot Cloud integration allows you to control SwitchBot [devices](https://www.switch-bot.com/) connected through the SwitchBot hub. It will automatically discover devices accessible by the hub and remotes configured in the hub using the SwitchBot API.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adding switchbot via api documentation


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/99607
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/4647
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
