### PR TITLE
fix container disable  jemalloc example

### DIFF
--- a/source/_includes/installation/container.md
+++ b/source/_includes/installation/container.md
@@ -130,7 +130,7 @@ As jemalloc can cause issues on certain hardware, it can be disabled by passing 
       homeassistant:
       ...
         environment:
-          - DISABLE_JEMALLOC=true
+          DISABLE_JEMALLOC: true
     ```
 
 {% endtabbed_block %}

--- a/source/_includes/installation/container.md
+++ b/source/_includes/installation/container.md
@@ -129,8 +129,8 @@ As jemalloc can cause issues on certain hardware, it can be disabled by passing 
     services:
       homeassistant:
       ...
-      environment:
-        - DISABLE_JEMALLOC: true
+        environment:
+          - DISABLE_JEMALLOC=true
     ```
 
 {% endtabbed_block %}


### PR DESCRIPTION
1. environment tag should be a child of the service homeassistant tag
2. environment variable value is set with "=" and not " :" . See [here](https://docs.docker.com/compose/environment-variables/set-environment-variables/#use-the-environment-attribute)

## Proposed change
### error
<img width="649" alt="Screenshot 2023-12-09 at 8 34 45 AM" src="https://github.com/home-assistant/home-assistant.io/assets/10516699/889bced9-79e7-4ddb-82fc-4934e93fb6ab">

### after syntax update
<img width="541" alt="Screenshot 2023-12-09 at 8 37 19 AM" src="https://github.com/home-assistant/home-assistant.io/assets/10516699/f7bfbbe2-1e6b-439b-bbaf-5577a89c08b8">


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/TaiPhamD/home-assistant.io
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
