### PR TITLE
supla.markdown: Fix access_token description

### DIFF
--- a/source/_integrations/supla.markdown
+++ b/source/_integrations/supla.markdown
@@ -44,7 +44,7 @@ servers:
       required: true
       type: string
     access_token:
-      description: An access token for REST API configuration. Under `Scopes`, `Channels`, at least `Read` and `Action execution` permissions are required to be enabled. A token can be obtained from the Security section of Supla Cloud for [Personal Access Token](https://cloud.supla.org/security/personal-access-tokens) page or your server instance.
+      description: An access token for REST API configuration. Under **Scopes** > **Channels**, at least **Read** and **Action execution(( permissions are required to be enabled. A token can be obtained from the Security section of Supla Cloud for [Personal Access Token](https://cloud.supla.org/security/personal-access-tokens) page or your server instance.
       required: true
       type: string
 {% endconfiguration %}

--- a/source/_integrations/supla.markdown
+++ b/source/_integrations/supla.markdown
@@ -44,7 +44,7 @@ servers:
       required: true
       type: string
     access_token:
-      description: An access token for REST API configuration. Can be acquired from `http[s]://your.server.org/integrations/tokens` (please add at least Channel's Read and Action Execution permissions).
+      description: An access token for REST API configuration. Under `Scopes`, `Channels`, at least `Read` and `Action execution` permissions are required to be enabled. A token can be obtained from the Security section of Supla Cloud for [Personal Access Token](https://cloud.supla.org/security/personal-access-tokens) page or your server instance.
       required: true
       type: string
 {% endconfiguration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Fix the link in the `access_token` description to point to the correct location, and improve wording slightly.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #28581

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
