### PR TITLE
Polling data procedure: remove YAML example

### DIFF
--- a/source/_includes/common-tasks/define_custom_polling.md
+++ b/source/_includes/common-tasks/define_custom_polling.md
@@ -11,22 +11,4 @@ If you want to define a specific interval at which your device is being polled f
    - Define any trigger and condition you like.
    - Under action, select **Call service** and use the [`homeassistant.update_entity` service](/integrations/homeassistant/#service-homeassistantupdate_entity).
    ![Update entity](/images/screenshots/custom_polling_02.png)
-   - Example in YAML.
-
-      ```yaml
-      automation:
-         - alias: "Only update weather information every 20 minutes when I'm home"
-            trigger:
-               - platform: time_pattern
-                 minutes: "/20"
-            condition:
-               - condition: state
-                 entity_id: device_tracker.cynthia
-                 state: home
-            action:
-               - service: homeassistant.update_entity
-                 target:
-                   entity_id: weather.home
-      ```
-
 4. Save your new automation to poll for data.


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Polling data procedure: remove YAML example
- Because this procedure is essintially the same for different integrations, it is reused in various places
- however, the elements in the example are specific to one integration.
- for the other integrations, this YAML example is more confusing than helping
- implements feedback provided in #29457


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #29457

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
