### PR TITLE
Document shell auto-completion for command line with core installation

### DIFF
--- a/source/_includes/installation/core.md
+++ b/source/_includes/installation/core.md
@@ -116,8 +116,6 @@ For more information, see [argcomplete](https://kislyuk.github.io/argcomplete/) 
 
 <div class='note warning'>
 
-If you followed all steps of this guide, `hass` run from a virtual environment.
-Auto-completion will work as soon as you wil have activated this virtual environment.
-While `hass` cannot directly be ran, no completion will be available.
+If you've followed all the steps in this guide `hass` has been installed in a virtual environment. Auto completion will only work when that environment is **activated**. You can tell when the virtual environment is active because your terminal prompt will include `(homeassistant)`.
 
 </div>

--- a/source/_includes/installation/core.md
+++ b/source/_includes/installation/core.md
@@ -105,12 +105,46 @@ When you run the `hass` command for the first time, it will download, install an
 
 ### Enable shell auto-completion
 
-Bash or ZSH auto-completion features can be used with the `hass` command.
-For example, if you use bash, you can add the following to your `~/.bashrc` file:
+Your shell auto-completion features can be used with the `hass` command.
+First of all, you must register `hass` for auto-completion.
+
+If you use bash, add the following to your `~/.bashrc` file:
 
 ```bash
 eval "$(register-python-argcomplete hass)"
 ```
+
+For ZSH, add the following in `~/.zshrc`:
+
+```bash
+autoload -U bashcompinit
+bashcompinit
+eval "$(register-python-argcomplete hass)"
+```
+
+<div class='note'>
+
+Two first lines are relevant only if you have not enabled bashcompinit yet.
+
+</div>
+
+For tcsh, add the following in `~/.tcshrc`:
+
+```bash
+eval `register-python-argcomplete --shell tcsh hass`
+```
+
+If you use fish, run the following command from your terminal:
+
+```bash
+register-python-argcomplete --shell fish pipx >~/.config/fish/completions/pipx.fish
+```
+
+<div class='note'>
+
+It is not required to be in the config file, only run once.
+
+</div>
 
 For more information, see [argcomplete](https://kislyuk.github.io/argcomplete/) documentation.
 

--- a/source/_includes/installation/core.md
+++ b/source/_includes/installation/core.md
@@ -102,3 +102,22 @@ If this address doesn't work you may also try `http://localhost:8123` or `http:/
 When you run the `hass` command for the first time, it will download, install and cache the necessary libraries/dependencies. This procedure may take anywhere between 5 to 10 minutes. During that time, you may get a **site cannot be reached** error when accessing the web interface. This will only happen the first time. Subsequent restarts will be much faster.
 
 </div>
+
+### Enable shell auto-completion
+
+Bash or ZSH auto-completion features can be used with the `hass` command.
+For example, if you use bash, you can add the following to your `~/.bashrc` file:
+
+```bash
+eval "$(register-python-argcomplete hass)"
+```
+
+For more information, see [argcomplete](https://kislyuk.github.io/argcomplete/) documentation.
+
+<div class='note warning'>
+
+If you followed all steps of this guide, `hass` run from a virtual environment.
+Auto-completion will work as soon as you wil have activated this virtual environment.
+While `hass` cannot directly be ran, no completion will be available.
+
+</div>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation about how to use shell auto-completion when running `hass` for core installation.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#103862
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
