### PR TITLE
Blueprint tutorial: Remove `filter:` from `target:` selector

### DIFF
--- a/source/_docs/blueprint/tutorial.markdown
+++ b/source/_docs/blueprint/tutorial.markdown
@@ -186,8 +186,7 @@ blueprint:
       selector:
         target:
           entity:
-            filter:
-              - domain: light
+            - domain: light
 ```
 
 By limiting our blueprint to working with lights and motion sensors, we unlock a couple of benefits: the UI will be able to limit suggested values to lights and motion sensors instead of all devices. It will also allow the user to pick an area to control the lights in.
@@ -218,8 +217,7 @@ blueprint:
       selector:
         target:
           entity:
-            filter:
-              - domain: light
+            - domain: light
 
 trigger:
   - platform: state


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This does not seem to be valid syntax based on https://www.home-assistant.io/docs/blueprint/selectors/#target-selector, and creates an error for me locally.

Example error: 
```
Invalid blueprint: extra keys not allowed @ data['blueprint']['input']['target_automation']['selector']['entity'][0]['filter']. Got None
```



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
