### PR TITLE
Add service documentation for Netatmo integration

### DIFF
--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -95,6 +95,12 @@ Set the outdoor camera light mode. This requires an entity id and a valid state.
 
 Set the heating schedule. This requires an entity id and a schedule name.
 
+### Set preset mode with optional end datetime
+
+`set_preset_mode_with_optional_end_datetime`
+
+Set the preset mode for a Netatmo climate device. The preset mode must match a preset mode configured at Netatmo.
+
 ### Set Person Home
 
 `set_persons_home`

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -100,6 +100,7 @@ Set the heating schedule. This requires an entity id and a schedule name.
 `set_preset_mode_with_end_datetime`
 
 Set the preset mode for a Netatmo climate device. The preset mode must match a preset mode configured at Netatmo.
+
 ### Set Person Home
 
 `set_persons_home`

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -95,12 +95,11 @@ Set the outdoor camera light mode. This requires an entity id and a valid state.
 
 Set the heating schedule. This requires an entity id and a schedule name.
 
-### Set preset mode with optional end datetime
+### Set preset mode with end datetime
 
-`set_preset_mode_with_optional_end_datetime`
+`set_preset_mode_with_end_datetime`
 
 Set the preset mode for a Netatmo climate device. The preset mode must match a preset mode configured at Netatmo.
-
 ### Set Person Home
 
 `set_persons_home`


### PR DESCRIPTION
Add service documentation for set_preset_mode_with_optional_end_datetime in Netatmo integration

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/101674
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
