### PR TITLE
Document OS error "Bad message" unhealthy case

### DIFF
--- a/source/more-info/unhealthy/oserror_bad_message.markdown
+++ b/source/more-info/unhealthy/oserror_bad_message.markdown
@@ -1,0 +1,17 @@
+---
+title: "Operating System error: Bad message"
+description: "More information on what to do when OS errors mark the installation as unhealthy."
+---
+
+## The issue
+
+The Supervisor received Operating System errors during file operation (Python OSError exceptions). The error number reported was 74, "Bad message", which is typically raised on file system corruption.
+
+## The solution
+
+File system corruption can happen due to power outage or when the system otherwise did not get shutdown properly. Typically Home Assistant recovers from file system corruption, so if you see this error the first time consider just ignoring it. Just in case the problem gets worse, make sure to create a full backup (and download it or store it on a different system).
+
+If this issue reappears even after a system restart, your system configuration or hardware might be at fault. Consider a clean reinstallation of your Operating System. If you are using a externally attached USB drive, consider replacing the USB adapter or the SSD. If you are confident that the hardware is not at fault and you are using a Raspberry Pi, it might be related to incompatibility with certain UAS drives (this [Raspberry Pi forum post][rpi-forum-uas] has some more background information). Home Assistant OS maintains a list of devices where UAS gets disabled to work around the problem (check config.txt on the first partition of your installation). If the USB PID/VID of your device is missing consider [opening an issue][haos-issue] in the Home Assistant OS project.
+
+[rpi-forum-uas]: https://forums.raspberrypi.com/viewtopic.php?t=245931
+[haos-issue]: https://github.com/home-assistant/operating-system/issues/new/choose

--- a/source/more-info/unhealthy/oserror_bad_message.markdown
+++ b/source/more-info/unhealthy/oserror_bad_message.markdown
@@ -5,13 +5,13 @@ description: "More information on what to do when OS errors mark the installatio
 
 ## The issue
 
-The Supervisor received Operating System errors during file operation (Python OSError exceptions). The error number reported was 74, "Bad message", which is typically raised on file system corruption.
+The Supervisor received Operating System errors during file operation (Python OSError exceptions). The error number reported was 74, "Bad message", which is typically raised on file system corruption. File system corruption can happen due to a power outage or when the system otherwise did not get shut down properly. 
 
 ## The solution
 
-File system corruption can happen due to power outage or when the system otherwise did not get shutdown properly. Typically Home Assistant recovers from file system corruption, so if you see this error the first time consider just ignoring it. Just in case the problem gets worse, make sure to create a full backup (and download it or store it on a different system).
+Typically, Home Assistant recovers from file system corruption. If you see this error for the first time, ignore it. In case the problem gets worse, make sure to create a full backup, download it, or store it on a different system.
 
-If this issue reappears even after a system restart, your system configuration or hardware might be at fault. Consider a clean reinstallation of your Operating System. If you are using a externally attached USB drive, consider replacing the USB adapter or the SSD. If you are confident that the hardware is not at fault and you are using a Raspberry Pi, it might be related to incompatibility with certain UAS drives (this [Raspberry Pi forum post][rpi-forum-uas] has some more background information). Home Assistant OS maintains a list of devices where UAS gets disabled to work around the problem (check config.txt on the first partition of your installation). If the USB PID/VID of your device is missing consider [opening an issue][haos-issue] in the Home Assistant OS project.
+If this issue reappears even after a system restart, your system configuration or hardware might be at fault. Consider a clean reinstallation of your Operating System. If you are using an external USB drive, consider replacing the USB adapter or the SSD. If you are confident that the hardware is not at fault and you are using a Raspberry Pi, it might be related to incompatibility with certain UAS drives. For more background information, read this [Raspberry Pi forum post][rpi-forum-uas]. The Home Assistant OS maintains a list of devices where UAS are disabled in order to work around the problem (check config.txt on the first partition of your installation). If the USB PID/VID of your device is missing, consider [opening an issue][haos-issue] in the Home Assistant OS project.
 
 [rpi-forum-uas]: https://forums.raspberrypi.com/viewtopic.php?t=245931
 [haos-issue]: https://github.com/home-assistant/operating-system/issues/new/choose


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
With Supervisor pull request https://github.com/home-assistant/supervisor/pull/4750 we've introduced a new unhealthy condition when the operating system raises "Bad message" errors on file system operations. This typically points to a corrupted file system.

According to the (opt-in) Sentry error reports we see ~580 affected systems in the last 30 days. A disproportional amount of systems are running HAOS on Raspberry Pi. We assume that this is releated to the known USB UAS storage problem on Raspberry Pi. Add this hints accordingnly.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/supervisor/pull/4750
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
