### PR TITLE
Frontier Silicon integration: mention OKTIV app

### DIFF
--- a/source/_integrations/frontier_silicon.markdown
+++ b/source/_integrations/frontier_silicon.markdown
@@ -15,7 +15,7 @@ ha_ssdp: true
 ha_config_flow: true
 ---
 
-This integration provides support for Internet Radios based on the [Frontier Silicon chipset]. Some of the manufacturers which offer products based on these chips include: Hama, Medion, Slivercrest, Auna, Technisat, Revo, Pinnel, etc. These devices will be usually controlled by the UNDOK app.
+This integration provides support for Internet Radios based on the [Frontier Silicon chipset]. Some of the manufacturers which offer products based on these chips include: Hama, Medion, Slivercrest, Auna, Technisat, Revo, Pinnel, etc. These devices will be usually controlled by the OKTIV or UNDOK apps.
 
 ## Supported models
 
@@ -32,7 +32,7 @@ Supported devices include, but are not limited to:
 
 This integration was developed and tested with a [Roberts Stream 94i].
 
-If your device is supported by the UNDOK app, then it is also supported by this integration.
+If your device is supported by the OKTIV or UNDOK apps, then it is also supported by this integration.
 
 ## Prerequisites
 


### PR DESCRIPTION

## Proposed change
OKTIV is a new (and preferred) app for controlling Frontier Silicon devices. So, mentioning this app in the documentation will make it easier to find the Frontier Silicon integration for users using the OKTIV app.

See: https://www.frontiersmart.com/insights/oktiv-takes-it-up-a-level/


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
