### PR TITLE
Update intent_script docs to use correct service call

### DIFF
--- a/source/_integrations/intent_script.markdown
+++ b/source/_integrations/intent_script.markdown
@@ -98,7 +98,7 @@ conversation:
 intent_script:
   EventCountToday:
     action:
-      - service: calendar.list_events
+      - service: calendar.get_events
         target:
           entity_id: calendar.my_calendar
         data_template:
@@ -108,7 +108,7 @@ intent_script:
       - stop: ""
         response_variable: result                     # and return it
     speech:
-      text: "{{ action_response.events | length }}"   # use the action's response
+      text: "{{ action_response['calendar.my_calendar'].events | length }}"   # use the action's response
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
The intent_script docs were using the depreciated service call to list the calendar events. I've updated this to use the new service call.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
