### PR TITLE
Owner required for UI locked_out.md

### DIFF
--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -45,11 +45,12 @@ If you are running Home Assistant in a container, you can use the command line i
 4. `exit` to exit the container command line
 5. `docker restart homeassistant` to restart the container.
 
-#### To reset a user's password, as an administrator via the web interface
+#### To reset a user's password, as an Owner via the web interface
 
 1. In the bottom left, select your user to go to the {% my profile title="**Profile**" %} page and make sure **Advanced Mode** is activated.
 2. Go to {% my people title="**Settings** > **People**" %} and select the person for which you want to change the password.
 3. At the bottom of the dialog box, select **Change Password**.
+   - Note: this is available as the owner, not administrator.
 4. Enter the new password, and select **OK**.
 5. Confirm the new password by entering it again, and select **OK** again.
 6. A confirmation box will be displayed with the text **Password was changed successfully**.

--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -45,7 +45,7 @@ If you are running Home Assistant in a container, you can use the command line i
 4. `exit` to exit the container command line
 5. `docker restart homeassistant` to restart the container.
 
-#### To reset a user's password, as an Owner via the web interface
+#### To reset a user's password, as an owner via the web interface
 
 1. In the bottom left, select your user to go to the {% my profile title="**Profile**" %} page and make sure **Advanced Mode** is activated.
 2. Go to {% my people title="**Settings** > **People**" %} and select the person for which you want to change the password.


### PR DESCRIPTION
## Proposed change

Clarify that Owner role is required not just Administrator to see Change Password in the UI


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


Discussed here: https://community.home-assistant.io/t/how-to-change-users-password/226374/19


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
