### PR TITLE
Update cover.template.markdown

### DIFF
--- a/source/_integrations/cover.template.markdown
+++ b/source/_integrations/cover.template.markdown
@@ -91,11 +91,11 @@ cover:
         required: false
         type: action
       set_cover_position:
-        description: Defines an action to set to a cover position (between `0` and `100`).
+        description: Defines an action to set to a cover position (between `0` and `100`). The variable `position` will contain the entity's set position.
         required: false
         type: action
       set_cover_tilt_position:
-        description: Defines an action to set the tilt of a cover (between `0` and `100`).
+        description: Defines an action to set the tilt of a cover (between `0` and `100`). The variable `tilt` will contain the entity's set tilt position.
         required: false
         type: action
       optimistic:


### PR DESCRIPTION
## Proposed change
Add explicit mentions of the `position` and `tilt` variables, not just in the examples. This creates parity with other pages such as the `set_value` action for the [number template](https://www.home-assistant.io/integrations/template/#number). 
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
