### PR TITLE
Add note regarding BT issues to Idasen Desk

### DIFF
--- a/source/_integrations/idasen_desk.markdown
+++ b/source/_integrations/idasen_desk.markdown
@@ -20,7 +20,7 @@ The IKEA IDÅSEN integration allows you to connect your IKEA Idåsen motorized d
 <div class='note warning'>
 The recommended way to connect the desk to Home Assistant is by using an [ESPHome Bluetooth Proxy](https://esphome.io/projects/?type=bluetooth), as they provide the best experience.
   
-If you are not using an ESPHome Bluetooth Proxy, you need to keep `bluetoothctl` (or any other Bluetooth Agent) open during the setup of the integration, or it will fail to authenticate with the desk. The connection process is also less reliable than with ESPHome, so you may need to retry a few times until it succeeds. This is due to a limitation in the thirdparty Bluetooth implementation used by Home Assistant.
+If you are not using an ESPHome Bluetooth Proxy, you need to keep `bluetoothctl` (or any other Bluetooth Agent) open during the integration setup, or it will fail to authenticate with the desk. The connection process is also less reliable than with ESPHome, so you may need to retry a few times until it succeeds. This is due to a limitation in the third-party Bluetooth implementation used by Home Assistant.
 </div>
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/idasen_desk.markdown
+++ b/source/_integrations/idasen_desk.markdown
@@ -17,6 +17,12 @@ ha_codeowners:
 
 The IKEA IDÅSEN integration allows you to connect your IKEA Idåsen motorized desk to Home Assistant, making it possible to control the desk height and also monitor height changes from the physical controller.
 
+<div class='note warning'>
+The recommended way to connect the desk to Home Assistant is by using an [ESPHome Bluetooth Proxy](https://esphome.io/projects/?type=bluetooth), as they provide the best experience.
+  
+If you are not using an ESPHome Bluetooth Proxy, you need to keep `bluetoothctl` (or any other Bluetooth Agent) open during the setup of the integration, or it will fail to authenticate with the desk. The connection process is also less reliable than with ESPHome, so you may need to retry a few times until it succeeds. This is due to a limitation in the thirdparty Bluetooth implementation used by Home Assistant.
+</div>
+
 {% include integrations/config_flow.md %}
 
 Home Assistant will display a list of addresses of the available desks, and you just need to select the one you want to add. Repeat the process to add more than one desk.

--- a/source/_integrations/idasen_desk.markdown
+++ b/source/_integrations/idasen_desk.markdown
@@ -18,9 +18,11 @@ ha_codeowners:
 The IKEA IDÅSEN integration allows you to connect your IKEA Idåsen motorized desk to Home Assistant, making it possible to control the desk height and also monitor height changes from the physical controller.
 
 <div class='note warning'>
+
 The recommended way to connect the desk to Home Assistant is by using an [ESPHome Bluetooth Proxy](https://esphome.io/projects/?type=bluetooth), as they provide the best experience.
   
 If you are not using an ESPHome Bluetooth Proxy, you need to keep `bluetoothctl` (or any other Bluetooth Agent) open during the integration setup, or it will fail to authenticate with the desk. The connection process is also less reliable than with ESPHome, so you may need to retry a few times until it succeeds. This is due to a limitation in the third-party Bluetooth implementation used by Home Assistant.
+
 </div>
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
Currently, bleak does not have an agent implementation, so pairing fails with an Authentication Failed error.
The workaround is to have an agent running during the initial setup, or to use ESPHome Bluetooth Proxy. ESPHome also seems to work better in general (much less failures during connect, for example).

I also plan to add some changes to Core to improve messaging when it fails, so that users get more info than "Connection Failed".

Related: https://github.com/hbldh/bleak/issues/1434


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
