### PR TITLE
Clearify independend Reolink push notification switch

### DIFF
--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -158,7 +158,12 @@ Depending on the supported features of the camera, switch entities are added for
 
 For NVRs, a global switch for **Record**, **Push**, **Buzzer**, **Email**, and **FTP** will be available under the NVR device as well as a switch per channel of the NVR under the camera device. The respective feature will only be active for a given channel if both the global and that channel switch are enabled (as is also the case in the Reolink app/client).
 
-**Push** notifications to a phone will only be provided if both the **Push notifications** switch in Home Assistant is ON (for NVRs both the global and channel switch) and the Push-notification in the Reolink App of that phone is ON. The Push-notification in the reolink app is independet of the Home Assistant setting and independent of the settings on other phones connected to the same camera. Reolink does this so you have a independed way of turning off push notifications per phone.
+**Push** notifications to a phone will only be provided if the following conditions are met: 
+- The **Push notifications** switch in Home Assistant is ON. 
+- For NVRs,  both the global and channel switch are ON.
+- The Push-notification in the Reolink App of that phone is ON.
+
+The Push-notification in the Reolink app is independent of the Home Assistant setting. It is also independent of the settings on other phones connected to the same camera. Reolink does this so you have an independent way of turning off push notifications per phone.
 
 ## Light entities
 

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -158,6 +158,8 @@ Depending on the supported features of the camera, switch entities are added for
 
 For NVRs, a global switch for **Record**, **Push**, **Buzzer**, **Email**, and **FTP** will be available under the NVR device as well as a switch per channel of the NVR under the camera device. The respective feature will only be active for a given channel if both the global and that channel switch are enabled (as is also the case in the Reolink app/client).
 
+**Push** notifications to a phone will only be provided if both the **Push notifications** switch in Home Assistant is ON (for NVRs both the global and channel switch) and the Push-notification in the Reolink App of that phone is ON. The Push-notification in the reolink app is independet of the Home Assistant setting and independent of the settings on other phones connected to the same camera. Reolink does this so you have a independed way of turning off push notifications per phone.
+
 ## Light entities
 
 Depending on the supported features of the camera, light entities are added for:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Clearify how the Reolink push notification switch works (to control how push notifications are send from the camera through the reolink cloud servers to a mobile phone).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/92890

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
