### PR TITLE
Velbus: Add information about the VMB7IN module

### DIFF
--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -102,8 +102,8 @@ Use this service when you make changes to your configuration via velbuslink.
 
 ## VMB7IN and the Energy dashboard
 
-The VMB7IN does not repport what the counter is counting, because of this we need to let Home Assistant know what device class each counter is, in case the counter is counting an energy device everything will work out of the box.
-But in case the VMB7IN channel is a water or gas counter you will need to make some modifications in your configuration.yaml.
+In some cases, the VMB7IN sensor does not report what the counter is counting. If the counter is related to an energy device, everything will work out of the box.
+But if the VMB7IN sensor is a water or gas counter, you will need to specify this in your configuration.yaml file.
 
 ```yaml
 homeassistant:

--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -113,8 +113,8 @@ homeassistant:
 ```
 
 The device_class attribute can have 2 values:
-- gas: in this case the counter is a gas meter
-- water: in this the counter is used to measure a water meter
+- gas: if the counter represents a gas meter
+- water: if the counter represents a water meter
 
 
 ## Example automation

--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -99,6 +99,24 @@ Use this service when you make changes to your configuration via velbuslink.
 | `interface`            | no       | The port used to connect to the bus (the same one used during configuration). |
 | `address`              | no       | The module address in decimal format, which is displayed on the device list on the integration page, if provided the service will only clear the cache for this model, without an address, the full velbuscache will be cleared. |
 
+
+## VMB7IN and the Energy dashboard
+
+The VMB7IN does not repport what the counter is counting, because of this we need to let homeassistant know what device class each counter is, in case the counter is counting an energy device everything will work out of the box.
+But in case the VMB7IN channel is a water or gas counter you will need to make some modifications in your configuration.yaml.
+
+```yaml
+homeassistant:
+  customize:
+    sensor.eau_counter:
+      device_class: water
+```
+
+The device_class attribute can have 2 values:
+- gas: in this case the counter is a gas meter
+- water: in this the counter is used to measure a water meter
+
+
 ## Example automation
 
 The Velbus integration allows you to link a Velbus button (i.e., a button of a [VMBGPOD](https://www.velbus.eu/products/view/?id=416302&lang=en) module) to a controllable entity of Home Assistant.

--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -102,7 +102,7 @@ Use this service when you make changes to your configuration via velbuslink.
 
 ## VMB7IN and the Energy dashboard
 
-The VMB7IN does not repport what the counter is counting, because of this we need to let homeassistant know what device class each counter is, in case the counter is counting an energy device everything will work out of the box.
+The VMB7IN does not repport what the counter is counting, because of this we need to let Home Assistant know what device class each counter is, in case the counter is counting an energy device everything will work out of the box.
 But in case the VMB7IN channel is a water or gas counter you will need to make some modifications in your configuration.yaml.
 
 ```yaml


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The VMB7IN module is not telling us what type of counter it exports, becasuse of this we need to customize the sensor in the configuration.yaml file.

This change describes how to do it.

This is related to:https://github.com/home-assistant/core/issues/101965

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/issues/101965
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
