### PR TITLE
Fix anchor on HomeKit controller page

### DIFF
--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -126,7 +126,7 @@ This section shows the the ways you can join a HomeKit device to a Thread networ
 There are two methods to add a HomeKit [compatible device](#supported-devices) to a Thread network:
 
 - via Home Assistant's preferred Thread network
-- via [Apple Thread border router](#adding-a-homekit-device-to-home-assistant-via-apple-thread-border-router)
+- via [Apple Thread border router](#adding-a-homekit-device-via-apple-thread-border-router)
 
 This section describes how to add it via Home Assistant's preferred Thread network.
 


### PR DESCRIPTION
## Proposed change
This fixes a non-resolvable anchor/link on the HomeKit Controller page.


(Related PR which renamed the title to remove "to Home Assistant": https://github.com/home-assistant/home-assistant.io/pull/27994/)



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
