### PR TITLE
Add documentation for todo.get_items service

### DIFF
--- a/source/_integrations/todo.markdown
+++ b/source/_integrations/todo.markdown
@@ -37,13 +37,13 @@ services provided by some To-do List entities are described below or you can rea
 
 ### Service `todo.list_items`
 
-Get To-do items from a To-do list. A To-do list `target` is selected with a [Target Selector](/docs/blueprint/selectors/#target-selector) and the `data` payload supports the following fields:
+Get to-do items from a to-do list. A to-do list `target` is selected with a [target selector](/docs/blueprint/selectors/#target-selector). The `data` payload supports the following fields:
 
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
-| `status` | yes | Only return To-do items with this status. |  `needs_action`, `completed`
+| `status` | yes | Only return to-do items with this status. |  `needs_action`, `completed`
 
-This is a full example that returns all To-do items with any status:
+This is a full example that returns all to-do items with any status:
 
 ```yaml
 service: todo.list_items

--- a/source/_integrations/todo.markdown
+++ b/source/_integrations/todo.markdown
@@ -34,6 +34,27 @@ incomplete items in the list.
 Some To-do List integrations allow Home Assistant to manage the To-do Items in the list. The
 services provided by some To-do List entities are described below or you can read more about [Service Calls](/docs/scripts/service-calls/).
 
+
+### Service `todo.list_items`
+
+Get To-do items from a To-do list. A To-do list `target` is selected with a [Target Selector](/docs/blueprint/selectors/#target-selector) and the `data` payload supports the following fields:
+
+| Service data attribute | Optional | Description | Example |
+| ---------------------- | -------- | ----------- | --------|
+| `status` | yes | Only return To-do items with this status. |  `needs_action`, `completed`
+
+This is a full example that returns all To-do items with any status:
+
+```yaml
+service: todo.list_items
+target:
+  entity_id: todo.personal_tasks
+data:
+  status:
+    - needs_action
+    - completed
+```
+
 ### Service `todo.add_item`
 
 Add a new To-do Item. A To-do list `target` is selected with a [Target Selector](/docs/blueprint/selectors/#target-selector) and the `data` payload supports the following fields:

--- a/source/_integrations/todo.markdown
+++ b/source/_integrations/todo.markdown
@@ -35,7 +35,7 @@ Some To-do List integrations allow Home Assistant to manage the To-do Items in t
 services provided by some To-do List entities are described below or you can read more about [Service Calls](/docs/scripts/service-calls/).
 
 
-### Service `todo.list_items`
+### Service `todo.get_items`
 
 Get to-do items from a to-do list. A to-do list `target` is selected with a [target selector](/docs/blueprint/selectors/#target-selector). The `data` payload supports the following fields:
 
@@ -43,16 +43,15 @@ Get to-do items from a to-do list. A to-do list `target` is selected with a [tar
 | ---------------------- | -------- | ----------- | --------|
 | `status` | yes | Only return to-do items with this status. |  `needs_action`, `completed`
 
-This is a full example that returns all to-do items with any status:
+This is a full example that returns all to-do items that have not been completed:
 
 ```yaml
-service: todo.list_items
+service: todo.get_items
 target:
   entity_id: todo.personal_tasks
 data:
   status:
     - needs_action
-    - completed
 ```
 
 ### Service `todo.add_item`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for todo.list_items service.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/103285
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
