### PR TITLE
add config flow to lutron integration

### DIFF
--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -29,15 +29,9 @@ Presently, there's only support for communicating with the [RadioRA 2](http://ww
 
 When configured, the `lutron` integration will automatically discover the rooms and their associated switches/dimmers as configured by the RadioRA 2 software from Lutron. Each room will be treated as a separate group.
 
-To use Lutron RadioRA 2 devices in your installation, you'll need to first create a username/password in your Lutron programming software. Once a telnet username/password has been programmed, add the following to your `configuration.yaml` file using the IP address of your RadioRA 2 main repeater:
+To use Lutron RadioRA 2 devices in your installation, you'll need to first create a username/password in your Lutron programming software. Once a telnet username/password has been programmed, you can use this My button:
 
-``` yaml
-# Example configuration.yaml entry
-lutron:
-  host: IP_ADDRESS
-  username: USERNAME
-  password: PASSWORD
-```
+{% include integrations/config_flow.md %}
 
 {% configuration %}
 host:

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -29,7 +29,7 @@ Presently, there's only support for communicating with the [RadioRA 2](http://ww
 
 When configured, the `lutron` integration will automatically discover the rooms and their associated switches/dimmers as configured by the RadioRA 2 software from Lutron. Each room will be treated as a separate group.
 
-To use Lutron RadioRA 2 devices in your installation, you'll need to first create a username/password in your Lutron programming software. Once a telnet username/password has been programmed, you can use this My button:
+To use Lutron RadioRA 2 devices in your installation, you'll need to first create a username/password in your Lutron programming software. Once a telnet username/password has been programmed, you can follow the instructions from the next chapter.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -33,21 +33,6 @@ To use Lutron RadioRA 2 devices in your installation, you'll need to first creat
 
 {% include integrations/config_flow.md %}
 
-{% configuration %}
-host:
-  description: The IP address of the Main Repeater.
-  required: true
-  type: string
-username:
-  description: The login name of the user. The user `lutron` always exists, but other users can be added via RadioRA 2 software.
-  required: true
-  type: string
-password:
-  description: The password for the user specified above. `integration` is the password for the always-present `lutron` user.
-  required: true
-  type: string
-{% endconfiguration %}
-
 <div class='note'>
 
 It is recommended to assign a static IP address to your main repeater. This ensures that it won't change IP addresses, so you won't have to change the `host` if it reboots and comes up with a different IP address.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This is a documentation update to reflect this integration having a config flow now.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/98489
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
