### PR TITLE
Add template support for discovery_id paramter on mqtt device triggers in automations

### DIFF
--- a/source/_integrations/device_trigger.mqtt.markdown
+++ b/source/_integrations/device_trigger.mqtt.markdown
@@ -145,3 +145,35 @@ Note that it is not necessary to provide the full device information in each mes
 
 - Trigger topic: `zigbee2mqtt/0x90fd9ffffedf1266/action`
 - Trigger payload: `arrow_right_click`
+
+#### Attaching a trigger from a device automation
+
+A device automation with an MQTT device trigger can be fully set up through the UI.
+In some cases it can be useful to to use templates, e.g. to set the `discovery_id` using a variable.
+The parameters `discovery_id`, `type` and `subtype` support templating using the [trigger variables](/docs/automation/trigger/#trigger-variables).
+
+{% raw %}
+
+The following example shows how the `discovery_id` can be set as a variable to be using in a template.
+
+```yaml
+# Example configuration.yaml
+automation:
+  trigger_variables:
+    discovery_id: '0x90fd9ffffedf1266'
+  trigger:
+  - platform: device
+    domain: mqtt
+    device_id: c2962db89494eb88654c20c34fab9285
+    type: action
+    subtype: arrow_left_click
+    discovery_id: '{{ discovery_id }} action_arrow_left_click'
+  condition: []
+  action:
+  - service: notify.persistent_notification
+    data:
+      message: "Arrow left clicked"
+  mode: single
+```
+
+{% endraw %}

--- a/source/_integrations/device_trigger.mqtt.markdown
+++ b/source/_integrations/device_trigger.mqtt.markdown
@@ -150,7 +150,7 @@ Note that it is not necessary to provide the full device information in each mes
 
 A device automation with an MQTT device trigger can be fully set up through the UI.
 In some cases it can be useful to to use templates, e.g. to set the `discovery_id` using a variable.
-The parameters `discovery_id`, `type` and `subtype` support templating using the [trigger variables](/docs/automation/trigger/#trigger-variables).
+The `discovery_id` parameter supports templating using the [trigger variables](/docs/automation/trigger/#trigger-variables).
 
 {% raw %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add example how to attach MQTT device triggers from a device automation using trigger variables.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/107830
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
