### PR TITLE
Document new configuration options for air-Q integration

### DIFF
--- a/source/_integrations/airq.markdown
+++ b/source/_integrations/airq.markdown
@@ -21,7 +21,7 @@ This integration allows integrating the sensors, provided by your [air-Q](https:
 
 {% include integrations/config_flow.md %}
 
-During the configuration, the user is prompted for the IP address of the device or the first 5 characters of the serial number, as well as the device password.
+During the initial configuration, the user is prompted for the IP address of the device or the first 5 characters of the serial number, as well as the device password.
 
 For this integration to communicate with the device, both must be connected to the same Wi-Fi network.
 
@@ -86,3 +86,13 @@ PM1, PM25, and PM10 correspond to concentrations of particulates with diameter l
 Virus Index uses CO2 as a proxy for potential aerosol load and can be seen as an indicator of ventilation sufficiency (0 %: insufficient ventilation, 100 %: all fine).
 
 Virtual sensors "Relative Pressure" and "Virus Index" are introduced in firmware v1.80.0 but deactivated by default. You can activate them in the air-Q mobile application under "Advanced settings".
+
+## Additional configuration
+
+After the integration is initialised, the user can configure any of the following three parameter:
+
+- **Polling interval in seconds**. Default: 10 seconds. Can be specified as a number greater than 1. The frequency of data generation by the device itself varies depending on the number of sensors included in the device (the more sensors, the more time the air-Q requires to produce the next batch of readings), but typically remains above 1–2 seconds. Furthermore, frequent polling of the device can have a negative impact on the performance of the smartphone app.
+
+- **Show values averaged by the device**. Default: on. In its default configuration, air-Q averages the stream of sensor values, and the strength of this averaging can be configured on the device side (not exposed through the HA). However, this integration allows to switch between polling the averaged the raw data from the device. To poll noisy sensor readings from the device, switch this feature off
+
+- **Clip negative values**. Default: on. For baseline calibration purposes, certain sensor values may briefly become negative. The default behavior is to clip such values to 0.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document new options proposed in a PR for the air-Q integration.
Namely, the following configurations are exposed
1. The polling interval can be specified freely (previously hard coded at 10s)
2. A choice between fetching the averaged (old behavior) vs. noisy sensor reading from the device
3. A toggle to clip (spuriously) negative sensor values (new and now default functionality)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/102802
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
