### PR TITLE
Remove legacy api password auth provider

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -29,8 +29,9 @@ You can supply more than one, for example:
 homeassistant:
   auth_providers:
     - type: homeassistant
-    - type: legacy_api_password
-      api_password: !secret http_password
+    - type: trusted_networks
+      trusted_networks:
+        - 192.168.0.0/24
 ```
 
 ## Available auth providers
@@ -193,31 +194,4 @@ Any leading and trailing whitespace is stripped from usernames before they're pa
 
 <div class='note'>
 For now, meta variables are only respected the first time a particular user is authenticated. Upon subsequent authentications of the same user, the previously created user object with the old values is reused.
-</div>
-
-### Legacy API password
-
-<div class='note warning'>
-This is a legacy feature for backwards compatibility and will be dropped in a future release. You should move to one of the other auth providers.
-</div>
-
-Activating this auth provider will allow you to authenticate with the API password set in the HTTP integration.
-
-```yaml
-homeassistant:
-  auth_providers:
-   - type: legacy_api_password
-     api_password: !secret http_password
-```
-
-`api_password` is required option since 0.90 release.
-
-Activating this auth provider will also allow you to provide the API password using an authentication header to make requests against the Home Assistant API. This feature will be dropped in the future in favor of long-lived access tokens.
-
-If you don't specify any `auth_providers` section in the `configuration.yaml` file then this provider will be set up automatically if `api_password` was configured under `http` section.
-
-<div class='note warning'>
-
-[Issue 16441](https://github.com/home-assistant/core/issues/16441): the legacy API password auth provider, won't be automatically configured if your API password is located in a package. This is because Home Assistant processes the `auth_provider` during the `core` section loading, which is earlier than the `packages` processing.
-
 </div>

--- a/source/_docs/configuration/secrets.markdown
+++ b/source/_docs/configuration/secrets.markdown
@@ -12,25 +12,27 @@ The workflow for moving private information to `secrets.yaml` is very similar to
 The entries for password and API keys in the `configuration.yaml` file usually looks like the example below.
 
 ```yaml
-homeassistant:
-  auth_providers:
-   - type: legacy_api_password
-     api_password: YOUR_PASSWORD
+rest:
+  - authentication: basic
+    username: "admin"
+    password: "YOUR_PASSWORD"
+    ...
 ```
 
 Those entries need to be replaced with `!secret` and an identifier.
 
 ```yaml
-homeassistant:
-  auth_providers:
-   - type: legacy_api_password
-     api_password: !secret http_password
+rest:
+  - authentication: basic
+    username: "admin"
+    password: !secret rest_password
+    ...
 ```
 
 The `secrets.yaml` file contains the corresponding password assigned to the identifier.
 
 ```yaml
-http_password: "YOUR_PASSWORD"
+rest_password: "YOUR_PASSWORD"
 ```
 
 ## Debugging secrets


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Remove legacy api password auth provider

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/104409
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
