### PR TITLE
Remove myStrom button documentation references

### DIFF
--- a/source/_integrations/mystrom.markdown
+++ b/source/_integrations/mystrom.markdown
@@ -23,7 +23,6 @@ There is currently support for the following device types within Home Assistant:
 
 - [Lights and switches](#lights-and-switches)
 - [Binary sensor](#binary-sensor)
-  - [Setup of myStrom buttons](#setup-of-mystrom-buttons)
 
 ## Lights and switches
 
@@ -93,54 +92,3 @@ binary_sensor:
 <div class='note'>
 The firmware version 2.56 doesn't support TLS/SSL. This means that you are only able to use the WiFi Buttons if you are using plain-text communication between Home Assistant and the clients/entities.
 </div>
-
-### Setup of myStrom Buttons
-
-You need to configure every button to make it work with Home Assistant. First connect the Wifi Buttons to your wireless network. Once a button is connected you have three minutes to set the actions for the push patterns if the button is not charging. The fastest way is to use `curl`. Check the [documentation](https://mystrom.ch/wp-content/uploads/REST_API_WBP.txt) of the WiFi Button for further details about the implementation (`http://` is replaced by `get://` or `post://`). `action` is the name of the corresponding push pattern (see above).
-
-The endpoint that is receiving the data is `http://[IP address Home Assistant]:8123/api/mystrom`. If you have set an [`api_password`](/integrations/http/) then this needs to be included in the URL.
-
-With `api_password:`
-
-```bash
-curl -d "[action]=get://[IP address Home Assistant]:8123/api/mystrom?api_password%3D[api_password]%26[action]%3D[ID of the button]" \
-    http://[IP address of the button]/api/v1/device/[MAC address of the button]
-```
-
-Without `api_password`:
-
-```bash
-$ curl -d "[action]=get://[IP address Home Assistant]:8123/api/mystrom?[action]%3D[ID of the button]" \
-    http://[IP address of the button]/api/v1/device/[MAC address of the button]
-{
-  "[MAC address of the button]": {
-    "type": "button",
-    "battery": true,
-    "reachable": true,
-    "meshroot": false,
-    "charge": true,
-    "voltage": 4.292,
-    "fw_version": "2.56",
-    "single": "get://[IP address Home Assistant]:8123/api/mystrom?single=[id of the button]",
-    "double": "",
-    "long": "",
-    "touch": ""
-  }
-}
-```
-
-A complete command to set the URL for a double click could look like the example below:
-
-```bash
-curl -d "double=get://192.168.1.3:8123/api/mystrom?double%3DButton1" http://192.168.1.12/api/v1/device/4D5F5D5CD553
-```
-
-With an `api_password`:
-
-```bash
-curl -d "double=get://192.168.1.3:8123/api/mystrom?api_password%3Dapi_password%26double%3DButton1" http://192.168.1.12/api/v1/device/4D5F5D5CD553
-```
-
-The command-line tool [`mystrom`](https://github.com/fabaff/python-mystrom) is a helper to configure myStrom buttons.
-
-If you have set [`login_attempts_threshold`](/integrations/http/) and forget to include the `api_password` for an action and that action is triggered then after the threshold is reached will the button no longer work because it is banned. See [IP filtering and banning](/integrations/http/#ip-filtering-and-banning) about how to revert the banning.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Cleans up the myStrom buttons, as the workaround listed in the documentation is reported no to be working anymore.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #29911

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
