### PR TITLE
Add target_temperature_range attribute to climate integration doc

### DIFF
--- a/source/_integrations/climate.markdown
+++ b/source/_integrations/climate.markdown
@@ -241,6 +241,7 @@ The climate entity has extra attributes to represent the state of the thermostat
 | Name | Description |
 | ---- | ----------- |
 | `hvac_action` | Current state: `heating` / `cooling` / `idle`.
+| `target_temperature_range` | The minimum range between the minimum and maximum temperatures in the `heat_cool` HVAC mode.
 | `fan` | If the fan is currently on or off: `on` / `off`.
 
 It depends on the thermostat you are using which states are available.


### PR DESCRIPTION
## Proposed change
Add the upcoming `target_temperature_range` attribute to the climate integration page.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/103880
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
