### PR TITLE
Document flume.list_notifications

### DIFF
--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -58,8 +58,8 @@ action:
   - if:
       - condition: template
         value_template: >-
-          "{{ (notifications.notifications | selectattr('type', 'equalto', 1)  | 
-          sort(attribute == 'created_datetime', reverse == true) | length  > 0) }}"
+          "{{ notifications.notifications | selectattr('type', 'equalto', 1) | 
+          sort(attribute == 'created_datetime', reverse == true) | length  > 0 }}"
     then:
       - service: notify.all
         data:
@@ -74,6 +74,7 @@ action:
             sort(attribute == 'created_datetime', reverse=true) | first %}
             {{ usage_alert.title }}"
 mode: single
+```
 
 { % endraw %}
 

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -49,7 +49,6 @@ alias: "Notify: flume"
 trigger:
   - platform: time_pattern
     minutes: /5
-condition: []
 action:
   - service: flume.list_notifications
     data:
@@ -73,7 +72,6 @@ action:
             selectattr('type', 'equalto', 1) |
             sort(attribute == 'created_datetime', reverse=true) | first %}
             {{ usage_alert.title }}
-mode: single
 ```
 
 {% endraw %}

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -56,20 +56,20 @@ action:
   - if:
       - condition: template
         value_template: >-
-          "{{ notifications.notifications | selectattr("type", "equalto", 1) |
-          sort(attribute="created_datetime", reverse=true) | length  > 0 }}"
+          "{{ notifications.notifications | selectattr('type', 'equalto', 1) |
+          sort(attribute='created_datetime', reverse=true) | length  > 0 }}"
     then:
       - service: notify.all
         data:
           message: >-
             "{%- set usage_alert = notifications.notifications |
-            selectattr("type", "equalto", 1) |
-            sort(attribute="created_datetime", reverse=true) | first %}
+            selectattr('type', 'equalto', 1) |
+            sort(attribute='created_datetime', reverse=true) | first %}
             {{ usage_alert.message }}"
           title: >-
             "{%- set usage_alert = notifications.notifications |
-            selectattr("type", "equalto", 1) |
-            sort(attribute="created_datetime", reverse=true) | first %}
+            selectattr('type', 'equalto', 1) |
+            sort(attribute='created_datetime', reverse=true) | first %}
             {{ usage_alert.title }}"
 mode: single
 ```

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -42,7 +42,7 @@ To clear the notifications, you will need to use your Flume app or go to: [https
 
 Example of an automation that sends a Home Assistant notification of the most recent usage alert:
 
-{ % raw %}
+{% raw %}
 
 ```yaml
 alias: "Notify: flume"
@@ -58,25 +58,25 @@ action:
   - if:
       - condition: template
         value_template: >-
-          "{{ notifications.notifications | selectattr('type', 'equalto', 1) | 
-          sort(attribute == 'created_datetime', reverse == true) | length  > 0 }}"
+          {{ notifications.notifications | selectattr('type', 'equalto', 1) | 
+          sort(attribute == ('created_datetime', reverse == true) | length > 0 }}
     then:
       - service: notify.all
         data:
           message: >-
-            "{%- set usage_alert == notifications.notifications |
+            {%- set usage_alert == notifications.notifications |
             selectattr('type', 'equalto', 1) |
             sort(attribute == 'created_datetime', reverse == true) | first %}
-            {{ usage_alert.message }}"
+            {{ usage_alert.message }}
           title: >-
-            "{%- set usage_alert == notifications.notifications |
+            {%- set usage_alert == notifications.notifications |
             selectattr('type', 'equalto', 1) |
             sort(attribute == 'created_datetime', reverse=true) | first %}
-            {{ usage_alert.title }}"
+            {{ usage_alert.title }}
 mode: single
 ```
 
-{ % endraw %}
+{% endraw %}
 
 ## Configuration for Binary Sensor
 

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -57,19 +57,19 @@ action:
       - condition: template
         value_template: >-
           "{{ notifications.notifications | selectattr('type', 'equalto', 1) |
-          sort(attribute='created_datetime', reverse=true) | length  > 0 }}"
+          sort(attribute == 'created_datetime', reverse == true) | length  > 0 }}"
     then:
       - service: notify.all
         data:
           message: >-
-            "{%- set usage_alert = notifications.notifications |
+            "{%- set usage_alert == notifications.notifications |
             selectattr('type', 'equalto', 1) |
             sort(attribute='created_datetime', reverse=true) | first %}
             {{ usage_alert.message }}"
           title: >-
-            "{%- set usage_alert = notifications.notifications |
+            "{%- set usage_alert == notifications.notifications |
             selectattr('type', 'equalto', 1) |
-            sort(attribute='created_datetime', reverse=true) | first %}
+            sort(attribute == 'created_datetime', reverse=true) | first %}
             {{ usage_alert.title }}"
 mode: single
 ```

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -56,8 +56,8 @@ action:
   - if:
       - condition: template
         value_template: >-
-          "{{ notifications.notifications | selectattr('type', 'equalto', 1) |
-          sort(attribute == 'created_datetime', reverse == true) | length  > 0 }}"
+          "{{ (notifications.notifications | selectattr('type', 'equalto', 1)  | 
+          sort(attribute == 'created_datetime', reverse == true) | length  > 0) }}"
     then:
       - service: notify.all
         data:

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -42,6 +42,8 @@ To clear the notifications, you will need to use your Flume app or go to: [https
 
 Example of an automation that sends a Home Assistant notification of the most recent usage alert:
 
+{ % raw %}
+
 ```yaml
 alias: "Notify: flume"
 trigger:
@@ -72,7 +74,8 @@ action:
             sort(attribute == 'created_datetime', reverse=true) | first %}
             {{ usage_alert.title }}"
 mode: single
-```
+
+{ % endraw %}
 
 ## Configuration for Binary Sensor
 

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -56,8 +56,8 @@ action:
   - if:
       - condition: template
         value_template: >-
-          {{ notifications.notifications | selectattr("type", "equalto", 1) |
-          sort(attribute="created_datetime", reverse=true) | length  > 0 }}
+          "{{ notifications.notifications | selectattr("type", "equalto", 1) |
+          sort(attribute="created_datetime", reverse=true) | length  > 0 }}"
     then:
       - service: notify.all
         data:

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -64,7 +64,7 @@ action:
           message: >-
             "{%- set usage_alert == notifications.notifications |
             selectattr('type', 'equalto', 1) |
-            sort(attribute='created_datetime', reverse=true) | first %}
+            sort(attribute == 'created_datetime', reverse == true) | first %}
             {{ usage_alert.message }}"
           title: >-
             "{%- set usage_alert == notifications.notifications |

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -62,15 +62,15 @@ action:
       - service: notify.all
         data:
           message: >-
-            {%- set usage_alert = notifications.notifications |
+            "{%- set usage_alert = notifications.notifications |
             selectattr("type", "equalto", 1) |
             sort(attribute="created_datetime", reverse=true) | first %}
-            {{ usage_alert.message }}
+            {{ usage_alert.message }}"
           title: >-
-            {%- set usage_alert = notifications.notifications |
+            "{%- set usage_alert = notifications.notifications |
             selectattr("type", "equalto", 1) |
             sort(attribute="created_datetime", reverse=true) | first %}
-            {{ usage_alert.title }}
+            {{ usage_alert.title }}"
 mode: single
 ```
 

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -31,9 +31,7 @@ To add `Flume` to your installation, go to **Settings** -> **Devices & Services*
 
 ## Notifications
 
-Flume notifications are available via the service `flume.list_notifications`.
-
-The following notifications are available via binary sensors:
+Flume notifications are fetched every 5 minutes and are available via the service `flume.list_notifications`. Some notifications are available via the following binary sensors:
 
 - Bridge disconnected
 - High flow
@@ -53,7 +51,7 @@ condition: []
 action:
   - service: flume.list_notifications
     data:
-      config_entry: <flume config entry>
+      config_entry: 1234 # replace this with your config entry id
     response_variable: notifications
   - if:
       - condition: template


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document `flume.list_notifications` and add an automation example that uses it.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/100621
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
