### PR TITLE
Document ignored ibeacons and the special Minor 40004

### DIFF
--- a/source/_integrations/ibeacon.markdown
+++ b/source/_integrations/ibeacon.markdown
@@ -29,17 +29,20 @@ iBeacon Devices are tracked by a combination of the following data:
 - UUID (universally unique identifier) is a 128-bit identifier that is generally set the same for all iBeacons at the same physical location.
 - Major is an integer to differentiate between iBeacons with the same UUID.
 - Minor is an integer to differentiate between iBeacons with the same UUID and Major value.
+  (The value 40004 has a special behavior, see below.)
 - MAC address (except for devices with a randomized MAC address)
 
 Consider setting up your iBeacons with a schema similar to the following:
 
-- uuid=UUID major=1000 minor=1000 Downstairs Front Room
-- uuid=UUID major=1000 minor=1001 Downstairs Bathroom
-- uuid=UUID major=2000 minor=1001 Upstairs Main Bedroom
-- uuid=UUID major=2000 minor=1002 Upstairs Guest Bedroom
-- uuid=UUID major=3000 minor=1000 Attic
+- uuid=UUID major=1000 minor=40004 Downstairs Front Room
+- uuid=UUID major=1001 minor=40004 Downstairs Bathroom
+- uuid=UUID major=2000 minor=40004 Upstairs Main Bedroom
+- uuid=UUID major=2001 minor=40004 Upstairs Guest Bedroom
+- uuid=UUID major=3000 minor=40004 Attic
 
 iBeacon devices that do not have stable Major and Minor values are not supported. The system automatically removes iBeacon devices with unstable Major and Minor values once ten (10) or more Major and Minor values have been seen with the same UUID from an iBeacon device with a fixed MAC address.
+
+Moreover, iBeacon devices that do not broadcast their device name are ignored (to avoid flooding your system with devices that are not real beacons). If a real iBeacon device does not broadcast its name, its detection can be forced by using the special Minor value `40004`).
 
 ## Considering an iBeacon Away
 


### PR DESCRIPTION
## Proposed change

Document the fact that ibeacons with no name are ignored, and the whitelist workaround using the Minor 40004. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/104419
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
