### PR TITLE
Update calendar.markdown

### DIFF
--- a/source/_integrations/calendar.markdown
+++ b/source/_integrations/calendar.markdown
@@ -212,7 +212,7 @@ Use only one of `end_date_time` or `duration`.
 
 {% raw %}
 ```yaml
-service: calendar.list_events
+service: calendar.get_events
 target:
   entity_id: calendar.school
 data:
@@ -222,7 +222,7 @@ response_variable: agenda
 ```
 {% endraw %}
 
-The response data field `events` is a list of events with these fields:
+The response is a list of the targeted calendars. The response data for each target will have an `events` field containing a list of events with these fields:
 
 | Response data | Description | Example |
 | ---------------------- | ----------- | -------- |
@@ -243,7 +243,7 @@ data:
   message: >-
     Your agenda for today:
     <p>
-    {% for event in agenda.events %}
+    {% for event in agenda['calendar.school'].events %}
     {{ event.start}}: {{ event.summary }}<br>
     {% endfor %}
     </p>


### PR DESCRIPTION

## Proposed change
Replace documentation for deprecated list_events with get_events per petro's suggestion in https://community.home-assistant.io/t/2023-12-welcome-home/651409/466


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.


## Additional information

- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: fixes # n/a


## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
