### PR TITLE
S32-S3-BOX: emphasize that install does not work from phone

### DIFF
--- a/source/_includes/voice_assistant/install_esp_firmware.md
+++ b/source/_includes/voice_assistant/install_esp_firmware.md
@@ -2,13 +2,14 @@
 
 2. Connect the {{ product_name }} to your computer.
    - In the pop-up window, view the available ports.
-   - Plug the USB-C cable into the {{ product_name }} and connect it to your computer.
+   - Plug the USB-C cable into the {{ product_name }} and connect it to your computer.{% if page.product_name == 'ESP32-S3-BOX' %}
+     - If you have an ESP32-S3-BOX-3, plug it into the box directly, not into the docking station (not into the blue part). {% endif %}
    - In the pop-up window, there should now appear a new entry. Select this USB serial port and select **Connect**.
    - **Troubleshooting**: If no new port shows, your system may be missing a driver. Close the pop-up window.
      - In the dialog, select the CH342 driver, install it, then **Try again**.
    ![Open My link](/images/assist/esp32-atom-flash-no-port.png)
 3. Select **Install Voice Assistant**, then **Install**.
-     - Follow the instructions provided by the installation wizard.
+     - Once the installation is complete, select **Next**.
      - Add the {{ product_name }} to your Wi-Fi:
        - When prompted, select your network from the list and enter the credentials to your 2.4&nbsp;GHz Wi-Fi network.
        - Select **Connect**.

--- a/source/voice_control/s3_box_voice_assistant.markdown
+++ b/source/voice_control/s3_box_voice_assistant.markdown
@@ -26,11 +26,9 @@ This tutorial will guide you to turn an ESP32-S3-BOX, ESP32-S3-BOX-3, or an ESP3
 
 Before you can use this device with Home Assistant, you need to install a bit of software on it.
 
-1. Make sure this page is opened in a Chromium-based browser on a desktop. It does not work on a tablet or phone.
+1. Make sure this page is opened in a Chromium-based browser on a **desktop**. The software installation does not work with a tablet or phone.
 
-   - If you have an ESP32-S3-BOX-3, select the **Connect** button below. If your browser does not support web serial, you will see a warning instead of a button.
-     - If your device does not readily connect for flashing, you may need to put your ESP32-S3-BOX-3 into "flash mode" by holding the "boot" button (left side upper button), tapping the "reset" button (left side lower button), and then releasing them both. Wait a few seconds before attempting to connect.
-
+   - If you have an ESP32-S3-BOX-3, select the **Connect** button below to show the current ports. Do not connect the ESP32-S3-BOX-3 yet. If your browser does not support web serial, you will see a warning instead of a button.
 
       <script type="module" src="https://unpkg.com/esp-web-tools@9/dist/web/install-button.js?module"></script>
       <esp-web-install-button manifest="https://firmware.esphome.io/voice-assistant/esp32-s3-box-3/manifest.json"></esp-web-install-button>

--- a/source/voice_control/s3_box_voice_assistant.markdown
+++ b/source/voice_control/s3_box_voice_assistant.markdown
@@ -28,7 +28,9 @@ Before you can use this device with Home Assistant, you need to install a bit of
 
 1. Make sure this page is opened in a Chromium-based browser on a **desktop**. The software installation does not work with a tablet or phone.
 
-   - If you have an ESP32-S3-BOX-3, select the **Connect** button below to show the current ports. Do not connect the ESP32-S3-BOX-3 yet. If your browser does not support web serial, you will see a warning instead of a button.
+   - If you have an ESP32-S3-BOX-3, select the **Connect** button below to show the current ports. Do not connect the ESP32-S3-BOX-3 yet.
+   - If your device does not readily connect for flashing, you may need to put your ESP32-S3-BOX-3 into "flash mode" by holding the "boot" button (left side upper button), tapping the "reset" button (left side lower button), and then releasing them both. Wait a few seconds before attempting to connect.
+   - If your browser does not support web serial, you will see a warning instead of a button.
 
       <script type="module" src="https://unpkg.com/esp-web-tools@9/dist/web/install-button.js?module"></script>
       <esp-web-install-button manifest="https://firmware.esphome.io/voice-assistant/esp32-s3-box-3/manifest.json"></esp-web-install-button>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

S32-S3-BOX: emphasize that install does not work from phone
- to address issue mentioned in #30343 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
