### PR TITLE
Document iBeacon allowlist option

### DIFF
--- a/source/_integrations/ibeacon.markdown
+++ b/source/_integrations/ibeacon.markdown
@@ -43,7 +43,7 @@ iBeacon devices that do not have stable Major and Minor values are not supported
 
 The system will not automatically create iBeacon devices for beacons that do not broadcast their name to avoid inundating your system with transient devices.
 
-To explicitly allow a list of UUIDs to be added even with an empty device name, add them via the integration options:
+To explicitly allow a list of UUIDs to be added even with an empty device name, add them via the integration options.
 
 {% include integrations/option_flow.md %}
 

--- a/source/_integrations/ibeacon.markdown
+++ b/source/_integrations/ibeacon.markdown
@@ -41,6 +41,12 @@ Consider setting up your iBeacons with a schema similar to the following:
 
 iBeacon devices that do not have stable Major and Minor values are not supported. The system automatically removes iBeacon devices with unstable Major and Minor values once ten (10) or more Major and Minor values have been seen with the same UUID from an iBeacon device with a fixed MAC address.
 
+The system will not automatically create iBeacon devices for beacons that do not broadcast their name to avoid inundating your system with transient devices.
+
+To explicitly allow a list of UUIDs to be added even with an empty device name, add them via the integration options:
+
+{% include integrations/option_flow.md %}
+
 ## Considering an iBeacon Away
 
 Due to various factors such as individual system settings and iBeacon firmware, iBeacons will not be marked as "Away" immediately. This could take several minutes.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR documents the new allowlist option of the iBeacon integration.




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/104790
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
