### PR TITLE
Update blink for new service calls

### DIFF
--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -54,7 +54,7 @@ Please note that each camera reports two different states: one as `sensor.blink_
 
 ## Services
 
-Any sequential calls to {% term services %}  relating to blink should have a minimum of a 5 second delay in between them to prevent the calls from being throttled and ignored.  Services have targets.
+Any sequential calls to {% term services %}  relating to blink should have a minimum of a 5 second delay in between them to prevent the calls from being throttled and ignored.  The services that act on a camera needs a target parameter.
 
 ### `blink.trigger_camera`
 
@@ -202,7 +202,7 @@ The file name of the downloaded video file is not configurable.
   action:
     - service: blink.save_recent_clips
       target:
-        entity_id: My Camera
+        entity_id: camera.my_camera
       data:
         file_path: /tmp/videos
 ```

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -54,7 +54,7 @@ Please note that each camera reports two different states: one as `sensor.blink_
 
 ## Services
 
-Any sequential calls to {% term services %}  relating to blink should have a minimum of a 5 second delay in between them to prevent the calls from being throttled and ignored.  The services that act on a camera needs a target parameter.
+Any sequential calls to {% term services %}  relating to blink should have a minimum of a 5 second delay in between them to prevent the calls from being throttled and ignored. The services that act on a camera needs a target parameter.
 
 ### `blink.trigger_camera`
 

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -74,6 +74,13 @@ homeassistant:
     - '/tmp'
     - '/path/to/whitelist'
 ```
+### `blink.save_recent_clips`
+
+Save the recent video clips of a camera to a local file in the pattern `%Y%m%d_%H%M%S_{name}.mp4`. Note that in most cases, Home Assistant will need to know that the directory is writable via the `allowlist_external_dirs` in your `configuration.yaml` file.
+
+| Service Data Attribute | Optional | Description                              |
+| ---------------------- | -------- | ---------------------------------------- |
+| `file_path`            | no       | Location of save files.                  |
 
 ### `blink.send_pin`
 

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -93,7 +93,7 @@ Send a new pin to blink.  Since Blink's 2FA implementation is new and changing, 
 
 ### Other services
 
-In addition to the services mentioned above, there are generic `camera`, `alarm_control_panel`, and `homeassistant` services are available. The `camera.enable_motion_detection` and `camera.disable_motion_detection` services allow for individual cameras to be enabled and disabled, respectively, within the Blink system. The `alarm_control_panel.alarm_arm_away` and `alarm_control_panel.alarm_disarm` services allow for the whole system to be armed and disarmed, respectively. The `homeassistant.update_entity` service will force an update of the blink system.  Blink Mini cameras linked to an existing sync module cannot be armed/disarmed individually via Home Assistant.
+In addition to the services mentioned above, there are generic `camera`, `alarm_control_panel`, and `homeassistant` services available. The `camera.enable_motion_detection` and `camera.disable_motion_detection` services allow for individual cameras to be enabled and disabled, respectively, within the Blink system. The `alarm_control_panel.alarm_arm_away` and `alarm_control_panel.alarm_disarm` services allow for the whole system to be armed and disarmed, respectively. The `homeassistant.update_entity` service will force an update of the blink system. Blink Mini cameras linked to an existing sync module cannot be armed/disarmed individually via Home Assistant.
 
 ## Examples
 

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -54,23 +54,11 @@ Please note that each camera reports two different states: one as `sensor.blink_
 
 ## Services
 
-Any sequential calls to {% term services %}  relating to blink should have a minimum of a 5 second delay in between them to prevent the calls from being throttled and ignored.
-
-### `blink.blink_update`
-
-Force a refresh of the Blink system.
-This service is depreciated, use `Home Assistant Core Integration: Update entity`
-| Service Data Attribute | Optional | Description                            |
-| ---------------------- | -------- | -------------------------------------- |
-| `config_entry_id`      | no       | Blink config to update.                |
+Any sequential calls to {% term services %}  relating to blink should have a minimum of a 5 second delay in between them to prevent the calls from being throttled and ignored.  Services have targets.
 
 ### `blink.trigger_camera`
 
 Trigger a camera to take a new still image.
-
-| Service Data Attribute | Optional | Description                            |
-| ---------------------- | -------- | -------------------------------------- |
-| `entity_id`            | no.      | Camera entity to take picture with.    |
 
 ### `blink.save_video`
 
@@ -78,7 +66,6 @@ Save the last recorded video of a camera to a local file. Note that in most case
 
 | Service Data Attribute | Optional | Description                              |
 | ---------------------- | -------- | ---------------------------------------- |
-| `entity_id`            | no       | Name of camera containing video to save. |
 | `filename`             | no       | Location of save file.                   |
 
 ```yaml
@@ -99,7 +86,7 @@ Send a new pin to blink.  Since Blink's 2FA implementation is new and changing, 
 
 ### Other services
 
-In addition to the services mentioned above, there are generic `camera` and `alarm_control_panel` services available for use as well. The `camera.enable_motion_detection` and `camera.disable_motion_detection` services allow for individual cameras to be enabled and disabled, respectively, within the Blink system. The `alarm_control_panel.alarm_arm_away` and `alarm_control_panel.alarm_disarm` services allow for the whole system to be armed and disarmed, respectively.  Blink Mini cameras linked to an existing sync module cannot be armed/disarmed individually via Home Assistant.
+In addition to the services mentioned above, there are generic `camera`, `alarm_control_panel`, and `homeassistant` services are available. The `camera.enable_motion_detection` and `camera.disable_motion_detection` services allow for individual cameras to be enabled and disabled, respectively, within the Blink system. The `alarm_control_panel.alarm_arm_away` and `alarm_control_panel.alarm_disarm` services allow for the whole system to be armed and disarmed, respectively.  The `homeassistant.update_entity` service will force an update of the blink system.  Blink Mini cameras linked to an existing sync module cannot be armed/disarmed individually via Home Assistant.
 
 ## Examples
 
@@ -176,10 +163,11 @@ The following example assumes your camera's name (in the Blink app) is `My Camer
     entity_id: binary_sensor.blink_my_camera_motion_detected
     to: "on"
   action:
-    service: blink.save_video
-    data:
-      entity_id: "My Camera"
-      filename: "/tmp/videos/blink_video_{{ now().strftime('%Y%m%d_%H%M%S') }}.mp4"
+    -  service: blink.save_video
+       target:
+         entity_id: camera.blink_my_camera
+       data:
+         filename: "/tmp/videos/blink_video_{{ now().strftime('%Y%m%d_%H%M%S') }}.mp4"
 ```
 
 {% endraw %}
@@ -204,7 +192,8 @@ The file name of the downloaded video file is not configurable.
       minutes: /3
   action:
     - service: blink.save_recent_clips
-      data:
+      target:
         entity_id: My Camera
+      data:
         file_path: /tmp/videos
 ```

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -59,7 +59,7 @@ Any sequential calls to {% term services %}  relating to blink should have a min
 ### `blink.blink_update`
 
 Force a refresh of the Blink system.
-
+This service is depreciated, use `Home Assistant Core Integration: Update entity`
 | Service Data Attribute | Optional | Description                            |
 | ---------------------- | -------- | -------------------------------------- |
 | `config_entry_id`      | no       | Blink config to update.                |

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -60,13 +60,17 @@ Any sequential calls to {% term services %}  relating to blink should have a min
 
 Force a refresh of the Blink system.
 
+| Service Data Attribute | Optional | Description                            |
+| ---------------------- | -------- | -------------------------------------- |
+| `config_entry_id`      | no       | Blink config to update.                |
+
 ### `blink.trigger_camera`
 
 Trigger a camera to take a new still image.
 
 | Service Data Attribute | Optional | Description                            |
 | ---------------------- | -------- | -------------------------------------- |
-| `entity_id`            | yes      | Camera entity to take picture with.    |
+| `entity_id`            | no.      | Camera entity to take picture with.    |
 
 ### `blink.save_video`
 
@@ -74,7 +78,7 @@ Save the last recorded video of a camera to a local file. Note that in most case
 
 | Service Data Attribute | Optional | Description                              |
 | ---------------------- | -------- | ---------------------------------------- |
-| `name`                 | no       | Name of camera containing video to save. |
+| `entity_id`            | no       | Name of camera containing video to save. |
 | `filename`             | no       | Location of save file.                   |
 
 ```yaml
@@ -90,6 +94,7 @@ Send a new pin to blink.  Since Blink's 2FA implementation is new and changing, 
 
 | Service Data Attribute | Optional | Description                  |
 | ---------------------- | -------- | ---------------------------- |
+| `config_entry_id`      | no       | Blink config to send pin to. |
 | `pin`                  | no       | 2FA Pin received from blink. |
 
 ### Other services
@@ -173,7 +178,7 @@ The following example assumes your camera's name (in the Blink app) is `My Camer
   action:
     service: blink.save_video
     data:
-      name: "My Camera"
+      entity_id: "My Camera"
       filename: "/tmp/videos/blink_video_{{ now().strftime('%Y%m%d_%H%M%S') }}.mp4"
 ```
 
@@ -200,6 +205,6 @@ The file name of the downloaded video file is not configurable.
   action:
     - service: blink.save_recent_clips
       data:
-        name: My Camera
+        entity_id: My Camera
         file_path: /tmp/videos
 ```

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -103,7 +103,9 @@ sequence:
     target:
       entity_id: camera.blink_my_camera
   - delay: 00:00:05
-  - service: blink.blink_update
+  - service: homeassistant.update_entity
+    target:
+      entity_id: camera.blink_my_camera
   - service: camera.snapshot
     target:
       entity_id: camera.blink_my_camera

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -54,7 +54,7 @@ Please note that each camera reports two different states: one as `sensor.blink_
 
 ## Services
 
-Any sequential calls to {% term services %}  relating to blink should have a minimum of a 5 second delay in between them to prevent the calls from being throttled and ignored. The services that act on a camera needs a target parameter.
+Any sequential calls to {% term services %} relating to blink should have a minimum of a 5 second delay in between them to prevent the calls from being throttled and ignored. The services that act on a camera needs a target parameter.
 
 ### `blink.trigger_camera`
 
@@ -93,7 +93,7 @@ Send a new pin to blink.  Since Blink's 2FA implementation is new and changing, 
 
 ### Other services
 
-In addition to the services mentioned above, there are generic `camera`, `alarm_control_panel`, and `homeassistant` services are available. The `camera.enable_motion_detection` and `camera.disable_motion_detection` services allow for individual cameras to be enabled and disabled, respectively, within the Blink system. The `alarm_control_panel.alarm_arm_away` and `alarm_control_panel.alarm_disarm` services allow for the whole system to be armed and disarmed, respectively.  The `homeassistant.update_entity` service will force an update of the blink system.  Blink Mini cameras linked to an existing sync module cannot be armed/disarmed individually via Home Assistant.
+In addition to the services mentioned above, there are generic `camera`, `alarm_control_panel`, and `homeassistant` services are available. The `camera.enable_motion_detection` and `camera.disable_motion_detection` services allow for individual cameras to be enabled and disabled, respectively, within the Blink system. The `alarm_control_panel.alarm_arm_away` and `alarm_control_panel.alarm_disarm` services allow for the whole system to be armed and disarmed, respectively. The `homeassistant.update_entity` service will force an update of the blink system.  Blink Mini cameras linked to an existing sync module cannot be armed/disarmed individually via Home Assistant.
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update service calls to match new keys, removing name and utilizing entity and config_entry values.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/105413
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
