### PR TITLE
Add digitalstrom-mqtt to the list of software that support MQTT discovery

### DIFF
--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -681,6 +681,7 @@ The following software has built-in support for MQTT discovery:
 - [ArduinoHA](https://github.com/dawidchyrzynski/arduino-home-assistant)
 - [Arilux AL-LC0X LED controllers](https://github.com/smrtnt/Arilux_AL-LC0X)
 - [ble2mqtt](https://github.com/devbis/ble2mqtt)
+- [digitalstrom-mqtt](https://github.com/gaetancollaud/digitalstrom-mqtt)
 - [ebusd](https://github.com/john30/ebusd)
 - [ecowitt2mqtt](https://github.com/bachya/ecowitt2mqtt)
 - [EMS-ESP32 (and EMS-ESP)](https://github.com/emsesp/EMS-ESP32)


### PR DESCRIPTION
Disclamer: I'm the developer of digitalstrom-mqtt

## Proposed change
Add digitalstrom-mqtt to the list of software that support MQTT discovery.

digitalstrom-mqtt supports MQTT discovery since 2 years already thanks to community supports. I recently implemented the V2 of the software and I made sure it's again 100% compatible with MQTT discovery from Home Assistant.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
 - https://github.com/gaetancollaud/digitalstrom-mqtt

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
