### PR TITLE
Add Twitch Breaking Change to 2023.10 Release Notes

### DIFF
--- a/source/_posts/2023-10-04-release-202310.markdown
+++ b/source/_posts/2023-10-04-release-202310.markdown
@@ -367,6 +367,17 @@ backup was initiated. Instead, the local date and time are used for the name.
 
 {% enddetails %}
 
+{% details "Twitch" %}
+
+Any existing app you have created in the [Twitch Developer Portal](https://dev.twitch.tv/console/apps/) to work with this integration must be updated to work with Home Assistant's UI authentication flow. Update the app's configuration to include `https://my.home-assistant.io/redirect/oauth` in its list of "OAuth Redirect URLs"
+
+([@joostlek] - [issue#101414]) ([documentation](/integrations/twitch))
+
+[@joostlek]: https://github.com/joostlek
+[issue#101414]: https://github.com/home-assistant/core/issues/101414
+
+{% enddetails %}
+
 {% details "Z-Wave" %}
 
 Multiple WebSocket commands have been renamed based on [this change in Z-Wave JS](https://zwave-js.github.io/node-zwave-js/#/getting-started/migrating-to-v12?id=renamed-network-heal-to-rebuild-routes).


### PR DESCRIPTION
## Proposed change
Add Twitch Breaking Change to 2023.10 Release Notes

Users who have had the Twitch integration configured in the past are running into errors using the new UI flow version of the integration. They must be instructed to add the oauth redirect URL to their app configuration on the Twitch side.


## Type of change


- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/101414

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
