### PR TITLE
Reolink: Clarify where the user account is needed

### DIFF
--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -29,7 +29,7 @@ The integration allows you to control [Reolink](https://reolink.com/) NVRs or ca
 
 {% include integrations/config_flow.md %}
 
-On the devive a user account with admin privileges is needed for the proper operation of this integration.
+On the Reolink device, a user account with admin privileges is needed for the proper operation of this integration.
 
 {% include integrations/option_flow.md %}
 {% configuration_basic %}

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -29,7 +29,7 @@ The integration allows you to control [Reolink](https://reolink.com/) NVRs or ca
 
 {% include integrations/config_flow.md %}
 
-A Reolink user account with admin privileges is needed for the proper operation of this integration.
+On the devive a user account with admin privileges is needed for the proper operation of this integration.
 
 {% include integrations/option_flow.md %}
 {% configuration_basic %}


### PR DESCRIPTION
## Proposed change
Clarify that the user account is needed on the device (and not in the Reolink cloud or something like that).



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
