### PR TITLE
Added H5104 and additional Govee product links

### DIFF
--- a/source/_integrations/govee_ble.markdown
+++ b/source/_integrations/govee_ble.markdown
@@ -30,15 +30,16 @@ The Govee BLE integration will automatically discover devices once the [Bluetoot
 - H5072 Hygrometer Thermometer
 - H5074 Hygrometer Thermometer
 - [H5075 Bluetooth Hygrometer Thermometer](https://us.govee.com/collections/thermo-hydrometer/products/govee-bluetooth-hygrometer-thermometer-h5075)
-- H5100 Hygrometer Thermometer
+- [H5100 Hygrometer Thermometer](https://us.govee.com/collections/thermo-hydrometer/products/govee-h5100-mini-hygrometer-thermometer-sensors)
 - H5101 Hygrometer Thermometer
 - H5102 Hygrometer Thermometer
+- [H5104 Hygrometer Thermometer](https://us.govee.com/products/goveelife-bluetooth-hygrometer-thermometer-h5104-white)
 - [H5177/5178 Bluetooth Thermo-Hygrometer](https://us.govee.com/collections/thermo-hydrometer/products/bluetooth-thermo-hygrometer)
-- H5179 Hygrometer Thermometer
+- [H5179 Hygrometer Thermometer](https://us.govee.com/products/wi-fi-temperature-humidity-sensor)
 - 5055 Meat Thermometer
 - 5181 Meat Thermometer
 - 5182 Meat Thermometer
 - 5183 Meat Thermometer
 - 5184 Meat Thermometer
 - 5185 Meat Thermometer
-- 5198 Meat Thermometer
+- [5198 Meat Thermometer](https://us.govee.com/products/govee-wi-fi-grilling-meat-thermometer-with-4-probes)


### PR DESCRIPTION
## Proposed change
Update govee_ble.markdown:
- Added H5104 which I have and works perfectly with the Govee BLE integration, identical to H5075 and H5074
- (Where found) added extra product links to Govee website


## Type of change
- [X ] Spelling, grammar or other readability improvements (`current` branch).
- [X ] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information
N/A

## Checklist
- [X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [X ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
