### PR TITLE
Add removing custom polling interval as breaking change for ping

### DIFF
--- a/source/_posts/2023-12-06-release-202312.markdown
+++ b/source/_posts/2023-12-06-release-202312.markdown
@@ -440,6 +440,21 @@ to customize the rounding of the value.
 
 {% enddetails %}
 
+{% details "Ping" %}
+
+The option to set a custom polling interval has been removed. If you are using
+custom interval and really need it, you can use the `homeassistant.update_entity`
+in an automation to poll at your custom pace. See our documentation on
+[defining a custom polling interval](/common-tasks/general/#defining-a-custom-polling-interval)
+for more information.
+
+([@jpbede] - [#103743]) ([documentation](/integrations/ping))
+
+[@jpbede]: https://github.com/jpbede
+[#103743]: https://github.com/home-assistant/core/pull/103743
+
+{% enddetails %}
+
 {% details "SMTP" %}
 
 The SMTP integration will send images as attachments to a plain text email


### PR DESCRIPTION
## Proposed change
Add the remove of the custom polling interval for ping as a breaking change to the release notes, as this may break for some users.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
