### PR TITLE
Add config_entry to easyEnergy

### DIFF
--- a/source/_integrations/easyenergy.markdown
+++ b/source/_integrations/easyenergy.markdown
@@ -76,6 +76,7 @@ Fetches the hourly prices for gas.
 
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
+| `config_entry` | no | Config entry to use. | 013713c172577bada2874a32dbe44feb
 | `incl_vat` | no | Defines whether the prices include or exclude VAT. Defaults to True | False
 | `start` | yes | Start time to get prices. Defaults to today 00:00:00 | 2023-01-01 00:00:00
 | `end` | yes | End time to get prices. Defaults to today 00:00:00 | 2023-01-01 00:00:00
@@ -105,6 +106,7 @@ Fetches the hourly prices for energy that you use (buy).
 
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
+| `config_entry` | no | Config entry to use. | 013713c172577bada2874a32dbe44feb
 | `incl_vat` | no | Defines whether the prices include or exclude VAT.  Defaults to True | False
 | `start` | yes | Start time to get prices. Defaults to today 00:00:00 | 2023-01-01 00:00:00
 | `end` | yes | End time to get prices. Defaults to today 00:00:00 | 2023-01-01 00:00:00
@@ -134,6 +136,7 @@ Fetches the hourly prices for energy that you return (sell).
 
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
+| `config_entry` | no | Config entry to use. | 013713c172577bada2874a32dbe44feb
 | `start` | yes | Start time to get prices. Defaults to today 00:00:00 | 2023-01-01 00:00:00
 | `end` | yes | End time to get prices from. Defaults to today 00:00:00 | 2023-01-01 00:00:00
 
@@ -171,6 +174,7 @@ template:
       - service: easyenergy.get_energy_usage_prices
         response_variable: response
         data:
+          config_entry: "013713c172577bada2874a32dbe44feb"
           incl_vat: true
     sensor:
       - name: Energy prices


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add the `config_entry` to the services tables and the trigger / sensor template.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/106288
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
