### PR TITLE
Document Dormakaba dKey only works with ESPHome BT proxies

### DIFF
--- a/source/_integrations/dormakaba_dkey.markdown
+++ b/source/_integrations/dormakaba_dkey.markdown
@@ -26,6 +26,6 @@ In addition to a lock entity, each added dKey lock will also have:
 - A binary_sensor which shows if the door is open or not
 - A binary_sensor which shows the position of the lock's dead bolt
 
-:::warning
+<div class='note warning'>
 The Dormakaba dKey lock is currently not working with USB dongles or built-in Bluetooth radios, only [ESPHome Bluetooth proxies](integrations/bluetooth/#remote-adapters-bluetooth-proxies) work reliably.
-:::
+</div>

--- a/source/_integrations/dormakaba_dkey.markdown
+++ b/source/_integrations/dormakaba_dkey.markdown
@@ -25,3 +25,7 @@ In addition to a lock entity, each added dKey lock will also have:
 - A battery sensor
 - A binary_sensor which shows if the door is open or not
 - A binary_sensor which shows the position of the lock's dead bolt
+
+:::warning
+The Dormakaba dKey lock is currently not working with USB dongles or built-in bluetooth radios, only [ESPHome Bluetooth proxies](integrations/bluetooth/#remote-adapters-bluetooth-proxies) work reliably.
+:::

--- a/source/_integrations/dormakaba_dkey.markdown
+++ b/source/_integrations/dormakaba_dkey.markdown
@@ -27,5 +27,7 @@ In addition to a lock entity, each added dKey lock will also have:
 - A binary_sensor which shows the position of the lock's dead bolt
 
 <div class='note warning'>
-The Dormakaba dKey lock is currently not working with USB dongles or built-in Bluetooth radios, only [ESPHome Bluetooth proxies](integrations/bluetooth/#remote-adapters-bluetooth-proxies) work reliably.
+
+The Dormakaba dKey lock is currently not working with USB dongles or built-in Bluetooth radios, only [ESPHome Bluetooth proxies](/integrations/bluetooth/#remote-adapters-bluetooth-proxies) work reliably.
+
 </div>

--- a/source/_integrations/dormakaba_dkey.markdown
+++ b/source/_integrations/dormakaba_dkey.markdown
@@ -27,5 +27,5 @@ In addition to a lock entity, each added dKey lock will also have:
 - A binary_sensor which shows the position of the lock's dead bolt
 
 :::warning
-The Dormakaba dKey lock is currently not working with USB dongles or built-in bluetooth radios, only [ESPHome Bluetooth proxies](integrations/bluetooth/#remote-adapters-bluetooth-proxies) work reliably.
+The Dormakaba dKey lock is currently not working with USB dongles or built-in Bluetooth radios, only [ESPHome Bluetooth proxies](integrations/bluetooth/#remote-adapters-bluetooth-proxies) work reliably.
 :::


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document Dormakaba dKey only works with ESPHome BT proxies

Related core issue: https://github.com/home-assistant/core/issues/102094

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
