### PR TITLE
Add in extended note for alexa integration to describe routines

### DIFF
--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -397,7 +397,7 @@ Alexa will now respond with a random phrase each time. You can use the include f
 
 ## Workaround for having to say the skill's name
 
-Sometimes, you want to run script or scene intents without using the skill's name. For example, 'Alexa <some script>' instead of 'Alexa ask Home Assistant to run <some script>' because it is shorter.
+Sometimes, you want to run script or scene intents without using the skill's name. For example, 'Alexa `<some script>`' instead of 'Alexa ask Home Assistant to run `<some script>`' because it is shorter.
 
 You can do this by using Alexa routines. 
 1. Configure a routine in the Alexa app that responds to the command you want to use:

--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -396,9 +396,14 @@ text: !include alexa_confirm.yaml
 Alexa will now respond with a random phrase each time. You can use the include for as many different intents as you like so you only need to create the list once.
 
 ## Workaround for having to say the skill's name
-Users may wish to run script and scene intents without using the skill's name. For example, `Alexa <some script>` may be preferrable to `Alexa ask Home Assistant to run <some script>` due to the length.
 
-One workaround to achieve this is to use Alexa routines as well. Configure a routine in the Alexa app that responds to the command you want to use (e.g 'Alexa, turn on the dryer'). This routine should include a customised action that contains the full phrase you configured in your Skill (e.g. 'Alexa, ask Home Assistant to run the dryer on script').
+Sometimes, you want to run script or scene intents without using the skill's name. For example, `Alexa <some script>` instead of `Alexa ask Home Assistant to run <some script>` because it is shorter.
+
+You can do this by using Alexa routines. 
+1. Configure a routine in the Alexa app that responds to the command you want to use:
+   -  For example, 'Alexa, turn on the dryer'. 
+2.  Make sure this routine includes a customized action that contains the full phrase you configured in your skill:
+     - For example, 'Alexa, ask Home Assistant to run the dryer on script'.
 
 [amazon-dev-console]: https://developer.amazon.com
 [large-icon]: /images/integrations/alexa/alexa-512x512.png

--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -397,7 +397,7 @@ Alexa will now respond with a random phrase each time. You can use the include f
 
 ## Workaround for having to say the skill's name
 
-Sometimes, you want to run script or scene intents without using the skill's name. For example, `Alexa <some script>` instead of `Alexa ask Home Assistant to run <some script>` because it is shorter.
+Sometimes, you want to run script or scene intents without using the skill's name. For example, 'Alexa <some script>' instead of 'Alexa ask Home Assistant to run <some script>' because it is shorter.
 
 You can do this by using Alexa routines. 
 1. Configure a routine in the Alexa app that responds to the command you want to use:

--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -396,7 +396,7 @@ text: !include alexa_confirm.yaml
 Alexa will now respond with a random phrase each time. You can use the include for as many different intents as you like so you only need to create the list once.
 
 ## Workaround for having to say the skill's name
-Like me, would you prefer to use the run script (or run scene) intents without using the skill's name. e.g instead of saying `Alexa ask Home Assistant to run <some script>` you'd prefer to say `Alexa <some script>` on a dev skill?
+Users may wish to run script and scene intents without using the skill's name. For example, `Alexa <some script>` may be preferrable to `Alexa ask Home Assistant to run <some script>` due to the length.
 
 One workaround to achieve this is to use Alexa routines as well. Configure a routine in the Alexa app that responds to the command you want to use (e.g 'Alexa, turn on the dryer'). This routine should include a customised action that contains the full phrase you configured in your Skill (e.g. 'Alexa, ask Home Assistant to run the dryer on script').
 

--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -395,6 +395,11 @@ text: !include alexa_confirm.yaml
 
 Alexa will now respond with a random phrase each time. You can use the include for as many different intents as you like so you only need to create the list once.
 
+## Workaround for having to say the skill's name
+Like me, would you prefer to use the run script (or run scene) intents without using the skill's name. e.g instead of saying `Alexa ask Home Assistant to run <some script>` you'd prefer to say `Alexa <some script>` on a dev skill?
+
+If so, a quick and perhaps a touch dirty, workaround is to use Alexa routines as well. Configure a routine in the Alexa app that responds to the command you want to use (e..g 'Alexa, turn on the dryer' and runs a customised action that would be the full phrase that you configured in your Skill e.g. 'Alexa, ask Home Assistant to run the dryer on script'
+
 [amazon-dev-console]: https://developer.amazon.com
 [large-icon]: /images/integrations/alexa/alexa-512x512.png
 [small-icon]: /images/integrations/alexa/alexa-108x108.png

--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -398,7 +398,7 @@ Alexa will now respond with a random phrase each time. You can use the include f
 ## Workaround for having to say the skill's name
 Like me, would you prefer to use the run script (or run scene) intents without using the skill's name. e.g instead of saying `Alexa ask Home Assistant to run <some script>` you'd prefer to say `Alexa <some script>` on a dev skill?
 
-If so, a quick and perhaps a touch dirty, workaround is to use Alexa routines as well. Configure a routine in the Alexa app that responds to the command you want to use (e..g 'Alexa, turn on the dryer' and runs a customised action that would be the full phrase that you configured in your Skill e.g. 'Alexa, ask Home Assistant to run the dryer on script'
+One workaround to achieve this is to use Alexa routines as well. Configure a routine in the Alexa app that responds to the command you want to use (e.g 'Alexa, turn on the dryer'). This routine should include a customised action that contains the full phrase you configured in your Skill (e.g. 'Alexa, ask Home Assistant to run the dryer on script').
 
 [amazon-dev-console]: https://developer.amazon.com
 [large-icon]: /images/integrations/alexa/alexa-512x512.png


### PR DESCRIPTION
Adds a block of text to describe a workaround to having to state the skill's name.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
