### PR TITLE
Add screenlogic super chlorination service descriptions

### DIFF
--- a/source/_integrations/screenlogic.markdown
+++ b/source/_integrations/screenlogic.markdown
@@ -47,6 +47,23 @@ Sets the operation of any connected color-capable lights.
 | `target`               | no       | An `area` containing the ScreenLogic device, the ScreenLogic `device` itself, or any `entity` from the ScreenLogic device you wish to set the color mode on. |
 | `color_mode`           | no       | The color mode to set. Valid values are listed below.                                                                                                        |
 
+### `screenlogic.start_super_chlorination`
+
+Begins super chlorination, running for the specified time period or 24 hours if none specified.
+
+| Service data attribute | Optional | Description                                                                                                                                                        |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `target`               | no       | An `area` containing the ScreenLogic device, the ScreenLogic `device` itself, or any `entity` from the ScreenLogic device you wish to start super chlorination on. |
+| `runtime`              | yes      | Number of hours to run super chlorination for. Defaults to 24 hours.                                                                                               |
+
+### `screenlogic.stop_super_chlorination`
+
+Stops super chlorination.
+
+| Service data attribute | Optional | Description                                                                                                                                                       |
+| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `target`               | no       | An `area` containing the ScreenLogic device, the ScreenLogic `device` itself, or any `entity` from the ScreenLogic device you wish to stop super chlorination on. |
+
 ## Reference
 
 ### Color modes

--- a/source/_integrations/screenlogic.markdown
+++ b/source/_integrations/screenlogic.markdown
@@ -49,7 +49,7 @@ Sets the operation of any connected color-capable lights.
 
 ### `screenlogic.start_super_chlorination`
 
-Begins super chlorination, running for the specified time period or 24 hours if none specified.
+Begins super chlorination, running for the specified period or 24 hours if none is specified.
 
 | Service data attribute | Optional | Description                                                                                                                                                        |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add screenlogic super chlorination service descriptions


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/108048
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
