### PR TITLE
Clarify Adax integration use

### DIFF
--- a/source/_integrations/adax.markdown
+++ b/source/_integrations/adax.markdown
@@ -18,14 +18,18 @@ Integrates Adax heater into Home Assistant.
 
 You can configure the heaters to use a local or cloud interface.
 
-The local integrations only works with newer Adax heaters with both Bluetooth and wifi. Home Assistant uses Bluetooth to configure the heaters. For the local integration, you have to reset the heater by pressing + and OK until the display shows 'Reset'. Then press and hold the OK button on the heater until the blue LED starts blinking before pressing Submit. Configuring the heater might take some minutes. Using the local integration will disable cloud communication and the Adax app will not work.
+The local integrations only works with newer Adax heaters with both Bluetooth and wifi. Home Assistant uses Bluetooth LE to configure the heaters, this means your machine running “Home Assistant” needs to have a Bluetooth adapter and the heater needs to be in range during setup. For the local integration, you have to reset the heater by pressing + and OK until the display shows 'Reset'. Then press and hold the OK button on the heater until the blue LED starts blinking before pressing Submit. Configuring the heater might take some minutes. Using the local integration will disable cloud communication and the Adax app will not work.
 
-For the cloud integration, you'll need the Account ID (which can be found in the Adax Wifi app, pressing 'Account'). You will also need a credential, which you can create in the Adax app:
+For the cloud integration, you'll need the Account ID (which can be found in the Adax Wifi app, pressing 'Account'. Which you will find as a number between the "log out" and "close account" buttons). 
+
+You will also need a credential, which you can create in the Adax app:
 
 1. Navigate to the Account tab.
 2. Go to **Third party integrations**.
 3. Select **Remote API**.
 4. Select **Add Credential**.
 5. Give some name to the created credential (e.g. 'Home Assistant') and copy the generated password.
+
+In the configuration popup you will need the Account ID, and the generated API password (not the account password)
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
Make clear what are the requirements for local integration, and how to correctly use the cloud integration. As i.e. the password to use was unclear.

## Proposed change

Documentation update so others don't have to spend time googling errors and read code until they figure out what the issue is.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
