### PR TITLE
Quotes needed in templates for sensor names

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -93,7 +93,7 @@ Recommended energy dashboard configuration for meter location in feed in path:
 
 Recommended energy dashboard configuration for meter location in consumption path:
 
-- The `Power grid` entity provided by the Fronius API is positive on import and negative on export. Split it up into import- and export-power entities by using helpers with templates `max(states(sensor.solarnet_power_grid) | float, 0)` and `max(0 - states(sensor.solarnet_power_grid) | float, 0)`.
+- The `Power grid` entity provided by the Fronius API is positive on import and negative on export. Split it up into import- and export-power entities by using helpers with templates `max(states('sensor.solarnet_power_grid') | float, 0)` and `max(0 - states('sensor.solarnet_power_grid') | float, 0)`.
 - Then use [Riemann sum](/integrations/integration/) to integrate these import-/export-power entities into energy values (kWh).
 - Use these energy entities for `Grid consumption` and `Return to grid` in the energy dashboard configuration.
 


### PR DESCRIPTION
## Proposed change
Small change to hopefully save people time, the template not having quoted sensor names tripped me up for awhile. 



## Type of change
Minor 

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
NA

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
