### PR TITLE
Add state options for tile card

### DIFF
--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -54,7 +54,7 @@ hide_state:
 state_content:
   required: false
   description: >
-    Content to display for the state. Can be `state`, `last-changed` or any attribute of the entity. Can be either a string with a single item, or a list of string item. Default depends of the entity domain.
+    Content to display for the state. Can be `state`, `last-changed`, or any attribute of the entity. Can be either a string with a single item, or a list of string items. Default depends on the entity domain.
   type: [string, list]
 tap_action:
   required: false

--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -25,11 +25,11 @@ entity:
   type: string
 name:
   required: false
-  description: Overwrites the name of entity.
+  description: Overwrites the entity name.
   type: string
 icon:
   required: false
-  description: Overwrites the icon of entity.
+  description: Overwrites the entity icon.
   type: string
 color:
   required: false
@@ -46,6 +46,16 @@ vertical:
   description: Displays the icon above the name and state.
   type: boolean
   default: false
+hide_state:
+  required: false
+  description: Hide the entity state.
+  type: boolean
+  default: false
+state_content:
+  required: false
+  description: >
+    Content to display for the state. Can be `state`, `last-changed` or any attribute of the entity. Can be either a string with a single item, or a list of string item. Default depends of the entity domain.
+  type: [string, list]
 tap_action:
   required: false
   description: Action taken on card tap. See [action documentation](/dashboards/actions/#tap-action). By default, it will show the "more-info" dialog.
@@ -86,6 +96,16 @@ show_entity_picture: true
 type: tile
 entity: person.anne_therese
 vertical: true
+hide_state: true
+```
+
+```yaml
+type: tile
+entity: light.living_room
+state_content: 
+  - state
+  - brightness
+  - last-changed
 ```
 
 ```yaml


### PR DESCRIPTION
## Proposed change

Add state options for tile card : `state_content` and `hide_state`

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/18180
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
