### PR TITLE
Add indicator for entities that are updated by listeners

### DIFF
--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -45,15 +45,17 @@ Once you log in with your Roborock account, the integration will automatically d
 
 Roborock devices have a variety of features that are supported on some devices but not on others. Only entities that your device supports will be added to your integration.
 
+As of Home Assistant 2023.12, as long as the cloud client is connected, we are able to instantly update some entities immediately, instead of waiting for the typical coordinator update. In the descriptions below, if an entity has a (🔥) by it, that means it will be automatically updated.
+
 ### Vacuum
 
 The vacuum entity holds the ability to control most things the vacuum can do, such as start a clean, return to the dock, or set the fan speed.
 
 ### Select
 
-Mop mode - Describes how to mop the floor. On some firmware, it is called 'mop route'.
+Mop mode (🔥) - Describes how to mop the floor. On some firmware, it is called 'mop route'.
 
-Mop intensity - How hard you would like your vacuum to mop.
+Mop intensity (🔥) - How hard you would like your vacuum to mop.
 
 ### Binary sensor
 
@@ -78,15 +80,15 @@ Cleaning progress - Only available on some newer devices - what percent of the c
 
 Dock error - Only available on the non-basic docks - The current error of the vacuum or 'Ok' if none exist
 
-Main brush time left - How much time is left before Roborock recommends you replace your main brush.
+Main brush time left (🔥) - How much time is left before Roborock recommends you replace your main brush.
 
 Mop drying remaining time - Only available on the non-basic docks - How much time is left until the mop is dry and ready to continue cleaning.
 
-Side brush time left - How much time is left before Roborock recommends you replace your side brush.
+Side brush time left (🔥) - How much time is left before Roborock recommends you replace your side brush.
 
-Filter time left - How much time is left before Roborock recommends you replace your vacuum's air filter.
+Filter time left (🔥) - How much time is left before Roborock recommends you replace your vacuum's air filter.
 
-Status - The current status of your vacuum. This typically describes the action that is currently being run. For example, 'spot_cleaning' or 'docking'.
+Status (🔥) - The current status of your vacuum. This typically describes the action that is currently being run. For example, 'spot_cleaning' or 'docking'.
 
 Last clean begin - the last time that your vacuum started cleaning.
 
@@ -96,7 +98,7 @@ Total cleaning time - The lifetime cleaning duration of your vacuum.
 
 Total cleaning area - The lifetime cleaning area of your vacuum.
 
-Vacuum error - The current error with your vacuum, if there is one.
+Vacuum error (🔥) - The current error with your vacuum, if there is one.
 
 ### Time
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I add a little bit of information about the listeners, and which entities they can update. Adding parent PR just so that ci doesn't yell at me


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/103651
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
