### PR TITLE
Add note on the cover template to make cover stateful in Overkiz 

### DIFF
--- a/source/_integrations/overkiz.markdown
+++ b/source/_integrations/overkiz.markdown
@@ -75,6 +75,33 @@ Over 6000 devices from 60 brands are compatible with the Overkiz platform. This 
 
 Even though most Overkiz hubs support adding Z-Wave, Hue, and Sonos devices, this isn't supported in the Overkiz integration. All these platforms have native integrations in Home Assistant which are more stable and feature-rich.
 
+### Stateless RTS covers 
+
+Covers that use the RTS protocol are stateless and do not report their state back to the hub. This means that Home Assistant will not know the state of the device after it has been controlled.
+
+If you only control your RTS cover from Home Assistant, you can use the [template cover](/integrations/cover.template/) to create a stateful cover entity. This will allow you to keep track of the current state (open or closed) and use the cover in automations and scenes.
+
+```yaml
+cover:
+  - platform: template
+    covers:
+      stateful_rts_test_shutter: # unique ID
+        friendly_name: "Stateful RTS Test Shutter" # your name
+        optimistic: true # default when no state is available
+        open_cover:
+          - service: cover.open_cover
+            target:
+              entity_id: cover.rts_test_shutter # change to your device id
+        close_cover:
+          - service: cover.close_cover
+            target:
+              entity_id: cover.rts_test_shutter # change to your device id
+        stop_cover:
+          - service: cover.stop_cover
+            target:
+              entity_id: cover.rts_test_shutter # change to your device id
+```
+
 ### Overkiz API limits
 
 **Server busy, please try again later. (Too many executions)**


### PR DESCRIPTION
## Proposed change
Multiple users face issues with regards to their Somfy RTS covers, that are stateless and thus use `assumed_state = True`. They create issues on GitHub and the community forums about this behavior, not understanding that optimistic mode in HA is not by default.

In an ideal world they would discover the cover template themselves, but I think it is good to add the example to the Overkiz page since many cover devices are stateless actually.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
