### PR TITLE
Update cli.md: add dbus access for Raspberry

### DIFF
--- a/source/_includes/installation/container.md
+++ b/source/_includes/installation/container.md
@@ -17,6 +17,7 @@ Installation with Docker is straightforward. Adjust the following command so tha
 
 - `/PATH_TO_YOUR_CONFIG` points at the folder where you want to store your configuration and run it.
 - `MY_TIME_ZONE` is a [tz database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), like `TZ=America/Los_Angeles`.
+- D-Bus is optional but required if you plan to use the [Bluetooth integration](/integrations/bluetooth).
 
 {% endif %}
 

--- a/source/_includes/installation/container/cli.md
+++ b/source/_includes/installation/container/cli.md
@@ -9,7 +9,8 @@
       --privileged \
       --restart=unless-stopped \
       -e TZ=MY_TIME_ZONE \
-      -v /PATH_TO_YOUR_CONFIG:/config -v /run/dbus:/run/dbus:ro \
+      -v /PATH_TO_YOUR_CONFIG:/config \
+      -v /run/dbus:/run/dbus:ro \
       --network=host \
       {{ site.installation.container }}:{{ include.tag | default: 'stable' }}
     ```
@@ -39,7 +40,8 @@
       --restart=unless-stopped \
       --privileged \
       -e TZ=MY_TIME_ZONE \
-      -v /PATH_TO_YOUR_CONFIG:/config -v /run/dbus:/run/dbus:ro \
+      -v /PATH_TO_YOUR_CONFIG:/config \
+      -v /run/dbus:/run/dbus:ro \
       --network=host \
       {{ site.installation.container }}:{{ include.tag | default: 'stable' }}
     ```

--- a/source/_includes/installation/container/cli.md
+++ b/source/_includes/installation/container/cli.md
@@ -9,7 +9,7 @@
       --privileged \
       --restart=unless-stopped \
       -e TZ=MY_TIME_ZONE \
-      -v /PATH_TO_YOUR_CONFIG:/config \
+      -v /PATH_TO_YOUR_CONFIG:/config -v /run/dbus:/run/dbus:ro \
       --network=host \
       {{ site.installation.container }}:{{ include.tag | default: 'stable' }}
     ```
@@ -39,7 +39,7 @@
       --restart=unless-stopped \
       --privileged \
       -e TZ=MY_TIME_ZONE \
-      -v /PATH_TO_YOUR_CONFIG:/config \
+      -v /PATH_TO_YOUR_CONFIG:/config -v /run/dbus:/run/dbus:ro \
       --network=host \
       {{ site.installation.container }}:{{ include.tag | default: 'stable' }}
     ```

--- a/source/_includes/installation/container/compose.md
+++ b/source/_includes/installation/container/compose.md
@@ -7,6 +7,7 @@
       volumes:
         - /PATH_TO_YOUR_CONFIG:/config
         - /etc/localtime:/etc/localtime:ro
+        - /run/dbus:/run/dbus:ro
       restart: unless-stopped
       privileged: true
       network_mode: host


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add "-v /run/dbus:/run/dbus:ro" (without quotes) to the Raspberry container configuration to fix Bluetooth issue.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes [#76151](https://github.com/home-assistant/core/issues/76151)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
