### PR TITLE
Describe the use of unencrypted tokens in Nuki

### DIFF
--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -36,7 +36,7 @@ For faster updates, the callback function of the Nuki bridge can be used. This r
   Token:
     description: Token to authenticate against the Nuki bridge HTTP API.
   Use an encrypted token for authentication:
-    description: Use encrypted token for API calls to the bridge. This should only be deactivated if you experience issues with the API (authentication, etc). Default is `True`.
+    description: Use an encrypted token for API calls to the bridge. This should only be deactivated if you experience issues with the API (authentication, etc). The default is `True`.
 {% endconfiguration_basic %}
 
 ## Services

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -35,8 +35,8 @@ For faster updates, the callback function of the Nuki bridge can be used. This r
     description: Port of the Nuki bridge HTTP API, default is `8080`.
   Token:
     description: Token to authenticate against the Nuki bridge HTTP API.
-  Use a secure connection to the Bridge:
-    description: Use encrypted token for API calls to the bridge. This should only be deactivated, if you experience issues with the API (authentication, etc). Default is `True`.
+  Use an encrypted token for authentication:
+    description: Use encrypted token for API calls to the bridge. This should only be deactivated if you experience issues with the API (authentication, etc). Default is `True`.
 {% endconfiguration_basic %}
 
 ## Services

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -35,6 +35,8 @@ For faster updates, the callback function of the Nuki bridge can be used. This r
     description: Port of the Nuki bridge HTTP API, default is `8080`.
   Token:
     description: Token to authenticate against the Nuki bridge HTTP API.
+  Use a secure connection to the Bridge:
+    description: Use encrypted token for API calls to the bridge. This should only be deactivated, if you experience issues with the API (authentication, etc). Default is `True`.
 {% endconfiguration_basic %}
 
 ## Services


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Describe the configuration option `Use a secure connection to the Bridge`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/104007
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
