### PR TITLE
Updated broken product links on Eufy page

### DIFF
--- a/source/_integrations/eufylife_ble.markdown
+++ b/source/_integrations/eufylife_ble.markdown
@@ -18,11 +18,11 @@ The EufyLife integration allows you to integrate Eufy smart scales with Home Ass
 
 ## Supported devices
 
-- [Smart Scale (T9140)](https://www.eufy.com/products/t9140)
-- [Smart Scale C1 (T9146)](https://www.eufy.com/products/t9146)
-- [Smart Scale P1 (T9147)](https://www.eufy.com/products/t9147)
-- [Smart Scale P2 (T9148)](https://www.eufy.com/products/t9148)
-- [Smart Scale P2 Pro (T9149)](https://www.eufy.com/products/t9149111)
+- [Smart Scale (T9140)](https://support.eufy.com/s/product/a085g000000Nm5FAAS/smart-scale(t9140))
+- [Smart Scale C1 (T9146)](https://us.eufy.com/products/t9146)
+- [Smart Scale P1 (T9147)](https://us.eufy.com/products/t9147)
+- [Smart Scale P2 (T9148)](https://us.eufy.com/products/t9148)
+- [Smart Scale P2 Pro (T9149)](https://us.eufy.com/products/t9149111)
 
 <div class='note'>
 


### PR DESCRIPTION
## Proposed change
All the links to the various Eufy smart scale models were outdated and did not resolve. I have found the correct products on Eufy's updated website and have updated the links accordingly.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
