### PR TITLE
Update google_cloud integration to reflect 3 changes: 1) new UX and pricing for 3 new tiers of TTS voices; 2) new UX; 3) new key download flow

### DIFF
--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -49,7 +49,7 @@ Basic instruction for all APIs:
 6. Set up authentication:
 
     1. Visit [this link](https://console.cloud.google.com/apis/credentials/serviceaccountkey)
-    2. From the `Service account` list, select `New service account`.
+    2. From the toolbar above the `Service account` list, select `Create service account`.
     3. In the `Service account name` field, enter any name.
 
     If you are requesting a text-to-speech API key:
@@ -66,10 +66,13 @@ Basic instruction for all APIs:
 
 The Cloud text-to-speech API is priced monthly based on the amount of characters to synthesize into audio sent to the service.
 
-| Feature                       | Monthly free tier         | Paid usage                        |
+| Voice                         | Monthly free tier         | Paid usage                        |
 | ----------------------------- | ------------------------- | --------------------------------- |
-| Standard (non-WaveNet) voices | 0 to 4 million characters | $4.00 USD / 1 million characters  |
-| WaveNet voices                | 0 to 1 million characters | $16.00 USD / 1 million characters |
+| Neural2                       | 0 to 1 million bytes      | $16.00 USD / 1 million bytes      |
+| Polyglot (Preview)            | 0 to 1 million bytes      | $16.00 USD / 1 million bytes      |
+| Studio (Preview)              | 0 to 100 thousand bytes   | $160.00 USD / 1 million bytes     |
+| Standard                      | 0 to 4 million characters | $4.00 USD / 1 million characters  |
+| WaveNet                       | 0 to 1 million characters | $16.00 USD / 1 million characters |
 
 ### Text-to-speech configuration
 

--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -55,8 +55,13 @@ Basic instruction for all APIs:
     If you are requesting a text-to-speech API key:
 
     4. Don't select a value from the Role list. **No role is required to access this service**.
-    5. Click `Create`. A note appears, warning that this service account has no role.
-    6. Click `Create without role`. A JSON file that contains your `API key` downloads to your computer.
+    5. Click `Create`. If a note appears, warning that this service account has no role, you may ignore that.
+    6. Return to the `Service account` list page and click on the service account you created in step 5 to see the details for this service account.
+    7. Choose the `Keys` tab within the details view for this service account.
+    8. In the `Add Key` dropdown, select `Create New Key`.
+    9. Specify a `JSON` key type  and click `Create`.
+    10. A `[serviceaccountname].json` file will download to your browser.
+
 
 ## Google Cloud text-to-speech
 


### PR DESCRIPTION
## Proposed change
Minor changes to Google Cloud Platform docs to:
1. reflect latest text-to-speech (TTS) voice types and pricing and
2. correct the instructions for latest UX changes
3. correct the instructions for creating `.json` API key file


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Very simple changes to bring docs in sync with [https://cloud.google.com/text-to-speech/pricing](https://cloud.google.com/text-to-speech/pricing) and the actual UI at [https://console.cloud.google.com/iam-admin/serviceaccounts](https://console.cloud.google.com/iam-admin/serviceaccounts).

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
