### PR TITLE
Add binary_sensor to Schlage documentation

### DIFF
--- a/source/_integrations/schlage.markdown
+++ b/source/_integrations/schlage.markdown
@@ -24,16 +24,16 @@ The Schlage integration provides connectivity with Schlage WiFi smart locks thro
 
 There is currently support for the following device types within Home Assistant:
 
-- Binary Sensor
+- Binary sensor
 - Lock
 - Sensor
 - Switch
 
-## Binary Sensor
+## Binary sensor
 
-Once you have enabled the Schlage integration, you should see the following binary sensors:
+Once you have enabled the Schlage integration, you should see the following binary sensor:
 
-- **Keypad Disabled** - Indicates that the keypad has been disabled, typically due to too many incorrect lock codes being attempted.
+- **Keypad disabled** - Indicates that the keypad has been disabled, typically due to too many incorrect lock codes being attempted.
 
 ## Sensor
 

--- a/source/_integrations/schlage.markdown
+++ b/source/_integrations/schlage.markdown
@@ -11,6 +11,7 @@ ha_config_flow: true
 ha_codeowners:
   - '@dknowles2'
 ha_platforms:
+  - binary_sensor
   - lock
   - sensor
   - switch
@@ -23,9 +24,16 @@ The Schlage integration provides connectivity with Schlage WiFi smart locks thro
 
 There is currently support for the following device types within Home Assistant:
 
+- Binary Sensor
 - Lock
 - Sensor
 - Switch
+
+## Binary Sensor
+
+Once you have enabled the Schlage integration, you should see the following binary sensors:
+
+- **Keypad Disabled** - Indicates that the keypad has been disabled, typically due to too many incorrect lock codes being attempted.
 
 ## Sensor
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update Schlage documentation with entities in the `binary_sensor` platform.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/99637
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
