### PR TITLE
Removed already illegal int8 from doc

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -570,8 +570,6 @@ climates:
           description: "64 bit signed float (4 register holds 1 value)."
         int:
           description: "**DEPRECATED** is silently converted to `int16`"
-        int8:
-          description: "8 bit signed integer (1 register holds 1 value in lower byte)."
         int16:
           description: "16 bit signed integer (1 register holds 1 value)."
         int32:
@@ -582,8 +580,6 @@ climates:
           description: "set of 8 bit characters, `count:` must be configured."
         uint:
           description: "**DEPRECATED** is silently converted to `uint16`"
-        uint8:
-          description: "8 bit unsigned integer (1 register holds 1 value in lower byte)."
         uint16:
           description: "16 bit unsigned integer (1 register holds 1 value)."
         uint32:
@@ -699,9 +695,9 @@ climates:
         byte:
           description: "Swap bytes AB -> BA."
         word:
-          description: "Swap word ABCD -> CDAB, **not valid with data types: `int8`, `uint8`, `int16`, `uint16`**"
+          description: "Swap word ABCD -> CDAB, **not valid with data types: `int16`, `uint16`**"
         word_byte:
-          description: "Swap word ABCD -> DCBA, **not valid with data types: `int8`, `uint8`, `int16`, `uint16`**"
+          description: "Swap word ABCD -> DCBA, **not valid with data types: `int16`, `uint16`**"
     target_temp_register:
       description: "Register address for target temperature (Setpoint)."
       required: true
@@ -1203,8 +1199,6 @@ sensors:
           description: "64 bit signed float (4 register holds 1 value)."
         int:
           description: "**DEPRECATED** is silently converted to `int16`"
-        int8:
-          description: "8 bit signed integer (1 register holds 1 value in lower byte)."
         int16:
           description: "16 bit signed integer (1 register holds 1 value)."
         int32:
@@ -1215,8 +1209,6 @@ sensors:
           description: "set of 8 bit characters, `count:` must be configured."
         uint:
           description: "**DEPRECATED** is silently converted to `uint16`"
-        uint8:
-          description: "8 bit unsigned integer (1 register holds 1 value in lower byte)."
         uint16:
           description: "16 bit unsigned integer (1 register holds 1 value)."
         uint32:
@@ -1307,9 +1299,9 @@ sensors:
         byte:
           description: "Swap bytes AB -> BA."
         word:
-          description: "Swap word ABCD -> CDAB, **not valid with data types: `int8`, `uint8`, `int16`, `uint16`**"
+          description: "Swap word ABCD -> CDAB, **not valid with data types: `int16`, `uint16`**"
         word_byte:
-          description: "Swap word ABCD -> DCBA, **not valid with data types: `int8`, `uint8`, `int16`, `uint16`**"
+          description: "Swap word ABCD -> DCBA, **not valid with data types: `int16`, `uint16`**"
     unit_of_measurement:
       description: "Unit to attach to value."
       required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
int8 and uint8 have always been illegal (and caused a configuration error), remove them from the documentation.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
https://github.com/home-assistant/core/pull/103489
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [z] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [z] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
