### PR TITLE
Add reolink.ptz_move service docs

### DIFF
--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -124,6 +124,15 @@ PTZ left, right, up, down, zoom in and zoom out will continually move the camera
 
 "Guard set current position" will set the current position as the new guard position.
 
+### Service reolink.ptz_move
+
+Some Reolink PTZ cameras are capable of moving at different speeds. For those cameras, the `reolink.ptz_move` service can be used in combination with the **PTZ left**, **right**, **up**, **down**, **zoom in** or **zoom out** entity which allows specifying the speed attribute. If the PTZ button entities for a specific camera are not shown under "choose entity" under "targets" of the `reolink.ptz_move` service, it means that camera does not support custom ptz speeds.
+
+| Service data attribute | Optional | Description                                                                              |
+| ---------------------- | -------- | -----------------------------------------------------------------------------------------|
+| `entity_id`            |      no  | Name of the reolink ptz button entity to control. For example `button.trackmix_ptz_left` |
+| `speed`                |      no  | PTZ move speed. For example `10`                                                         |
+
 ## Select entities
 
 Depending on the supported features of the camera, select entities are added for:

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -126,11 +126,11 @@ PTZ left, right, up, down, zoom in and zoom out will continually move the camera
 
 ### Service reolink.ptz_move
 
-Some Reolink PTZ cameras are capable of moving at different speeds. For those cameras, the `reolink.ptz_move` service can be used in combination with the **PTZ left**, **right**, **up**, **down**, **zoom in** or **zoom out** entity which allows specifying the speed attribute. If the PTZ button entities for a specific camera are not shown under "choose entity" under "targets" of the `reolink.ptz_move` service, it means that camera does not support custom ptz speeds.
+Some Reolink PTZ cameras are capable of moving at different speeds. For those cameras, the `reolink.ptz_move` service can be used in combination with the **PTZ left**, **right**, **up**, **down**, **zoom in** or **zoom out** entity which allows specifying the speed attribute. If the PTZ button entities for a specific camera are not shown under "choose entity" under "targets" of the `reolink.ptz_move` service, it means that camera does not support custom PTZ speeds.
 
 | Service data attribute | Optional | Description                                                                              |
 | ---------------------- | -------- | -----------------------------------------------------------------------------------------|
-| `entity_id`            |      no  | Name of the reolink ptz button entity to control. For example `button.trackmix_ptz_left` |
+| `entity_id`            |      no  | Name of the reolink PTZ button entity to control. For example `button.trackmix_ptz_left` |
 | `speed`                |      no  | PTZ move speed. For example `10`                                                         |
 
 ## Select entities

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -126,12 +126,12 @@ PTZ left, right, up, down, zoom in and zoom out will continually move the camera
 
 ### Service reolink.ptz_move
 
-Some Reolink PTZ cameras are capable of moving at different speeds. For those cameras, the `reolink.ptz_move` service can be used in combination with the **PTZ left**, **right**, **up**, **down**, **zoom in** or **zoom out** entity which allows specifying the speed attribute. If the PTZ button entities for a specific camera are not shown under "choose entity" under "targets" of the `reolink.ptz_move` service, it means that camera does not support custom PTZ speeds.
+Some Reolink <abbr title="pan, tilt, and zoom">PTZ</abbr> cameras can move at different speeds. For those cameras, the `reolink.ptz_move` service can be used in combination with the **PTZ left**, **right**, **up**, **down**, **zoom in**, or **zoom out** entity which allows specifying the speed attribute. If the <abbr title="pan, tilt, and zoom">PTZ</abbr> button entities for a specific camera are not shown under **Choose entity** under **targets** of the `reolink.ptz_move` service, it means that this camera does not support custom <abbr title="pan, tilt, and zoom">PTZ</abbr> speeds.
 
 | Service data attribute | Optional | Description                                                                              |
 | ---------------------- | -------- | -----------------------------------------------------------------------------------------|
-| `entity_id`            |      no  | Name of the reolink PTZ button entity to control. For example `button.trackmix_ptz_left` |
-| `speed`                |      no  | PTZ move speed. For example `10`                                                         |
+| `entity_id`            |      no  | Name of the Reolink <abbr title="pan, tilt, and zoom">PTZ</abbr> button entity to control. For example, `button.trackmix_ptz_left`. |
+| `speed`                |      no  | <abbr title="pan, tilt, and zoom">PTZ</abbr> move speed. For example `10`.                                                         |
 
 ## Select entities
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add reolink.ptz_move service docs, see PR: https://github.com/home-assistant/core/pull/104350


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/104350
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
