### PR TITLE
Draw attention to and clarify adding a slack bot to a channel

### DIFF
--- a/source/_integrations/slack.markdown
+++ b/source/_integrations/slack.markdown
@@ -43,10 +43,11 @@ In `Features/OAuth and Permissions/OAuth Tokens for Your Workspace`:
 
 ![](/images/integrations/slack/oauth-tokens-for-workspace.png)
 
+6. Ensure that the bot user is added to the channel in which you want it to post. This can be completed in several ways:
 
-Ensure that the bot user is added to the channel in which you want it to post. 
-In Slack, tag the bot user in a message, then add it to the channel. 
-
+- Using `/invite @bot` from the channel
+- Tagging the bot user in a message, then adding it to the channel via the Slackbot prompt.
+- Channel settings -> `Integrations` -> `Add apps`
 
 #### Sample App Manifest
 


### PR DESCRIPTION
## Proposed change

Sending messages to some channels will fail if the configured Slack bot is not in the target channel. The current instructions do mention this but it can be missed since it isn't listed as a step. This update moves that information to a numbered step and adds a touch more detail to the invite process for those that haven't used a Slack app before.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #29368

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
