### PR TITLE
Document new `homeassistant_exclude_database` option

### DIFF
--- a/source/_integrations/hassio.markdown
+++ b/source/_integrations/hassio.markdown
@@ -159,7 +159,7 @@ Create a partial backup.
 | `password` | yes | Optional password for backup
 | `compressed` | yes | `false` to create uncompressed backups
 | `location` | yes | Alternate backup location instead of using the default location for backups
-| `homeassistant` | yes | Include home assistant and associated config in backup
+| `homeassistant` | yes | Include Home Assistant and associated config in backup
 | `homeassistant_exclude_database` | yes | Exclude the Home Assistant database file from backup
 
 ### Service hassio.restore_full

--- a/source/_integrations/hassio.markdown
+++ b/source/_integrations/hassio.markdown
@@ -145,6 +145,7 @@ Create a full backup.
 | `password` | yes | Optional password for backup
 | `compressed` | yes | `false` to create uncompressed backups
 | `location` | yes | Alternate backup location instead of using the default location for backups
+| `homeassistant_exclude_database` | yes | Exclude the Home Assistant database file from backup
 
 ### Service hassio.backup_partial
 
@@ -158,6 +159,8 @@ Create a partial backup.
 | `password` | yes | Optional password for backup
 | `compressed` | yes | `false` to create uncompressed backups
 | `location` | yes | Alternate backup location instead of using the default location for backups
+| `homeassistant` | yes | Include home assistant and associated config in backup
+| `homeassistant_exclude_database` | yes | Exclude the Home Assistant database file from backup
 
 ### Service hassio.restore_full
 


### PR DESCRIPTION
## Proposed change

Document new option being added to backup service calls in https://github.com/home-assistant/core/pull/101958

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/101958
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
