### PR TITLE
Add unique_id to Pilight integration documentation

### DIFF
--- a/source/_integrations/pilight.markdown
+++ b/source/_integrations/pilight.markdown
@@ -109,6 +109,10 @@ name:
   description: Name of the sensor.
   required: false
   type: string
+unique_id:
+  description: An ID that uniquely identifies this binary sensor. Set this to a unique value to allow customization through the UI.
+  required: false
+  type: string
 payload_on:
   description: "Variable `on` value. The integration will recognize this as logical '1'."
   required: false
@@ -140,6 +144,7 @@ A full configuration example could look like this:
 binary_sensor:
   - platform: pilight
     name: "Motion"
+    unique_id: "motion_uid"
     variable: "state"
     payload:
       unitcode: 371399
@@ -177,6 +182,10 @@ name:
   required: false
   default: Pilight Sensor
   type: string
+unique_id:
+  description: An ID that uniquely identifies this sensor. Set this to a unique value to allow customization through the UI.
+  required: false
+  type: string
 unit_of_measurement:
   description: Defines the units of measurement of the sensor, if any.
   required: false
@@ -193,6 +202,7 @@ sensor:
   - platform: pilight
     name: "Temperature"
     variable: "temperature"
+    unique_id: "temperature_uid"
     payload:
       uuid: 0000-b8-27-eb-f1f72e
     unit_of_measurement: "°C"
@@ -226,6 +236,7 @@ switch:
   - platform: pilight
     switches:
       Bed light:
+        unique_id: piantana_studio
         on_code:
           protocol: intertechno_old
           'on': 1
@@ -261,6 +272,11 @@ switches:
           description: If given, this command will turn the switch off if it is received by pilight.
           required: false
           type: list
+        unique_id:
+          description: An ID that uniquely identifies this switch. Set this to a unique value to allow customization through the UI.
+          required: false
+          type: string
+
 {% endconfiguration %}
 
 Variables for the different codes (`on_code` and `off_code`):
@@ -311,6 +327,7 @@ switch:
           unit: 6
           id: 34
           state: "off"
+        unique_id: light_uid
 ```
 
 ## Light


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add unique_id to Pilight integration documentation.  The corresponding PR to add the actual code for the unique_id will follow.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/101814
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
