### PR TITLE
New integration: Medcom Bluetooth radiation monitors

### DIFF
--- a/source/_integrations/medcom_ble.markdown
+++ b/source/_integrations/medcom_ble.markdown
@@ -5,7 +5,7 @@ ha_category:
   - Environment
   - Sensor
 ha_release: '2023.10'
-ha_iot_class: Local Poll
+ha_iot_class: Local Polling
 ha_codeowners:
   - '@elafargue'
 ha_domain: medcom_ble
@@ -13,20 +13,20 @@ ha_bluetooth: true
 ha_platforms:
   - sensor
 ha_config_flow: true
-hw_integration_type: integration
+ha_integration_type: integration
 ---
 
 Integrates International Medcom Bluetooth-enabled radiation monitors into Home Assistant.
 
-[International Medcom](https://medcom.com/) is an American company that manufactures high quality radiation detection instruments that are used in professional environments, for home and office, and by community projects worldwide.
+[International Medcom](https://medcom.com/) is an American company that manufactures radiation detection instruments for professional environments, home and office, and community projects worldwide.
 
-This integration adds support for the Medcom [Inspector BLE](https://medcom.com/product/inspector-ble/) which is equipped with a Bluetooth low energy interface.
+This integration supports the Medcom [Inspector BLE](https://medcom.com/product/inspector-ble/) via a Bluetooth low-energy interface.
 
 {% include integrations/config_flow.md %}
 
 The Medcom Bluetooth integration will automatically discover devices once the [Bluetooth](integrations/bluetooth) integration is enabled and working. It will list each detected Inspector using its Bluetooth MAC address as the serial number.
 
-In order to limit the load on the Bluetooth radio on the Home Assistant side, the integration only polls for a reading every 5 minutes, which should be perfectly adequate for ongoing background monitoring. An Inspector BLE battery should last several months with continuous use before needing replacement.
+To limit the load on the Bluetooth radio on the Home Assistant side, the integration only polls for a reading every 5 minutes, which should be adequate for ongoing background monitoring. An Inspector BLE battery should last several months with continuous use before needing replacement.
 
 ## Supported Devices
 

--- a/source/_integrations/medcom_ble.markdown
+++ b/source/_integrations/medcom_ble.markdown
@@ -1,0 +1,37 @@
+---
+title: Medcom Bluetooth
+description: Integrate International Medcom radiation monitors
+ha_category:
+  - Environment
+  - Sensor
+ha_release: '2023.10'
+ha_iot_class: Local Poll
+ha_codeowners:
+  - '@elafargue'
+ha_domain: medcom_ble
+ha_bluetooth: true
+ha_platforms:
+  - sensor
+ha_config_flow: true
+hw_integration_type: integration
+---
+
+Integrates International Medcom Bluetooth-enabled radiation monitors into Home Assistant.
+
+[International Medcom](https://medcom.com/) is an American company that manufactures high quality radiation detection instruments that are used in professional environments, for home and office, and by community projects worldwide.
+
+This integration adds support for the Medcom [Inspector BLE](https://medcom.com/product/inspector-ble/) which is equipped with a Bluetooth low energy interface.
+
+{% include integrations/config_flow.md %}
+
+The Medcom Bluetooth integration will automatically discover devices once the [Bluetooth](integrations/bluetooth) integration is enabled and working. It will list each detected Inspector using its Bluetooth MAC address as the serial number.
+
+In order to limit the load on the Bluetooth radio on the Home Assistant side, the integration only polls for a reading every 5 minutes, which should be perfectly adequate for ongoing background monitoring. An Inspector BLE battery should last several months with continuous use before needing replacement.
+
+## Supported Devices
+
+- Medcom Inspector BLE
+
+## Sensors
+
+This integration adds a counts-per-minute ("CPM") sensor for each detected Inspector BLE device. See the Inspector BLE manual for how to convert this CPM reading into another unit if desired, which can be done via a custom [template sensor](integrations/template)

--- a/source/_integrations/medcom_ble.markdown
+++ b/source/_integrations/medcom_ble.markdown
@@ -18,7 +18,7 @@ ha_integration_type: integration
 
 Integrates International Medcom Bluetooth-enabled radiation monitors into Home Assistant.
 
-[International Medcom](https://medcom.com/) is an American company that manufactures radiation detection instruments for professional environments, home and office, and community projects worldwide.
+[International Medcom](https://medcom.com/) is an American company that manufactures radiation detection instruments that are used in professional environments, for home and office, and by community projects worldwide.
 
 This integration supports the Medcom [Inspector BLE](https://medcom.com/product/inspector-ble/) via a Bluetooth low-energy interface.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
 
Documentation for the proposed "Medcom Bluetooth" new integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/100289
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/4716
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
