### PR TITLE
Minimal interval time to 10s for dsmr meters

### DIFF
--- a/source/_integrations/dsmr.markdown
+++ b/source/_integrations/dsmr.markdown
@@ -42,7 +42,8 @@ To configure options for DSMR integration go to **Settings** -> **Devices & Serv
 
 #### Time between updates
 
-Typically the smart meter sends new data every 5-10 seconds. This value defines the minimum time between entity updates in seconds. Setting this value to 0 will update entities each time data is received from the smart meter.
+Typically the smart meter sends new data every 1-10 seconds. This value defines the minimum time between entity updates in seconds. In most cases the data is updated every 10 seconds and every 300 seconds for connected MBUS devices.
+Home Assistant allows you to updated the update time between measurements. The default is 30 seconds. The minimal interval is 10 seconds.
 
 <div class='note warning'>
 Reducing the default time between updates will increase the amount of events generated and can potentially flood the system with events.

--- a/source/_integrations/dsmr.markdown
+++ b/source/_integrations/dsmr.markdown
@@ -43,7 +43,7 @@ To configure options for DSMR integration go to **Settings** -> **Devices & Serv
 #### Time between updates
 
 Typically the smart meter sends new data every 1-10 seconds. This value defines the minimum time between entity updates in seconds. In most cases the data is updated every 10 seconds and every 300 seconds for connected MBUS devices.
-Home Assistant allows you to updated the update time between measurements. The default is 30 seconds. The minimal interval is 10 seconds.
+Home Assistant allows you to update the time between measurements. The default is 30 seconds. The minimal interval time is 10 seconds.
 
 <div class='note warning'>
 Reducing the default time between updates will increase the amount of events generated and can potentially flood the system with events.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The minimal interval time for DSMR meters is now 10 sec. A setting of 0 is no longer allowed.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/104900 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
