### PR TITLE
Show search modal over the nav-bar

### DIFF
--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -877,6 +877,10 @@ code {
 }
 
 @media only screen and (max-width: $menu-collapse) {
+  .DocSearch-Container {
+    z-index: 1000;
+  }
+
   #not_found {
     .page {
       text-align: center;

--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -35,6 +35,10 @@ $primary-color: #1abcf2;
   }
 }
 
+.DocSearch-Container {
+  z-index: 1000;
+}
+
 .integration-alert-container {
   margin: -1em 0;
 }
@@ -877,9 +881,6 @@ code {
 }
 
 @media only screen and (max-width: $menu-collapse) {
-  .DocSearch-Container {
-    z-index: 1000;
-  }
 
   #not_found {
     .page {


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Currently, the search is not accessible on mobile.
This changes the z-index of the search container to 1000 (the navbar has 999)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
