### PR TITLE
spotify: Update name of user management page in developer console

### DIFF
--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -107,7 +107,7 @@ This integration supports multiple Spotify accounts at once. You don't need to
 create another Spotify application in the Spotify Developer Portal.
 Multiple Spotify accounts can be linked to a _single_ Spotify application.
 
-You will have to add those accounts into the **Users and Access** section of
+You will have to add those accounts into the **User Management** section of
 your application in the Spotify Developer Portal.
 
 To add an additional Spotify account to Home Assistant, go to the Spotify


### PR DESCRIPTION
## Proposed change

This updates the spotify integration docs to match the labels in the Spotify developer dashboard, which at some point were updated to say 'User Management'.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
