### PR TITLE
Add the setup detail that ViCare is required on the device

### DIFF
--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -44,6 +44,8 @@ The required Client ID can be obtained as follows:
 
 The `heating_type` can either be `auto` to automatically find the most suitable type for your device or one of `gas`, `oil`, `pellets`, `heatpump`, `fuelcell`, `hybrid`.
 
+Important: the redirect URI that you configure requires that you perform the initial setup on a device that has the 'ViCare' application installed. If your device does not know how to handle the `vicare://` URL you will receive a 'Invalid credentials' notification and the setup procedure will fail. This means: install 'ViCare' on your phone and setup the integration from your phone.
+
 Multiple device instances might be generated depending on the number of burners and/or circuits of your installation. If there is more than a single instance all devices are suffixed with the circuit or burner ID.
 
 ## Viessmann API limits

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -44,7 +44,7 @@ The required Client ID can be obtained as follows:
 
 The `heating_type` can either be `auto` to automatically find the most suitable type for your device or one of `gas`, `oil`, `pellets`, `heatpump`, `fuelcell`, `hybrid`.
 
-Important: the redirect URI that you configure requires that you perform the initial setup on a device that has the 'ViCare' application installed. If your device does not know how to handle the `vicare://` URL you will receive a 'Invalid credentials' notification and the setup procedure will fail. This means: install 'ViCare' on your phone and setup the integration from your phone.
+Important: the redirect URI that you configure requires that you perform the initial setup on a device that has the ViCare application installed. If your device does not know how to handle the `vicare://` URL, you will receive an **Invalid credentials** notification and the setup procedure will fail. This means: install the ViCare app on your phone and set up the integration from your phone.
 
 Multiple device instances might be generated depending on the number of burners and/or circuits of your installation. If there is more than a single instance all devices are suffixed with the circuit or burner ID.
 


### PR DESCRIPTION
I ran into the problem that the setup procedure always resulted in an 'invalid credentials' error.

Reason: I was doing the integration setup on my computer. Only after some time it dawned to me that the vicare:// URI probably needs the ViCare application and hence that I needed to run the setup on my mobile phone.

Once I did that I was in business. Since I lost some time finding this out I think it makes sense to explicitly add this information to the setup procedure.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
