### PR TITLE
Add binary sensors to Roborock

### DIFF
--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -49,6 +49,15 @@ Mop mode - Describes how to mop the floor. On some firmware, it is called 'mop r
 
 Mop intensity - How hard you would like your vacuum to mop.
 
+### Binary Sensor
+
+Mop attached - States if the mop is currently attached.
+
+Mop drying status - Only available on docks with drying capabilites - States if the mop is currently being driven.
+
+Water box attached - States if the water box is currently attached.
+
+
 ### Sensor
 
 Cleaning area - How much area the vacuum has cleaned in its current run.  If the vacuum is not currently cleaning, how much area it has cleaned during its last run.

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to integrate Roborock vacuums into Home Assista
 ha_category:
   - Number
   - Select
+  - Binary Sensor
   - Sensor
   - Switch
   - Time
@@ -18,6 +19,7 @@ ha_domain: roborock
 ha_platforms:
   - diagnostics
   - number
+  - binary_sensor
   - select
   - sensor
   - switch

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -49,7 +49,7 @@ Mop mode - Describes how to mop the floor. On some firmware, it is called 'mop r
 
 Mop intensity - How hard you would like your vacuum to mop.
 
-### Binary Sensor
+### Binary sensor
 
 Mop attached - States if the mop is currently attached.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds 3 new binary sensors to roborock, mop attached, waterbox attached, mop is drying



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/99990
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
