### PR TITLE
Adding documentation for new sensors on myStrom switches

### DIFF
--- a/source/_integrations/mystrom.markdown
+++ b/source/_integrations/mystrom.markdown
@@ -29,12 +29,18 @@ There is currently support for the following device types within Home Assistant:
 The myStrom integration allows you to control your [myStrom](https://mystrom.ch/) Wi-Fi Bulbs and Wi-Fi Switches. Make sure that you have enabled the REST API under **Advanced** in the web frontend of the switch.
 
 Supported devices are:
- - Switch CH v1 (101)
- - Bulb (102)
- - LED strip (105)
- - Switch CH v2 (106)
- - Switch EU (107)
- - Switch Zero (120)
+
+- Switch CH v1 (101)
+- Bulb (102)
+- LED strip (105)
+- Switch CH v2 (106)
+- Switch EU (107)
+- Switch Zero (120)
+
+Two new sensors are available for switches:
+
+- temperature
+- energy consumption
 
 {%include integrations/config_flow.md %}
 

--- a/source/_integrations/mystrom.markdown
+++ b/source/_integrations/mystrom.markdown
@@ -39,8 +39,8 @@ Supported devices are:
 
 Two sensors are available for switches:
 
-- temperature
-- energy consumption
+- Temperature
+- Energy consumption
 
 {%include integrations/config_flow.md %}
 

--- a/source/_integrations/mystrom.markdown
+++ b/source/_integrations/mystrom.markdown
@@ -37,7 +37,7 @@ Supported devices are:
 - Switch EU (107)
 - Switch Zero (120)
 
-Two new sensors are available for switches:
+Two sensors are available for switches:
 
 - temperature
 - energy consumption


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Informs people that two new sensors are available for myStrom switches


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/97024
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
