### PR TITLE
Update sensor.rest.markdown

### DIFF
--- a/source/_integrations/sensor.rest.markdown
+++ b/source/_integrations/sensor.rest.markdown
@@ -411,7 +411,7 @@ rest:
 
 {% endraw %}
 
-The example below shows how to extract multiple values from a dictionary from the XML file of a Steamist Steambath Wi-Fi interface. The values are used to create a switch and multiple sensors without having to poll the endpoint numerous times.
+The example below shows how to extract multiple values from a dictionary from the XML file of a Steamist Steambath Wi-Fi interface. The values are used to create multiple sensors without having to poll the endpoint numerous times.
 
 {% raw %}
 
@@ -430,32 +430,6 @@ rest:
       - name: "Steam Time Remaining"
         value_template: "{{ json_value['response']['time0'] }}"
         unit_of_measurement: "minutes"
-
-    switch:
-      - name: "Steam"
-        value_template: "{{ json_value['response']['usr0'] | int >= 1 }}"
-        turn_on:
-          - service: rest_command.set_steam_led
-            data:
-               led: 6
-          - service: homeassistant.update_entity
-            target:
-               entity_id: sensor.steam_system_data
-          - delay: 00:00:15
-          - service: homeassistant.update_entity
-            target:
-               entity_id: sensor.steam_system_data
-        turn_off:
-          - service: rest_command.set_steam_led
-            data:
-               led: 7
-          - service: homeassistant.update_entity
-            target:
-               entity_id: sensor.steam_system_data
-          - delay: 00:00:15
-          - service: homeassistant.update_entity
-            target:
-               entity_id: sensor.steam_system_data
 
 rest_command:  
   set_steam_led:


### PR DESCRIPTION
The `rest` integration does not support switches. Only the rest switch platform does. 

See: https://www.home-assistant.io/integrations/rest/#sensor

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
