### PR TITLE
Document `set_conversation_response` script action

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -920,22 +920,23 @@ The `set_conversation_response` script action allows returning a custom response
 when an automation is triggered by a conversation engine, for example a voice
 assistant. The conversation response can be templated.
 
+{% raw %}
+
 ```yaml
 # Example of a templated conversation response resulting in "Testing 123"
 - variables:
     my_var: "123"
 - set_conversation_response: "{{ 'Testing ' + my_var }}":
-```
 
 The response is handed to the conversation engine when the automation finishes. If
 the `set_conversation_response` is executed multiple times, the most recent
 response will be handed to the conversation engine. To clear the response, set it
 to `None`:
+
 ```yaml
 # Example of a clearing a conversation response
 set_conversation_response: ~
 ```
-
 
 If the automation was not triggered by a conversation engine, the response
 will not be used by anything.

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -923,8 +923,8 @@ assistant. The conversation response can be templated.
 ```yaml
 # Example of a templated conversation response resulting in "Testing 123"
 - variables:
-    my_var: 123
-- set_conversation_response: "Testing {my_var}":
+    my_var: "123"
+- set_conversation_response: "{{ 'Testing ' + my_var }}":
 ```
 
 The response is handed to the conversation engine when the automation finishes. If

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -914,6 +914,32 @@ script:
           entity_id: light.ceiling
 ```
 
+## Respond to a conversation
+
+The `set_conversation_response` script action allows returning a custom response
+when an automation is triggered by a conversation engine, for example a voice
+assistant. The conversation response can be templated.
+
+```yaml
+# Example of a templated conversation response resulting in "Testing 123"
+- variables:
+    my_var: 123
+- set_conversation_response: "Testing {my_var}":
+```
+
+The response is handed to the conversation engine when the automation finishes. If
+the `set_conversation_response` is executed multiple times, the most recent
+response will be handed to the conversation engine. To clear the response, set it
+to `None`:
+```yaml
+# Example of a clearing a conversation response
+set_conversation_response: ~
+```
+
+
+If the automation was not triggered by a conversation engine, the response
+will not be used by anything.
+
 [Script integration]: /integrations/script/
 [automations]: /docs/automation/action/
 [Alexa/Amazon Echo]: /integrations/alexa/

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -928,6 +928,8 @@ assistant. The conversation response can be templated.
     my_var: "123"
 - set_conversation_response: "{{ 'Testing ' + my_var }}":
 
+{% endraw %}
+
 The response is handed to the conversation engine when the automation finishes. If
 the `set_conversation_response` is executed multiple times, the most recent
 response will be handed to the conversation engine. To clear the response, set it

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -927,6 +927,7 @@ assistant. The conversation response can be templated.
 - variables:
     my_var: "123"
 - set_conversation_response: "{{ 'Testing ' + my_var }}":
+```
 
 {% endraw %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document `set_conversation_response` script action

Parent PR: https://github.com/home-assistant/core/pull/108233


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
