### PR TITLE
Fix: Typo in private_ble_device.markdown

### DIFF
--- a/source/_integrations/private_ble_device.markdown
+++ b/source/_integrations/private_ble_device.markdown
@@ -31,7 +31,7 @@ There are two common representations for encoding an IRK - base64 encoding or he
 
 If you are trying to get the IRK for your iPhone or Apple Watch, you must be logged in to the Mac with the same iCloud account on those devices. This procedure should also work for devices that you pair with macOS.
 
-1. Start the **Keychain Acess** application.
+1. Start the **Keychain Access** application.
 2. In the left sidebar, make sure iCloud is selected.
 3. In the search bar in the upper right, type Bluetooth.
 4. A list of GUIDs is shown.


### PR DESCRIPTION
## Proposed change

Typo fix


## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
