### PR TITLE
Move tts_service from example to configuration

### DIFF
--- a/source/_integrations/notify.tts.markdown
+++ b/source/_integrations/notify.tts.markdown
@@ -25,8 +25,6 @@ notify:
     media_player: media_player.living_room
 ```
 
-Please note that the `tts_service` parameter, must match the `service_name` defined in the TTS integration.
-
 {% configuration %}
   name:
     description: The name of the notify service.
@@ -37,7 +35,7 @@ Please note that the `tts_service` parameter, must match the `service_name` defi
     required: exclusive
     type: string
   tts_service:
-    description: "The `service_name` of a TTS platform. Either use `entity_id` or `tts_service` to target a TTS platform."
+    description: "The `service_name` of a TTS platform. Either use `entity_id` or `tts_service` to target a TTS platform. This must match the `service_name` defined in the TTS integration."
     required: exclusive
     type: string
   media_player:

--- a/source/_integrations/notify.tts.markdown
+++ b/source/_integrations/notify.tts.markdown
@@ -35,7 +35,7 @@ notify:
     required: exclusive
     type: string
   tts_service:
-    description: "The `service_name` of a TTS platform. Either use `entity_id` or `tts_service` to target a TTS platform. This must match the `service_name` defined in the TTS integration."
+    description: "The `service_name` of a TTS platform. Either use `entity_id` or `tts_service` to target a TTS platform."
     required: exclusive
     type: string
   media_player:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The note under the example provided provides information on a paramter that's mutually exclusive with the one included. This moves the note to the appropriate section of the configuration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

Partially addresses #29831

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
