### PR TITLE
Ensure unique categories on integrations view

### DIFF
--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -22,7 +22,7 @@ regenerate: false
 
 {%- assign components = site.integrations | sort: 'title' -%}
 {%- assign components_by_version = site.integrations | group_components_by_release -%}
-{%- assign categories = components | map: 'ha_category' | join: ',' | join: ',' | split: ',' | uniq | sort -%}
+{%- assign categories = components | map: 'ha_category' | join: ',' | downcase | split: ',' | uniq | sort -%}
 
 <p class='note'>
   Support for these integrations is provided by the Home Assistant community.
@@ -45,10 +45,28 @@ regenerate: false
           {%- endfor -%}
         </select></div>
       {%- for category in categories -%}
-      {%- assign components_count = components | where: 'ha_category', category | size -%}
-      {%- if category and category != 'Other' and components_count != 0 -%}
-      <a href='#{{ category | slugify }}' class="btn" onclick="document.querySelector('.page-content').scrollTop = 0">{{ category }} ({{ components_count }})</a>
-      {%- endif -%}
+        {%- assign category_name = "" -%}
+        {%- assign components_count = 0 -%}
+        {%- for comp in components -%}
+          {%- assign comp_categories = comp.ha_category | join: ',' | downcase -%}
+          {%- if comp_categories contains category -%}
+            {%- if category_name == "" -%}
+              {%- for cat in comp.ha_category -%}
+                {%- assign lower_cat = cat | downcase -%}
+                {%- if lower_cat == category -%}
+                  {%- assign category_name = cat -%}
+                {%- endif -%}
+              {%- endfor -%}
+            {%- endif -%} 
+            {%- assign components_count = components_count | plus: 1 -%}
+          {%- endif -%}
+        {%- endfor -%}
+        {%- if category != 'other' and components_count != 0 -%}
+          {%- if category_name == "" -%}
+            {%- assign category_name = category | capitalize -%}
+          {%- endif -%}
+          <a href='#{{ category_name | slugify }}' class="btn" onclick="document.querySelector('.page-content').scrollTop = 0">{{ category_name }} ({{ components_count }})</a>
+        {%- endif -%}
       {%- endfor -%}
 
       <a href='#other' class="btn" onclick="document.querySelector('.page-content').scrollTop = 0">Other ({{ components | where: 'ha_category', 'Other' | size }})</a>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

With #29893, which changes the casing for categories, it showed duplicate entries on this page.
While this PR initially was made as a temporary workaround for that, it can also be kept after to make sure if integration pages are added/updated with the wrong casing it will not cause duplicates here.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
