### PR TITLE
Remove UniFi Protect EA docs

### DIFF
--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -59,39 +59,11 @@ UCKP with Firmware v1.x **do NOT run UniFi OS**, you must upgrade to firmware `[
 
 The absolute **minimal** software version is `[v1.20.0](https://community.ui.com/releases/UniFi-Protect-Application-1-20-0/d43c0905-3fb4-456b-a7ca-73aa830cb011)` for UniFi Protect. If you have an older version, you will get errors trying to set up the integration. However, the general advice is the latest 2 minor versions of UniFi Protect and hardware supported by those are supported.
 
-#### About UniFi Early Access
-
 <div class='note warning'>
 
-**Early Access releases are not supported by Home Assistant.**
+**Early Access and Release Candidate versions are not supported by Home Assistant.**
 
-Using Early Access versions will likely cause your UniFi Protect {% term integration %} to break unexpectedly.
-
-</div>
-
-#### Downgrading UniFi Protect
-
-In the event you accidentally upgrade to an Early Access version of UniFi Protect, you can downgrade to a stable version by either [restoring a backup](https://help.ui.com/hc/articles/360008976393) or by manually downgrading your UniFi Protect.
-
-##### Manually downgrade
-
-Manually downgrading comes with its own risks and it is not recommended unless you do not have a backup available. Some Protect versions cannot be downgraded from (like `v2.0` to `v1.21`). To downgrade, you can access your [UniFi OS Console via SSH](https://help.ui.com/hc/articles/204909374) and then do the following:
-
-```bash
-# Run this command first _only_ if you are on a 1.x firmware of the UDM Pro.
-# It is not needed for the UDM SE, UNVR, etc.
-unifi-os shell
-
-# Downgrade UniFi Protect.
-apt-get update
-apt-get install --reinstall --allow-downgrades unifi-protect=2.0.0~beta.5 -y
-```
-
-You can replace `2.0.0~beta.5` with whatever version of UniFi Protect you want to downgrade to. Any dashes in the version (`-`), replace with tilde (`~`).
-
-<div class='note'>
-
-If you want to downgrade to another Early Access version, you must have [Remote Access enabled](https://help.ui.com/hc/articles/115012240067) and have the Early Access release channel enabled.
+Using Early Access Release Candidate versions of UniFi Protect or UniFi OS will likely cause your UniFi Protect {% term integration %} to break unexpectedly. If you choose to opt into either the Early Access or the Release Candidate release channel and anything breaks in Home Assistant, you will need to wait until that version goes to the official Stable Release channel before it is expected to work.
 
 </div>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Ubiquiti is getting a lot more hostile about users downgrading versions and are actively removing all comments/etc. from users that tell others how to downgrade. As a result, I am also removing our documentation on it. Early Access is fully not supported. If a user uses an EA version at any time and something breaks, they are on their own. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
