### PR TITLE
Set default ping interval to 15 seconds instead 5 minutes

### DIFF
--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -27,8 +27,8 @@ There is currently support for the following device types within Home Assistant:
 
 ## Polling interval
 
-By default, the integration will ping the device every 5 minutes. 
-If you wish to do a ping more frequently, you can disable the automatic refresh in the integration's system options (Enable polling for updates) and create your own automation with your desired frequency.
+By default, the integration will ping the device every 15 seconds. 
+If you wish to do a ping at a different interval, you can disable the automatic refresh in the integration's system options (Enable polling for updates) and create your own automation with your desired frequency.
 
 For more detailed steps on how to define a custom interval, follow the procedure below.
 
@@ -39,7 +39,7 @@ For more detailed steps on how to define a custom interval, follow the procedure
 ## Binary sensor
 
 The `ping` binary sensor platform allows you to use `ping` to send ICMP echo requests. This way you can check if a given host is online and determine the round trip times from your Home Assistant instance to that system.
-This sensor is enabled by default. The default polling interval is 5 minutes.
+This sensor is enabled by default. The default polling interval is 15 seconds.
 
 The sensor exposes the different round trip times in milliseconds measured by `ping` as attributes:
 


### PR DESCRIPTION
## Proposed change

When moving ping integration from yaml to GUI instead of a configurable interval, a fixed interval of 5 minutes is used. An interval that long does not make much sense in a home automation context. This PR changes that interval to a way more sane 15 seconds.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/105191
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
