### PR TITLE
Revert "Timer start service remove duration parameter"

### DIFF
--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -91,12 +91,13 @@ Pick an icon from [Material Design Icons](https://pictogrammers.com/library/mdi/
 
 ### Service `timer.start`
 
-Starts or restarts a timer. It will either restart with its initial value, or continue a paused timer with the remaining duration.  
+Starts or restarts a timer with the provided duration. If no duration is given, it will either restart with its initial value, or continue a paused timer with the remaining duration. If a new duration is provided, this will be the new default for the timer until Home Assistant is restarted (which loads your default values). The duration can be specified as a number of seconds or the easier to read `01:23:45` format.  
 You can also use `entity_id: all` and all active timers will be started.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id`            |      no  | Name of the entity to take action, e.g., `timer.timer0`. |
+| `duration`             |      yes | Duration in seconds or `01:23:45` format until the timer finishes. |
 
 ### Service `timer.change`
 


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#28754

Parent PR has been reverted: https://github.com/home-assistant/core/pull/99613