### PR TITLE
Add cover platform to Tailwind integration

### DIFF
--- a/source/_integrations/tailwind.markdown
+++ b/source/_integrations/tailwind.markdown
@@ -13,6 +13,7 @@ ha_zeroconf: true
 ha_platforms:
   - binary_sensor
   - button
+  - cover
   - number
 ha_integration_type: device
 ---
@@ -45,7 +46,13 @@ You will need two pieces of information:
 
 ## Provided entities
 
-This integration provides the following entities:
+The Tailwind integration provides a cover entity for each garage door that is
+connected to your Tailwind garage door controller.
+
+Using the cover entity, you can open and close your garage door, and see the
+current state of your garage door.
+
+Additionally, the integration provides the following entities:
 
 - **Identify** - A button entity that allows you to identify your Tailwind
   device by flashing the status LED on the device.

--- a/source/_integrations/tailwind.markdown
+++ b/source/_integrations/tailwind.markdown
@@ -49,7 +49,7 @@ You will need two pieces of information:
 The Tailwind integration provides a cover entity for each garage door that is
 connected to your Tailwind garage door controller.
 
-Using the cover entity, you can open and close your garage door, and see the
+Using the cover entity, you can open and close your garage door and see the
 current state of your garage door.
 
 Additionally, the integration provides the following entities:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds documentation for the cover entities added to the Tailwind integration in the linked core PR.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/106042
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
