### PR TITLE
Add button platform to Roborock

### DIFF
--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -3,13 +3,13 @@ title: Roborock
 description: Instructions on how to integrate Roborock vacuums into Home Assistant
 ha_category:
   - Binary Sensor
+  - Button
   - Number
   - Select
   - Sensor
   - Switch
   - Time
   - Vacuum
-  - Button
 ha_iot_class: Local Polling
 ha_release: 2023.5
 ha_config_flow: true
@@ -19,6 +19,7 @@ ha_codeowners:
 ha_domain: roborock
 ha_platforms:
   - binary_sensor
+  - button
   - diagnostics
   - number
   - select
@@ -26,7 +27,6 @@ ha_platforms:
   - switch
   - time
   - vacuum
-  - button
 ha_integration_type: integration
 ---
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -124,7 +124,7 @@ Reset side brush consumable - The side brush is expected to be replaced every 20
 
 Reset main brush consumable - The main brush/ roller is expected to be replaced every 300 hours.
 
-Reset air filter - The Air filter is expected to be replaced every 150 hours.
+Reset air filter - The air filter is expected to be replaced every 150 hours.
 
 
 ## FAQ

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -9,6 +9,7 @@ ha_category:
   - Switch
   - Time
   - Vacuum
+  - Button
 ha_iot_class: Local Polling
 ha_release: 2023.5
 ha_config_flow: true
@@ -25,6 +26,7 @@ ha_platforms:
   - switch
   - time
   - vacuum
+  - button
 ha_integration_type: integration
 ---
 
@@ -111,6 +113,18 @@ Do not disturb - This enables _Do not disturb_ during the time frame you have se
 ### Number
 
 Volume - This allows you to control the volume of the robot's voice. For example, when it states "Starting cleaning". This allows you to set the volume to 0%, while the app limits it to 20%.
+
+### Button
+
+There are currently four buttons that allow you to reset the various maintenance items on your vacuum. This cannot be undone after pressing - so they are disabled by default to make sure you know what you are doing before you click on them.
+
+Reset sensor consumable - The sensors on your vacuum are intended to be cleaned after 30 hours of use
+
+Reset side brush consumable - The side brush is expected to be replaced every 200 hours.
+
+Reset main brush consumable - the Main brush/ roller is expected ot be replaced every 300 hours.
+
+Reset air filter - the Air filter is expected to be replaced every 150 hours.
 
 
 ## FAQ

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -116,7 +116,7 @@ Volume - This allows you to control the volume of the robot's voice. For example
 
 ### Button
 
-There are currently four buttons that allow you to reset the various maintenance items on your vacuum. Pressing the button cannot be undone. For this reason,  they are disabled by default to make sure they are not pressed unintentionally.
+There are currently four buttons that allow you to reset the various maintenance items on your vacuum. Pressing the button cannot be undone. For this reason, the buttons are disabled by default to make sure they are not pressed unintentionally.
 
 Reset sensor consumable - The sensors on your vacuum are expected to be cleaned after 30 hours of use.
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -116,15 +116,15 @@ Volume - This allows you to control the volume of the robot's voice. For example
 
 ### Button
 
-There are currently four buttons that allow you to reset the various maintenance items on your vacuum. This cannot be undone after pressing - so they are disabled by default to make sure you know what you are doing before you click on them.
+There are currently four buttons that allow you to reset the various maintenance items on your vacuum. Pressing the button cannot be undone. For this reason,  they are disabled by default to make sure they are not pressed unintentionally.
 
-Reset sensor consumable - The sensors on your vacuum are intended to be cleaned after 30 hours of use
+Reset sensor consumable - The sensors on your vacuum are expected to be cleaned after 30 hours of use.
 
 Reset side brush consumable - The side brush is expected to be replaced every 200 hours.
 
-Reset main brush consumable - the Main brush/ roller is expected ot be replaced every 300 hours.
+Reset main brush consumable - The main brush/ roller is expected to be replaced every 300 hours.
 
-Reset air filter - the Air filter is expected to be replaced every 150 hours.
+Reset air filter - The Air filter is expected to be replaced every 150 hours.
 
 
 ## FAQ


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
adds 4 new buttons that can reset the consumables/ maintenance items.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/103010
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
