### PR TITLE
Adds a note about shutting down a flexit device

### DIFF
--- a/source/_integrations/flexit_bacnet.markdown
+++ b/source/_integrations/flexit_bacnet.markdown
@@ -34,7 +34,7 @@ Flexit recommends that the function to turn off the unit is not made accessible 
 
 The consequences of shutting down the unit can be costly and extensive. For example, there can be condensation issues in freezing temperatures, and rotary heat exchangers can freeze.
 
-If the unit is to be shut down, the system should be secured with frost protection dampers, etc.
+If you need to shut down the unit, make sure to take all necessary precautions, such as securing the system with frost protection dampers.
 
 Furthermore, Flexit recommends that filter replacement is made with the unit unplugged from the power socket. To prevent damage when unplugging the device, a controlled shutdown initiated from the control panel (or in the future, from a service call in Home Assistant) is required.
 

--- a/source/_integrations/flexit_bacnet.markdown
+++ b/source/_integrations/flexit_bacnet.markdown
@@ -32,7 +32,7 @@ To configure the integration, you need to obtain the IP address and Device ID fo
  
 Flexit recommends that the function to turn off the unit is not made accessible in the interface for an ordinary user. It will therefore be removed from the integration in the future.
 
-The consequences of shutting down the unit can be costly and extensive, considering the freezing of rotary heat exchangers and condensation issues when there are freezing temperatures.
+The consequences of shutting down the unit can be costly and extensive. For example, there can be condensation issues in freezing temperatures, and rotary heat exchangers can freeze.
 
 If the unit is to be shut down, the system should be secured with frost protection dampers, etc.
 

--- a/source/_integrations/flexit_bacnet.markdown
+++ b/source/_integrations/flexit_bacnet.markdown
@@ -30,7 +30,7 @@ To configure the integration, you need to obtain the IP address and Device ID fo
 
 ### A note about shutting down the device
  
-Flexit recommends that the function to turn off the unit is not made accessible in the interface for an ordinary user, and it will therefore be removed from the integration in the future.
+Flexit recommends that the function to turn off the unit is not made accessible in the interface for an ordinary user. It will therefore be removed from the integration in the future.
 
 The consequences of shutting down the unit can be costly and extensive, considering the freezing of rotary heat exchangers and condensation issues when there are freezing temperatures.
 

--- a/source/_integrations/flexit_bacnet.markdown
+++ b/source/_integrations/flexit_bacnet.markdown
@@ -28,4 +28,14 @@ To configure the integration, you need to obtain the IP address and Device ID fo
 5. Go to **More** > **Installer** > **Communication**  > **BACnet settings**.
 6. Note down the **IP address** and **Device ID**.
 
+### A note about shutting down the device
+ 
+Flexit recommends that the function to turn off the unit is not made accessible in the interface for an ordinary user, and it will therefore be removed from the integration in the future.
+
+The consequences of shutting down the unit can be costly and extensive, considering the freezing of rotary heat exchangers and condensation issues when there are freezing temperatures.
+
+If the unit is to be shut down, the system should be secured with frost protection dampers, etc.
+
+Furthermore, Flexit recommends that filter replacement is made with the unit unplugged from the power socket. To prevent damage when unplugging the device, a controlled shutdown initiated from the control panel (or in the future, from a service call in Home Assistant) is required.
+
 {% include integrations/config_flow.md %}

--- a/source/_integrations/flexit_bacnet.markdown
+++ b/source/_integrations/flexit_bacnet.markdown
@@ -36,6 +36,6 @@ The consequences of shutting down the unit can be costly and extensive. For exam
 
 If you need to shut down the unit, make sure to take all necessary precautions, such as securing the system with frost protection dampers.
 
-Furthermore, Flexit recommends that filter replacement is made with the unit unplugged from the power socket. To prevent damage when unplugging the device, a controlled shutdown initiated from the control panel (or in the future, from a service call in Home Assistant) is required.
+Furthermore, Flexit recommends to unplug the unit from the power socket before replacing a filter. To prevent damage, always initiate a controlled shutdown from the control panel (or, in the future, from a service call in Home Assistant) before unplugging the device.
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The flexit_bacnet integration was added recently. The climate entity supports power down from the UI. I got an email from Flexit stating that it is probably a bad idea making it too easy for the average user to shut down the HVAC device.

This PR adds a note about how and when a device should be powered off securely.

I'm not a native english speaker so suggestions for improvements are very welcome.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
