### PR TITLE
Update switchbot_cloud documentation with instructions on how to access Developer Options

### DIFF
--- a/source/_integrations/switchbot_cloud.markdown
+++ b/source/_integrations/switchbot_cloud.markdown
@@ -21,7 +21,7 @@ The SwitchBot Cloud integration allows you to control SwitchBot [devices](https:
 
 ## Prerequisites
 
-In order to use this integration, you will need at least a SwitchBot Hub and a SwitchBot account to get a token and secret key from the SwitchBot mobile app in Profiles>Preferences>Developer Options.
+In order to use this integration, you will need at least a SwitchBot Hub and a SwitchBot account to get a token and secret key from the SwitchBot mobile app in Profiles>Preferences>Developer Options (Tap "App Version" repeatedly to show the Developer Options menu).
 
 Please note, device names configured in the SwitchBot app are transferred into Home Assistant.
 


### PR DESCRIPTION
## Proposed change
The switchbot app requires the user to tap the App Version repeatedly to unhide developer options. This was not made clear in the integration documentation.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
