### PR TITLE
Google Generative AI: Document service for prompts consisting of text and images using Gemini Pro Vision

### DIFF
--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -46,3 +46,30 @@ Top K:
   description: Number of top-scored tokens to consider during generation.
 
 {% endconfiguration_basic %}
+
+## Services
+
+### Service `google_generative_ai_conversation.generate_content`
+
+Allows you to ask Gemini Pro or Gemini Pro Vision to generate content from a prompt consisting of text and optionally images.
+This service populates [Response Data](/docs/scripts/service-calls#use-templates-to-handle-response-data) with the generated content.
+
+| Service data attribute | Optional | Description                                    | Example             |
+| ---------------------- | -------- | ---------------------------------------------- | ------------------- |
+| `prompt`               | no       | The prompt for generating the content.         | Describe this image |
+| `image_filename`       | yes      | Filenames for images to include in the prompt. | /tmp/image.jpg      |
+
+{% raw %}
+```yaml
+service: google_generative_ai_conversation.generate_content
+data:
+  prompt: >-
+    Very briefly describe what you see in this image from my doorbell camera.
+    Your message needs to be short to fit in a phone notification. Don't
+    descrive stationary objects or buildings.
+  image_filename: /tmp/doorbell_snapshot.jpg
+response_variable: generated_content
+```
+{% endraw %}
+
+The response data field `text` will contain the generated content.

--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -73,3 +73,21 @@ response_variable: generated_content
 {% endraw %}
 
 The response data field `text` will contain the generated content.
+
+Another example with multiple images:
+
+{% raw %}
+```yaml
+service: google_generative_ai_conversation.generate_content
+data:
+  prompt: >-
+    Briefly describe what happened in the following sequence of images
+    from my driveway camera.
+  image_filename:
+    - /tmp/driveway_snapshot1.jpg
+    - /tmp/driveway_snapshot2.jpg
+    - /tmp/driveway_snapshot3.jpg
+    - /tmp/driveway_snapshot4.jpg
+response_variable: generated_content
+```
+{% endraw %}

--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -52,12 +52,12 @@ Top K:
 ### Service `google_generative_ai_conversation.generate_content`
 
 Allows you to ask Gemini Pro or Gemini Pro Vision to generate content from a prompt consisting of text and optionally images.
-This service populates [Response Data](/docs/scripts/service-calls#use-templates-to-handle-response-data) with the generated content.
+This service populates [response data](/docs/scripts/service-calls#use-templates-to-handle-response-data) with the generated content.
 
 | Service data attribute | Optional | Description                                    | Example             |
 | ---------------------- | -------- | ---------------------------------------------- | ------------------- |
 | `prompt`               | no       | The prompt for generating the content.         | Describe this image |
-| `image_filename`       | yes      | Filenames for images to include in the prompt. | /tmp/image.jpg      |
+| `image_filename`       | yes      | File names for images to include in the prompt. | /tmp/image.jpg      |
 
 {% raw %}
 ```yaml
@@ -66,7 +66,7 @@ data:
   prompt: >-
     Very briefly describe what you see in this image from my doorbell camera.
     Your message needs to be short to fit in a phone notification. Don't
-    descrive stationary objects or buildings.
+    describe stationary objects or buildings.
   image_filename: /tmp/doorbell_snapshot.jpg
 response_variable: generated_content
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
SSIA


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/105789
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
