### PR TITLE
Fix transmission example automation doc, list syntax for trigger

### DIFF
--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -63,8 +63,8 @@ Example of an automation that notifies on successful download and removes the to
 ```yaml
 - alias: "Notify and remove completed torrent"
   trigger:
-    platform: event
-    event_type: transmission_downloaded_torrent
+    - platform: event
+      event_type: transmission_downloaded_torrent
   action:
     - service: notify.telegram_notifier
       data:


### PR DESCRIPTION
## Type of change
<!--
    Fix typo in transmission example automation doc, there is list syntax for trigger key
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).


## Checklist
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
