### PR TITLE
Update alternative.md to avoid a common error with :/config

### DIFF
--- a/source/_includes/installation/container/alternative.md
+++ b/source/_includes/installation/container/alternative.md
@@ -34,7 +34,7 @@ To use a Z-Wave USB stick for Z-Wave control, the HA Docker container needs extr
 
 Adjust the following Terminal command as follows :
 
-- Replace `/PATH_TO_YOUR_CONFIG` points at the folder where you want to store your configuration
+- Replace `/PATH_TO_YOUR_CONFIG` points at the folder where you want to store your configuration -  make sure that you keep the `:/config` part
 - Replace `/PATH_TO_YOUR_USB_STICK` matches the path for your USB stick (e.g., `/dev/ttyACM0` for most Synology users)
 - Replace "Australia/Melbourne" with [your timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

It wasn't fully clear that the `:/config` part had to be kept. It led to users losing their configuration. This pull request adds a remark to avoid that.

See also https://github.com/home-assistant/home-assistant.io/pull/28822 (same for Raspberry Pi) 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- This PR aims to prevent this common error: https://community.home-assistant.io/t/docker-config-destination-directory-stays-empty/529710

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
