### PR TITLE
Added Govee H5105 to supported devices

### DIFF
--- a/source/_integrations/govee_ble.markdown
+++ b/source/_integrations/govee_ble.markdown
@@ -33,6 +33,7 @@ The Govee BLE integration will automatically discover devices once the [Bluetoot
 - H5100 Hygrometer Thermometer
 - H5101 Hygrometer Thermometer
 - H5102 Hygrometer Thermometer
+- [H5105 Bluetooth Thermo-Hygrometer](https://us.govee.com/products/goveelife-smart-thermo-hygrometer-2s)
 - [H5177/5178 Bluetooth Thermo-Hygrometer](https://us.govee.com/collections/thermo-hydrometer/products/bluetooth-thermo-hygrometer)
 - H5179 Hygrometer Thermometer
 - 5055 Meat Thermometer


### PR DESCRIPTION
## Proposed change
Added H5105/GoveeLife Smart Thermo-Hygrometer 2s to supported models. \
Recognized as "H5101/H5102/H5177"

![grafik](https://github.com/home-assistant/home-assistant.io/assets/39765956/95337e7c-4e4d-4f12-92a6-8167ff45c470)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
