### PR TITLE
Fix anchor link on Thread page and improve grammar

### DIFF
--- a/source/_integrations/thread.markdown
+++ b/source/_integrations/thread.markdown
@@ -16,7 +16,7 @@ ha_zeroconf: true
 
 The Thread integration helps you track the different Thread networks in your home and store the Thread network credentials (similar to a Wi-Fi password). The Thread integration in Home Assistant is currently still a work in progress.
 
-You do not need to install this integration. The Thread integration shows up automatically when Home Assistant detects a [border router](#thread-border-router-devices).
+You do not need to install this integration. The Thread integration shows up automatically when Home Assistant detects a [border router](#about-thread-border-routers).
 
 ## Logos on Thread-based smart home devices
 
@@ -127,7 +127,7 @@ You can only set a Thread network as preferred if the credentials are known.
 
 1. To import Thread credentials, you need your Android and iOS companion app.
 2. On your companion app, navigate to the Thread configuration page.
-   - You should see an **Import credentials** button on the lower right corner.
+   - You should see an **Import credentials** button in the lower right corner.
 
    <img width="400" src='/images/integrations/thread/thread-import-credentials.png'>
 


### PR DESCRIPTION
## Proposed change
This fixes a non-resolvable anchor link on the Thread integration page.

And for a slight grammar improvement, I've also changed "**on** [...] corner" to "**in** [...] corner".

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
