### PR TITLE
Add template modifyers to energyzero

### DIFF
--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -31,6 +31,21 @@ Partners who purchase their energy through EnergyZero:
 
 {% include integrations/config_flow.md %}
 
+{% include integrations/option_flow.md %}
+
+{% configuration %}
+gas_modifyer:
+  description: Gas price modifyer template that is used to customize the price.
+  required: false
+  type: string
+  default: {{ "{% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}" | escape_once }}
+energy_modifyer:
+  description: Energy price modifyer template that is used to customize the price.
+  required: false
+  type: string
+  default: {{ "{% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}" | escape_once }}
+{% endconfiguration %}
+
 ## Sensors
 
 The EnergyZero integration creates a number of sensor entities for both gas and electricity prices.

--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -38,12 +38,12 @@ gas_modifyer:
   description: Gas price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: {{ "{% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}" | escape_once }}
+  default: {{ "\{\% set s = \{"BTW": 1.21 \} \%\}\{\{ price * s.BTW | float | round(5) \}\}" }}
 energy_modifyer:
   description: Energy price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: {{ "{% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}" | escape_once }}
+  default: {{ "\{\% set s = \{"BTW": 1.21 \} \%\}\{\{ price * s.BTW | float | round(5) \}\}" }}
 {% endconfiguration %}
 
 ## Sensors

--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -38,12 +38,12 @@ gas_modifyer:
   description: Gas price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: {% raw %}{% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}{% endraw %}
+  default: {{ "{% set s = {\"BTW\": 1.21 } %}{{ price * s.BTW | float | round(5) }}" | escape }}
 energy_modifyer:
   description: Energy price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: {% raw %}{% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}{% endraw %}
+  default: {{ "{% set s = {\"BTW\": 1.21 } %}{{ price * s.BTW | float | round(5) }}" | escape }}
 {% endconfiguration %}
 
 ## Sensors

--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -38,12 +38,12 @@ gas_modifyer:
   description: Gas price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: {{ "\{\% set s = \{"BTW": 1.21 \} \%\}\{\{ price * s.BTW | float | round(5) \}\}" }}
+  default: {{ "\{\% set s = \{\"BTW\": 1.21 \} \%\}\{\{ price * s.BTW | float | round(5) \}\}" }}
 energy_modifyer:
   description: Energy price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: {{ "\{\% set s = \{"BTW": 1.21 \} \%\}\{\{ price * s.BTW | float | round(5) \}\}" }}
+  default: {{ "\{\% set s = \{\"BTW\": 1.21 \} \%\}\{\{ price * s.BTW | float | round(5) \}\}" }}
 {% endconfiguration %}
 
 ## Sensors

--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -38,12 +38,12 @@ gas_modifyer:
   description: Gas price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: &lbrace;% set s = &lbrace;\&quot;BTW\&quot;: 1.21 &rbrace; %&rbrace;&lbrace;&lbrace; price * s.BTW | float | round(5) &rbrace;&rbrace;
+  default:
 energy_modifyer:
   description: Energy price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: &lbrace;% set s = &lbrace;\&quot;BTW\&quot;: 1.21 &rbrace; %&rbrace;&lbrace;&lbrace; price * s.BTW | float | round(5) &rbrace;&rbrace;
+  default:
 {% endconfiguration %}
 
 ## Sensors

--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -38,12 +38,12 @@ gas_modifyer:
   description: Gas price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: {{ "{% set s = {\"BTW\": 1.21 } %}{{ price * s.BTW | float | round(5) }}" | escape }}
+  default: &lbrace;% set s = &lbrace;\&quot;BTW\&quot;: 1.21 &rbrace; %&rbrace;&lbrace;&lbrace; price * s.BTW | float | round(5) &rbrace;&rbrace;
 energy_modifyer:
   description: Energy price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: {{ "{% set s = {\"BTW\": 1.21 } %}{{ price * s.BTW | float | round(5) }}" | escape }}
+  default: &lbrace;% set s = &lbrace;\&quot;BTW\&quot;: 1.21 &rbrace; %&rbrace;&lbrace;&lbrace; price * s.BTW | float | round(5) &rbrace;&rbrace;
 {% endconfiguration %}
 
 ## Sensors

--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -38,12 +38,12 @@ gas_modifyer:
   description: Gas price modifyer template that is used to customize the price.
   required: false
   type: string
-  {% raw %}default: {% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}{% endraw %}
+  default: {% raw %}{% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}{% endraw %}
 energy_modifyer:
   description: Energy price modifyer template that is used to customize the price.
   required: false
   type: string
-  {% raw %}default: {% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}{% endraw %}
+  default: {% raw %}{% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}{% endraw %}
 {% endconfiguration %}
 
 ## Sensors

--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -34,13 +34,13 @@ Partners who purchase their energy through EnergyZero:
 {% include integrations/option_flow.md %}
 
 {% configuration %}
-gas_modifyer:
-  description: Gas price modifyer template that is used to customize the price.
+gas_modifier:
+  description: Gas price modifier template that is used to customize the price.
   required: false
   type: string
   default:
-energy_modifyer:
-  description: Energy price modifyer template that is used to customize the price.
+energy_modifier:
+  description: Energy price modifier template that is used to customize the price.
   required: false
   type: string
   default:

--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -38,16 +38,12 @@ gas_modifyer:
   description: Gas price modifyer template that is used to customize the price.
   required: false
   type: string
-{% raw %}
-  default: {% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}
-{% endraw %}
+  {% raw %}default: {% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}{% endraw %}
 energy_modifyer:
   description: Energy price modifyer template that is used to customize the price.
   required: false
   type: string
-{% raw %}
-  default: {% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}
-{% endraw %}
+  {% raw %}default: {% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}{% endraw %}
 {% endconfiguration %}
 
 ## Sensors

--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -38,12 +38,16 @@ gas_modifyer:
   description: Gas price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: {{ "\{\% set s = \{\"BTW\": 1.21 \} \%\}\{\{ price * s.BTW | float | round(5) \}\}" }}
+{% raw %}
+  default: {% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}
+{% endraw %}
 energy_modifyer:
   description: Energy price modifyer template that is used to customize the price.
   required: false
   type: string
-  default: {{ "\{\% set s = \{\"BTW\": 1.21 \} \%\}\{\{ price * s.BTW | float | round(5) \}\}" }}
+{% raw %}
+  default: {% set s = {"BTW": 1.21 } %}{{ price * s.BTW | float | round(5) }}
+{% endraw %}
 {% endconfiguration %}
 
 ## Sensors


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add docs for new feature: template modifyers in energyzero


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/100370
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
