### PR TITLE
Add 800 series controllers issues

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -74,7 +74,7 @@ Supported
  - Setting Device Configuration Values
  - Getting Device Configuration Values
  - Command Classes: Multilevel Switch v2 and v4, Color Switch v1, and Config v1 and v2
- - Device Heal
+ - Route Rebuild
 
 ### Aeotec Z-Stick
 

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -20,7 +20,7 @@ Users should upgrade the firmware on all 700 series controllers to version 7.17.
 
 </div>
 
-- 800 series controllers
+- 800 series controllers (with some caveats, see notes)
   - Zooz 800 Series Z-Wave Long Range S2 Stick (ZST39 LR)
 
 - 700 series controllers
@@ -62,6 +62,10 @@ The alternative to a stick is a hub that supports Z-Wave. Home Assistant support
 - [Z-Wave.Me Z-Way](/integrations/zwave_me)
 
 ## Controller Notes
+
+### 800 Series Controllers
+
+Some features are not supported with 800 series controllers yet. You can find the full list of supported and unsupported features with 800 seires controllers [here](https://github.com/zwave-js/node-zwave-js/issues/5257).
 
 ### Aeotec Z-Stick
 

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -66,7 +66,9 @@ The alternative to a stick is a hub that supports Z-Wave. Home Assistant support
 ### 800 Series Controllers
 
 Z-Wave JS and Z-Wave JS UI do not support the following features available on most 800 series controllers.
-Unsupported
+
+Unsupported:
+
  - Long Range
  - NVM Backup/Restore
 

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -65,7 +65,7 @@ The alternative to a stick is a hub that supports Z-Wave. Home Assistant support
 
 ### 800 Series Controllers
 
-Z-wave JS and Z-wave JS UI do not support the following features available on most 800 series controllers.
+Z-Wave JS and Z-Wave JS UI do not support the following features available on most 800 series controllers.
 Unsupported
  - Long Range
  - NVM Backup/Restore

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -65,16 +65,10 @@ The alternative to a stick is a hub that supports Z-Wave. Home Assistant support
 
 ### 800 Series Controllers
 
-Some features are not supported with 800 series controllers yet.
+Z-wave JS and Z-wave JS UI do not support the following features available on most 800 series controllers.
 Unsupported
  - Long Range
- - NVM Backup/Restore 
-Supported
- - Device inclusion + exclusion (Basic and SmartStart)
- - Setting Device Configuration Values
- - Getting Device Configuration Values
- - Command Classes: Multilevel Switch v2 and v4, Color Switch v1, and Config v1 and v2
- - Route Rebuild
+ - NVM Backup/Restore
 
 ### Aeotec Z-Stick
 

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -65,7 +65,16 @@ The alternative to a stick is a hub that supports Z-Wave. Home Assistant support
 
 ### 800 Series Controllers
 
-Some features are not supported with 800 series controllers yet. You can find the full list of supported and unsupported features with 800 seires controllers [here](https://github.com/zwave-js/node-zwave-js/issues/5257).
+Some features are not supported with 800 series controllers yet.
+Unsupported
+ - Long Range
+ - NVM Backup/Restore 
+Supported
+ - Device inclusion + exclusion (Basic and SmartStart)
+ - Setting Device Configuration Values
+ - Getting Device Configuration Values
+ - Command Classes: Multilevel Switch v2 and v4, Color Switch v1, and Config v1 and v2
+ - Device Heal
 
 ### Aeotec Z-Stick
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I propose that supported feature information about 800 series controllers should be added alongside its listing on the supported controllers page. This provides more information to the user about possible issues before purchasing a controller that has some features that may not work properly.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

This is my first pull request to home assistant 🎉! Feel free to tell me anything I have done wrong or could do better so I can improve any of my contributions in the future. Thanks for all the work you guys do 😁.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
