### PR TITLE
Authentication: remove screenshot showing disabled login screen

### DIFF
--- a/source/_docs/authentication.markdown
+++ b/source/_docs/authentication.markdown
@@ -7,21 +7,13 @@ The authentication system secures access to Home Assistant.
 
 ## Login screen
 
-If you log in from within your local network, you are greeted with a login screen showing all the people in Home Assistant.
-
-<img src='/images/docs/authentication/login.png' alt='Screenshot of the login screen, when logging in from within the local network' style='border: 0;box-shadow: none;'>
-
-### Privacy: Not showing users when logging in from outside the network
-
-When logging in from outside your local network, the users are not shown. This is to protect your privacy. In this case, you need to enter your user name.
-
-You might also see this screen if you are using a Chromium-based browser (Chrome, Edge) and IPv6. Home Assistant might not be able to detect if your are logging in from a local network. This is a known issue with Chromium.
+You are greeted with a log in screen, asking you for user name and password.
 
 <img src='/images/docs/authentication/login-outside-local-network.png' alt='Screenshot of the login screen, when logging in from within the local network' style='border: 0;box-shadow: none;'>
 
 ## User accounts
 
-When you start Home Assistant for the first time the _owner_ user account is created. This account has some special privileges and can:
+When you start Home Assistant for the first time, the _owner_ user account is created. This account has some special privileges and can:
 
 - Create and manage other user accounts.
 - Configure integrations and other settings (coming soon).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Authentication: remove screenshot showing disabled login screen


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
