### PR TITLE
Enhance Ubus Integration Documentation & Refine ACL Permissions

### DIFF
--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -20,17 +20,33 @@ opkg update
 opkg install rpcd-mod-file uhttpd-mod-ubus
 ```
 
-And create on your OpenWrt device a read-only user to be used by setting up the ACL file `/usr/share/rpcd/acl.d/user.json`.
+Add new system user `hass` (or do it in any other way that you prefer):
+
+* Add line to /etc/passwd: hass:x:10001:10001:hass:/var:/bin/false
+* Add line to /etc/shadow: hass:x:0:0:99999:7:::
+
+Edit `/etc/config/rpcd` and add:
+
+```
+config login
+        option username 'hass'
+        option password '$p$hass'
+        list read hass
+        list read unauthenticated
+        list write hass
+```
+
+And create an ACL file at `/usr/share/rpcd/acl.d/hass.json` for the user `hass` with:
 
 ```json
 {
-  "user": {
-    "description": "Read only user access role",
+  "hass": {
+    "description": "Access role for OpenWrt ubus integration",
     "read": {
       "ubus": {
-        "*": [ "*" ]
+        "hostapd.*": ["get_clients"],
+        "uci": ["get"]
       },
-      "uci": [ "*" ]
     },
     "write": {}
   }

--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -20,12 +20,12 @@ opkg update
 opkg install rpcd-mod-file uhttpd-mod-ubus
 ```
 
-Add new system user `hass` (or do it in any other way that you prefer):
+Add a new system user `hass` (or do it in any other way that you prefer):
 
-* Add line to /etc/passwd: hass:x:10001:10001:hass:/var:/bin/false
-* Add line to /etc/shadow: hass:x:0:0:99999:7:::
+-Add line to /etc/passwd: hass:x:10001:10001:hass:/var:/bin/false
+- Add line to /etc/shadow: hass:x:0:0:99999:7:::
 
-Edit `/etc/config/rpcd` and add:
+Edit the `/etc/config/rpcd` and add the following lines:
 
 ```
 config login
@@ -36,7 +36,7 @@ config login
         list write hass
 ```
 
-And create an ACL file at `/usr/share/rpcd/acl.d/hass.json` for the user `hass` with:
+Then, create an ACL file at `/usr/share/rpcd/acl.d/hass.json` for the user `hass`:
 
 ```json
 {

--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -27,7 +27,7 @@ Add a new system user `hass` (or do it in any other way that you prefer):
 
 Edit the `/etc/config/rpcd` and add the following lines:
 
-```
+```yaml
 config login
         option username 'hass'
         option password '$p$hass'

--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -22,7 +22,7 @@ opkg install rpcd-mod-file uhttpd-mod-ubus
 
 Add a new system user `hass` (or do it in any other way that you prefer):
 
--Add line to /etc/passwd: hass:x:10001:10001:hass:/var:/bin/false
+- Add line to /etc/passwd: hass:x:10001:10001:hass:/var:/bin/false
 - Add line to /etc/shadow: hass:x:0:0:99999:7:::
 
 Edit the `/etc/config/rpcd` and add the following lines:


### PR DESCRIPTION
## Proposed change

The current documentation does not contain enough information to start using the OpenWRT ubus integration, and the current ACL config file gives more permission than is actually needed.

This change explains how to add a system user `hass` and documents the configuration of `/etc/config/rpcd` configuration file. Those steps are missing from the current configuration.

Credits for those valuable steps go to: https://github.com/kvj/hass_openwrt.

Further more, the current ACLs config file gives more permission than is actually needed to make the integration work.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
