### PR TITLE
Add supported models for A. O. Smith integration

### DIFF
--- a/source/_integrations/aosmith.markdown
+++ b/source/_integrations/aosmith.markdown
@@ -21,9 +21,15 @@ Before using this integration, your water heater must be connected to a Wi-Fi ne
 
 ## Known compatible models
 
-- [HPTS-50](https://www.hotwater.com/products/HPTS-50-SG200.html)
-- [HPTS-66](https://www.hotwater.com/products/HPTS-66-SG200.html)
-- [HPTS-80](https://www.hotwater.com/products/HPTS-80-SG200.html)
+- HPS10-50H45DV
+- HPS10-66H45DV
+- HPS10-80H45DV
+- HPTS-50
+- HPTS-66
+- HPTS-80
+- HPV10-50H01DV
+- HPV10-66H01DV
+- HPV10-80H01DV
 
 Water heaters that can be controlled using the A. O. Smith mobile app should be compatible with this integration. If your water heater is not detected by the integration, but it can be controlled using the mobile app, please [open an issue on GitHub](https://github.com/home-assistant/core/issues/new?template=bug_report.yml&integration_name=A.%20O.%20Smith&integration_link=https%3A%2F%2Fwww.home-assistant.io%2Fintegrations%2Faosmith) so that support can be added. Similarly, if your water heater is working with this integration, but its model number is not listed here, please [open an documentation issue](https://github.com/home-assistant/home-assistant.io/issues/new?template=feedback.yml&url=https%3A%2F%2Fwww.home-assistant.io%2Fintegrations%2Faosmith) so it can be added to the list.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Added more supported models to the list. Removed the URLs since they are not very useful and not all models have URLs available.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue:
  - Fixes #30704
  - Fixes #30743

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
