### PR TITLE
Update schedule sensor reference

### DIFF
--- a/source/_integrations/schedule.markdown
+++ b/source/_integrations/schedule.markdown
@@ -104,13 +104,13 @@ automations and templates.
 
 ### Automation example
 
-A schedule creates an on/off (binary) sensor within the times set. Using the thermostat schedule example above, you can turn on your thermostat:
+A schedule creates an on/off (schedule) sensor within the times set. Using the thermostat schedule example above, you can turn on your thermostat:
 
 ```yaml
 trigger:
     - platform: state
       entity_id:
-        - binary_sensor.thermostat_schedule
+        - schedule.thermostat_schedule
       to: "on"
   action:
     - service: climate.turn_on


### PR DESCRIPTION
The schedule helper now creates a `schedule` sensor instead of a binary sensor.  I am not sure when this changed, but when I added a schedule helper on 2024.1.3 it did not create a binary_sensor but instead a schedule sensor that has an on/off state.

## Proposed change

I removed the reference to the binary sensor and added the schedule sensor language as well as updating the example.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
