### PR TITLE
Update lupusec documentation for config flow

### DIFF
--- a/source/_integrations/lupusec.markdown
+++ b/source/_integrations/lupusec.markdown
@@ -33,7 +33,4 @@ The following devices are supported by the underlying `lupupy` Python library an
 - **Binary sensor**: Displays the status of binary sensors. Door, window, water, and smoke sensors are supported.
 - **Switch**: Turn off and on your Lupus power switches.
 
-## Configuration
-
 {% include integrations/config_flow.md %}
-

--- a/source/_integrations/lupusec.markdown
+++ b/source/_integrations/lupusec.markdown
@@ -9,7 +9,8 @@ ha_category:
 ha_release: 0.83
 ha_iot_class: Local Polling
 ha_codeowners:
-  - '@majuss', '@suaveolent'
+  - '@majuss'
+  - '@suaveolent'
 ha_domain: lupusec
 ha_platforms:
   - alarm_control_panel
@@ -36,32 +37,3 @@ The following devices are supported by the underlying `lupupy` Python library an
 
 {% include integrations/config_flow.md %}
 
-### Manual Configuration
-To use Lupusec devices in your installation, add the following `lupusec` section to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-lupusec:
-  username: YOUR_USERNAME
-  password: YOUR_PASSWORD
-  ip_address: YOUR_IP_ADDRESS
-```
-
-{% configuration %}
-username:
-  description: The login username of your Lupusec alarm panel.
-  required: true
-  type: string
-password:
-  description: The login password of your Lupusec alarm panel.
-  required: true
-  type: string
-ip_address:
-  description: The IP address of your Lupusec alarm panel.
-  required: true
-  type: string
-name:
-  description: Name for your Lupusec panel.
-  required: false
-  type: string
-{% endconfiguration %}

--- a/source/_integrations/lupusec.markdown
+++ b/source/_integrations/lupusec.markdown
@@ -9,7 +9,7 @@ ha_category:
 ha_release: 0.83
 ha_iot_class: Local Polling
 ha_codeowners:
-  - '@majuss'
+  - '@majuss', '@suaveolent'
 ha_domain: lupusec
 ha_platforms:
   - alarm_control_panel
@@ -24,6 +24,7 @@ Supported units:
 
 - Lupusec XT1
 - Lupusec XT2 Plus
+- Lupusec XT3 Plus
 
 The following devices are supported by the underlying `lupupy` Python library and integrated into Home Assistant.
 
@@ -33,6 +34,9 @@ The following devices are supported by the underlying `lupupy` Python library an
 
 ## Configuration
 
+{% include integrations/config_flow.md %}
+
+### Manual Configuration
 To use Lupusec devices in your installation, add the following `lupusec` section to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update the lupusec documentation to account for new config flow feature:
https://github.com/home-assistant/core/pull/108740


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/108740
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
