### PR TITLE
Fix Google Calendar links needed by the comon config templates

### DIFF
--- a/source/_integrations/google.markdown
+++ b/source/_integrations/google.markdown
@@ -13,7 +13,7 @@ ha_platforms:
 ha_codeowners:
   - '@allenporter'
 ha_integration_type: integration
-google_dev_console_link: https://console.cloud.google.com/apis/library/calendar-json.googleapis.com
+google_dev_console_link: https://console.developers.google.com/apis/credentials
 api: Google Calendar API
 api_link: https://console.cloud.google.com/apis/library/calendar-json.googleapis.com
 ---

--- a/source/_integrations/google.markdown
+++ b/source/_integrations/google.markdown
@@ -13,6 +13,9 @@ ha_platforms:
 ha_codeowners:
   - '@allenporter'
 ha_integration_type: integration
+google_dev_console_link: https://console.cloud.google.com/apis/library/calendar-json.googleapis.com
+api: Google Calendar API
+api_link: https://console.cloud.google.com/apis/library/calendar-json.googleapis.com
 ---
 
 The *Google Calendar* integration allows you to connect your [Google Calendar](https://calendar.google.com) to Home Assistant. The integration adds calendar entities that are shown on the *Calendar* dashboard, and can be used for automations based on any event, or limited to specific matching criteria.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Fix Google Calendar links needed by the comon config templates that I mistakenly forgot to test in #29792

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/103570
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
