### PR TITLE
apt dependencies libtiff 5 -> 6

### DIFF
--- a/source/_includes/installation/core.md
+++ b/source/_includes/installation/core.md
@@ -33,7 +33,7 @@ sudo apt-get upgrade -y
 Install the dependencies:
 
 ```bash
-sudo apt-get install -y python3 python3-dev python3-venv python3-pip bluez libffi-dev libssl-dev libjpeg-dev zlib1g-dev autoconf build-essential libopenjp2-7 libtiff5 libturbojpeg0-dev tzdata ffmpeg liblapack3 liblapack-dev libatlas-base-dev
+sudo apt-get install -y python3 python3-dev python3-venv python3-pip bluez libffi-dev libssl-dev libjpeg-dev zlib1g-dev autoconf build-essential libopenjp2-7 libtiff6 libturbojpeg0-dev tzdata ffmpeg liblapack3 liblapack-dev libatlas-base-dev
 ```
 
 The above-listed dependencies might differ or missing, depending on your system or personal use of Home Assistant.


### PR DESCRIPTION
In the install documentation libtiff5 has been superseeded by libtiff6
