### PR TITLE
Document logging changes for zwave_js

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -874,14 +874,14 @@ Many users have reported issues with interference when the USB stick was directl
 
 ###### Enable Z-Wave JS logging
 
-1. Go to the Z-Wave integration panel: {% my integration domain="zwave_js" %}
+1. Go to the Z-Wave integration panel: {% my integration badge domain="zwave_js" %}
 2. Click `Enable debug logging`
 
 The log level will be set to `debug` for the integration, library, and optionally the driver (if the driver log level is not already set to `verbose`, `debug`, or `silly`), and all Z-Wave JS logs will be added to the Home Assistant logs.
 
 ###### Disable Z-Wave JS logging
 
-1. Go to the Z-Wave integration panel: {% my integration domain="zwave_js" %}
+1. Go to the Z-Wave integration panel: {% my integration badge domain="zwave_js" %}
 2. Click `Disable debug logging`
 
 The log level will be reset to its previous value for the integration, library, and driver, and the Home Assistant frontend will automatically send you the Z-Wave logs generated during that time period for download.

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -864,11 +864,11 @@ When trying to determine why something isn't working as you expect, or when repo
 2. Select the **Z-Wave** integration. Then, select the three dots.
 3. From he dropdown menu, select **Download diagnostics**.
 
-### Interference issues
+#### How do I address interference issues?
 
 Many users have reported issues with interference when the USB stick was directly connected to the machine (proximity). If you are having issues, try to use a short USB&nbsp;2.0&nbsp;A (male to female) extension cord.
 
-#### How to access the Z-Wave logs
+#### How do I access the Z-Wave logs?
 
 ##### The easy way
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -875,7 +875,7 @@ Many users have reported issues with interference when the USB stick was directl
 ###### Enable Z-Wave JS logging
 
 1. Go to the Z-Wave integration panel: {% my integration badge domain="zwave_js" %}
-2. Click `Enable debug logging` on the left hand side of the screen.
+2. Select `Enable debug logging` on the left-hand side of the screen.
 
 The log level will be set to `debug` for the integration, library, and optionally the driver (if the driver log level is not already set to `verbose`, `debug`, or `silly`), and all Z-Wave JS logs will be added to the Home Assistant logs.
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -892,7 +892,6 @@ To enable Z-Wave JS logging in the Home Assistant logs, set the log level for `z
 
 To disable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to a level higher than `debug`. If the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original setting and the Z-Wave JS logs will no longer be included in the Home Assistant logs.
 
-
 ## Z-Wave terminology
 
 For some of the concepts, you may come across different terminology in Z-Wave than in Home Assistant.

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -875,14 +875,14 @@ Many users have reported issues with interference when the USB stick was directl
 ###### Enable Z-Wave JS logging
 
 1. Go to the Z-Wave integration panel: {% my integration badge domain="zwave_js" %}
-2. Click `Enable debug logging`
+2. Click `Enable debug logging` on the left hand side of the screen.
 
 The log level will be set to `debug` for the integration, library, and optionally the driver (if the driver log level is not already set to `verbose`, `debug`, or `silly`), and all Z-Wave JS logs will be added to the Home Assistant logs.
 
 ###### Disable Z-Wave JS logging
 
 1. Go to the Z-Wave integration panel: {% my integration badge domain="zwave_js" %}
-2. Click `Disable debug logging`
+2. Click `Disable debug logging` on the left hand side of the screen.
 
 The log level will be reset to its previous value for the integration, library, and driver, and the Home Assistant frontend will automatically send you the Z-Wave logs generated during that time period for download.
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -872,14 +872,14 @@ Many users have reported issues with interference when the USB stick was directl
 
 ##### The easy way
 
-###### Enable Z-Wave JS Logging
+###### Enable Z-Wave JS logging
 
 1. Go to the Z-Wave integration panel: {% my integration domain="zwave_js" %}
 2. Click `Enable debug logging`
 
 The log level will be set to `debug` for the integration, library, and optionally the driver (if the driver log level is not already set to `verbose`, `debug`, or `silly`), and all Z-Wave JS logs will be added to the Home Assistant logs.
 
-###### Disable Z-Wave JS Logging
+###### Disable Z-Wave JS logging
 
 1. Go to the Z-Wave integration panel: {% my integration domain="zwave_js" %}
 2. Click `Disable debug logging`
@@ -888,9 +888,13 @@ The log level will be reset to its previous value for the integration, library, 
 
 ##### The advanced way
 
-To enable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. When the integration detects that the log level has been set to `debug`, it will also set the Z-Wave JS logs to `debug` if the level isn't already `verbose`, `debug`, or `silly` and will include those logs in the Home Assistant logs. The Z-Wave JS logs can be found under the logger name `zwave_js_server.server`.
+###### Enable Z-Wave JS logging manually, or via an automation
 
-To disable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to a level higher than `debug`. If the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original setting and the Z-Wave JS logs will no longer be included in the Home Assistant logs.
+Set the log level for `zwave_js_server` to `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. When the integration detects that the log level has been set to `debug`, it will also set the Z-Wave JS logs to `debug` if the level isn't already `verbose`, `debug`, or `silly` and will include those logs in the Home Assistant logs. The Z-Wave JS logs can be found under the logger name `zwave_js_server.server`.
+
+###### Disable Z-Wave JS logging manually, or via an automation
+
+Set the log level for `zwave_js_server` to a level higher than `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. If the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original setting and the Z-Wave JS logs will no longer be included in the Home Assistant logs.
 
 ## Z-Wave terminology
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -894,7 +894,7 @@ Set the log level for `zwave_js_server` to `debug`. This can either be done in y
 
 ###### Disable Z-Wave JS logging manually, or via an automation
 
-Set the log level for `zwave_js_server` to a level higher than `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. If the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original setting and the Z-Wave JS logs will no longer be included in the Home Assistant logs.
+Set the log level for `zwave_js_server` to a level higher than `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. The Z-Wave JS logs will no longer be included in the Home Assistant logs, and if the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original level.
 
 ## Z-Wave terminology
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -870,7 +870,7 @@ Many users have reported issues with interference when the USB stick was directl
 
 #### How to access the Z-Wave logs
 
-To enable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. When the integration detects that the log level has been set to `debug`, it will also set the Z-Wave JS logs to `debug` if the level isn't already `verbose`, `debug`, or `silly` and will include those logs in the Home Assistant logs. The Z-Wave JS logs can be found under the logger name `zwave_js_server.server`.
+To enable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. When the integration detects that the log level for `zwave_js_server` has been set to `debug`, it will also set the Z-Wave JS logs to `debug` if its log level isn't already `verbose`, `debug`, or `silly` and will include those logs in the Home Assistant logs. The Z-Wave JS logs can be found under the logger name `zwave_js_server.server`.
 
 To disable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to a level higher than `debug`. If the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original setting and the Z-Wave JS logs will no longer be included in the Home Assistant logs.
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -870,9 +870,27 @@ Many users have reported issues with interference when the USB stick was directl
 
 #### How to access the Z-Wave logs
 
-To enable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. When the integration detects that the log level for `zwave_js_server` has been set to `debug`, it will also set the Z-Wave JS logs to `debug` if its log level isn't already `verbose`, `debug`, or `silly` and will include those logs in the Home Assistant logs. The Z-Wave JS logs can be found under the logger name `zwave_js_server.server`.
+##### The easy way
 
-To disable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to a level higher than `debug` (e.g. `info`, `warn`, or `error`). If the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original setting and the Z-Wave JS logs will no longer be included in the Home Assistant logs.
+###### Enable Z-Wave JS Logging
+
+1. Go to the Z-Wave integration panel: {% my integration domain="zwave_js" %}
+2. Click `Enable debug logging`
+
+The log level will be set to `debug` for the integration, library, and optionally the driver (if the driver log level is not already set to `verbose`, `debug`, or `silly`), and all Z-Wave JS logs will be added to the Home Assistant logs.
+
+###### Disable Z-Wave JS Logging
+
+1. Go to the Z-Wave integration panel: {% my integration domain="zwave_js" %}
+2. Click `Disable debug logging`
+
+The log level will be reset to its previous value for the integration, library, and driver, and the Home Assistant frontend will automatically send you the Z-Wave logs generated during that time period for download.
+
+##### The advanced way
+
+To enable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. When the integration detects that the log level has been set to `debug`, it will also set the Z-Wave JS logs to `debug` if the level isn't already `verbose`, `debug`, or `silly` and will include those logs in the Home Assistant logs. The Z-Wave JS logs can be found under the logger name `zwave_js_server.server`.
+
+To disable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to a level higher than `debug`. If the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original setting and the Z-Wave JS logs will no longer be included in the Home Assistant logs.
 
 
 ## Z-Wave terminology

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -870,12 +870,10 @@ Many users have reported issues with interference when the USB stick was directl
 
 #### How to access the Z-Wave logs
 
-Z-Wave JS writes details to its logs. To access these logs, follow these steps:
+To enable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. When the integration detects that the log level has been set to `debug`, it will also set the Z-Wave JS logs to `debug` if the level isn't already `verbose`, `debug`, or `silly` and will include those logs in the Home Assistant logs. The Z-Wave JS logs can be found under the logger name `zwave_js_server.server`.
 
-1. Go to {% my integrations title="**Settings** > **Devices & Services**" %}.
-2. Select the **Z-Wave** integration. Then, select **Configure**.
-3. Open the **Logs** tab.
-4. Make sure to keep this browser tab open. Otherwise the logging is not active.
+To disable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to a level higher than `debug`. If the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original setting and the Z-Wave JS logs will no longer be included in the Home Assistant logs.
+
 
 ## Z-Wave terminology
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -872,7 +872,7 @@ Many users have reported issues with interference when the USB stick was directl
 
 To enable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` service. When the integration detects that the log level for `zwave_js_server` has been set to `debug`, it will also set the Z-Wave JS logs to `debug` if its log level isn't already `verbose`, `debug`, or `silly` and will include those logs in the Home Assistant logs. The Z-Wave JS logs can be found under the logger name `zwave_js_server.server`.
 
-To disable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to a level higher than `debug`. If the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original setting and the Z-Wave JS logs will no longer be included in the Home Assistant logs.
+To disable Z-Wave JS logging in the Home Assistant logs, set the log level for `zwave_js_server` to a level higher than `debug` (e.g. `info`, `warn`, or `error`). If the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original setting and the Z-Wave JS logs will no longer be included in the Home Assistant logs.
 
 
 ## Z-Wave terminology


### PR DESCRIPTION
## Proposed change
As a result of https://github.com/home-assistant/core/pull/100837 collecting logs for Z-Wave JS will be easier. Adjusting the docs accordingly.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/100837
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
