### PR TITLE
Update twitch.markdown to include instructions that prevent OAuth error

### DIFF
--- a/source/_integrations/twitch.markdown
+++ b/source/_integrations/twitch.markdown
@@ -18,6 +18,7 @@ The Twitch integration will allow you to monitor [Twitch](https://www.twitch.tv/
 
 ## Get Twitch application credentials
 
-Create a new app at "Register Your Application" in the [Twitch developer portal](https://dev.twitch.tv/console/apps). Then get the __Client ID__ and __Client secret__ for the new application.
+Create a new app at "Register Your Application" in the [Twitch developer portal](https://dev.twitch.tv/console/apps). When it asks for "OAuth Redirect URLs" include `https://my.home-assistant.io/redirect/oauth` in the list.
+Then get the __Client ID__ and __Client secret__ for the new application.
 
 {% include integrations/config_flow.md %}

--- a/source/_posts/2023-10-04-release-202310.markdown
+++ b/source/_posts/2023-10-04-release-202310.markdown
@@ -367,6 +367,17 @@ backup was initiated. Instead, the local date and time are used for the name.
 
 {% enddetails %}
 
+{% details "Twitch" %}
+
+Any existing app you have created in the [Twitch Developer Portal](https://dev.twitch.tv/console/apps/) to work with this integration must be updated to work with Home Assistant's UI authentication flow. Update the app's configuration to include `https://my.home-assistant.io/redirect/oauth` in its list of "OAuth Redirect URLs"
+
+([@joostlek] - [issue#101414]) ([documentation](/integrations/twitch))
+
+[@joostlek]: https://github.com/joostlek
+[issue#101414]: https://github.com/home-assistant/core/issues/101414
+
+{% enddetails %}
+
 {% details "Z-Wave" %}
 
 Multiple WebSocket commands have been renamed based on [this change in Z-Wave JS](https://zwave-js.github.io/node-zwave-js/#/getting-started/migrating-to-v12?id=renamed-network-heal-to-rebuild-routes).


### PR DESCRIPTION
## Proposed change
The OAuth redirect URL must be included when configuring a Twitch developer app. This avoids an error during the new UI flow.

Related issue: https://github.com/home-assistant/core/issues/101414



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/101414

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
