### PR TITLE
Fixed dead link to yr.no documentation

### DIFF
--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -63,7 +63,7 @@ In this section, you find some real-life examples of how to use this camera plat
 
 - Still Image URL: `https://www.yr.no/en/content/1-72837/meteogram.svg`
 
-Instructions on how to locate the SVG for your location are available at [developer.yr.no](https://developer.yr.no/doc/guides/deprecating-old-widgets/)
+Instructions on how to locate the SVG for your location are available at [developer.yr.no](https://developer.yr.no/doc/guides/available-widgets/)
 
 ### Local image
 


### PR DESCRIPTION
## Proposed change
The link to the Norwegian yr.no Meteogram SVG documentation returned a 404. This is likely due to a restructuring of the website. I have found the new page the relevant documentation is on, and have linked to it accordingly.




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
