### PR TITLE
Removed deprecated close_comm_on_error from snippets

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -115,7 +115,6 @@ modbus:
     host: IP_ADDRESS
     port: 502
 
-    close_comm_on_error: true
     delay: 0
     message_wait_milliseconds: 30
     retries: 3
@@ -163,7 +162,6 @@ modbus:
     host: IP_ADDRESS
     port: 502
 
-    close_comm_on_error: true
     delay: 0
     message_wait_milliseconds: 30
     retries: 3
@@ -207,7 +205,6 @@ modbus:
     host: IP_ADDRESS
     port: 502
 
-    close_comm_on_error: true
     delay: 0
     message_wait_milliseconds: 30
     retries: 3
@@ -303,7 +300,6 @@ modbus:
     parity: E
     stopbits: 1
 
-    close_comm_on_error: true
     delay: 0
     message_wait_milliseconds: 30
     retries: 3

--- a/source/_posts/2023-10-04-release-202310.markdown
+++ b/source/_posts/2023-10-04-release-202310.markdown
@@ -87,7 +87,7 @@ So, if you see these buttons showing up somewhere, you now know what they do! Yo
 In the last release, we added [lots of new features for the tile card](/blog/2023/09/06/release-20239/#lots-of-new-tile-features),
 including features specifically for controlling your climate devices. This release, we are adding even more!
 
-[@Weissnix4711] contributed a feature that allows you to add buttons for the presets of your climate device to the tile card. Next,[@piitaya] took it a step further: You can now select which presets you want to show and if you want them in a dropdown list instead of a series of buttons.
+[@Weissnix4711] contributed a feature that allows you to add buttons for the presets of your climate device to the tile card. Next, [@piitaya] took it a step further: You can now select which presets you want to show and if you want them in a dropdown list instead of a series of buttons.
 
 <img class='no-shadow' src='/images/blog/2023-10/tile-card-climate-presets.png' alt='Screenshot showing the new preset feature of the tile cards in both button and dropdown variants.'>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
‘close_comm_on_error' is deprecated, and will be removed in 2024.4
I removed the parameter from configuration examples in addition to PR https://github.com/home-assistant/home-assistant.io/pull/28853.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
 https://github.com/home-assistant/core/pull/99946
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
