### PR TITLE
Remove deprecated YAML support from freebox

### DIFF
--- a/source/_integrations/freebox.markdown
+++ b/source/_integrations/freebox.markdown
@@ -45,12 +45,6 @@ You can find out your Freebox host and port by opening this address <http://mafr
 The returned JSON should contain an `api_domain` (`host`) and a `https_port` (`port`).
 Please consult the [API documentation](https://dev.freebox.fr/sdk/os/) for more information.
 
-### Via the UI
-
-Menu: **Settings** -> **Devices & Services**. Search for "Freebox", add your host and port, click submit.
-
-If you add the integration for the first time, follow the instructions in the [Initial setup](#initial-setup) section.
-
 ### Initial setup
 
 <div class='note warning'>

--- a/source/_integrations/freebox.markdown
+++ b/source/_integrations/freebox.markdown
@@ -45,36 +45,11 @@ You can find out your Freebox host and port by opening this address <http://mafr
 The returned JSON should contain an `api_domain` (`host`) and a `https_port` (`port`).
 Please consult the [API documentation](https://dev.freebox.fr/sdk/os/) for more information.
 
-### Via the frontend
+### Via the UI
 
 Menu: **Settings** -> **Devices & Services**. Search for "Freebox", add your host and port, click submit.
 
 If you add the integration for the first time, follow the instructions in the [Initial setup](#initial-setup) section.
-
-### Via the configuration file
-
-```yaml
-freebox:
-  host: foobar.fbxos.fr
-  port: 1234
-```
-
-{% configuration %}
-host:
-  description: The URL of the Freebox.
-  required: true
-  type: string
-port:
-  description: The HTTPS port the Freebox is listening on.
-  required: true
-  type: string
-{% endconfiguration %}
-
-<div class='note warning'>
-  
-  If you change your Freebox router for a new one, go into your Home Assistant configuration `.storage` folder and delete the "freebox" folder, then add the integration again.
-
-</div>
 
 ### Initial setup
 


### PR DESCRIPTION
## Proposed change
Remove the deprecated `freebox` YAML support, deprecated with 2023.8, completely. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/107497
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
