### PR TITLE
Blueprints: add re-importing procedure

### DIFF
--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -41,12 +41,24 @@ Home Assistant can import blueprints from the Home Assistant forums, GitHub, and
 
 The blueprint can now be used for creating automations.
 
-## Keeping blueprints up to date
+## Re-importing a blueprint
 
 Blueprints created by the community may go through multiple revisions. Sometimes a user creates a blueprint,
 the community provides feedback, and new functionality is added.
 
-While there's no built-in functionality to update a blueprint you've already imported, you can manually edit
+The quickest way to get these changes is by re-importing the blueprint. This will overwrite the blueprint you currently have.
+
+1. **Before you do this**: If the re-imported blueprint is not compatible, it can break your automations.
+   - In this case, you will need to manually adjust your automations.
+2. Go to **{% my blueprints title="Settings > Automations & Scenes > Blueprints" %}**.
+3. On the blueprint that you want to re-import, select the three-dot menu, and select **Re-import blueprint**.
+
+## Updating an imported blueprint manually
+
+Blueprints created by the community may go through multiple revisions. Sometimes a user creates a blueprint,
+the community provides feedback, and new functionality is added.
+
+If you do not want to [re-import the blueprint](/docs/automation/using_blueprints/#re-importing-a-blueprint) for some reason, you can manually edit
 its YAML content to keep it up to date:
 
 1. Navigate to the blueprints directory (`blueprints/automation/`).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Blueprints: 
- add procedure on how to re-import a blueprint
- this feature was added in 2023.12

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #30197 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
