### PR TITLE
Change OpenWeatherMap unit_of_measurement from mm to mm/h

### DIFF
--- a/source/_integrations/openweathermap.markdown
+++ b/source/_integrations/openweathermap.markdown
@@ -71,8 +71,8 @@ The Weather entity provides data only in English. Home Assistant automatically t
 | `humidity`               | Humidity, %.                                                                                                                      |
 | `precipitation_kind`     | The kind of precipitation (Rain, Snow, Snow and Rain, None) for the last hour.                                                    |
 | `pressure`               | Atmospheric pressure at sea level, hPa.                                                                                           |
-| `rain`                   | Rain volume for the last hour, mm.                                                                                                |
-| `snow`                   | Snow volume for the last hour, mm.                                                                                                |
+| `rain`                   | Average rain rate since the last update, mm/hr.                                                                                   |
+| `snow`                   | Average rain rate since the last update, mm/hr.                                                                                   |
 | `temperature`            | Temperature, ºC.                                                                                                                  |
 | `uv_index`               | UV Index.                                                                                                                         |
 | `weather`                | A human-readable description of the [weather condition](https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2). |

--- a/source/_integrations/openweathermap.markdown
+++ b/source/_integrations/openweathermap.markdown
@@ -71,8 +71,8 @@ The Weather entity provides data only in English. Home Assistant automatically t
 | `humidity`               | Humidity, %.                                                                                                                      |
 | `precipitation_kind`     | The kind of precipitation (Rain, Snow, Snow and Rain, None) for the last hour.                                                    |
 | `pressure`               | Atmospheric pressure at sea level, hPa.                                                                                           |
-| `rain`                   | Average rain rate since the last update, mm/hr.                                                                                   |
-| `snow`                   | Average rain rate since the last update, mm/hr.                                                                                   |
+| `rain`                   | Rain precipitation, mm/h.                                                                                                         |
+| `snow`                   | Snow precipitation, mm/h.                                                                                                         |
 | `temperature`            | Temperature, ºC.                                                                                                                  |
 | `uv_index`               | UV Index.                                                                                                                         |
 | `weather`                | A human-readable description of the [weather condition](https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2). |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
In OpenWeatherMap integration, rain and snow sensors have measurement unit `mm` and the documentation page says that this refers to Rain volume for the last hour, mm, but they refer to `mm/h`.
This PR replaces measurement unit, so data has the same meaning that it has on the OpenWeatherMap server.
Let me know if I misunderstood the API documentation and this is not the correct behaviour, and I'll close this PR.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/101485

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
