### PR TITLE
Update bluetooth to include a section on selecting how to integrate Bluetooth first

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -21,7 +21,9 @@ The Bluetooth integration will detect nearby Bluetooth devices. Discovered devic
 
 ## Before you begin
 
-The Linux Kernel can occasionally cause Bluetooth problems as it doesn't prioritize stability of the Bluetooth stack. Some users have found that a better approach than a directly connected adapter or card is to use a Bluetooth proxy by means of an ESP32. This is particularly of interest to users who virtualize their instance, where the USB pass thru may cause additional problems. More information is available in the Remote Adapters section below or by visiting ESPhome's [Bluetooth proxy page](https://esphome.github.io/bluetooth-proxies/).
+In many cases, a better approach than a directly connected adapter or card is to use a Bluetooth proxy using an ESP32 since Linux kernel updates have previously broken Bluetooth functionality and Bluetooth driver support Linux generally falls behind other operating systems for newer adapters. A Bluetooth proxy is particularly interesting to users who virtualize their instance, where the USB pass-through may cause additional problems. More information is available in the Remote Adapters section below or by visiting ESPhome's [Bluetooth proxy page](https://esphome.github.io/bluetooth-proxies/).
+
+Suppose a Bluetooth proxy is not a good fit for your use case. Consider using the Home Assistant Operating System when using a local adapter because it includes Bluetooth patches for issues unsolved in other operating systems.
 
 ## Configuration
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -19,6 +19,10 @@ The Bluetooth integration will detect nearby Bluetooth devices. Discovered devic
 
 {% include integrations/config_flow.md %}
 
+## Before you begin
+
+The Linux kernel does not prioritise Bluetooth stability and whilst it is possible to use your own Bluetooth card (or one of the many high perofrmance ones listed below), there may be issues. An alternative "just works" solution is to use an ESP32 and ESPhome's [Bluetooth Proxy](https://esphome.github.io/bluetooth-proxies/). This will provide you with a much smoother experience, espeically if you virtualise and pass through your adapter.
+
 ## Configuration
 
 While this integration is part of [`default_config:`](/integrations/default_config/) to enable automatic discovery of the Bluetooth Adapter, it will only be enabled by setting up the configuration flow, or manually adding it to your `configuration.yaml`.

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -21,7 +21,7 @@ The Bluetooth integration will detect nearby Bluetooth devices. Discovered devic
 
 ## Before you begin
 
-The Linux kernel does not prioritize Bluetooth stability and whilst it is possible to use your own Bluetooth card (or one of the many high performance adapter listed below), there may be issues. An alternative "just works" solution is to use an ESP32 and ESPhome's [Bluetooth Proxy](https://esphome.github.io/bluetooth-proxies/). This will provide you with a much smoother experience, espeically if you virtualize and pass thru your adapter. More information is available in the Remote Adapters section below.
+The Linux Kernel can occasionally cause Bluetooth problems as it doesn't prioritize stability of the Bluetooth stack. Some users have found that a better approach than a directly connected adapter or card is to use a Bluetooth proxy by means of an ESP32. This is particularly of interest to users who virtualize their instance, where the USB pass thru may cause additional problems. More information is available in the Remote Adapters section below or by visiting ESPhome's [Bluetooth proxy page](https://esphome.github.io/bluetooth-proxies/).
 
 ## Configuration
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -21,7 +21,7 @@ The Bluetooth integration will detect nearby Bluetooth devices. Discovered devic
 
 ## Before you begin
 
-The Linux kernel does not prioritise Bluetooth stability and whilst it is possible to use your own Bluetooth card (or one of the many high perofrmance ones listed below), there may be issues. An alternative "just works" solution is to use an ESP32 and ESPhome's [Bluetooth Proxy](https://esphome.github.io/bluetooth-proxies/). This will provide you with a much smoother experience, espeically if you virtualise and pass through your adapter.
+The Linux kernel does not prioritize Bluetooth stability and whilst it is possible to use your own Bluetooth card (or one of the many high performance adapter listed below), there may be issues. An alternative "just works" solution is to use an ESP32 and ESPhome's [Bluetooth Proxy](https://esphome.github.io/bluetooth-proxies/). This will provide you with a much smoother experience, espeically if you virtualize and pass thru your adapter. More information is available in the Remote Adapters section below.
 
 ## Configuration
 


### PR DESCRIPTION
Add warning about Bluetooth stability and the Linux Kernel. Added link to ESPhome's Bluetooth proxy.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

Due to the amount of people who experienced [this issue](https://github.com/home-assistant/operating-system/issues/2485) there should be a warning at the top of the Bluetooth docs. I've also mentioned and linked to the ESPhome Bluetooth proxy page at the top, as it is quite often a better (preferred?) alternative.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
