### PR TITLE
Fixed menu hover dead spot

### DIFF
--- a/sass/oscailte/base/_navigation.scss
+++ b/sass/oscailte/base/_navigation.scss
@@ -136,7 +136,7 @@ header .grid {
   background: $site-background;
   box-shadow: inset 0px 5px $navigation-color;
   color: $navigation-color;
-  padding-bottom: 22px;
+  padding-bottom: 32px;
 }
 
 .toggle {


### PR DESCRIPTION
## Proposed change
Fixes a "dead spot" in the `Documentation` menu where it will deselect the menu while moving the mouse down to select one of the list items.

## Type of change
Bug fix with GUI

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Before:
[Peek 2023-10-19 19-14.webm](https://github.com/home-assistant/home-assistant.io/assets/2666891/bd6325a6-abcd-419c-8025-769290e72aa7)

After:
[Peek 2023-10-19 19-35.webm](https://github.com/home-assistant/home-assistant.io/assets/2666891/1433e3c4-0f76-4fdf-9637-2d08da1cf7f2)

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
