### PR TITLE
Add documentation for EnOcean integration extension

### DIFF
--- a/source/_integrations/enocean.markdown
+++ b/source/_integrations/enocean.markdown
@@ -322,6 +322,30 @@ The window handle sensor can have the following states:
 - **open**: The window handle is in open position (typically left or right, or 3 o'clock or 9 o'clock)
 - **tilt**: The window handle is in tilt position (typically up or 12 o'clock)
 
+
+### Magnet contact
+
+There are simple Reed sensors consisting of a sensor on the wall or window/door frame and a magnet on the window/door. As soon as the magnet is more than a few millimeters distant from the sensor, it reports open. This supports devices according to EEPs (EnOcean Equipment Profiles): D5-00-01 (Single Input Contact).
+
+To configure a window handle, add the following code to your `configuration.yaml`:
+
+```yaml
+# Example configuration.yaml entry for window handle EEP D5-00-01
+sensor:
+  - name: Living Room Window
+    platform: enocean
+    id: [0x01,0x02,0x03,0x04]
+    device_class: magnetcontact
+```
+
+The configuration does not have any optional parameters.
+
+The magnet contact sensor can have the following states:
+
+- **closed**: The magnet contact is closed, that means the associated window or door is closed
+- **open**: The magnet contact is open, that means the associated window or door is open
+
+
 ## Switch
 
 An EnOcean switch can take many forms. Currently, only a few types have been tested: Permundo PSC234 and Nod On SIN-2-1-01.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Added documentation for the code PR #108582 which adds support for EnOcean magnet contact devices with EEPs (EnOcean Equipment Profiles): D5-00-01 (Single Input Contact)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/108582
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
