### PR TITLE
Assist - add link to built-in sentences

### DIFF
--- a/source/voice_control/builtin_sentences.markdown
+++ b/source/voice_control/builtin_sentences.markdown
@@ -2,8 +2,9 @@
 title: "Assist - default sentences"
 ---
 
-Home Assistant comes with built-in sentences [contributed by the community](https://github.com/home-assistant/intents/) for [dozens of languages](https://developers.home-assistant.io/docs/voice/intent-recognition/supported-languages).
-These sentences allow you to:
+Home Assistant comes with [built-in sentences](https://github.com/home-assistant/intents/tree/main/sentences) contributed by the community for [dozens of languages](https://developers.home-assistant.io/docs/voice/intent-recognition/supported-languages).
+
+These sentences allow you, for example, to:
 
 - **Turn entities on and off**
     - *"turn on the living room light"*
@@ -22,9 +23,9 @@ In addition to individual entities, commands can target **areas**:
 - *"change kitchen brightness to 50%"*
 - *"set bedroom lights to green"*
 
-Entity [aliases](/voice_control/aliases) are also matched so multiple names can be used, even in different languages.
+Entity [aliases](/voice_control/aliases) are also matched so that multiple names can be used, even in different languages.
 
-You can extend the built-in sentences or [add your own](/voice_control/custom_sentences) to trigger any action in Home Assistant.
+You can extend the [built-in sentences](https://github.com/home-assistant/intents/tree/main/sentences) or [add your own](/voice_control/custom_sentences) to trigger any action in Home Assistant.
 
 ## View existing sentences
 
@@ -46,7 +47,7 @@ To get an idea of the specific sentences that are supported for your language, y
 
         ![Example of a set of test sentences](/images/assist/assist-test-file-light-turn-on.png)
 
-2. View the sentence definition:
+2. View the sentence definition for the tests:
     - On GitHub, in the [tests](https://github.com/home-assistant/intents/tree/main/tests) folder, open the subfolder for your language.
     - Open the file of interest.
 
@@ -54,12 +55,16 @@ To get an idea of the specific sentences that are supported for your language, y
 
         - () mean alternative elements.
         - [] mean optional elements.
-        - <> mean an expansion rule. The view these rules, search for `expansion_rules` in the [_common.yaml](https://github.com/home-assistant/intents/blob/main/sentences/en/_common.yaml)   file.
+        - <> mean an expansion rule. The view these rules, search for `expansion_rules` in the [_common.yaml](https://github.com/home-assistant/intents/blob/main/sentences/en/_common.yaml) file.
         - The syntax is explained in detail in the [template sentence syntax documentation](https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax/).
+3. View the [sentence definition](https://github.com/home-assistant/intents/tree/main/sentences) for your language.
+4. View the [response definition](https://github.com/home-assistant/intents/tree/main/responses)
 
 ## Related topics
 
 - [Create aliases](/voice_control/aliases/)
 - [Create your own sentences](/voice_control/custom_sentences/)
+- [Built-in sentence definitions](https://github.com/home-assistant/intents/tree/main/sentences)
+- [Built-in response definitions](https://github.com/home-assistant/intents/tree/main/responses)
 - [Template sentence syntax documentation](https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax/)
 - [Sentence test cases](https://github.com/home-assistant/intents/tree/main/sentences)


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Assist - built-in sentences
- Fix / add links to built-in sentence definitions on github
- add link to response definition on github
- addresses feedback from #29935

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
