### PR TITLE
Add new govee models

### DIFF
--- a/source/_integrations/govee_ble.markdown
+++ b/source/_integrations/govee_ble.markdown
@@ -24,15 +24,21 @@ The Govee BLE integration will automatically discover devices once the [Bluetoot
 
 ## Supported devices
 
+- H5051 Hygrometer Thermometer
+- H5052 Hygrometer Thermometer
 - H5071 Hygrometer Thermometer
 - H5072 Hygrometer Thermometer
 - H5074 Hygrometer Thermometer
 - [H5075 Bluetooth Hygrometer Thermometer](https://us.govee.com/collections/thermo-hydrometer/products/govee-bluetooth-hygrometer-thermometer-h5075)
 - H5100 Hygrometer Thermometer
 - H5101 Hygrometer Thermometer
+- H5102 Hygrometer Thermometer
 - [H5177/5178 Bluetooth Thermo-Hygrometer](https://us.govee.com/collections/thermo-hydrometer/products/bluetooth-thermo-hygrometer)
 - H5179 Hygrometer Thermometer
+- 5055 Meat Thermometer
 - 5181 Meat Thermometer
+- 5182 Meat Thermometer
 - 5183 Meat Thermometer
 - 5184 Meat Thermometer
 - 5185 Meat Thermometer
+- 5198 Meat Thermometer


### PR DESCRIPTION
## Proposed change

Add Govee models supported by previous updates but not added to docs, and H5055 which is supported in 0.24 of the library.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/100365

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
