### PR TITLE
Yellow: add info that PoE variant needs PoE capable network HW

### DIFF
--- a/source/yellow/index.html
+++ b/source/yellow/index.html
@@ -183,18 +183,18 @@ frontpage_image: /images/frontpage/yellow-frontpage.jpg
     <div><img src="/images/yellow/yellow-kit-poe-2d.jpg" alt="2D overview of the content of the Home Assistant Yellow Kit Power-over-Ethernet variant"></div>
     <div>
       <b>Yellow Kit with Power-over-Ethernet</b><br>
-      <a href="https://yellow.home-assistant.io/poe/">Some assembly required!</a> This kit supports Power-over-Ethernet (PoE) but is otherwise almost the same as the flagship version. <b>Without the Raspberry Pi Compute Module 4</b>.
+      <a href="https://yellow.home-assistant.io/poe/">Some assembly required!</a> This kit supports Power-over-Ethernet (PoE) but is otherwise almost the same as the flagship version. Custom enclosure, custom heat sink, and Ethernet cable included. <b>Without the Raspberry Pi Compute Module 4</b>.
       <br><br>
-      You must provide your own Raspberry Pi Compute Module 4 and install Home Assistant on it. This allows you to pick the compute module with the memory and eMMC storage to fit your needs. Custom enclosure, custom heat sink, and Ethernet cable included. This kit does not include a power supply (because power comes from PoE).
+      <b>Not included</b>: You must provide your own Raspberry Pi Compute Module 4 and install Home Assistant on it. This allows you to pick the compute module with the memory and eMMC storage to fit your needs. This kit also does not include a power supply (because power comes from PoE). The router or switch must supply Power-over-Ethernet. Typically, PoE capable ports are labelled as such.
     </div>
   </div>
   <div class="yellow-variant">
     <div><img src="/images/yellow/yellow-kit-2d.jpg" alt="2D overview of the content of the Home Assistant Yellow Kit"></div>
     <div>
       <b>Yellow Kit with power supply</b><br>
-      <a href="https://yellow.home-assistant.io/power-supply/">Some assembly required!</a> This kit is almost the same as the flagship version. <b> Without the Raspberry Pi Compute Module 4</b>.
+      <a href="https://yellow.home-assistant.io/power-supply/">Some assembly required!</a> This kit is almost the same as the flagship version. Custom enclosure, custom heat sink, and Ethernet cable included.<b> Without the Raspberry Pi Compute Module 4</b>.
       <br><br>
-      You must provide your own Raspberry Pi Compute Module 4 and install Home Assistant on it. This allows you to pick the compute module with the memory and eMMC storage to fit your needs. Custom enclosure, custom heat sink, and Ethernet cable included. This kit comes with a power supply, but does not support Power-over-Ethernet.
+      <b>Not included</b>: You must provide your own Raspberry Pi Compute Module 4 and install Home Assistant on it. This allows you to pick the compute module with the memory and eMMC storage to fit your needs. This kit comes with a power supply, but does not support Power-over-Ethernet.
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Yellow: add info that PoE variant needs PoE capable network HW
- minor content edits

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
