### PR TITLE
Revert "Update Stookwijzer integration markdown (#30037)"

### DIFF
--- a/source/_integrations/stookwijzer.markdown
+++ b/source/_integrations/stookwijzer.markdown
@@ -16,12 +16,6 @@ ha_platforms:
 ha_integration_type: service
 ---
 
-The Stookwijzer integration queries the [Atlas Leefomgeving Stookwijzer](https://www.atlasleefomgeving.nl/stookwijzer) API for air quality index and windspeed. Based on these values, Stookwijzer advises people not to burn pallets or wood, or not to use the barbecue. This can help prevent health issues for people in the area.
-
-The Stookwijzer integration can provide three different levels of recommendations:
-
-- Code Yellow: Please note: burning wood causes discomfort and air pollution.
-- Code Orange: It is recommended not to burn wood now.
-- Code Red: Do not burn wood now.
+The Stookwijzer integration queries the [Stookwijzer](https://www.stookwijzer.nu) API for windspeed and gets the air quality index from [Luchtmeetnet](https://www.luchtmeetnet.nl). Using these parameters, Stookwijzer advises people not to burn pallets or wood, or to use the barbecue. This can prevent health problems for people in the area.
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This reverts commit eb5adad7380f018885c968fd1f2eb0f0cacaac59 which is PR #30037

The parent PR is being reverted here: https://github.com/home-assistant/core/pull/104705


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/104705
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
