### PR TITLE
Add Frontier Silicon integration to SSDP discoverable integrations

### DIFF
--- a/source/_integrations/ssdp.markdown
+++ b/source/_integrations/ssdp.markdown
@@ -33,6 +33,7 @@ The following integrations are automatically discovered by the SSDP integration:
  - [Denon AVR](/integrations/denonavr/)
  - [Denon HEOS](/integrations/heos/)
  - [DirecTV](/integrations/directv/)
+ - [Frontier Silicon](/integrations/frontier_silicon/)
  - [Huawei LTE](/integrations/huawei_lte/)
  - [Hyperion](/integrations/hyperion/)
  - [Keenetic NDMS2 Router](/integrations/keenetic_ndms2/)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The Frontier Silicon integration is also discoverable by SSDP (SSDP ST: `urn:schemas-frontier-silicon-com:undok:fsapi:1`), so it should be mentioned in the documentation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
