### PR TITLE
Re-capitalize proper names

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -429,9 +429,9 @@ trigger:
       event_label: "Keypad unlock operation"
 ```
 
-#### Notification command class
+#### Notification Command Class
 
-These are notification events fired by devices using the notification command class. The `parameters` attribute in the example below is optional, and when it is included, the keys in the attribute will vary depending on the event.
+These are notification events fired by devices using the Notification Command Class. The `parameters` attribute in the example below is optional, and when it is included, the keys in the attribute will vary depending on the event.
 
 ```json
 {
@@ -450,9 +450,9 @@ These are notification events fired by devices using the notification command cl
 }
 ```
 
-#### Multilevel switch command class
+#### Multilevel Switch Command Class
 
-These are notification events fired by devices using the multilevel switch command class. There are events for start level change and stop level change. These would typically be used in a device like the Aeotec Nano Dimmer with an external switch to respond to long button presses.
+These are notification events fired by devices using the Multilevel Switch Command Class. There are events for start level change and stop level change. These would typically be used in a device like the Aeotec Nano Dimmer with an external switch to respond to long button presses.
 
 ##### Start level change
 
@@ -488,9 +488,9 @@ These are notification events fired by devices using the multilevel switch comma
 },
 ```
 
-#### Entry control command class
+#### Entry Control Command Class
 
-These are notification events fired by devices using the entry control command class.
+These are notification events fired by devices using the Entry Control Command Class.
 
 ```json
 {
@@ -620,8 +620,8 @@ In addition to the [standard automation trigger data](/docs/automation/templatin
 | ---------------------------- | ------------------------------------------------------------------------------------------ |
 | `trigger.device_id`          | Device ID for the device in the device registry.                                           |
 | `trigger.node_id`            | Z-Wave node ID.                                                                            |
-| `trigger.command_class`      | Command class ID.                                                                          |
-| `trigger.command_class_name` | Command class name.                                                                        |
+| `trigger.command_class`      | Command Class ID.                                                                          |
+| `trigger.command_class_name` | Command Class name.                                                                        |
 | `trigger.property`           | Z-Wave Value's property.                                                                   |
 | `trigger.property_name`      | Z-Wave Value's property name.                                                              |
 | `trigger.property_key`       | Z-Wave Value's property key.                                                               |
@@ -731,11 +731,11 @@ If you're running full Home Assistant with supervisor, you will be presented wit
 
 If you're not running the supervisor or you've unchecked the above-mentioned box, you will be asked to enter a WebSocket URL (defaults to ws://localhost:3000). It is very important that you fill in the correct (Docker) IP/hostname here. For example for the Z-Wave JS UI add-on this is `ws://a0d7b954-zwavejs2mqtt:3000`.
 
-## FAQ: Supported devices and command classes
+## FAQ: Supported devices and Command Classes
 
 See the [Z-Wave JS device database](https://devices.zwave-js.io/).
 
-While there is support for the most common devices, some command classes are not yet (fully) implemented in Z-Wave JS. You can track the status [here](https://github.com/zwave-js/node-zwave-js/issues/6).
+While there is support for the most common devices, some Command Classes are not yet (fully) implemented in Z-Wave JS. You can track the status [here](https://github.com/zwave-js/node-zwave-js/issues/6).
 
 You can also keep track of the road map for the Z-Wave integration [here](https://github.com/home-assistant-libs/zwave-js-server-python/issues/56).
 


### PR DESCRIPTION
## Proposed change
Per https://github.com/home-assistant/home-assistant.io/pull/29409#discussion_r1364335315 we should make sure that proper names are capitalized to avoid removing context.

CC @c0ffeeca7 @MartinHjelmare 



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
