### PR TITLE
Add entity type attribute to Deutscher Wetterdienst (DWD)

### DIFF
--- a/source/_integrations/dwd_weather_warnings.markdown
+++ b/source/_integrations/dwd_weather_warnings.markdown
@@ -32,6 +32,7 @@ Warncell ID or name:
 | `last_update` | *(time)* Time and date (UTC) of last update from DWD. |
 | `region_name` | *(str)* Requested region name. This should be the same as the region name in the configuration, if a name was given. |
 | `region_id` | *(int)* Region ID assigned by DWD. This should be the same as the region id in the configuration, if an id was given. |
+| `type` | *(str)* Type of warnings provided by this entity. Can ether be `current` or `advance`. |s
 | `warning_count` | *(int)* Number of issued warnings. There can be more than one warning issued at once. |
 | `warning_<x>` | *(list)* The warning as a whole object containing the following attributes as nested attributes. |
 | `warning_<x>_level` | *(int)* Issued warning level (0 - 4).<br/>0: Keine Warnungen <br/>1: Wetterwarnungen <br/>2: Warnungen vor markantem Wetter<br/>3: Unwetterwarnungen<br/>4: Warnungen vor extremem Unwetter |

--- a/source/_integrations/dwd_weather_warnings.markdown
+++ b/source/_integrations/dwd_weather_warnings.markdown
@@ -32,7 +32,7 @@ Warncell ID or name:
 | `last_update` | *(time)* Time and date (UTC) of last update from DWD. |
 | `region_name` | *(str)* Requested region name. This should be the same as the region name in the configuration, if a name was given. |
 | `region_id` | *(int)* Region ID assigned by DWD. This should be the same as the region id in the configuration, if an id was given. |
-| `type` | *(str)* Type of warnings provided by this entity. Can ether be `current` or `advance`. |s
+| `type` | *(str)* Type of warnings provided by this entity. Can ether be `current` or `advance`. |
 | `warning_count` | *(int)* Number of issued warnings. There can be more than one warning issued at once. |
 | `warning_<x>` | *(list)* The warning as a whole object containing the following attributes as nested attributes. |
 | `warning_<x>_level` | *(int)* Issued warning level (0 - 4).<br/>0: Keine Warnungen <br/>1: Wetterwarnungen <br/>2: Warnungen vor markantem Wetter<br/>3: Unwetterwarnungen<br/>4: Warnungen vor extremem Unwetter |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Docs for: https://github.com/home-assistant/core/pull/105073

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/105073
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
