### PR TITLE
Use Wi-Fi in devolo_home_network

### DIFF
--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -53,22 +53,22 @@ Currently the following device types within Home Assistant are supported.
 
 ### Images
 
-- QR code of your guest wifi credentials
+- QR code of your guest Wi-Fi credentials
   - Updates every 15 seconds if changes are detected
   - Is enabled by default
 
 ### Presence detection
 
-- Detect presence of devices connected to the main or the guest wifi
+- Detect presence of devices connected to the main or the guest Wi-Fi
   - Updates every 15 seconds
   - Automatically adds new devices as disabled entities unless disabled via system option
 
 ### Sensors
 
-- Number of connected wifi clients
+- Number of connected Wi-Fi clients
   - Updates every 15 seconds
   - Is enabled by default
-- Number of neighbored wifi networks
+- Number of neighbored Wi-Fi networks
   - Updates every 5 minutes
   - Is disabled by default because it runs quite long
 - Number of PLC devices in the same PLC network
@@ -77,7 +77,7 @@ Currently the following device types within Home Assistant are supported.
 
 ### Switch
 
-- Turn on/off guest wifi
+- Turn on/off guest Wi-Fi
   - Is enabled by default
 - Turn on/off the device LEDs
   - Is enabled by default
@@ -103,7 +103,7 @@ The list of supported devolo devices depends on the device firmware and the devi
 - dLAN 550+ Wifi
 - dLAN 550 WiFi
 
-Since firmware 7.10 also the following device without Wifi can be used as long as the corresponding entities are supported:
+Since firmware 7.10 also the following device without Wi-Fi can be used as long as the corresponding entities are supported:
 
 - Magic 2 LAN triple
 - Magic 2 DinRail


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Assumingly for legal reasons, devolo uses Wifi everywhere while Home Assistant uses Wi-Fi. Let's unify this except for the product names, obviously.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
