### PR TITLE
Add support for lupusec smoke and water sensor

### DIFF
--- a/source/_integrations/lupusec.markdown
+++ b/source/_integrations/lupusec.markdown
@@ -23,11 +23,12 @@ The `lupusec` integration allows the user to integrate their Lupusec alarm contr
 Supported units:
 
 - Lupusec XT1
+- Lupusec XT2 Plus
 
 The following devices are supported by the underlying `lupupy` Python library and integrated into Home Assistant.
 
 - **Alarm Control Panel**: Displays the alarm status and controls arming, disarming and home modus.
-- **Binary Sensor**: Displays the status of binary sensors. Currently only Door and window sensors are supported.
+- **Binary Sensor**: Displays the status of binary sensors. Door, window, water and smoke sensors are supported.
 - **Switch**: Turn off and on your Lupus power switches.
 
 ## Configuration

--- a/source/_integrations/lupusec.markdown
+++ b/source/_integrations/lupusec.markdown
@@ -28,7 +28,7 @@ Supported units:
 The following devices are supported by the underlying `lupupy` Python library and integrated into Home Assistant.
 
 - **Alarm Control Panel**: Displays the alarm status and controls arming, disarming and home modus.
-- **Binary Sensor**: Displays the status of binary sensors. Door, window, water and smoke sensors are supported.
+- **Binary Sensor**: Displays the status of binary sensors. Door, window, water, and smoke sensors are supported.
 - **Switch**: Turn off and on your Lupus power switches.
 
 ## Configuration


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updating documentation for lupus to include support for water and smoke sensor for XT2 Plus.

https://github.com/home-assistant/core/pull/103905


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
