### PR TITLE
Add serial_number config attribute to MQTT device mapping

### DIFF
--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -135,6 +135,10 @@ device:
       description: "The name of the device."
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -138,7 +138,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -103,7 +103,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -100,6 +100,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/button.mqtt.markdown
+++ b/source/_integrations/button.mqtt.markdown
@@ -97,6 +97,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/button.mqtt.markdown
+++ b/source/_integrations/button.mqtt.markdown
@@ -100,7 +100,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -99,6 +99,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -102,7 +102,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -121,7 +121,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -118,6 +118,10 @@ device:
       description: 'The name of the device.'
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -110,6 +110,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -113,7 +113,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/device_trigger.mqtt.markdown
+++ b/source/_integrations/device_trigger.mqtt.markdown
@@ -75,7 +75,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/device_trigger.mqtt.markdown
+++ b/source/_integrations/device_trigger.mqtt.markdown
@@ -72,6 +72,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/event.mqtt.markdown
+++ b/source/_integrations/event.mqtt.markdown
@@ -94,7 +94,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/event.mqtt.markdown
+++ b/source/_integrations/event.mqtt.markdown
@@ -91,6 +91,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -108,7 +108,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -105,6 +105,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -127,7 +127,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -124,6 +124,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/image.mqtt.markdown
+++ b/source/_integrations/image.mqtt.markdown
@@ -102,6 +102,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/image.mqtt.markdown
+++ b/source/_integrations/image.mqtt.markdown
@@ -105,7 +105,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/lawn_mower.mqtt.markdown
+++ b/source/_integrations/lawn_mower.mqtt.markdown
@@ -103,7 +103,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/lawn_mower.mqtt.markdown
+++ b/source/_integrations/lawn_mower.mqtt.markdown
@@ -100,6 +100,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -171,7 +171,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false
@@ -614,7 +614,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     sw_version:
       description: 'The firmware version of the device.'
       required: false
@@ -987,7 +987,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     sw_version:
       description: 'The firmware version of the device.'
       required: false

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -168,6 +168,10 @@ device:
       description: 'The name of the device.'
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false
@@ -607,6 +611,10 @@ device:
       description: 'The name of the device.'
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     sw_version:
       description: 'The firmware version of the device.'
       required: false
@@ -976,6 +984,10 @@ device:
       description: 'The name of the device.'
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     sw_version:
       description: 'The firmware version of the device.'
       required: false

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -115,7 +115,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -112,6 +112,10 @@ device:
       description: 'The name of the device.'
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -557,6 +557,7 @@ support_url:
     'hw':                  'hw_version',
     'sw':                  'sw_version',
     'sa':                  'suggested_area',
+    'sn':                  'serial_number',
 ```
 {% enddetails %}
 {% details "Supported abbreviations for origin info" %}
@@ -900,6 +901,7 @@ Setting up a [light that takes JSON payloads](/integrations/light.mqtt/#json-sch
       "mf": "Bla electronics",
       "mdl": "xya",
       "sw": "1.0",
+      "sn": "ea334450945afc",
       "hw": "1.0rev2",
     },
     "o": {

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -94,7 +94,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -91,6 +91,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -95,6 +95,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -98,7 +98,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -103,6 +103,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -106,7 +106,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -92,6 +92,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -95,7 +95,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -114,6 +114,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -117,7 +117,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -104,7 +104,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -101,6 +101,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/tag.mqtt.markdown
+++ b/source/_integrations/tag.mqtt.markdown
@@ -57,6 +57,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/tag.mqtt.markdown
+++ b/source/_integrations/tag.mqtt.markdown
@@ -60,7 +60,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/text.mqtt.markdown
+++ b/source/_integrations/text.mqtt.markdown
@@ -99,6 +99,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/text.mqtt.markdown
+++ b/source/_integrations/text.mqtt.markdown
@@ -102,7 +102,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/update.mqtt.markdown
+++ b/source/_integrations/update.mqtt.markdown
@@ -99,7 +99,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/update.mqtt.markdown
+++ b/source/_integrations/update.mqtt.markdown
@@ -96,6 +96,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -91,7 +91,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -88,6 +88,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/valve.mqtt.markdown
+++ b/source/_integrations/valve.mqtt.markdown
@@ -134,6 +134,10 @@ device:
       description: The name of the device.
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: Suggest an area if the device isn’t in one yet.
       required: false

--- a/source/_integrations/valve.mqtt.markdown
+++ b/source/_integrations/valve.mqtt.markdown
@@ -137,7 +137,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: Suggest an area if the device isn’t in one yet.
       required: false

--- a/source/_integrations/water_heater.mqtt.markdown
+++ b/source/_integrations/water_heater.mqtt.markdown
@@ -100,6 +100,10 @@ device:
       description: 'The name of the device.'
       required: false
       type: string
+    serial_number:
+      description: "The serial number of the device."
+      required: false
+      type: str
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false

--- a/source/_integrations/water_heater.mqtt.markdown
+++ b/source/_integrations/water_heater.mqtt.markdown
@@ -103,7 +103,7 @@ device:
     serial_number:
       description: "The serial number of the device."
       required: false
-      type: str
+      type: string
     suggested_area:
       description: 'Suggest an area if the device isn’t in one yet.'
       required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add serial_number config attribute to MQTT device mapping


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/108105
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
