### PR TITLE
AlarmDecoder: align description of host field

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -33,15 +33,15 @@ This is a fully event-based integration. Any {% term event %} sent by the AlarmD
 You will be prompted to select a protocol (i.e. `socket` or `serial`). Depending on your selection, you will be asked for the following connection information:
 
 - **socket**:
-  - **host** - the hostname or IP address of the machine connected to the AlarmDecoder device
-  - **port** - the port that AlarmDecoder is accessible on (i.e. `10000`)
+  - **host** - The hostname or IP address of AlarDecoder device that is connected to your alarm panel.
+  - **port** - The port that AlarmDecoder is accessible on (i.e. `10000`).
 - **serial**:
-  - **path** - the path to the AlarmDecoder device (i.e. `/dev/ttyUSB0`)
-  - **baud rate** - the baud rate of the AlarmDecoder device (i.e. `115200`)
+  - **path** - The path to the AlarmDecoder device (i.e. `/dev/ttyUSB0`).
+  - **baud rate** - The baud rate of the AlarmDecoder device (i.e. `115200`).
 
 ## Settings
 
-Once AlarmDecoder has been set up according to the instructions above, the arming settings and zones can be configured by selecting _Options_ on the _AlarmDecoder_ card on the **{% my integrations title="Settings -> Devices & Services" %}** page.
+Once AlarmDecoder has been set up according to the instructions above, the arming settings and zones can be configured by selecting _Options_ on the _AlarmDecoder_ card on the **{% my integrations title="Settings > Devices & services" %}** page.
 
 ### Arming settings
 


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

AlarmDecoder: align description of host field
- with description used on UI
- see https://github.com/home-assistant/core/pull/104685

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
