### PR TITLE
TP-Link EP25 HW support note

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -55,7 +55,7 @@ See [Supported Devices in python-kasa](https://github.com/python-kasa/python-kas
 - KP125
 - KP401
 - EP10
-- EP25
+- EP25 (HW versions 2.5 and earlier)
 
 ### Power Strips
 


### PR DESCRIPTION
Based on https://github.com/python-kasa/python-kasa#plugs and python-kasa/python-kasa#548 new version of EP25 aren't compatible with this lib

## Proposed change
Based on the comment from [rytilahti](https://github.com/rytilahti) i have added a note abou thte HW versions supported by the lib

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes # [30027](https://github.com/home-assistant/home-assistant.io/issues/30027)

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
