### PR TITLE
Remove `beat` display option from Time & Date documentation

### DIFF
--- a/source/_integrations/time_date.markdown
+++ b/source/_integrations/time_date.markdown
@@ -30,19 +30,18 @@ sensor:
       - 'date_time_iso'
       - 'time_date'
       - 'time_utc'
-      - 'beat'
 ```
 
 
 {% configuration %}
 display_options:
-  description: The sensors to create. The types *date_time*, *date_time_utc*, *time_date*, and *date_time_iso* create combined date and the time sensors. The other types just the time sensor or the date sensor. *beat* creates the [Swatch Internet Time](https://en.wikipedia.org/wiki/Swatch_Internet_Time).
+  description: The sensors to create. The types *date_time*, *date_time_utc*, *time_date*, and *date_time_iso* create combined date and the time sensors. The other types just the time sensor or the date sensor.
   required: true
   type: list
 {% endconfiguration %}
 
 
-Sensors including the time update every minute, the date sensor updates each day at midnight, and the beat sensor updates with each beat (86.4 seconds).
+Sensors including the time update every minute, the date sensor updates each day at midnight.
 
 <p class='img'>
   <img src='/images/screenshots/time_date.png' />


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove `beat` display option from Time & Date documentation


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/106871
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
