### PR TITLE
Adding button to ha_platforms for opengarage

### DIFF
--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -12,6 +12,7 @@ ha_codeowners:
   - '@danielhiversen'
 ha_platforms:
   - binary_sensor
+  - button
   - cover
   - sensor
 ha_integration_type: integration


### PR DESCRIPTION
## Proposed change
Very minor change to add button to the list of HA platforms, since I've added a button to the integration for rebooting the device.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Suggested/requested by @joostlek in https://github.com/home-assistant/core/pull/103569

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
