### PR TITLE
Document switch_as_x valve support

### DIFF
--- a/source/_integrations/switch_as_x.markdown
+++ b/source/_integrations/switch_as_x.markdown
@@ -9,6 +9,7 @@ ha_category:
   - Lock
   - Siren
   - Switch
+  - Valve
 ha_release: 2022.4
 ha_iot_class: Calculated
 ha_quality_scale: internal
@@ -22,11 +23,12 @@ ha_platforms:
   - light
   - lock
   - siren
+  - valve
 ha_integration_type: helper
 ---
 
 The **Change device type of a switch** helper integrations lets you convert any Home Assistant switch into
-a Home Assistant Light, Cover, Fan, Lock, or Siren.
+a Home Assistant Light, Cover, Fan, Lock, Siren or Valve.
 
 In Home Assistant's world, a wall plug is a switch. And while that is correct
 for a wall plug in general, those plugs are often used with e.g, a light

--- a/source/_integrations/switch_as_x.markdown
+++ b/source/_integrations/switch_as_x.markdown
@@ -28,7 +28,7 @@ ha_integration_type: helper
 ---
 
 The **Change device type of a switch** helper integrations lets you convert any Home Assistant switch into
-a Home Assistant Light, Cover, Fan, Lock, Siren or Valve.
+a Home Assistant Light, Cover, Fan, Lock, Siren, or Valve.
 
 In Home Assistant's world, a wall plug is a switch. And while that is correct
 for a wall plug in general, those plugs are often used with e.g, a light


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document switch_as_x valve support


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/105988
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
