### PR TITLE
Update todo.markdown

### DIFF
--- a/source/_integrations/todo.markdown
+++ b/source/_integrations/todo.markdown
@@ -76,6 +76,7 @@ data:
   item: "Submit Income Tax Return"
   due_date: "2024-04-10"
   description: "Collect all necessary documents and submit the final return."
+```
 
 ### Service `todo.update_item`
 


### PR DESCRIPTION
Added missing closing backticks on the example yaml for todo.add_item

## Proposed change
Add missing closing backticks, as described above.



## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
