### PR TITLE
unique_id for ping sensor

### DIFF
--- a/source/_integrations/command_line.markdown
+++ b/source/_integrations/command_line.markdown
@@ -58,6 +58,10 @@ command_line:
           required: false
           type: string
           default: "Binary Command Sensor"
+        icon:
+          description: Defines a template for the icon of the entity.
+          required: false
+          type: template
         payload_on:
           description: The payload that represents enabled state.
           required: false
@@ -169,6 +173,10 @@ command_line:
           required: false
           type: string
           default: "Command Sensor"
+        icon:
+          description: Defines a template for the icon of the entity.
+          required: false
+          type: template
         unique_id:
           description: An ID that uniquely identifies this sensor. Set this to a unique value to allow customization through the UI.
           required: false

--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -48,6 +48,10 @@ name:
   required: false
   type: string
   default: Ping [hostname]
+unique_id:
+  description: An ID that uniquely identifies this binary sensor. Set this to a unique value to allow customization through the UI.
+  required: false
+  type: string
 {% endconfiguration %}
 
 The sensor exposes the different round trip times in milliseconds measured by `ping` as attributes:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updates docs with unique_id field for ping binary sensors.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: /home-assistant/core#101253
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
