### PR TITLE
Make it clearer where auth command has to be entered

### DIFF
--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -22,23 +22,22 @@ If you are the owner or have administrator, there are different methods to reset
 
 ### To reset a password while still logged in (including Supervised)
 
-If you are still logged in to the web interface with your user, then you are in luck.
+The method used to reset a password depends on your user rights:
 
-1. If you are a regular user without administrator rights, ask the owner to give you a new password.
-2. If you are the owner, choose one of the procedures below to reset your password.
-   - You cannot recover an owner password from within Home Assistant.
-   - There is only one owner per system. You cannot add a new owner.
-3. If you are an administrator, add a new user as an administrator and give the new user a password you can remember.
-4. Then log out, and log in with this new user.
-5. Reset your password via this new administrator account (and then delete this new account).
-   - Your configuration will remain, and you don't have to do a new onboarding process.
+- If you are a regular user without administrator rights, ask the owner to [give you a new password](/docs/locked_out/#to-reset-a-users-password-as-an-owner-via-the-web-interface).
+- If you are the owner, choose one of the procedures below to reset your password.
+  - You cannot recover an owner password from within Home Assistant.
+  - There is only one owner per system. You cannot add a new owner.
+- If you are an administrator, add a new user as an administrator and give the new user a password you can remember.
+  1. Then log out, and log in with this new user.
+  2. Reset your password via this new administrator account (and then [delete this new account](/docs/locked_out/#to-delete-a-user)).
+     - Your configuration will remain, and you don't have to do a new onboarding process.
 
 ### To reset an owner's password, via console
 
 Use this procedure only if the following conditions are met:
 
 - You know the username.
-- You are not logged in to Home Assistant. If you are logged in, refer to the procedure above.
 - You can access the [Home Assistant console](/hassio/commandline/) **on the device itself** (not via the SSH terminal from the add-ons).
 
 1. Connect to the console of the Home Assistant server:
@@ -48,7 +47,7 @@ Use this procedure only if the following conditions are met:
      - [Using the serial console on macOS / Linux](https://yellow.home-assistant.io/guides/use-serial-console-linux-macos/)
    - If you are using a Home Assistant Green, refer to the following procedure:
      - [Using the terminal](https://green.home-assistant.io/guides/use-terminal/)
-   - If you are using another board, connect a keyboard and monitor to your device and access the terminal.
+   - If you are using another board, connect a keyboard and monitor to your device and access the terminal. The procedure is likely very similar to the one described for the Green in the step above.
 2. Once you have opened the Home Assistant command line, enter the following command:
    - Note: `existing_user` is a placeholder. Replace it with your user name.
    - Note: `new_password` is a placeholder. Replace it with your new password.
@@ -67,6 +66,8 @@ If you are running Home Assistant in a container, you can use the command line i
 5. `docker restart homeassistant` to restart the container.
 
 ### To reset a user's password, as an owner via the web interface
+
+Only the owner can change other user's passwords.
 
 1. In the bottom left, select your user to go to the {% my profile title="**Profile**" %} page and make sure **Advanced Mode** is activated.
 2. Go to {% my people title="**Settings** > **People**" %} and select the person for which you want to change the password.

--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -6,32 +6,49 @@ description: "Options for regaining access"
 The sections below deal with recovering from a situation where you are not able to sign in,
 or need to recover your data.
 
+## Forgot user name
+
+If you’ve forgotten your username, ask the owner to help you.
+If you are the owner and have forgotten your user name, then you need to [prepare the system to start a new onboarding process](/docs/locked_out/#to-prepare-the-system-to-start-a-new-onboarding-process).
+
 ## Forgot password
 
-### Home Assistant (including Supervised)
+If you are not the owner or do not have administrator rights, ask the owner to give you a new password.
+
+- In the navigation pane on the left, check if you see the **Settings** menu listed above the **Notifications**.
+  - If you don't, you do not have administrator rights.
+
+If you are the owner or have administrator, there are different methods to reset a password, depending on your setup:
+
+### To reset a password while still logged in (including Supervised)
 
 If you are still logged in to the web interface with your user, then you are in luck.
 
-1. Add a new user as an administrator and give the new user a password you can remember.
-2. Then log out, and log in with this new user.
-3. Reset your password via this new administrator account (and then delete this new account).
+1. If you are a regular user without administrator rights, ask the owner to give you a new password.
+2. If you are the owner, choose one of the procedures below to reset your password.
+   - You cannot recover an owner password from within Home Assistant.
+   - There is only one owner per system. You cannot add a new owner.
+3. If you are an administrator, add a new user as an administrator and give the new user a password you can remember.
+4. Then log out, and log in with this new user.
+5. Reset your password via this new administrator account (and then delete this new account).
    - Your configuration will remain, and you don't have to do a new onboarding process.
 
-If you’ve forgotten your username, then deleting the files mentioned further below will be necessary to start a new onboarding process.
-
-#### To reset a user's password, via console
+### To reset an owner's password, via console
 
 Use this procedure only if the following conditions are met:
 
 - You know the username.
+- You are not logged in to Home Assistant. If you are logged in, refer to the procedure above.
 - You can access the [Home Assistant console](/hassio/commandline/) **on the device itself** (not via the SSH terminal from the add-ons).
 
-1. Connect a keyboard and monitor to your device and access the terminal:
+1. Connect to the console of the Home Assistant server:
+   - If you are using a virtual machine, connect to your virtual machine console.
    - If you are using a Home Assistant Yellow, refer to the following procedure:
      - [Using the serial console on Windows](https://yellow.home-assistant.io/guides/use-serial-console-windows/)
      - [Using the serial console on macOS / Linux](https://yellow.home-assistant.io/guides/use-serial-console-linux-macos/)
    - If you are using a Home Assistant Green, refer to the following procedure:
      - [Using the terminal](https://green.home-assistant.io/guides/use-terminal/)
+   - If you are using another board, connect a keyboard and monitor to your device and access the terminal.
 2. Once you have opened the Home Assistant command line, enter the following command:
    - Note: `existing_user` is a placeholder. Replace it with your user name.
    - Note: `new_password` is a placeholder. Replace it with your new password.
@@ -39,7 +56,7 @@ Use this procedure only if the following conditions are met:
    - **Troubleshooting**: If you see the message `zsh: command not found: auth`, you likely did not enter the command in the serial console connected to the device itself, but in the terminal within Home Assistant.
 3. You can now log in to Home Assistant using this new password.
 
-#### To reset a user's password, via the container command line
+### To reset a user's password, via the container command line
 
 If you are running Home Assistant in a container, you can use the command line in the container with the `hass` command to change your password. The steps below refer to a Home Assistant container in Docker named `homeassistant`. Note that while working in the container, commands will take a few moments to execute.
   
@@ -49,7 +66,7 @@ If you are running Home Assistant in a container, you can use the command line i
 4. `exit` to exit the container command line
 5. `docker restart homeassistant` to restart the container.
 
-#### To reset a user's password, as an owner via the web interface
+### To reset a user's password, as an owner via the web interface
 
 1. In the bottom left, select your user to go to the {% my profile title="**Profile**" %} page and make sure **Advanced Mode** is activated.
 2. Go to {% my people title="**Settings** > **People**" %} and select the person for which you want to change the password.
@@ -59,7 +76,9 @@ If you are running Home Assistant in a container, you can use the command line i
 5. Confirm the new password by entering it again, and select **OK** again.
 6. A confirmation box will be displayed with the text **Password was changed successfully**.
 
-#### To delete a user, as an administrator via the web interface
+### To delete a user
+
+You need to be an owner or have administrator rights to delete a user.
 
 1. Go to {% my people title="**Settings** > **People**" %} and select the person which you want to delete.
    - Note: you cannot delete the owner.
@@ -67,9 +86,12 @@ If you are running Home Assistant in a container, you can use the command line i
    - A confirmation dialog box will be displayed.
 3. To confirm, select **OK**.
 
-#### Start a new onboarding process
+### To prepare the system to start a new onboarding process
 
-If you lose the password associated with the owner account and the steps above do not work to reset the password, the only way to resolve this is to start a new onboarding process. If you have an external backup with an administrator account of which you still know the login credentials, you can restore that backup. If you do not have a backup, resetting the device will erase all data.
+If you lose the password associated with the owner account and the steps above do not work to reset the password, the only way to resolve this is to start a new onboarding process. 
+
+- If you have an external backup with an administrator account of which you still know the login credentials, you can restore that backup.
+- If you do not have a backup, resetting the device will erase all data.
 
 - If you have a Home Assistant Green, [reset the Green](https://green.home-assistant.io/guides/reset/).
 - If you have a Home Assistant Yellow, [reset the Yellow](https://yellow.home-assistant.io/guides/factory-reset/).

--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -21,7 +21,10 @@ If you’ve forgotten your username, then deleting the files mentioned further b
 
 #### To reset a user's password, via console
 
-Use this procedure if you know the username, and you can access the [Home Assistant console](/hassio/commandline/) on the device itself (not the SSH terminal from the add-ons). 
+Use this procedure only if the following conditions are met:
+
+- You know the username.
+- You can access the [Home Assistant console](/hassio/commandline/) **on the device itself** (not via the SSH terminal from the add-ons).
 
 1. Connect a keyboard and monitor to your device and access the terminal:
    - If you are using a Home Assistant Yellow, refer to the following procedure:
@@ -33,6 +36,7 @@ Use this procedure if you know the username, and you can access the [Home Assist
    - Note: `existing_user` is a placeholder. Replace it with your user name.
    - Note: `new_password` is a placeholder. Replace it with your new password.
    - **Command**: `auth reset --username existing_user --password new_password`
+   - **Troubleshooting**: If you see the message `zsh: command not found: auth`, you likely did not enter the command in the serial console connected to the device itself, but in the terminal within Home Assistant.
 3. You can now log in to Home Assistant using this new password.
 
 #### To reset a user's password, via the container command line


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Make it clearer where the auth command has to be entered
- addresses issue mentioned in #30190

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #30190

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
