### PR TITLE
Add smart hose timer info to Rachio

### DIFF
--- a/source/_integrations/rachio.markdown
+++ b/source/_integrations/rachio.markdown
@@ -38,7 +38,7 @@ They will be automatically added if the Rachio integration is loaded.
 
 <div class='note'>
 
-In order for Rachio switches and sensors to update, your Home Assistant instance must be accessible from the internet, either via Home Assistant Cloud or another method. See the [Remote Access documentation](/docs/configuration/remote/) for more information.
+In order for Rachio switches and sensors to update, your Home Assistant instance must be accessible from the internet, either via Home Assistant Cloud or another method. See the [Remote Access documentation](/docs/configuration/remote/) for more information. The smart hose timers use polling, and don't require external access to be setup.
 
 </div>
 
@@ -48,6 +48,10 @@ In order for Rachio switches and sensors to update, your Home Assistant instance
 After setting up the integration, change the options to set the duration in minutes to run when activating a zone switch to a maximum failsafe value when using scripts to control zones. If something goes wrong with your script, Home Assistant, or you hit the Rachio API rate limit of 1700 calls per day, the controller will still turn off the zone after this amount of time.
 
 </div>
+
+### Smart Hose Timers
+
+The Rachio smart hose timers are not currently capable of receiving real-time updates, and instead rely on polling. Because of this, the current state of valves started from a schedule or the physical button will not show up immediately. Polling occurs every 2 minutes when one base station is used, with an additional minute added for every additional base station to remain with the API rate limit. Up to 4 valves can be paired to a single base station.
 
 ### iFrame
 

--- a/source/_integrations/rachio.markdown
+++ b/source/_integrations/rachio.markdown
@@ -63,11 +63,24 @@ panel_iframe:
 
 ## Switch
 
-The `rachio` switch platform allows you to toggle zones and schedules connected to your [Rachio irrigation system](https://rachio.com/) on and off.
+The `rachio` switch platform allows you to toggle zones, valves and schedules connected to your [Rachio irrigation system](https://rachio.com/) on and off.
 
-Once configured, a switch will be added for every zone that is enabled on every controller in the account provided and a switch to start or stop every schedule on a controller. There will also be a switch to toggle each controller's standby mode, as well as to activate a 24 hour rain delay on the device.
+Once configured, a switch will be added for every zone that is enabled on every controller in the account provided, a switch for each smart hose timer valve and a switch to start or stop every schedule on a controller. There will also be a switch to toggle each controller's standby mode, as well as to activate a 24 hour rain delay on the device.
 
 ## Services
+
+### Service `rachio.start_single_entity`
+
+Allows starting one zone on a sprinkler controller, or any number of smart hose timer valves. To sequentially start multiple zones on a sprinkler controller, use the `start_multiple_zone_schedule` below.
+
+Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | Individual zone, or multiple smart hose timer valves to run. A smart hose timer base station device can also be selected to run all valves on the given base.
+| `duration` | no | Duration in minutes to run the zone or valves.
+
+<div class='note'>
+The services below only apply to sprinkler controllers and will not be shown if only smart hose timers are on the account.
+</div>
 
 ### Service `rachio.start_multiple_zone_schedule`
 
@@ -85,7 +98,7 @@ It is not currently possible to have zones from multiple controllers in the same
 ### Examples
 
 ```yaml
-#Example sctipt to start multiple zones with individual duration for each zone.
+#Example script to start multiple zones with individual duration for each zone.
 script:
   run_grass_zones:
     sequence: 
@@ -100,7 +113,7 @@ script:
 ```
 
 ```yaml
-#Example sctipt to start multiple zones with one duration for all zones.
+#Example script to start multiple zones with one duration for all zones.
 script:
   run_grass_zones:
     sequence: 
@@ -113,6 +126,7 @@ script:
         data:
           duration: 20
 ```
+
 ### Service `rachio.set_zone_moisture_percent`
 
 Set the zone moisture percentage for a zone or group of zones.

--- a/source/_integrations/rachio.markdown
+++ b/source/_integrations/rachio.markdown
@@ -73,14 +73,14 @@ Once configured, a switch will be added for every zone that is enabled on every 
 
 ## Services
 
-### Service `rachio.start_single_entity`
+### Service `rachio.start_watering`
 
-Allows starting one zone on a sprinkler controller, or any number of smart hose timer valves. To sequentially start multiple zones on a sprinkler controller, use the `start_multiple_zone_schedule` service below.
+Allows starting one zone on a sprinkler controller, any number of smart hose timer valves or a schedule. To sequentially start multiple zones on a sprinkler controller, use the `start_multiple_zone_schedule` service below.
 
 Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | Individual zone, or multiple smart hose timer valves to run. A smart hose timer base station device can also be selected to run all valves on the given base.
-| `duration` | no | Duration in minutes to run the zone or valves.
+| `entity_id` | no | Individual zone, schedule or multiple smart hose timer valves to run. A smart hose timer base station device can also be selected to run all valves on the given base.
+| `duration` | yes | Duration in minutes to run the zone or valves. Leave empty for schedules.
 
 <div class='note'>
 The services below only apply to sprinkler controllers and will not be shown if only smart hose timers are on the account.

--- a/source/_integrations/rachio.markdown
+++ b/source/_integrations/rachio.markdown
@@ -71,7 +71,7 @@ Once configured, a switch will be added for every zone that is enabled on every 
 
 ### Service `rachio.start_single_entity`
 
-Allows starting one zone on a sprinkler controller, or any number of smart hose timer valves. To sequentially start multiple zones on a sprinkler controller, use the `start_multiple_zone_schedule` below.
+Allows starting one zone on a sprinkler controller, or any number of smart hose timer valves. To sequentially start multiple zones on a sprinkler controller, use the `start_multiple_zone_schedule` service below.
 
 Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |

--- a/source/_integrations/rachio.markdown
+++ b/source/_integrations/rachio.markdown
@@ -38,7 +38,7 @@ They will be automatically added if the Rachio integration is loaded.
 
 <div class='note'>
 
-In order for Rachio switches and sensors to update, your Home Assistant instance must be accessible from the internet, either via Home Assistant Cloud or another method. See the [Remote Access documentation](/docs/configuration/remote/) for more information. The smart hose timers use polling, and don't require external access to be setup.
+In order for Rachio switches and sensors to update, your Home Assistant instance must be accessible from the internet, either via Home Assistant Cloud or another method. See the [Remote Access documentation](/docs/configuration/remote/) for more information. The smart hose timers use polling and don't require external access to be setup.
 
 </div>
 
@@ -49,9 +49,9 @@ After setting up the integration, change the options to set the duration in minu
 
 </div>
 
-### Smart Hose Timers
+### Smart hose timers
 
-The Rachio smart hose timers are not currently capable of receiving real-time updates, and instead rely on polling. Because of this, the current state of valves started from a schedule or the physical button will not show up immediately. Polling occurs every 2 minutes when one base station is used, with an additional minute added for every additional base station to remain with the API rate limit. Up to 4 valves can be paired to a single base station.
+The Rachio smart hose timers are not currently capable of receiving real-time updates. Instead, they rely on polling. Because of this, the current state of valves started from a schedule or the physical button will not show up immediately. Polling occurs every 2 minutes when one base station is used, with an additional minute added for every additional base station to remain with the API rate limit. Up to 4 valves can be paired to a single base station.
 
 ### iFrame
 
@@ -67,19 +67,19 @@ panel_iframe:
 
 ## Switch
 
-The `rachio` switch platform allows you to toggle zones, valves and schedules connected to your [Rachio irrigation system](https://rachio.com/) on and off.
+The `rachio` switch platform allows you to toggle zones, valves, and schedules connected to your [Rachio irrigation system](https://rachio.com/) on and off.
 
-Once configured, a switch will be added for every zone that is enabled on every controller in the account provided, a switch for each smart hose timer valve and a switch to start or stop every schedule on a controller. There will also be a switch to toggle each controller's standby mode, as well as to activate a 24 hour rain delay on the device.
+Once configured, a switch will be added for every zone that is enabled on every controller in the account provided, as well as a switch for each smart hose timer valve and a switch to start or stop every schedule on a controller. There will also be a switch to toggle each controller's standby mode, as well as to activate a 24-hour rain delay on the device.
 
 ## Services
 
 ### Service `rachio.start_watering`
 
-Allows starting one zone on a sprinkler controller, any number of smart hose timer valves or a schedule. To sequentially start multiple zones on a sprinkler controller, use the `start_multiple_zone_schedule` service below.
+Allows starting one zone on a sprinkler controller, any number of smart hose timer valves, or a schedule. To sequentially start multiple zones on a sprinkler controller, use the `start_multiple_zone_schedule` service below.
 
 Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | Individual zone, schedule or multiple smart hose timer valves to run. A smart hose timer base station device can also be selected to run all valves on the given base.
+| `entity_id` | no | Individual zone, schedule, or multiple smart hose timer valves to run. A smart hose timer base station device can also be selected to run all valves on the given base.
 | `duration` | yes | Duration in minutes to run the zone or valves. Leave empty for schedules.
 
 <div class='note'>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update Rachio docs to include smart hose timer and new service.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/107901
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
