### PR TITLE
Adds 'Python Scripts' documentation on using responses from services.

### DIFF
--- a/source/_integrations/python_script.markdown
+++ b/source/_integrations/python_script.markdown
@@ -128,6 +128,14 @@ The above `python_script` can be called using the following YAML as an input.
     rgb_color: [255, 0, 0]
 ```
 
+Introduced in Home Assistant [2023.7](/blog/2023/07/05/release-20237/), services can respond with data. Retrieving this data in your Python script can be done by setting the 'blocking' and 'return_response' arguments of the 'hass.services.call' function to 'True'. This is shown in the example below, in this case retrieving the weather forecast and putting it into a variable:
+
+```python
+# get_forecast.py
+service_data = {"type": "daily", "entity_id": "weather.my_home"}
+current_forecast = hass.services.call("weather", "get_forecast", service_data, blocking=True, return_response=True)
+```
+
 ## Documenting your Python scripts
 
 You can add names and descriptions for your Python scripts that will be shown in the frontend. To do so, simply create a `services.yaml` file in your `<config>/python_scripts` folder. Using the above Python script as an example, the `services.yaml` file would look like:

--- a/source/_integrations/python_script.markdown
+++ b/source/_integrations/python_script.markdown
@@ -128,7 +128,7 @@ The above `python_script` can be called using the following YAML as an input.
     rgb_color: [255, 0, 0]
 ```
 
-Services can also respond with data. Retrieving this data in your Python script can be done by setting the 'blocking' and 'return_response' arguments of the 'hass.services.call' function to 'True'. This is shown in the example below, in this case retrieving the weather forecast and putting it into a variable:
+Services can also respond with data. Retrieving this data in your Python script can be done by setting the `blocking` and `return_response` arguments of the `hass.services.call` function to `True`. This is shown in the example below, in this case, retrieving the weather forecast and putting it into a variable:
 
 ```python
 # get_forecast.py

--- a/source/_integrations/python_script.markdown
+++ b/source/_integrations/python_script.markdown
@@ -128,7 +128,7 @@ The above `python_script` can be called using the following YAML as an input.
     rgb_color: [255, 0, 0]
 ```
 
-Introduced in Home Assistant [2023.7](/blog/2023/07/05/release-20237/), services can respond with data. Retrieving this data in your Python script can be done by setting the 'blocking' and 'return_response' arguments of the 'hass.services.call' function to 'True'. This is shown in the example below, in this case retrieving the weather forecast and putting it into a variable:
+Services can also respond with data. Retrieving this data in your Python script can be done by setting the 'blocking' and 'return_response' arguments of the 'hass.services.call' function to 'True'. This is shown in the example below, in this case retrieving the weather forecast and putting it into a variable:
 
 ```python
 # get_forecast.py

--- a/source/_integrations/python_script.markdown
+++ b/source/_integrations/python_script.markdown
@@ -132,7 +132,7 @@ Introduced in Home Assistant [2023.7](/blog/2023/07/05/release-20237/), services
 
 ```python
 # get_forecast.py
-service_data = {"type": "daily", "entity_id": "weather.my_home"}
+service_data = {"type": "daily", "entity_id": "weather.YOUR_HOME"}
 current_forecast = hass.services.call("weather", "get_forecast", service_data, blocking=True, return_response=True)
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds documentation to the "Python Scripts" page on how responses from services, as introduced in 2023.7, can be used in Python scripts. It also adds an example of this using the weather.get_forecast service.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
* Link to parent pull request in the codebase: /
* Link to parent pull request in the Brands repository: /
* This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
