### PR TITLE
Update documentation to reflect "Add torrent status metadata to qBittorrent integration"

### DIFF
--- a/source/_integrations/qbittorrent.markdown
+++ b/source/_integrations/qbittorrent.markdown
@@ -29,3 +29,17 @@ The qBittorrent integration will add the following sensors:
 - `sensor.qbittorrent_status`: The status of qBittorrent - `up_down`, `seeding`, `downloading` or `idle`.
 - `sensor.qbittorrent_up_speed`: The current total upload speed in kB/s.
 - `sensor.qbittorrent_down_speed`: The current total download speed in kB/s.
+
+When "Create sensors for torrent statuses" is enabled under Integrations > qBittorrent > Configure, the following additional sensors will be added:
+
+- `sensor.qbittorrent_torrents`: The total number of torrents in qBittorrent.
+- `sensor.qbittorrent_torrents_downloading`: The number of downloading torrents.
+- `sensor.qbittorrent_torrents_uploading`: The number of uploading (seeding) torrents.
+- `sensor.qbittorrent_torrents_stalled`: The number of torrents which have stalled to download.
+- `sensor.qbittorrent_torrents_stopped`: The number of torrents which were stopped from downloading or uploading by the user.
+- `sensor.qbittorrent_torrents_completed`: The number of torrents which have been downloaded and met their required upload threshold.
+- `sensor.qbittorrent_torrents_queued`: The number of torrents which are in the download queue.
+- `sensor.qbittorrent_torrents_checking`: The number of torrents which are being checked.
+- `sensor.qbittorrent_torrents_error`: The number of torrents which experienced errors during download.
+
+On each sensor, a state attribute `torrent_names` will contain an array of the affected torrent names.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/103042
- Link to parent pull request in the Brands repository:  n/a
- This PR fixes or closes issue: n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - **I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.**
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
