### PR TITLE
Improve ecowitt docs around HTTP requirements

### DIFF
--- a/source/_integrations/ecowitt.markdown
+++ b/source/_integrations/ecowitt.markdown
@@ -21,13 +21,19 @@ ha_integration_type: integration
 
 ## Ecowitt Weather Station configuration
 
-The following steps must be performed to set up this integration. For security reason, use the token path that you get from the Home Assistant config flow.
+The following steps must be performed to set up this integration. For security reasons, use the token path that you get from the Home Assistant config flow.
+
+<div class='note'>
+
+If you have taken additional steps to enable HTTPS (secure) access to your Home Assistant instance, the Ecowitt integration will require extra configuration.
+
+Ecowitt devices do not support sending data to HTTPS URLs. A solution exists using the NGINX TLS Proxy Add-on to support HTTP and HTTPS at the same time (for more information read this [community discussion](https://community.home-assistant.io/t/nginx-tls-proxy-add-on-config-to-allow-simultaneous-https-and-http-access-required-by-ecowitt-integration/589276)).
+
+</div>
 
 1. Use the Ecowitt App (on your phone) or access the Ecowitt WebUI in a browser at the station IP address.
 2. Pick your station -> Menu Others -> DIY Upload Servers.
 3. Hit next and select 'Customized'
 4. Pick the protocol Ecowitt, and put in the ip/hostname of your Home Assistant server.
-5. Path has to match! If using the Ecowitt App, remove the first forward slash from the API token, as the app will prepend one.
+5. The path has to match! If using the Ecowitt App, remove the first forward slash from the API token, as the app will prepend one.
 6. Save configuration.
-
-Ecowitt doesn't support TLS/SSL, you can use the NGINX TLS Proxy Add-on to support HTTPS and HTTP at the same time.


### PR DESCRIPTION
## Proposed change

Clarifies HTTP requirements for folks that might not see the message and try to use HTTPS (like Nabu Casa)

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Ref: https://github.com/home-assistant/core/issues/93000

## Checklist


- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
