### PR TITLE
Add Todoist todo component documentation

### DIFF
--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -3,6 +3,7 @@ title: Todoist
 description: Instructions on how to integrate Todoist into Home Assistant.
 ha_category:
   - Calendar
+  - To-do List
 ha_iot_class: Cloud Polling
 ha_release: 0.54
 ha_codeowners:
@@ -14,7 +15,10 @@ ha_integration_type: integration
 ha_config_flow: true
 ---
 
-This platform allows you to connect to your [Todoist Projects](https://todoist.com) as [calendar](/integrations/calendar/) entities. A calendar entity will be `on` if you have a task due in that project or `off` if all the tasks in the project are completed or if the project doesn't have any tasks at all. All tasks get updated roughly every 15 minutes.
+This platform allows you to connect to your [Todoist Projects](https://todoist.com) as [todo](/integrations/todo/) or [calendar](/integrations/calendar/) entities. All tasks get updated roughly every 15 minutes.
+
+
+A calendar entity will be `on` if you have a task due in that project or `off` if all the tasks in the project are completed or if the project doesn't have any tasks at all. 
 
 ## Prerequisites
 
@@ -24,7 +28,10 @@ You need to determine your Todoist API token. Go to the [**Integrations** > **De
 
 ## Custom Projects
 
-You can manually configure the integration using `configuration.yaml` which can specify "custom" projects which match against criteria you set.
+You can manually configure the Todoist calendar (only) integration using `configuration.yaml` which can specify "custom" projects which match against criteria you set. You should
+prefer the above instructions for configuring Todoist from the UI.
+
+{% details "Manual custom projects configuration" %}
 
 {% configuration %}
 token:
@@ -89,6 +96,14 @@ You can mix-and-match these attributes to create all sorts of custom projects. Y
 
 Home Assistant does its best to [determine what task in each project is "most" important](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/todoist/calendar.py), and it's that task which has its state reported. You can access the other tasks you have due soon via the `all_tasks` array (see below).
 
+{% enddetails %}
+
+## To-do Entities
+
+See the [todo](/integrations/todo/) integration for details on how to manage
+items on the Todoist To-do list including services for creating and
+deleting To-do items.
+
 ## Calendar Entity attributes
 
  - **offset_reached**: Not used.
@@ -119,7 +134,13 @@ Home Assistant does its best to [determine what task in each project is "most" i
 
 ## Services
 
-Todoist also comes with access to a service, `todoist.new_task`. This service can be used to create a new Todoist task. You can specify labels and a project, or you can leave them blank, and the task will go to your "Inbox" project.
+You may use the services from the [todo](/integrations/todo/) integration for
+creating, updating, or deleting To-do Items on the To-do List.
+
+Todoist also comes with an additional service, `todoist.new_task` that offers
+more advanced attributes when creating a Todoist task. You can specify labels
+and a project, or you can leave them blank, and the task will go to your
+"Inbox" project.
 
 Here are two example JSON payloads resulting in the same task:
 

--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -15,7 +15,7 @@ ha_integration_type: integration
 ha_config_flow: true
 ---
 
-This platform allows you to connect to your [Todoist Projects](https://todoist.com) as [todo](/integrations/todo/) or [calendar](/integrations/calendar/) entities. All tasks get updated roughly every 15 minutes.
+This platform allows you to connect to your [Todoist projects](https://todoist.com) as [todo](/integrations/todo/) or [calendar](/integrations/calendar/) entities. All tasks get updated roughly every 15 minutes.
 
 
 A calendar entity will be `on` if you have a task due in that project. It will be `off` if all the tasks in the project are completed or if the project doesn't have any tasks at all. 
@@ -26,7 +26,7 @@ You need to determine your Todoist API token. Go to the [**Integrations** > **De
 
 {% include integrations/config_flow.md %}
 
-## Custom Projects
+## Custom projects
 
 You can manually configure the Todoist calendar (only) integration using `configuration.yaml` which can specify "custom" projects which match against criteria you set. You should
 prefer the above instructions for configuring Todoist from the UI.
@@ -98,10 +98,10 @@ Home Assistant does its best to [determine what task in each project is "most" i
 
 {% enddetails %}
 
-## To-do List Entity
+## To-do list entity
 
 See the [todo](/integrations/todo/) integration for details on how to manage
-items on the Todoist to-do list including services for creating and
+items on the Todoist to-do list, including services for creating and
 deleting to-do items.
 
 Todoist completed to-do items are not visible in Home Assistant because they
@@ -109,7 +109,7 @@ are not returned by the Todoist REST API. Marking a To-do item as completed is
 effectively deleting it from Home Assistant, though completed tasks are visible in
 the Todoist UI.
 
-## Calendar Entity attributes
+## Calendar entity attributes
 
  - **offset_reached**: Not used.
 

--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -18,7 +18,7 @@ ha_config_flow: true
 This platform allows you to connect to your [Todoist Projects](https://todoist.com) as [todo](/integrations/todo/) or [calendar](/integrations/calendar/) entities. All tasks get updated roughly every 15 minutes.
 
 
-A calendar entity will be `on` if you have a task due in that project or `off` if all the tasks in the project are completed or if the project doesn't have any tasks at all. 
+A calendar entity will be `on` if you have a task due in that project. It will be `off` if all the tasks in the project are completed or if the project doesn't have any tasks at all. 
 
 ## Prerequisites
 
@@ -101,12 +101,12 @@ Home Assistant does its best to [determine what task in each project is "most" i
 ## To-do List Entity
 
 See the [todo](/integrations/todo/) integration for details on how to manage
-items on the Todoist To-do list including services for creating and
-deleting To-do items.
+items on the Todoist to-do list including services for creating and
+deleting to-do items.
 
-Todoist completed To-do items are not visible in Home Assistant because they
+Todoist completed to-do items are not visible in Home Assistant because they
 are not returned by the Todoist REST API. Marking a To-do item as completed is
-effectively delete it from Home Assistant, though completed tasks are visible in
+effectively deleting it from Home Assistant, though completed tasks are visible in
 the Todoist UI.
 
 ## Calendar Entity attributes
@@ -140,12 +140,12 @@ the Todoist UI.
 ## Services
 
 You may use the services from the [todo](/integrations/todo/) integration for
-creating, updating, or deleting To-do Items on the To-do List.
+creating, updating, or deleting to-do items on the to-do list.
 
 Todoist also comes with an additional service, `todoist.new_task` that offers
 more advanced attributes when creating a Todoist task. You can specify labels
 and a project, or you can leave them blank, and the task will go to your
-"Inbox" project.
+**Inbox** project.
 
 Here are two example JSON payloads resulting in the same task:
 
@@ -192,4 +192,4 @@ Here are two example JSON payloads resulting in the same task:
 - **reminder_date_lang** (*Optional*): When `reminder_date_string` is set, it is possible to set the language.
   Valid languages are: `en`, `da`, `pl`, `zh`, `ko`, `de`, `pt`, `ja`, `it`, `fr`, `sv`, `ru`, `es`, `nl`
 
-- **reminder_date** (*Optional*): When should user be reminded of this task, in either YYYY-MM-DD format or YYYY-MM-DD HH:MM format (in UTC timezone). Mutually exclusive with `reminder_date_string`.
+- **reminder_date** (*Optional*): When should the user be reminded of this task, in either YYYY-MM-DD format or YYYY-MM-DD HH:MM format (in UTC timezone). Mutually exclusive with `reminder_date_string`.

--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -98,11 +98,16 @@ Home Assistant does its best to [determine what task in each project is "most" i
 
 {% enddetails %}
 
-## To-do Entities
+## To-do List Entity
 
 See the [todo](/integrations/todo/) integration for details on how to manage
 items on the Todoist To-do list including services for creating and
 deleting To-do items.
+
+Todoist completed To-do items are not visible in Home Assistant because they
+are not returned by the Todoist REST API. Marking a To-do item as completed is
+effectively delete it from Home Assistant, though completed tasks are visible in
+the Todoist UI.
 
 ## Calendar Entity attributes
 
@@ -188,5 +193,3 @@ Here are two example JSON payloads resulting in the same task:
   Valid languages are: `en`, `da`, `pl`, `zh`, `ko`, `de`, `pt`, `ja`, `it`, `fr`, `sv`, `ru`, `es`, `nl`
 
 - **reminder_date** (*Optional*): When should user be reminded of this task, in either YYYY-MM-DD format or YYYY-MM-DD HH:MM format (in UTC timezone). Mutually exclusive with `reminder_date_string`.
-
-Note that there's (currently) no way to mark tasks as done through Home Assistant; task names do not necessarily have to be unique, so you could find yourself in a situation where you close the wrong task.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the Todoist To-do List feature.

The existing calendar platform configuration yaml has been de-emphasized, given it does not support the todo platform.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/102633
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
