### PR TITLE
More detailed image_url information

### DIFF
--- a/source/_integrations/msteams.markdown
+++ b/source/_integrations/msteams.markdown
@@ -50,6 +50,8 @@ The following attributes can be placed inside `data` for extended functionality.
 | ---------------------- | -------- | ----------- |
 | `image_url`            |      yes | Attach an image to the message.
 
+The image URL must start with http, and as outlined from Microsoft in the [Documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#common-properties-for-all-cards), the picture must be on a publicly available location.
+
 Example for posting file from URL:
 
 ```yaml

--- a/source/_integrations/msteams.markdown
+++ b/source/_integrations/msteams.markdown
@@ -50,7 +50,7 @@ The following attributes can be placed inside `data` for extended functionality.
 | ---------------------- | -------- | ----------- |
 | `image_url`            |      yes | Attach an image to the message.
 
-The image URL must start with http, and as outlined from Microsoft in the [Documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#common-properties-for-all-cards), the picture must be on a publicly available location.
+The image must be an HTTPS URL, and as outlined by Microsoft in the [Documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#common-properties-for-all-cards), the picture must be on a publicly available location.
 
 Example for posting file from URL:
 


### PR DESCRIPTION
As Discussed in https://github.com/home-assistant/core/issues/90121, the usage of the image_url tends to be unclear. Added detailed information of the image_url string and requirements with link to teams cards documentation

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
