### PR TITLE
Fix next link on onboarding.markdown so it matches the navigation and doesn't skip over dashboards

### DIFF
--- a/source/_includes/asides/getting_started_navigation.html
+++ b/source/_includes/asides/getting_started_navigation.html
@@ -4,8 +4,8 @@
     <ul class="divided sidebar-menu">
       <li>{% active_link /installation/ Installation %}</li>
       <li>{% active_link /getting-started/onboarding/ Onboarding %}</li>
-      <li>{% active_link /getting-started/onboarding_dashboard/ Edit the dashboard %}</li>
       <li>{% active_link /getting-started/concepts-terminology/ Concepts and terminology %}</li>
+      <li>{% active_link /getting-started/onboarding_dashboard/ Edit the dashboard %}</li>
       <li>{% active_link /getting-started/integration/ Integration %}</li>
       <li>{% active_link /getting-started/automation/ Automation %}</li>
       <li>

--- a/source/getting-started/concepts-terminology.markdown
+++ b/source/getting-started/concepts-terminology.markdown
@@ -70,4 +70,4 @@ Depending on your [installation type](/installation), you can install third part
 
 ![Add-ons](/images/getting-started/add-ons.png)
 
-{% include getting-started/next_step.html step="Adding Integrations In Home Assistant" link="/getting-started/integration/" %}
+{% include getting-started/next_step.html step="Edit the dashboard" link="/getting-started/onboarding_dashboard/" %}

--- a/source/getting-started/onboarding.markdown
+++ b/source/getting-started/onboarding.markdown
@@ -53,4 +53,4 @@ We will now create the owner's account of Home Assistant. This account is an adm
 7. Finally, select **Finish**.
    - Now you're brought to the Home Assistant web interface. If some of your devices were discovered and set up automatically, this default dashboard may already show some of your devices.
 
-{% include getting-started/next_step.html step="Concepts & Terminology" link="/getting-started/concepts-terminology/" %}
+{% include getting-started/next_step.html step="Edit the dashboard" link="/getting-started/onboarding_dashboard/" %}

--- a/source/getting-started/onboarding.markdown
+++ b/source/getting-started/onboarding.markdown
@@ -53,4 +53,4 @@ We will now create the owner's account of Home Assistant. This account is an adm
 7. Finally, select **Finish**.
    - Now you're brought to the Home Assistant web interface. If some of your devices were discovered and set up automatically, this default dashboard may already show some of your devices.
 
-{% include getting-started/next_step.html step="Edit the dashboard" link="/getting-started/onboarding_dashboard/" %}
+{% include getting-started/next_step.html step="Concepts & Terminology" link="/getting-started/concepts-terminology/" %}

--- a/source/getting-started/onboarding_dashboard.markdown
+++ b/source/getting-started/onboarding_dashboard.markdown
@@ -48,4 +48,4 @@ The procedure below is optional. The idea is to learn some basics on changing th
    - When you are done, in the top right corner, select **Done**.
 9. Congratulations! You have completed your first dashboard customization.
 
-{% include getting-started/next_step.html step="Concepts & Terminology" link="/getting-started/concepts-terminology/" %}
+{% include getting-started/next_step.html step="Integrations" link="/getting-started/integration/" %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
As a new user (loving it!) I was going through the on boarding docs and noticed an inconsistency in the next page links. 

When you're on the Onboarding page, the "Next" link takes you to Concepts & Terminology and skips of Edit the dashboard. 

This bug is inconsistency was jarring, especially in mobile mode where you don't see the nav and miss an entire piece of content. 

<img width="1149" alt="Screenshot 2023-12-08 at 9 52 10 AM" src="https://github.com/home-assistant/home-assistant.io/assets/99417/4eb17d63-bb26-46d7-a44b-139146b00fa7">

My PR contains the updated link.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: `N/A`
- Link to parent pull request in the Brands repository:  `N/A`
- This PR fixes or closes issue: fixes  `N/A`

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
