### PR TITLE
unprivileged doc: Warn about running installation script again

### DIFF
--- a/source/more-info/unhealthy/privileged.markdown
+++ b/source/more-info/unhealthy/privileged.markdown
@@ -16,3 +16,7 @@ If you are running an older version of our Home Assistant OS, update it in the
 If this is not our Home Assistant OS, your operating system might be out of date. Try checking for and
 installing updates, then restarting your system. If this doesn't work, you may need to re-run our
 [convenience installation script](https://github.com/home-assistant/supervised-installer).
+
+Note this may lock you out of your instance unless you have physical access, since it will reset all
+network settings and take over the machine again. If you are able, a more targeted fix is probably
+warranted.

--- a/source/more-info/unhealthy/privileged.markdown
+++ b/source/more-info/unhealthy/privileged.markdown
@@ -14,9 +14,9 @@ If you are running an older version of our Home Assistant OS, update it in the
 {% my configuration title="Configuration" %} panel.
 
 If this is not our Home Assistant OS, your operating system might be out of date. Try checking for and
-installing updates, then restarting your system. If this doesn't work, you may need to re-run our
-[convenience installation script](https://github.com/home-assistant/supervised-installer).
+installing updates, then _restarting your system_.
 
-Note this may lock you out of your instance unless you have physical access, since it will reset all
-network settings and take over the machine again. If you are able, a more targeted fix is probably
-warranted.
+If this doesn't work, you may need to re-run our
+[convenience installation script](https://github.com/home-assistant/supervised-installer). Note this 
+may lock you out of your instance unless you have physical access, since it will reset all
+network settings.


### PR DESCRIPTION
I did the very unfortunate thing to run the dpkg installation again as suggested to 'quick fix' the issue Home Assistant was seeing. It was not a quick fix, it's quite invasive since it can block you out from the entire home assistant computer. (it changed the /etc/interfaces etc, even if those were in fact made by home assistant itself)

This install did show up as 'supported', so even if it had some extra packages on the outside (ssh, and gnome) everything else was as expected.

So now I'm locked out of a computer that's in an empty house 7 hours one way away. :'(

I did think it would take over the computer, which is okay, it's only used for home assistant, but it making itself inaccessible from internet should probably get an extra mention here I think :)

## Proposed change

Mention that the suggested fix can change internet settings.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
