### PR TITLE
Adds 4 extra switches to v2c 

### DIFF
--- a/source/_integrations/v2c.markdown
+++ b/source/_integrations/v2c.markdown
@@ -62,6 +62,6 @@ The V2C integration currently exposes the following switches:
 
 - pause session: pause the charging session
 - lock EVSE: disables the EVSE
-- charge point timer: only allow charging durint predefined period (set on the mobile application)
+- charge point timer: only allow charging during predefined period (set on the mobile application)
 - dynamic intensity modulation: enable dynamic intensity modulation
 - pause dynamic control modulation: paused the dynamic control modulation

--- a/source/_integrations/v2c.markdown
+++ b/source/_integrations/v2c.markdown
@@ -61,3 +61,7 @@ The V2C integration currently exposes the following number entity:
 The V2C integration currently exposes the following switches:
 
 - pause session: pause the charging session
+- lock EVSE: disables the EVSE
+- charge point timer: only allow charging durint predefined period (set on the mobile application)
+- dynamic intensity modulation: enable dynamic intensity modulation
+- pause dynamic control modulation: paused the dynamic control modulation


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds 4 more switches:

- EVSE Lock
- Charge Point Timer
- Dynamic Intensity Modulation
- Pause Dynamic Control Modulation

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/105531
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
