### PR TITLE
Unifiprotect: fix unsupported glossary term reference

### DIFF
--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -254,7 +254,7 @@ Below are the accepted identifiers to resolve media. Since events do not necessa
 
 ## Services
 
-### {% term Service %} unifiprotect.set_default_doorbell_text
+### Service unifiprotect.set_default_doorbell_text
 
 Sets the default doorbell message. This will be the message that is automatically selected when a message "expires".
 
@@ -263,7 +263,7 @@ Sets the default doorbell message. This will be the message that is automaticall
 | `device_id`            | No       | Any device from the UniFi Protect instance you want to change. In case you have multiple Protect instances. |
 | `message`              | No       | The default message for your Doorbell. Must be less than 30 characters.                                     |
 
-### {% term Service %} unifiprotect.add_doorbell_text
+### Service unifiprotect.add_doorbell_text
 
 Adds a new custom message for Doorbells.
 
@@ -272,7 +272,7 @@ Adds a new custom message for Doorbells.
 | `device_id`            | No       | Any device from the UniFi Protect instance you want to change. In case you have multiple Protect instances. |
 | `message`              | No       | New custom message to add for Doorbells. Must be less than 30 characters.                                   |
 
-### {% term Service %} unifiprotect.remove_doorbell_text
+### Service unifiprotect.remove_doorbell_text
 
 Removes an existing message for Doorbells.
 
@@ -281,7 +281,7 @@ Removes an existing message for Doorbells.
 | `device_id`            | No       | Any device from the UniFi Protect instance you want to change. In case you have multiple Protect instances. |
 | `message`              | No       | Existing custom message to remove for Doorbells.                                                            |
 
-### {% term Service %} unifiprotect.set_chime_paired_doorbells
+### Service unifiprotect.set_chime_paired_doorbells
 
 Use to set the paired doorbell(s) with a smart chime.
 


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Unifyprotect: 
- fix unsupported glossary term reference
- the term reference is not supported in titles

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
