### PR TITLE
Clean up ecovacs documentation

### DIFF
--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -9,6 +9,7 @@ ha_release: 0.77
 ha_codeowners:
   - '@OverloadUT'
   - '@mib1185'
+  - '@edenhaus'
 ha_domain: ecovacs
 ha_platforms:
   - vacuum
@@ -23,89 +24,14 @@ There is currently support for the following device types within Home Assistant:
 
 {% include integrations/config_flow.md %}
 
-Note: For some countries, you will need to set `continent` to `ww` (meaning worldwide.) There is unfortunately no way to know the correct settings other than guessing and checking. See the [py-sucks library protocol documentation](https://github.com/mib1185/py-sucks/blob/master/protocol.md) for more information about what has been figured out about the Ecovacs servers.
+Note: For some countries, you will need to set `continent` to `ww` (meaning worldwide). There is unfortunately no way to know the correct settings other than guessing and checking.
 
 Additional note: There are some issues during the password encoding. Using some special characters (e.g., `-`) in your password does not work.
-
-### Stability and Reporting Bugs
-
-The library that talks to the Ecovacs servers is in a very early state and still under development. As such, it is likely that not all regions and devices will work at the current time.
-
-Please see the [py-sucks library documentation](https://github.com/mib1185/py-sucks) for some more information about what has been tested, and check out the GitHub issues to see if the issue you're having is known or being worked on.
-
-If you have an issue with the Ecovacs integration, please file a [GitHub Issue](https://github.com/home-assistant/home-assistant/issues) and include your Home Assistant logs in the report. To get full debug output from both the Ecovacs integration and the underlying `sucks` library, place this in your `configuration.yaml` file:
-
-```yaml
-logger:
-  logs:
-    homeassistant.components.ecovacs: debug
-    homeassistant.components.vacuum.ecovacs: debug
-    sucks: debug
-```
-
-**Warning**: doing this will cause your authentication token to be visible in your log files. Be sure to remove any tokens and other authentication details from your log before posting them in an issue.
 
 
 ## Vacuum
 
 The `ecovacs` vacuum platform allows you to monitor and control your Ecovacs Deebot vacuums.
-
-### Service `vacuum.start`
-
-Start a new cleaning task.
-
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-
-### Service `vacuum.stop`
-
-Stop the current cleaning task and return to the dock.
-
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-
-### Service `vacuum.pause`
-
-Pause a cleaning task.
-
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-
-### Service `vacuum.clean_spot`
-
-Begin a spot cleaning operation.
-
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-
-### Service `vacuum.locate`
-
-Locate the vacuum.
-
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-
-### Service `vacuum.set_fan_speed`
-
-Pause a cleaning task.
-
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-| `fan_speed`               |      no  | Fan speed. Values are `normal` or `high`.                               |
-
-### Service `vacuum.return_to_base`
-
-Return to charging base/dock immediately.
-
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 ### Integration lifespan
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Removed outdated documentation about ecovacs.
HA has a built-in functionality to get the logs from an integration.
The vacuum service calls are documented on the vacuum doc page.

Also the ecovacs integration used now two libraries and therefore removed pointing to only one of it.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/108167
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
