### PR TITLE
Add 7590 AX and DECT 302 to tested devices for Fritz! Smart Home

### DIFF
--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -48,11 +48,13 @@ Additionally, we also support to trigger smarthome templates.
 - FRITZ!Box 6490 Cable
 - [FRITZ!Box 6591 Cable](https://en.avm.de/products/fritzbox/fritzbox-6591-cable/)
 - [FRITZ!Box 7590](https://en.avm.de/products/fritzbox/fritzbox-7590/)
+- [FRITZ!Box 7590 AX](https://en.avm.de/products/fritzbox/fritzbox-7590-ax/)
 - FRITZ!Box 7490
 - FRITZ!Box 7430
 - [FRITZ!DECT 200](https://en.avm.de/products/fritzdect/fritzdect-200/)
 - [FRITZ!DECT 210](https://en.avm.de/products/fritzdect/fritzdect-210/)
 - [FRITZ!DECT 301](https://en.avm.de/products/fritzdect/fritzdect-301/)
+- [FRITZ!DECT 302](https://en.avm.de/products/fritzdect/fritzdect-302/)
 - [FRITZ!DECT 500](https://en.avm.de/products/fritzdect/fritzdect-500/)
 - [Eurotronic Comet DECT](https://eurotronic.org/produkte/dect-ule-heizkoerperthermostat/comet-dect/)
 - [Magenta SmartHome LED E27 Color](https://www.smarthome.de/geraete/smarthome-led-lampe-e27-farbig-weiss)


### PR DESCRIPTION
## Proposed change
I tested the two devices on my own setup with the latest versions of everything (Fritz!OS, Device Firmware, Home Assistant + Integrations).


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Previously discussed in #29643

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
