### PR TITLE
remove retry_on_empty.

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -59,11 +59,6 @@ retries:
   required: false
   default: 3
   type: integer
-retry_on_empty:
-  description: "Retry request, when receiving an empty message."
-  required: false
-  default: false
-  type: boolean
 timeout:
   description: "Timeout while waiting for a response in seconds."
   required: false
@@ -126,7 +121,6 @@ modbus:
     delay: 0
     message_wait_milliseconds: 30
     retries: 3
-    retry_on_empty: false
     timeout: 5
 ```
 
@@ -175,7 +169,6 @@ modbus:
     delay: 0
     message_wait_milliseconds: 30
     retries: 3
-    retry_on_empty: false
     timeout: 5
 ```
 
@@ -220,7 +213,6 @@ modbus:
     delay: 0
     message_wait_milliseconds: 30
     retries: 3
-    retry_on_empty: false
     timeout: 5
 ```
 
@@ -317,7 +309,6 @@ modbus:
     delay: 0
     message_wait_milliseconds: 30
     retries: 3
-    retry_on_empty: false
     timeout: 5
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
'retry_on_empty' is deprecated, and will be removed in 2024.4



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
https://github.com/home-assistant/core/pull/100292
- Link to parent pull request in the Brands repository: 
-
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
