### PR TITLE
Document Wyoming satellite audio settings

### DIFF
--- a/source/_integrations/wyoming.markdown
+++ b/source/_integrations/wyoming.markdown
@@ -28,3 +28,17 @@ The **Wyoming** {% term integration %} connects external voice services to Home 
 ## Satellites
 
 [Remote voice satellites](https://github.com/rhasspy/wyoming-satellite) can be connected to Home Assistant using the Wyoming protocol. These satellites typically run on Raspberry Pi's, and are automatically discovered by Home Assistant through [Zeroconf](/integrations/zeroconf).
+
+
+### Audio Settings
+
+The following settings control audio processing of a satellite's microphone input:
+
+- Noise suppression
+    - Level of noise suppression (uses [webrtc]). Audio distortion may occur as the level increases.
+- Auto gain
+    - Automatically adjusts volume based on ambient noise (uses [webrtc]). The setting value is the target dBFS.
+- Mic volume
+    - Fixed multiplier applied to microphone audio samples. 2.0 doubles the volume, while 0.5 is halves it. Values above 1.0 may increase noise or cause audio distortion.
+
+[webrtc]: https://github.com/rhasspy/webrtc-noise-gain


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds documentation for Wyoming satellite audio settings.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/105261
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
