### PR TITLE
Update tplink docs for auth and tapo

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -1,5 +1,5 @@
 ---
-title: TP-Link Kasa Smart
+title: TP-Link Smart Home
 description: Instructions on integrating TP-Link Smart Home Devices to Home Assistant.
 ha_category:
   - Hub
@@ -24,9 +24,12 @@ ha_quality_scale: platinum
 ha_integration_type: integration
 ---
 
-The `tplink` integration allows you to control your [TP-Link Smart Home Devices](https://www.tp-link.com/kasa-smart/) such as plugs, power strips, wall switches and bulbs.
+The `tplink` integration allows you to control your [TP-Link Kasa Smart Home Devices](https://www.tp-link.com/kasa-smart/) and [TP-Link Tapo Devices](https://www.tapo.com/) such as plugs, power strips, wall switches and bulbs.
 
-You need to provision your newly purchased device to connect to your network before it can be added via the integration. This can be done either by using [kasa command-line tool](https://python-kasa.readthedocs.io/en/latest/cli.html#provisioning) or by adding it to the official Kasa app before trying to add them to Home Assistant. If you use the app, do not upgrade the firmware if it presents the option to avoid blocking the local access by potential firmware updates.
+You need to provision your newly purchased device to connect to your network before it can be added via the integration. This can be done either by using [kasa command-line tool](https://python-kasa.readthedocs.io/en/latest/cli.html#provisioning) or by adding it to the official Kasa or Tapo app before trying to add them to Home Assistant.
+
+If your device is a newer Kasa or Tapo device it will require your TP-Link cloud username and password to authenticate for local access.
+If you have an older device that does not currently require authentication and you want it to stay that way, then you should disable automatic firmware updates, otherwise it may upgrade to firmware that requires it.
 
 There is currently support for the following device types within Home Assistant:
 
@@ -40,7 +43,7 @@ There is currently support for the following device types within Home Assistant:
 
 See [Supported Devices in python-kasa](https://github.com/python-kasa/python-kasa#supported-devices) for an up to date list.
 
-## Supported devices
+## Supported devices not requiring authentication
 
 ### Plugs
 
@@ -55,14 +58,16 @@ See [Supported Devices in python-kasa](https://github.com/python-kasa/python-kas
 - KP125
 - KP401
 - EP10
-- EP25 (HW versions 2.5 and earlier)
+- EP25 (hw_version < 2.6)
 
 ### Power Strips
 
 - EP40
 - HS300
 - KP303
+- KP200
 - KP400
+- KP405
 
 ### Wall switches
 
@@ -96,13 +101,39 @@ See [Supported Devices in python-kasa](https://github.com/python-kasa/python-kas
 - KL420
 - KL430
 
-Other bulbs may also work, but with limited color temperature range (2700-5000). If you find a bulb isn't reaching the full-color temperature boundaries, submit a bug report to [python-kasa](https://github.com/python-kasa/python-kasa).
-
-## Unsupported devices
+## Supported devices requiring authentication
 
 ### Plugs
 
-- KP125M (supported via [Matter](/integrations/matter/#tp-link-tapo-p125m-power-plug), but without energy monitoring features)
+- EP25 (hw_version >= 2.6)
+- KP125M
+- P110
+- HS100 (UK hw_version = 4.1 fw_version = 1.1.0)
+
+### Wall switches
+
+- KS205
+- KS225
+
+### Bulbs
+
+- L510B
+- L530E
+
+### Light strips
+
+- L900-5
+- L900-10
+
+
+## Unsupported devices
+
+Other devices may work but if you encuonter issues submit a bug report to [python-kasa](https://github.com/python-kasa/python-kasa).
+
+Other bulbs may also work, but with limited color temperature range (2700-5000).
+If you find a bulb isn't reaching the full-color temperature boundaries, submit a bug report to [python-kasa](https://github.com/python-kasa/python-kasa).
+
+## Light strip effects
 
 ### Random Effect - Service `tplink.random_effect`
 

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -13,6 +13,7 @@ ha_codeowners:
   - '@rytilahti'
   - '@thegardenmonkey'
   - '@bdraco'
+  - '@sdb9696'
 ha_domain: tplink
 ha_platforms:
   - diagnostics
@@ -29,13 +30,7 @@ The `tplink` integration allows you to control your [TP-Link Kasa Smart Home Dev
 You need to provision your newly purchased device to connect to your network before it can be added via the integration. This can be done either by using [kasa command-line tool](https://python-kasa.readthedocs.io/en/latest/cli.html#provisioning) or by adding it to the official Kasa or Tapo app before trying to add them to Home Assistant.
 
 If your device is a newer Kasa or Tapo device it will require your TP-Link cloud username and password to authenticate for local access.
-If you have an older device that does not currently require authentication and you want it to stay that way, then you should disable automatic firmware updates, otherwise it may upgrade to firmware that requires it.
-
-There is currently support for the following device types within Home Assistant:
-
-- **Light**
-- **Switch**
-- **Sensor**
+If you have an older device that does not currently require authentication, you may consider disabling automatic firmware updates to keep it that way.
 
 {% include integrations/config_flow.md %}
 
@@ -43,9 +38,11 @@ There is currently support for the following device types within Home Assistant:
 
 See [Supported Devices in python-kasa](https://github.com/python-kasa/python-kasa#supported-devices) for an up to date list.
 
-## Supported devices not requiring authentication
+Devices not listed below may work but if you encounter issues submit a bug report to [python-kasa](https://github.com/python-kasa/python-kasa).
 
-### Plugs
+### Not requiring authentication
+
+#### Plugs
 
 - HS100
 - HS103
@@ -58,9 +55,9 @@ See [Supported Devices in python-kasa](https://github.com/python-kasa/python-kas
 - KP125
 - KP401
 - EP10
-- EP25 (hw_version < 2.6)
+- EP25 (Hardware version < 2.6)
 
-### Power Strips
+#### Power Strips
 
 - EP40
 - HS300
@@ -69,7 +66,7 @@ See [Supported Devices in python-kasa](https://github.com/python-kasa/python-kas
 - KP400
 - KP405
 
-### Wall switches
+#### Wall switches
 
 - ES20M
 - HS200
@@ -79,7 +76,7 @@ See [Supported Devices in python-kasa](https://github.com/python-kasa/python-kas
 - KS220M
 - KS230
 
-### Bulbs
+#### Bulbs
 
 - EP40
 - LB100
@@ -95,45 +92,40 @@ See [Supported Devices in python-kasa](https://github.com/python-kasa/python-kas
 - KL130
 - KL135
 
-### Light strips
+#### Light strips
 
 - KL400
 - KL420
 - KL430
 
-## Supported devices requiring authentication
+### Requiring authentication
 
-### Plugs
+#### Plugs
 
-- EP25 (hw_version >= 2.6)
+- EP25 (Hardware version >= 2.6)
 - KP125M
 - P110
-- HS100 (UK hw_version = 4.1 fw_version = 1.1.0)
+- HS100 (UK Hardware version 4.1 with firmware 1.1.0)
 
-### Wall switches
+#### Wall switches
 
 - KS205
 - KS225
 
-### Bulbs
+#### Bulbs
 
 - L510B
 - L530E
 
-### Light strips
+#### Light strips
 
 - L900-5
 - L900-10
 
 
-## Unsupported devices
-
-Other devices may work but if you encuonter issues submit a bug report to [python-kasa](https://github.com/python-kasa/python-kasa).
-
-Other bulbs may also work, but with limited color temperature range (2700-5000).
-If you find a bulb isn't reaching the full-color temperature boundaries, submit a bug report to [python-kasa](https://github.com/python-kasa/python-kasa).
-
 ## Light strip effects
+
+Light strip effects are currently only supported for the device types not requiring authentication.
 
 ### Random Effect - Service `tplink.random_effect`
 

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -121,6 +121,7 @@ Devices not listed below may work but if you encounter issues submit a bug repor
 
 - L900-5
 - L900-10
+- L920
 
 
 ## Light strip effects


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updated documentation relating to [core PR](https://github.com/home-assistant/core/pull/105143) enabling newer Kasa and Tapo devices.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/105143
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
