### PR TITLE
RFLink: remove logo from header

### DIFF
--- a/source/_integrations/binary_sensor.rflink.markdown
+++ b/source/_integrations/binary_sensor.rflink.markdown
@@ -1,7 +1,6 @@
 ---
 title: "RFLink Binary Sensor"
 description: "Instructions on how to integrate RFLink binary sensors into Home Assistant."
-logo: rflink.png
 ha_category:
   - Binary Sensor
 ha_iot_class: Local Push

--- a/source/_integrations/cover.rflink.markdown
+++ b/source/_integrations/cover.rflink.markdown
@@ -1,7 +1,6 @@
 ---
 title: "RFLink Cover"
 description: "Instructions on how to integrate RFLink Somfy RTS and KAKU ASUN-650 covers into Home Assistant."
-logo: rflink.png
 ha_category:
   - Cover
 ha_iot_class: Assumed State

--- a/source/_integrations/light.rflink.markdown
+++ b/source/_integrations/light.rflink.markdown
@@ -1,7 +1,6 @@
 ---
 title: "RFLink Light"
 description: "Instructions on how to integrate RFLink lights into Home Assistant."
-logo: rflink.png
 ha_category:
   - Light
 ha_iot_class: Assumed State

--- a/source/_integrations/sensor.rflink.markdown
+++ b/source/_integrations/sensor.rflink.markdown
@@ -1,7 +1,6 @@
 ---
 title: "RFLink Sensor"
 description: "Instructions on how to integrate RFLink sensors into Home Assistant."
-logo: rflink.png
 ha_category:
   - Sensor
 ha_iot_class: Local Push

--- a/source/_integrations/switch.rflink.markdown
+++ b/source/_integrations/switch.rflink.markdown
@@ -1,7 +1,6 @@
 ---
 title: "RFLink Switch"
 description: "Instructions on how to integrate RFLink switches into Home Assistant."
-logo: rflink.png
 ha_category:
   - Switch
 ha_iot_class: Assumed State


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

RFLink: remove logo from header
- no longer required, as the logos are stored in the brands repo

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
