### PR TITLE
A-b entities: add info that integration is a building block for other…

### DIFF
--- a/source/_integrations/air_quality.markdown
+++ b/source/_integrations/air_quality.markdown
@@ -25,3 +25,5 @@ The platforms cover the following levels (if they are available):
 - The N2O (nitrogen oxide) level.
 - The NO (nitrogen monoxide) level.
 - The NO2 (nitrogen dioxide) level.
+
+{% include integrations/building_block_integration.md %}

--- a/source/_integrations/alarm_control_panel.markdown
+++ b/source/_integrations/alarm_control_panel.markdown
@@ -14,6 +14,9 @@ ha_integration_type: entity
 Home Assistant can give you an interface which is similar to a classic alarm system.
 Please see [manual alarm](/integrations/manual) or [template alarm](/integrations/alarm_control_panel.template) for alarm configuration.
 
+
+{% include integrations/building_block_integration.md %}
+
 ### Services
 
 Depending on features supported by a specific integration alarm may expose the following services:

--- a/source/_integrations/binary_sensor.markdown
+++ b/source/_integrations/binary_sensor.markdown
@@ -25,7 +25,10 @@ Some binary sensors are created automatically when you add a device integration.
 For example, adding the [ecobee integration](/integrations/ecobee/) will create
 a binary sensor to detect room occupancy. Other binary sensors can be created
 manually using the [template integration](/integrations/template/)
-or using an [input boolean helper](/integrations/input_boolean),
+or using an [input boolean helper](/integrations/input_boolean).
+
+
+{% include integrations/building_block_integration.md %}
 
 ### Device Class
 

--- a/source/_integrations/button.markdown
+++ b/source/_integrations/button.markdown
@@ -17,8 +17,7 @@ a device or service but remains stateless from the Home Assistant perspective.
 It can be compared to a real live momentary switch, push-button, or some other
 form of a stateless switch.
 
-The button entities cannot be implemented manually, but can be provided by
-other integrations.
+{% include integrations/building_block_integration.md %}
 
 ## The state of a button
 


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
A-b entities: 
- add info that integration is a building block for other integrations
 
## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
