### PR TITLE
Revert 'sentence-style capitalization' in HomeWizard

### DIFF
--- a/source/_integrations/homewizard.markdown
+++ b/source/_integrations/homewizard.markdown
@@ -69,7 +69,7 @@ Sensors for Water meter:
 - **Active usage (L/min)**: Flow of water that is measured at that time.
 - **Total usage (m³)**: Total water usage since the installation of the HomeWizard Water meter.
 
-## Energy socket
+## Energy Socket
 
 The Energy Socket outlet state and status light can be controlled. There are two switches:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I just noticed https://github.com/home-assistant/home-assistant.io/pull/29861, which is a nice move. But it also changed "Energy Socket" to "Energy socket". In the context of HomeWizard, this should be kept as "Energy Socket" (a brand).

I would suggest to revert this, or: "HomeWizard Energy Socket" or "Controlling the state"?


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
