### PR TITLE
Add documentation for graph Y axis limits options

### DIFF
--- a/source/_dashboards/history-graph.markdown
+++ b/source/_dashboards/history-graph.markdown
@@ -53,6 +53,19 @@ logarithmic_scale:
   description: If true, numerical values on the Y-axis will be displayed with a logarithmic scale.
   type: boolean
   default: false
+min_y_axis:
+  required: false
+  description: Lower bound for the Y axis range.
+  type: float
+max_y_axis:
+  required: false
+  description: Upper bound for the Y axis range.
+  type: float
+fit_y_data:
+  required: false
+  description: If true, configured Y axis bounds would automatically extend (but not shrink) to fit the data.
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 ### Options for entities

--- a/source/_dashboards/history-graph.markdown
+++ b/source/_dashboards/history-graph.markdown
@@ -55,15 +55,15 @@ logarithmic_scale:
   default: false
 min_y_axis:
   required: false
-  description: Lower bound for the Y axis range.
+  description: Lower bound for the Y-axis range.
   type: float
 max_y_axis:
   required: false
-  description: Upper bound for the Y axis range.
+  description: Upper bound for the Y-axis range.
   type: float
 fit_y_data:
   required: false
-  description: If true, configured Y axis bounds would automatically extend (but not shrink) to fit the data.
+  description: If true, configured Y-axis bounds would automatically extend (but not shrink) to fit the data.
   type: boolean
   default: false
 {% endconfiguration %}

--- a/source/_dashboards/statistics-graph.markdown
+++ b/source/_dashboards/statistics-graph.markdown
@@ -69,6 +69,19 @@ logarithmic_scale:
   description: If true, numerical values on the Y-axis will be displayed with a logarithmic scale.
   type: boolean
   default: false
+min_y_axis:
+  required: false
+  description: Lower bound for the Y axis range.
+  type: float
+max_y_axis:
+  required: false
+  description: Upper bound for the Y axis range.
+  type: float
+fit_y_data:
+  required: false
+  description: If true, configured Y axis bounds would automatically extend (but not shrink) to fit the data.
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 ### Options for entities

--- a/source/_dashboards/statistics-graph.markdown
+++ b/source/_dashboards/statistics-graph.markdown
@@ -69,19 +69,6 @@ logarithmic_scale:
   description: If true, numerical values on the Y-axis will be displayed with a logarithmic scale.
   type: boolean
   default: false
-min_y_axis:
-  required: false
-  description: Lower bound for the Y-axis range.
-  type: float
-max_y_axis:
-  required: false
-  description: Upper bound for the Y-axis range.
-  type: float
-fit_y_data:
-  required: false
-  description: If true, configured Y-axis bounds would automatically extend (but not shrink) to fit the data.
-  type: boolean
-  default: false
 {% endconfiguration %}
 
 ### Options for entities

--- a/source/_dashboards/statistics-graph.markdown
+++ b/source/_dashboards/statistics-graph.markdown
@@ -71,15 +71,15 @@ logarithmic_scale:
   default: false
 min_y_axis:
   required: false
-  description: Lower bound for the Y axis range.
+  description: Lower bound for the Y-axis range.
   type: float
 max_y_axis:
   required: false
-  description: Upper bound for the Y axis range.
+  description: Upper bound for the Y-axis range.
   type: float
 fit_y_data:
   required: false
-  description: If true, configured Y axis bounds would automatically extend (but not shrink) to fit the data.
+  description: If true, configured Y-axis bounds would automatically extend (but not shrink) to fit the data.
   type: boolean
   default: false
 {% endconfiguration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds documentation for the new Y axis limits options in the History graph card

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/19297
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
