### PR TITLE
Deprecate close_comm_on_error.

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -38,9 +38,7 @@ The modbus integration provides a number of parameters to help communicate with 
 
 {% configuration %}
 close_comm_on_error:
-  description: "Close connection when an error occurs.
-  Some serial-rs485 adapters deliver garble when opened, this leads to a disconnect and a new connect, which can continue.
-  If the log contains a message from pymodbus, with the text 'cleaning....', then try this parameter."
+  description: "Deprecated, Close connection when an error occurs."
   required: false
   default: true
   type: boolean

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -37,11 +37,6 @@ The modbus integration allows you to use multiple connections each with multiple
 The modbus integration provides a number of parameters to help communicate with "difficult" devices, these parameters are independent of the type of communication.
 
 {% configuration %}
-close_comm_on_error:
-  description: "Deprecated, Close connection when an error occurs."
-  required: false
-  default: true
-  type: boolean
 delay:
   description: "Time to delay sending messages in seconds after connecting.
   Some modbus devices need a delay of typically 1-2 seconds after connection is established to prepare the communication.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Deprecate close_comm_on_error.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
https://github.com/home-assistant/core/pull/99946

- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
