### PR TITLE
Add additional information about Shelly.click events

### DIFF
--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -125,6 +125,7 @@ For generation 2 hardware it's possible to select if a device's input is connect
 ## Event entities (generation 1)
 
 If the **BUTTON TYPE** of the switch connected to the device is set to `momentary` or `detached switch`, the integration creates an event entity for this switch. You can use this entity in your automations.
+(Important to note: for relay devices, this is not the same as the binary sensor - it doesn't track the state of a relay, it only fires events when an detached switch is turned from `off` to `on`, and doesn't fire when a detached switch is turned from `on` to `off`)
 
 ## Event entities (generation 2)
 
@@ -135,6 +136,9 @@ If the **Input Mode** of the switch connected to the device is set to `Button`, 
 If the **BUTTON TYPE** of the switch connected to the device is set to `momentary` or `detached switch`, integration fires events under the type `shelly.click` when the switch is used. You can use these events in your automations.
 
 Also, some devices do not add an entity for the button/switch. For example, the Shelly Button1 has only one entity for the battery level. It does not have an entity for the button itself. To trigger automations based on button presses, use the `shelly.click` event.
+
+In addition to this, for Shelly relays, if you configure the switch as `detached`, then `shelly.click` event will only be fired when the switch is turned from `off` to `on` and won't be fired when turned from `on` to `off`.
+In these instances, it's best to use the `binary_sensor` state of the `input` in your automations. (for more details, see: [shelly1-configured-as-detached-edge-switch](https://community.home-assistant.io/t/shelly1-configured-as-detached-edge-switch)
 
 ### Listening for events
 

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -125,7 +125,7 @@ For generation 2 hardware it's possible to select if a device's input is connect
 ## Event entities (generation 1)
 
 If the **BUTTON TYPE** of the switch connected to the device is set to `momentary` or `detached switch`, the integration creates an event entity for this switch. You can use this entity in your automations.
-(Important to note: for relay devices, this is not the same as the binary sensor - it doesn't track the state of a relay, it only fires events when an detached switch is turned from `off` to `on`, and doesn't fire when a detached switch is turned from `on` to `off`)
+(Important to note: for relay devices, this is not the same as the binary sensor - it doesn't track the state of a relay, it only fires events when a detached switch is turned from `off` to `on`, and doesn't fire when a detached switch is turned from `on` to `off`)
 
 ## Event entities (generation 2)
 


### PR DESCRIPTION
## Proposed change

Several users have been caught out by `shelly.click` events not working as they expect for relay devices like Shelly 1/1pm/2.5 etc - the integration does not fire an event when a switch attached to the relay in `detached` mode is turned from `on` to `off`, as explained in this forum post [here](https://community.home-assistant.io/t/shelly1-configured-as-detached-edge-switch/322213)

## Type of change

Adds additional context for Shelly relay devices, with a link to the forum article, to help other users that might assume that using the `shelly.click` event would work for them as they expect.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Isssue in core: https://github.com/home-assistant/core/issues/102583

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
