### PR TITLE
Add template and scripts to alerts

### DIFF
--- a/source/_integrations/alert.markdown
+++ b/source/_integrations/alert.markdown
@@ -109,7 +109,15 @@ notifiers:
 data:
   description: "Dictionary of extra parameters to send to the notifier."
   required: false
-  type: list  
+  type: list
+script:
+  description: "`script` integration to call on alert fires, ack, unack, and done."
+  required: false
+  type: string
+variables:
+  description: "Dictionary of extra variables to send to the script."
+  required: false
+  type: list
 {% endconfiguration %}
 
 In this example, the garage door status (`input_boolean.garage_door`) is watched
@@ -269,6 +277,10 @@ alert:
     data:
       inline_keyboard:
         - 'Close garage:/close_garage, Acknowledge:/garage_acknowledge'
+      subtitle: >-
+        {% if states('sensor.garage_doors_open_count') | int(0) > 0 %}
+        {{ states('sensor.garage_doors_open_count') }} garage doors have been left open!
+        {% endif %}
     notifiers:
       - frank_telegram
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Describe new `script` field to alerts, corresponding to PR https://github.com/home-assistant/core/pull/100525


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/100525
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
