### PR TITLE
Replace data_template: with data:

### DIFF
--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -53,7 +53,7 @@ light:
               value: "{{ s }}"
               entity_id: input_number.s_input
           - service: light.turn_on
-            data_template:
+            data:
               entity_id:
                 - light.led_strip
               transition: "{{ transition | float }}"
@@ -62,7 +62,7 @@ light:
                 - "{{ hs[1] }}"
         set_effect:
           - service: light.turn_on
-            data_template:
+            data:
               entity_id:
                 - light.led_strip
               effect: "{{ effect }}"
@@ -399,12 +399,12 @@ light:
         set_level:
           service: light.turn_on
           entity_id: light.wled_master
-          data_template:
+          data:
             brightness: "{{ brightness }}"
         set_rgbw:
           service: light.turn_on
           entity_id: light.wled_segment_0, light.wled_segment_1
-          data_template:
+          data:
             rgbw_color:
               - "{{ r }}"
               - "{{ g }}"
@@ -414,7 +414,7 @@ light:
         set_effect:
           service: light.turn_on
           entity_id: light.wled_segment_0, light.wled_segment_1
-          data_template:
+          data:
             effect: "{{ effect }}"
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

`data_template:` was deprecated long ago in favor of `data:`, but was still present in the examples on this page.  I did a global search-and-replace.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
