### PR TITLE
Deprecate legacy platform keys and use modern keys

### DIFF
--- a/source/_integrations/lcn.markdown
+++ b/source/_integrations/lcn.markdown
@@ -57,19 +57,19 @@ Consider to store your credentials in a [`secrets.yaml`](/docs/configuration/sec
 
 ```yaml
 lcn:
-  connections:
+  connection:
     - name: myhome
       host: 192.168.2.41
       port: 4114
       username: lcn
       password: lcn
 
-  binary_sensors:
+  binary_sensor:
     - name: Kitchen window
       address: myhome.s0.m7
       source: binsensor1
 
-  climates:
+  climate:
     - name: Temperature bedroom
       address: myhome.s0.m7
       source: var1
@@ -79,19 +79,19 @@ lcn:
       lockable: true
       unit_of_measurement: °C
 
-  covers:
+  cover:
     - name: Living room cover
       address: myhome.s0.m7
       motor: motor1
 
-  lights:
+  light:
     - name: Bedroom light
       address: myhome.s0.m7
       output: output1
       dimmable: true
       transition: 5
 
-  scenes:
+  scene:
     - name: Romantic
       address: myhome.s0.m7
       register: 1
@@ -99,20 +99,20 @@ lcn:
       outputs: [output1, output2, relais1, relais3, relais4]
       transition: 5
 
-  sensors:
+  sensor:
     - name: Temperature
       address: myhome.s0.m7
       source: var3
       unit_of_measurement: °C
 
-  switches:
+  switche:
     - name: Sprinkler switch
       address: myhome.s0.m7
       output: relay1
 ```
 
 {% configuration %}
-connections:
+connection:
   description: List of your connections.
   required: true
   type: map
@@ -149,7 +149,7 @@ connections:
       default: steps50
       type: string
 
-binary_sensors:
+binary_sensor:
   description: List of your binary sensors.
   required: false
   type: map
@@ -167,7 +167,7 @@ binary_sensors:
       required: true
       type: string
 
-climates:
+climate:
   description: List of your climate devices.
   required: false
   type: map
@@ -209,7 +209,7 @@ climates:
       type: boolean
       default: false
 
-covers:
+cover:
   description: List of your covers.
   required: false
   type: map
@@ -231,7 +231,7 @@ covers:
       required: false
       type: string
 
-lights:
+light:
   description: List of your lights.
   required: true
   type: map
@@ -259,7 +259,7 @@ lights:
       type: integer
       default: 0
 
-scenes:
+scene:
   description: List of your scenes.
   required: false
   type: map
@@ -290,7 +290,7 @@ scenes:
       type: integer
       default: None
 
-sensors:
+sensor:
   description: List of your sensors.
   required: false
   type: map
@@ -313,7 +313,7 @@ sensors:
       type: string
       default: "native"
 
-switches:
+switch:
   description: List of your switches.
   required: false
   type: map


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Change the platform keys for LCN integration from ancient to modern format (e.g. sensors->sensor, lights->light, ...).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/106353
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
