### PR TITLE
Fix dead link in ToC

### DIFF
--- a/source/_posts/2023-11-01-release-202311.markdown
+++ b/source/_posts/2023-11-01-release-202311.markdown
@@ -54,7 +54,7 @@ Enjoy the (beta) release!
 
 - [There is a lot todo!](#there-is-a-lot-todo)
 - [Shopping lists are now TODOs too!](#shopping-lists-are-now-todos-too)
-- [Integrations providings your todos](#integrations-providings-your-todos)
+- [Integrations providing your todos](#integrations-providing-your-todos)
 - [Custom state content for Tile cards](#custom-state-content-for-tile-cards)
 - [Matter 1.2 is here!](#matter-12-is-here)
 - [Custom date ranges in the energy dashboard!](#custom-date-ranges-in-the-energy-dashboard)


### PR DESCRIPTION
## Proposed change

Fixed a dead link in the ToC for 2023.11. This was caused by one of my previous PRs changing the heading, but I forgot to change the link.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
