### PR TITLE
Update voice_remote_local_assistant.markdown

### DIFF
--- a/source/voice_control/voice_remote_local_assistant.markdown
+++ b/source/voice_control/voice_remote_local_assistant.markdown
@@ -63,7 +63,7 @@ The options are also documented in the add-on itself. Go to the {% my supervisor
 
 ## Related topics
 
-- [Create your own a wake word](/voice_control/create_wake_word/)
+- [Create your own wake word](/voice_control/create_wake_word/)
 - [Expose your devices to Assist](/voice_control/voice_remote_expose_devices/#exposing-your-devices)
 - [Whisper for speech-to-text](https://github.com/openai/whisper)
 - [Piper for text-to-speech](https://github.com/rhasspy/piper)


### PR DESCRIPTION
Removed an erroneous "a"

## Proposed change

[Create your own a wake word](https://www.home-assistant.io/voice_control/create_wake_word/) to [Create your own wake word](https://www.home-assistant.io/voice_control/create_wake_word/)
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
