### PR TITLE
OTBR integration: usually doesn't need to be installed manually

### DIFF
--- a/source/_integrations/otbr.markdown
+++ b/source/_integrations/otbr.markdown
@@ -18,10 +18,7 @@ This integration is installed automatically when the **Open Thread Border Router
 - [Enabling Thread on Home Assistant Yellow](https://yellow.home-assistant.io/procedures/enable-thread/)
 - [Enabling Thread on Home Assistant SkyConnect](https://skyconnect.home-assistant.io/procedures/enable-thread/)
 
-The integration is installed automatically when the **Silicon Labs Multiprotocol** add-on is installed. This happens when you do one of the following procedures:
-
-- [Enabling Multiprotocol on Home Assistant Yellow](https://yellow.home-assistant.io/guides/enable-multiprotocol/)
-- [Enabling Multiprotocol on Home Assistant SkyConnect](https://skyconnect.home-assistant.io/procedures/enable-multiprotocol/)
+The integration is also installed automatically when enabling the experimental **Silicon Labs Multiprotocol** support.
 
 Installing this integration manually is an advanced use case, for example if you run your own border router. If you do have such a use case, follow these steps:
 

--- a/source/_integrations/otbr.markdown
+++ b/source/_integrations/otbr.markdown
@@ -13,7 +13,7 @@ ha_config_flow: true
 
 The Open Thread Border Router integration allows calling an Open Thread Border Router's REST API from Python and via WebSocket.
 
-This integration is installed automatically when the **Open Thread Border Router** add-on is installed. This happens when you do one of the following procedures:
+This integration is installed automatically when the **Open Thread Border Router** add-on is installed. For  Home Assistant Yellow or SkyConnect refer to the following procedures:
 
 - [Enabling Thread on Home Assistant Yellow](https://yellow.home-assistant.io/procedures/enable-thread/)
 - [Enabling Thread on Home Assistant SkyConnect](https://skyconnect.home-assistant.io/procedures/enable-thread/)

--- a/source/_integrations/otbr.markdown
+++ b/source/_integrations/otbr.markdown
@@ -12,6 +12,16 @@ ha_config_flow: true
 ---
 
 The Open Thread Border Router integration allows calling an Open Thread Border Router's REST API from Python and via WebSocket.
-The integration is automatically set up when the "Silicon Labs Multiprotocol" add-on is installed.
+
+This integration is being installed automatically when the **Open Thread Border Router** add-on is installed. This happens for example as part of one of the following procedures:
+
+- [Enabling Thread on Home Assistant Yellow](https://yellow.home-assistant.io/procedures/enable-thread/)
+- [Enabling Thread on Home Assistant SkyConnect](https://skyconnect.home-assistant.io/procedures/enable-thread/)
+- [Adding a HomeKit device via Thread](https://www.home-assistant.io/integrations/homekit_controller/)
+- [Adding a Matter device via Thread](https://www.home-assistant.io/integrations/matter/#adding-a-matter-device-to-home-assistant)
+
+The integration is automatically set up when the **Silicon Labs Multiprotocol** add-on is installed.
+
+Installing this integration manually is an advanced use case, for example if ou run your own border router. If you do have such a use case, follow these steps:
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/otbr.markdown
+++ b/source/_integrations/otbr.markdown
@@ -13,14 +13,17 @@ ha_config_flow: true
 
 The Open Thread Border Router integration allows calling an Open Thread Border Router's REST API from Python and via WebSocket.
 
-This integration is being installed automatically when the **Open Thread Border Router** add-on is installed. This happens for example as part of one of the following procedures:
+This integration is installed automatically when the **Open Thread Border Router** add-on is installed. This happens when you do one of the following procedures:
 
 - [Enabling Thread on Home Assistant Yellow](https://yellow.home-assistant.io/procedures/enable-thread/)
 - [Enabling Thread on Home Assistant SkyConnect](https://skyconnect.home-assistant.io/procedures/enable-thread/)
 - [Adding a HomeKit device via Thread](https://www.home-assistant.io/integrations/homekit_controller/)
 - [Adding a Matter device via Thread](https://www.home-assistant.io/integrations/matter/#adding-a-matter-device-to-home-assistant)
 
-The integration is automatically set up when the **Silicon Labs Multiprotocol** add-on is installed.
+The integration is installed automatically when the **Silicon Labs Multiprotocol** add-on is installed. This happens when you do one of the following procedures:
+
+- [Enabling Multiprotocol on Home Assistant Yellow](https://yellow.home-assistant.io/guides/enable-multiprotocol/)
+- [Enabling Multiprotocol on Home Assistant SkyConnect](https://skyconnect.home-assistant.io/procedures/enable-multiprotocol/)
 
 Installing this integration manually is an advanced use case, for example if you run your own border router. If you do have such a use case, follow these steps:
 

--- a/source/_integrations/otbr.markdown
+++ b/source/_integrations/otbr.markdown
@@ -22,6 +22,6 @@ This integration is being installed automatically when the **Open Thread Border 
 
 The integration is automatically set up when the **Silicon Labs Multiprotocol** add-on is installed.
 
-Installing this integration manually is an advanced use case, for example if ou run your own border router. If you do have such a use case, follow these steps:
+Installing this integration manually is an advanced use case, for example if you run your own border router. If you do have such a use case, follow these steps:
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/otbr.markdown
+++ b/source/_integrations/otbr.markdown
@@ -17,8 +17,6 @@ This integration is installed automatically when the **Open Thread Border Router
 
 - [Enabling Thread on Home Assistant Yellow](https://yellow.home-assistant.io/procedures/enable-thread/)
 - [Enabling Thread on Home Assistant SkyConnect](https://skyconnect.home-assistant.io/procedures/enable-thread/)
-- [Adding a HomeKit device via Thread](https://www.home-assistant.io/integrations/homekit_controller/)
-- [Adding a Matter device via Thread](https://www.home-assistant.io/integrations/matter/#adding-a-matter-device-to-home-assistant)
 
 The integration is installed automatically when the **Silicon Labs Multiprotocol** add-on is installed. This happens when you do one of the following procedures:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

OTBR integration: usually doesn't need to be installed manually
- add links to procedures where the OTBR integration is installed by the OTBR add-on
- addresses feedback from #30867 
 
## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #30867

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
