### PR TITLE
Clarify duration/end_date_time usage

### DIFF
--- a/source/_integrations/calendar.markdown
+++ b/source/_integrations/calendar.markdown
@@ -201,7 +201,7 @@ with calendar events within a date range.
 | ---------------------- | -------- | ----------- | --------|
 | `start_date_time` | yes | Return active events after this time (exclusive). When not set, defaults to now. | 2019-03-10 20:00:00
 | `end_date_time` | yes | Return active events before this time (exclusive). Cannot be used with 'duration'. | 2019-03-10 23:00:00
-| `duration` | yes | Return active events from start_date_time until the specified duration. | `days: 2`
+| `duration` | yes | Return active events from start_date_time until the specified duration. Cannot be used with 'end_date_time'. | `days: 2`
 
 <div class='note'>
 

--- a/source/_integrations/calendar.markdown
+++ b/source/_integrations/calendar.markdown
@@ -201,7 +201,7 @@ with calendar events within a date range.
 | ---------------------- | -------- | ----------- | --------|
 | `start_date_time` | yes | Return active events after this time (exclusive). When not set, defaults to now. | 2019-03-10 20:00:00
 | `end_date_time` | yes | Return active events before this time (exclusive). Cannot be used with `duration`. You must specify either `end_date_time` or `duration`.| 2019-03-10 23:00:00
-| `duration` | yes | Return active events from start_date_time until the specified duration. Cannot be used with `end_date_time`. You must specify either `duration` or `end_date_time`. | `days: 2`
+| `duration` | yes | Return active events from `start_date_time` until the specified duration. Cannot be used with `end_date_time`. You must specify either `duration` or `end_date_time`. | `days: 2`
 
 <div class='note'>
 

--- a/source/_integrations/calendar.markdown
+++ b/source/_integrations/calendar.markdown
@@ -200,8 +200,8 @@ with calendar events within a date range.
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
 | `start_date_time` | yes | Return active events after this time (exclusive). When not set, defaults to now. | 2019-03-10 20:00:00
-| `end_date_time` | yes | Return active events before this time (exclusive). Cannot be used with 'duration'. | 2019-03-10 23:00:00
-| `duration` | yes | Return active events from start_date_time until the specified duration. Cannot be used with 'end_date_time'. | `days: 2`
+| `end_date_time` | yes | Return active events before this time (exclusive). Cannot be used with `duration`. You must specify either `end_date_time` or `duration`.| 2019-03-10 23:00:00
+| `duration` | yes | Return active events from start_date_time until the specified duration. Cannot be used with `end_date_time`. You must specify either `duration` or `end_date_time`. | `days: 2`
 
 <div class='note'>
 


### PR DESCRIPTION
## Proposed change

Add a note to `duration` that it's mutually exclusive with `end_date_time`. (the latter of which already had this note)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #29787

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
