### PR TITLE
Fix link in help/Trivia to Skyconnect

### DIFF
--- a/source/help/trivia.markdown
+++ b/source/help/trivia.markdown
@@ -26,7 +26,7 @@ Home Assistant is open source software and available under the [Apache 2.0](http
 
 - End of 2020, [Home Assistant Blue](/blue/) was launched. The first dedicated smart home hub for Home Assistant. This limited edition is based on an ODROID and known for its blue aluminum case.
 - In September 2021, [Home Assistant Yellow](/yellow/) was launched. This extendable smart home hub is a custom, open-source design powered by a Raspberry Pi Compute Module 4. Home Assistant Yellow supports both Zigbee and Thread.
-- End of 2022, [Home Assistant SkyConnect](skyconnect) was launched: a USB dongle that provides Zigbee and Thread network support for hubs that do not have this built-in.
+- End of 2022, [Home Assistant SkyConnect](/skyconnect/) was launched: a USB dongle that provides Zigbee and Thread network support for hubs that do not have this built-in.
 
 ## Numbers
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fix link in Trivia documentation to the SkyConnect.
https://www.home-assistant.io/help/trivia#hardware 
builds upon: 266a88ac4d397dbdb3e942ad2d4efe30b87bf9b9



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
