### PR TITLE
Improve Oral-B documentation

### DIFF
--- a/source/_integrations/oralb.markdown
+++ b/source/_integrations/oralb.markdown
@@ -48,3 +48,7 @@ The integration can discover most Bluetooth-enabled Oral-B toothbrushes. Brushes
 - Time - total brushing time in seconds.
 - Toothbrush state - whether the toothbrush is running, idle.
 - Battery - toothbrush battery percentage.
+
+<div class='note'>
+Updates of the battery sensor require an active bluetooth connection and relatively close proximity. If you are using a [bluetooth proxy](https://www.home-assistant.io/integrations/bluetooth/#remote-adapters-bluetooth-proxies), please ensure it supports active connections. All other sensors (i.e., all sensors except the battery sensor) will update with active or passive connections. 
+</div>

--- a/source/_integrations/oralb.markdown
+++ b/source/_integrations/oralb.markdown
@@ -50,5 +50,5 @@ The integration can discover most Bluetooth-enabled Oral-B toothbrushes. Brushes
 - Battery - toothbrush battery percentage.
 
 <div class='note'>
-Updates of the battery sensor require an active bluetooth connection and relatively close proximity. If you are using a [bluetooth proxy](https://www.home-assistant.io/integrations/bluetooth/#remote-adapters-bluetooth-proxies), please ensure it supports active connections. All other sensors (i.e., all sensors except the battery sensor) will update with active or passive connections. 
+Updates of the battery sensor require an active Bluetooth connection and relatively close proximity. If you use a [bluetooth proxy](https://www.home-assistant.io/integrations/bluetooth/#remote-adapters-bluetooth-proxies), please ensure it supports active connections. All the other sensors update with active or passive connections. 
 </div>


### PR DESCRIPTION
## Proposed change
Add a note about the fact that one of the sensors (and only one of them) requires an active bluetooth connection and close proximity. This is a frequent source of confusion for users, as seen in https://github.com/home-assistant/core/issues/90711


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
