### PR TITLE
Adjust latest release notes redirects to also contain the Release-Notes category

### DIFF
--- a/source/_includes/asides/categories.html
+++ b/source/_includes/asides/categories.html
@@ -4,7 +4,7 @@
     {% assign categories = site.categories | sort %}
     {% for category in categories %}
       {% assign category_name = category | first | downcase %}
-      {% if category_name != "core" and category_name != "ios" %}
+      {% if category_name != "core"%}
         <li><a href="/blog/categories/{{ category_name }}/">{{ category | first | replace: '-', ' '}}</a></li>
       {% endif %}
     {% endfor %}

--- a/source/_redirects
+++ b/source/_redirects
@@ -4,7 +4,7 @@ layout: null
 
 # These redirects are handled by Netlify
 #
-{% assign recent_release_post = site.categories['Core'].first %}
+{% assign release_notes = site.categories['Release-Notes'] %}
 
 # General use redirects
 /join-chat https://discord.gg/home-assistant
@@ -18,10 +18,9 @@ layout: null
 /community https://community.home-assistant.io/
 /latest-security-alert /security/
 
-# Link to latest release note
-/latest-release-notes/ {{ recent_release_post.url }}{{ site.patch_version_notes }} 302!
-
-/latest-ios-release-notes/ {{ site.categories["iOS"].first.url }} 302!
+# Link to latest release notes
+/latest-release-notes/ {{ release_notes | where: "categories", "Core" | map: 'url' | first }}{{ site.patch_version_notes }} 302!
+/latest-ios-release-notes/ {{ release_notes | where: "categories", "iOS" | map: 'url' | first }} 302!
 
 # Matter workshop June 2022
 /skyconnect-interest https://docs.google.com/forms/d/e/1FAIpQLScEjHSBJszUZfgO3MIDO51IHr3Oeohcs8BLpRIjY1liJ58IpA/viewform?usp=sf_link


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Currently, all blog posts tagged with "iOS" or "Core" would be used for the redirect, this might not always be wanted.
This change requires also "Release-Notes" to be added for the redirect to change.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
