### PR TITLE
Authentication: remove .storage section

### DIFF
--- a/source/_docs/authentication.markdown
+++ b/source/_docs/authentication.markdown
@@ -76,17 +76,7 @@ INFO (MainThread) [homeassistant.components.http.auth] You need to use a bearer 
 
 ### Lost owner password
 
-Before using the procedure below, make sure you explore options provided [here](/docs/locked_out).
-
-While you should hopefully be storing your passwords in a password manager, if you lose the password associated with the owner account the only way to resolve this is to delete _all_ the authentication data. You do this by shutting down Home Assistant and deleting the following files from the `.storage/` folder in your [configuration folder](/docs/configuration/):
-
-- `auth`
-- `auth_provider.homeassistant`
-- `onboarding`
-- `hassio`
-- `cloud`
-
-When you start Home Assistant next, you'll be required to set up authentication again.
+If you lose the password associated with the owner account, you need to [start a new onboarding process](/docs/locked_out/#to-prepare-the-system-to-start-a-new-onboarding-process).
 
 ### Error: invalid client id or redirect URL
 

--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -89,22 +89,13 @@ You need to be an owner or have administrator rights to delete a user.
 
 ### To prepare the system to start a new onboarding process
 
-If you lose the password associated with the owner account and the steps above do not work to reset the password, the only way to resolve this is to start a new onboarding process. 
+If you lose the password associated with the owner account and the steps above do not work to reset the password, the only way to resolve this is to start a new onboarding process.
 
 - If you have an external backup with an administrator account of which you still know the login credentials, you can restore that backup.
 - If you do not have a backup, resetting the device will erase all data.
 
 - If you have a Home Assistant Green, [reset the Green](https://green.home-assistant.io/guides/reset/).
 - If you have a Home Assistant Yellow, [reset the Yellow](https://yellow.home-assistant.io/guides/factory-reset/).
-- If you have a Raspberry Pi, delete *all* the authentication data.
-  - Shut down Home Assistant.
-  - Remove your SD card and access it from your PC.
-  - Delete the following files from the `.storage/` folder in your [configuration folder](/docs/configuration/):
-    - `auth`
-    - `auth_provider.homeassistant`
-    - `onboarding`
-    - `hassio`
-    - `cloud`
 
 ## Recovering data for Home Assistant (including Supervised)
 

--- a/source/getting-started/onboarding.markdown
+++ b/source/getting-started/onboarding.markdown
@@ -26,7 +26,9 @@ We will now create the owner's account of Home Assistant. This account is an adm
     - Continue with the procedure on [restoring from backup](/common-tasks/os/#restoring-a-backup).
     - Ignore the rest of this procedure. The following steps describe how to create a new installation, not how to restore from backup.
 2. If this is your initial installation, select **Create my smart home**.
-3. Enter a name, username, and password. Select **Create account**.
+3. Enter a name, username, and password.
+   - Store the name, username, and password in a password manager. There is no way to recover the owner credentials.
+   - Select **Create account**.
 
     ![Set your username and password.](/images/getting-started/username.png)
 


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Authentication: remove .storage section
- Remove section on deleting files in .storage
- In onboarding procedure, add step to store credentials in a password manager

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
