### PR TITLE
Fix capitalization of Alza in Green distributors list

### DIFF
--- a/source/green/index.html
+++ b/source/green/index.html
@@ -2313,7 +2313,7 @@ frontpage_image: /images/frontpage/green-frontpage.png
         <div class="distributor">
           <div>
             <div>🇨🇿</div>
-            <div>ALZA</div>
+            <div>Alza.cz</div>
             <div>Shipping from the Czech Republic</div>
           </div>
           <svg width="24" height="24" viewBox="0 0 24 24">


### PR DESCRIPTION
It should not be spelled in all caps. Moreover the official name of the business is "Alza.cz", so changing it to that.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - ~~I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.~~
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
