### PR TITLE
Updated unifi.markdown to new redirected url

### DIFF
--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -78,7 +78,7 @@ Provides QR Code images that can be scanned to easily join a specific WLAN. Enti
 
 ## Presence detection
 
-This platform allows you to detect presence by looking at devices connected to a [Ubiquiti](https://ui.com/) [UniFi Network](https://ui.com/us/en/cloud-gateways) application. By default devices are marked as away 300 seconds after they were last seen.
+This platform allows you to detect presence by looking at devices connected to a [Ubiquiti](https://ui.com/) [UniFi Network](https://ui.com/cloud-gateways) application. By default devices are marked as away 300 seconds after they were last seen.
 
 ### Troubleshooting and Time Synchronization
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -78,7 +78,7 @@ Provides QR Code images that can be scanned to easily join a specific WLAN. Enti
 
 ## Presence detection
 
-This platform allows you to detect presence by looking at devices connected to a [Ubiquiti](https://ui.com/) [UniFi Network](https://ui.com/consoles) application. By default devices are marked as away 300 seconds after they were last seen.
+This platform allows you to detect presence by looking at devices connected to a [Ubiquiti](https://ui.com/) [UniFi Network](https://ui.com/us/en/cloud-gateways) application. By default devices are marked as away 300 seconds after they were last seen.
 
 ### Troubleshooting and Time Synchronization
 


### PR DESCRIPTION
## Proposed change

Fixed a url that redirects to a different url because of the new Unifi site https://ui.com/cloud-gateways (wouldn't have made this a fork if it wasn't for: https://github.com/home-assistant/home-assistant.io/issues/30568#issuecomment-1887448402


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist


- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
