### PR TITLE
Documentation for select_random on select and input_select

### DIFF
--- a/source/_integrations/input_select.markdown
+++ b/source/_integrations/input_select.markdown
@@ -101,6 +101,14 @@ Select the previous option.
 | ---------------------- | -------- | ----------- |
 | `cycle` | yes | Whether to cycle to the last value before the first. Default: `true`
 
+#### Service `input_select.select_random`
+
+Select a random option.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `avoid_repeat` | yes | Exclude the current selection from the list of choices. Default: `true`
+
 ### Scenes
 
 Specifying a target option in a [Scene](/integrations/scene/) is simple:

--- a/source/_integrations/select.markdown
+++ b/source/_integrations/select.markdown
@@ -141,3 +141,33 @@ target:
 data:
   cycle: false
 ```
+
+### Service `select.select_random`
+
+The {% my developer_call_service service="select.select_random" %} service
+changes the selected option of the select entity to a random choice from the
+list of options available.
+
+The default behavior is to exclude the current selection from the list of options
+that will be chosen at random. This behavior can be disabled by setting the
+`avoid_repeat` option to `false` in the service call data. If there is only
+one option in the list a repeat selection cannot be avoided.
+
+{% my developer_call_service badge service="select.select_random" %}
+
+Examples in YAML:
+
+```yaml
+service: select.select_random
+target:
+  entity_id: select.my_entity
+```
+
+```yaml
+# Allow the current option to be a candidate for the random selection
+service: select.select_random
+target:
+  entity_id: select.my_entity
+data:
+  avoid_repeat: false
+```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document the changes made for [this PR](https://github.com/home-assistant/core/pull/107513):
Add `select_random` service to `select` and `input_select`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/107513

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
