### PR TITLE
Add glossary term refs for Thread, Matter, and Thread border router

### DIFF
--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -98,9 +98,9 @@ You can add a HomeKit [compatible device](#supported-devices) to Home Assistant 
    - There is no way to recover this if you do not have it. In this case, you will need to contact the manufacturer to see what options you have.
 - If your Home Assistant instance does not natively support Bluetooth, use an ESPHome Bluetooth proxy.
   - A proxy can also be helpful if your Home Assistant device is too far away from the device you are trying to pair.
-- If your HomeKit device has been used with Thread before, or is still paired with iOS, reset the device.
+- If your HomeKit device has been used with {% term Thread %} before, or is still paired with iOS, reset the device.
   - HomeKit devices can only be paired to a single controller at once.
-  - If it has been in a Thread network before, the device might remember the Thread credentials of a different network. A reset makes sure the device is not connected to any Thread network.
+  - If it has been in a {% term Thread %} network before, the device might remember the {% term Thread %} credentials of a different network. A reset makes sure the device is not connected to any {% term Thread %} network.
 
 ### To add a HomeKit device through Bluetooth
 
@@ -116,28 +116,28 @@ You can add a HomeKit [compatible device](#supported-devices) to Home Assistant 
 
 ## Adding a HomeKit device through Thread
 
-This section shows the the ways you can join a HomeKit device to a Thread network:
+This section shows the the ways you can join a HomeKit device to a {% term Thread %} network:
 
 1. via Home Assistant
-2. via Apple Thread border router
+2. via Apple {% term Thread border router %}
 
 ### Adding a HomeKit device to a Thread network via Home Assistant
 
-There are two methods to add a HomeKit [compatible device](#supported-devices) to a Thread network:
+There are two methods to add a HomeKit [compatible device](#supported-devices) to a {% term Thread %} network:
 
-- via Home Assistant's preferred Thread network
+- via Home Assistant's preferred {% term Thread %} network
 - via [Apple Thread border router](#adding-a-homekit-device-via-apple-thread-border-router)
 
-This section describes how to add it via Home Assistant's preferred Thread network.
+This section describes how to add it via Home Assistant's preferred {% term Thread %} network.
 
 #### Prerequisites
 
-- A HomeKit device which supports Thread. This is indicated by the Thread label on the packaging.
+- A HomeKit device which supports {% term Thread %}. This is indicated by the Thread label on the packaging.
 - Make sure the HomeKit device has been [joined using Bluetooth](#adding-a-homekit-device-through-bluetooth).
 - **Thread network**: In order to use HomeKit over Thread, you need a working border router.
   - Make sure your Home Assistant device is on the same network (LAN) as the border router.
-  - Make sure the Thread network you'd like to use is known by Home Assistant and marked as **Preferred network** in the Thread configuration.
-  - If you have a Home Assistant Yellow or SkyConnect, you can enable multiprotocol to set up an Open Thread border router and with that a Thread network.
+  - Make sure the {% term Thread %} network you'd like to use is known by Home Assistant and marked as **Preferred network** in the {% term Thread %} configuration.
+  - If you have a Home Assistant Yellow or SkyConnect, you can enable multiprotocol to set up an Open Thread border router and with that a {% term Thread %} network.
     - Documentation on [enabling multiprotocol on Yellow](https://yellow.home-assistant.io/guides/enable-multiprotocol/)
     - Documentation on [enabling multiprotocol on SkyConnect](https://skyconnect.home-assistant.io/procedures/enable-multiprotocol/)
 
@@ -146,34 +146,34 @@ This section describes how to add it via Home Assistant's preferred Thread netwo
 1. To open the device configuration page, on the **HomeKit** integration, select the **device**.
 2. Under **Diagnostic**, you can see the **Thread Status** as **Disabled**.
    ![Device configuration page](/images/integrations/homekit_controller/homekit_controller_add_02.png)
-3. To enable Thread, under **Configuration**, select **Press**. This will provision the preferred Thread credentials.
+3. To enable {% term Thread %}, under **Configuration**, select **Press**. This will provision the preferred Thread credentials.
    - The status has now changed:
      - Depending on the device type, the mesh size and health, the Thread status can be **Child**, **Router**, or **Leader**.
        ![Thread status](/images/integrations/homekit_controller/homekit_controller_add_02.png)
-   - That's it. Your HomeKit device now communicates via Thread.
+   - That's it. Your HomeKit device now communicates via {% term Thread %}.
 
 ### Adding a HomeKit device via Apple Thread border router
 
-There are two methods to add a HomeKit [compatible device](#supported-devices) to a Thread network:
+There are two methods to add a HomeKit [compatible device](#supported-devices) to a {% term Thread %} network:
 
 - via [Home Assistant's preferred Thread network](#adding-a-homekit-device-to-a-thread-network-via-home-assistant)
-- via Apple Thread border router
+- via Apple {% term Thread border router %}
 
 This section describes how to add a HomeKit [compatible device](#supported-devices) using an Apple Thread border router device such as a HomePod mini.
 
 #### Prerequisites
 
-- An Apple device that can act as a Thread border router, such as a HomePod mini.
-- A HomeKit device which supports Thread. This is indicated by the Thread label on the packaging.
+- An Apple device that can act as a {% term Thread border router %}, such as a HomePod mini.
+- A HomeKit device which supports {% term Thread %}. This is indicated by the Thread label on the packaging.
 - Make sure your Home Assistant instance is on the same network (LAN) as the border router.
 - Make sure the HomeKit device has been paired in the Apple Home app (using the iOS Home app).
 
 #### To add a HomeKit device via Apple Thread border router
 
 1. Remove the HomeKit device from the Apple Home app. Don't reset the device.
-   - This leaves the Thread network details on the HomeKit device.
+   - This leaves the {% term Thread %} network details on the HomeKit device.
    - The device will be automatically discovered by the HomeKit controller integration in Home Assistant.
-   - It will appear as a discovered device over Thread.
+   - It will appear as a discovered device over {% term Thread %}.
 2. Under **{% my integrations title="Settings > Devices & Services" %}**, on the HomeKit integration, select **Configure**.
 
    ![HomeKit integration](/images/integrations/homekit_controller/homekit_controller_add_01.png)
@@ -186,7 +186,7 @@ This section describes how to add a HomeKit [compatible device](#supported-devic
 5. Under **Diagnostic**, check the status:
    - Depending on the device type, the mesh size and health, the Thread status can be **Child**, **Router**, or **Leader**.
      ![Thread status](/images/integrations/homekit_controller/homekit_controller_add_02.png)
-   - That's it. Your HomeKit device now communicates via Thread.
+   - That's it. Your HomeKit device now communicates via {% term Thread %}.
 
 ## Supported devices
 

--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -119,7 +119,7 @@ You can add a HomeKit [compatible device](#supported-devices) to Home Assistant 
 This section shows the the ways you can join a HomeKit device to a {% term Thread %} network:
 
 1. via Home Assistant
-2. via Apple {% term Thread border router %}
+2. via Apple Thread border router
 
 ### Adding a HomeKit device to a Thread network via Home Assistant
 
@@ -157,7 +157,7 @@ This section describes how to add it via Home Assistant's preferred {% term Thre
 There are two methods to add a HomeKit [compatible device](#supported-devices) to a {% term Thread %} network:
 
 - via [Home Assistant's preferred Thread network](#adding-a-homekit-device-to-a-thread-network-via-home-assistant)
-- via Apple {% term Thread border router %}
+- via Apple Thread border router
 
 This section describes how to add a HomeKit [compatible device](#supported-devices) using an Apple Thread border router device such as a HomePod mini.
 

--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -163,7 +163,7 @@ This section describes how to add a HomeKit [compatible device](#supported-devic
 
 #### Prerequisites
 
-- An Apple device that can act as a {% term Thread border router %}, such as a HomePod mini.
+- An Apple device that can act as a Thread border router, such as a HomePod mini.
 - A HomeKit device which supports {% term Thread %}. This is indicated by the Thread label on the packaging.
 - Make sure your Home Assistant instance is on the same network (LAN) as the border router.
 - Make sure the HomeKit device has been paired in the Apple Home app (using the iOS Home app).

--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -88,7 +88,7 @@ Running Matter on a Home Assistant Core installation is not supported.
 
 Each Matter network is called a fabric. Each home automation controller that controls Matter devices has its own "fabric". You can add devices directly to the fabric of your Home Assistant instance, or share them from another fabric (for example from Google or Apple) to Home Assistant's fabric. We're going to explore all these options below.
 
-Note: The section below mentions third-party Thread border routers such as the Nest Hub v2 or the HomePod Mini. This doesn’t mean you have to add your devices into these ecosystems. Home Assistant only uses them to access the Thread radio network. The communication between the Home Assistant Matter controller and your Matter devices is encrypted. The {% term Thread border router %} passes the data along, it cannot read its content.
+Note: The section below mentions third-party Thread border routers such as the Nest Hub v2 or the HomePod Mini. This doesn’t mean you have to add your devices to these ecosystems. Home Assistant only uses them to access the Thread radio network. The communication between the Home Assistant Matter controller and your Matter devices is encrypted. The Thread border router passes the data along. It cannot read its content.
 
 ### Prerequisites
 
@@ -113,11 +113,11 @@ Note: The section below mentions third-party Thread border routers such as the N
     - Have the latest version of the Home Assistant Companion app installed.
     - Have Google Home app installed on the Android.
     - We are not going to add the new device to Google Home. The app is needed because Google included the Matter SDK there.
-    - If you are using {% term Thread %}: Make sure there is a {% term Thread border router %} device (Nest Hub v2 or Nest Wi-Fi Pro) present in your home network.
+    - If you are using {% term Thread %}: Make sure there is a Thread border router device (Nest Hub v2 or Nest Wi-Fi Pro) present in your home network.
   - iPhone
     - Have the iOS version 16 or higher
     - Have the latest version of the Home Assistant Companion app installed.
-    - If you are using {% term Thread %}: Make sure there is a {% term Thread border router %} device (HomePod Mini or V2, Apple TV 4K) present in your home network.
+    - If you are using {% term Thread %}: Make sure there is a Thread border router device (HomePod Mini or V2, Apple TV 4K) present in your home network.
 - Make sure the device is in close range of the border router and your phone.
 
 ### To add a new device using the iOS Companion app
@@ -257,7 +257,7 @@ NOTE for Android users: You need to follow the instructions at the bottom of the
 
 - Using Thread-based Matter devices in Home Assistant requires Home Assistant OS version 10 and above. Not using Home Assistant OS is at your own risk. We do provide some [documentation](https://github.com/home-assistant-libs/python-matter-server/blob/main/README.md) on how to run the Matter Server as a Docker container. The documentation includes a description of the host and networking requirements.
 
-- To use {% term Thread %} devices you will need a {% term Thread %} network with at least one {% term Thread border router %} in your network nearby the {% term Thread %} device(s). Apple users need for example the Apple TV 4K or the HomePod Mini, while Google users need a Nest Hub V2. Use the Thread integration in Home Assistant to diagnose your {% term Thread %} network(s).
+- To use {% term Thread %} devices you will need a {% term Thread %} network with at least one Thread border router in your network nearby the {% term Thread %} device(s). Apple users, for example, need the Apple TV 4K or the HomePod Mini, while Google users need a Nest Hub V2. Use the Thread integration in Home Assistant to diagnose your {% term Thread %} network(s).
 
 - Start simple and work from there, keep your network simple and add for example an ESP32 test device. Once that works, move on to the next step or more devices.
 

--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -88,7 +88,7 @@ Running Matter on a Home Assistant Core installation is not supported.
 
 Each Matter network is called a fabric. Each home automation controller that controls Matter devices has its own "fabric". You can add devices directly to the fabric of your Home Assistant instance, or share them from another fabric (for example from Google or Apple) to Home Assistant's fabric. We're going to explore all these options below.
 
-Note: The section below mentions third-party {% term Thread border routers %} such as the Nest Hub v2 or the HomePod Mini. This doesn’t mean you have to add your devices into these ecosystems. Home Assistant only uses them to access the Thread radio network. The communication between the Home Assistant Matter controller and your Matter devices is encrypted. The {% term Thread border router %} passes the data along, it cannot read its content.
+Note: The section below mentions third-party Thread border routers such as the Nest Hub v2 or the HomePod Mini. This doesn’t mean you have to add your devices into these ecosystems. Home Assistant only uses them to access the Thread radio network. The communication between the Home Assistant Matter controller and your Matter devices is encrypted. The {% term Thread border router %} passes the data along, it cannot read its content.
 
 ### Prerequisites
 
@@ -283,7 +283,7 @@ Also see this [extended troubleshooting guide](https://developers.home.google.co
 
 ### Unable to commission devices, it keeps giving errors or stops working randomly
 
-The Matter protocol relies on (local) IPv6 and mDNS (multicast traffic) which should be able to travel freely in your network. Matter devices that use Wi-Fi (including {% term Thread border routers %}) must be on the same LAN/VLAN as Home Assistant. Matter devices that only use {% term Thread %} must be joined to {% term Thread %} networks for which there is at least one border router connected to the Home Assistant LAN.
+The Matter protocol relies on (local) IPv6 and mDNS (multicast traffic) which should be able to travel freely in your network. Matter devices that use Wi-Fi (including Thread border routers) must be on the same LAN/VLAN as Home Assistant. Matter devices that only use {% term Thread %} must be joined to {% term Thread %} networks for which there is at least one border router connected to the Home Assistant LAN.
 
 If you experience any issues with discovering devices (for example, if the initial {% term commissioning %} keeps failing or if devices become unavailable randomly), investigate your network topology. For instance, a setting on your router or Wi-Fi access point to "optimize" multicast traffic can harm the (discovery) traffic from Matter devices. Keep this in mind when you experience issues trying to add or control Matter devices. Protocols like Matter are designed for regular residential network setups and may not integrate well with enterprise networking solutions like VLANs, Multicast filtering, and (malfunctioning) IGMP snooping. To avoid issues, try to keep your network topology as simple and flat as possible.
 

--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -97,7 +97,7 @@ Running Matter on a Home Assistant Core installation is not supported.
 
 Each Matter network is called a fabric. Each home automation controller that controls Matter devices has its own "fabric". You can add devices directly to the fabric of your Home Assistant instance, or share them from another fabric (for example from Google or Apple) to Home Assistant's fabric. We're going to explore all these options below.
 
-Note: The section below mentions third-party Thread border routers such as the Nest Hub v2 or the HomePod Mini. This doesn’t mean you have to add your devices into these ecosystems. Home Assistant only uses them to access the Thread radio network. The communication between the Home Assistant Matter controller and your Matter devices is encrypted. The Thread border router passes the data along, it cannot read its content.
+Note: The section below mentions third-party {% term Thread border routers %} such as the Nest Hub v2 or the HomePod Mini. This doesn’t mean you have to add your devices into these ecosystems. Home Assistant only uses them to access the Thread radio network. The communication between the Home Assistant Matter controller and your Matter devices is encrypted. The {% term Thread border router %} passes the data along, it cannot read its content.
 
 ### Prerequisites
 
@@ -122,11 +122,11 @@ Note: The section below mentions third-party Thread border routers such as the N
     - Have the latest version of the Home Assistant Companion app installed.
     - Have Google Home app installed on the Android.
     - We are not going to add the new device to Google Home. The app is needed because Google included the Matter SDK there.
-    - If you are using {% term Thread %}: Make sure there is a Thread border router device (Nest Hub v2 or Nest Wi-Fi Pro) present in your home network.
+    - If you are using {% term Thread %}: Make sure there is a {% term Thread border router %} device (Nest Hub v2 or Nest Wi-Fi Pro) present in your home network.
   - iPhone
     - Have the iOS version 16 or higher
     - Have the latest version of the Home Assistant Companion app installed.
-    - If you are using {% term Thread %}: Make sure there is a Thread border router device (HomePod Mini or V2, Apple TV 4K) present in your home network.
+    - If you are using {% term Thread %}: Make sure there is a {% term Thread border router %} device (HomePod Mini or V2, Apple TV 4K) present in your home network.
 - Make sure the device is in close range of the border router and your phone.
 
 ### To add a new device using the iOS Companion app
@@ -264,7 +264,7 @@ NOTE for Android users: You need to follow the instructions at the bottom of the
 
 - Using Thread-based Matter devices in Home Assistant requires Home Assistant OS version 10 and above. Not using Home Assistant OS is at your own risk. We do provide some [documentation](https://github.com/home-assistant-libs/python-matter-server/blob/main/README.md) on how to run the Matter Server as a Docker container. The documentation includes a description of the host and networking requirements.
 
-- To use {% term Thread %} devices you will need a {% term Thread %} network with at least one Thread Border Router in your network nearby the {% term Thread %} device(s). Apple users need for example the Apple TV 4K or the HomePod Mini, while Google users need a Nest Hub V2. Use the Thread integration in Home Assistant to diagnose your {% term Thread %} network(s).
+- To use {% term Thread %} devices you will need a {% term Thread %} network with at least one {% term Thread border router %} in your network nearby the {% term Thread %} device(s). Apple users need for example the Apple TV 4K or the HomePod Mini, while Google users need a Nest Hub V2. Use the Thread integration in Home Assistant to diagnose your {% term Thread %} network(s).
 
 - Start simple and work from there, keep your network simple and add for example an ESP32 test device. Once that works, move on to the next step or more devices.
 
@@ -290,7 +290,7 @@ Also see this [extended troubleshooting guide](https://developers.home.google.co
 
 ### Unable to commission devices, it keeps giving errors or stops working randomly
 
-The Matter protocol relies on (local) IPv6 and mDNS (multicast traffic) which should be able to travel freely in your network. Matter devices that use Wi-Fi (including Thread Border routers) must be on the same LAN/VLAN as Home Assistant. Matter devices that only use {% term Thread %} must be joined to {% term Thread %} networks for which there is at least one border router connected to the Home Assistant LAN.
+The Matter protocol relies on (local) IPv6 and mDNS (multicast traffic) which should be able to travel freely in your network. Matter devices that use Wi-Fi (including {% term Thread border routers %}) must be on the same LAN/VLAN as Home Assistant. Matter devices that only use {% term Thread %} must be joined to {% term Thread %} networks for which there is at least one border router connected to the Home Assistant LAN.
 
 If you experience any issues with discovering devices (for example, if the initial {% term commissioning %} keeps failing or if devices become unavailable randomly), investigate your network topology. For instance, a setting on your router or Wi-Fi access point to "optimize" multicast traffic can harm the (discovery) traffic from Matter devices. Keep this in mind when you experience issues trying to add or control Matter devices. Protocols like Matter are designed for regular residential network setups and may not integrate well with enterprise networking solutions like VLANs, Multicast filtering, and (malfunctioning) IGMP snooping. To avoid issues, try to keep your network topology as simple and flat as possible.
 

--- a/source/_integrations/thread.markdown
+++ b/source/_integrations/thread.markdown
@@ -26,15 +26,15 @@ If you have a Thread-based consumer device, you will typically see a Thread logo
 
 The "Built on Thread: requires border router" logo means Thread is the only supported network protocol for this device. You cannot use Wi-Fi to communicate with this device.
 
-In addition, you will see a Matter or Apple HomeKit logo on the packaging.
+In addition, you will see a {% term Matter %} or Apple HomeKit logo on the packaging.
 
-Matter and Apple HomeKit are smart home protocols. They are responsible for handling the Thread credentials and connecting your Thread device to the Thread network. A smart home protocol is needed to control your device. Both home automation standards are supported natively by Home Assistant.
+{% term Matter %} and Apple HomeKit are smart home protocols. They are responsible for handling the Thread credentials and connecting your Thread device to the Thread network. A smart home protocol is needed to control your device. Both home automation standards are supported natively by Home Assistant.
 
 ## Adding a Thread-based device to Home Assistant
 
 How a Thread-based device is added to Home Assistant depends on the home automation standard it uses.
 
-1. If you see the Matter logo on your device packaging, follow the procedure [adding a Matter device to Home Assistant](/integrations/matter/#adding-a-matter-device-to-home-assistant).
+1. If you see the {% term Matter %} logo on your device packaging, follow the procedure [adding a Matter device to Home Assistant](/integrations/matter/#adding-a-matter-device-to-home-assistant).
 
    <img src="/images/integrations/thread/matter_onpackbadge_logo.png"  width="200">
 
@@ -50,7 +50,7 @@ This section introduces the terms *Thread* and *border router* and lists border 
 
 Thread is a low-power mesh networking standard for IoT devices. The low-power aspect is important for battery-powered smart home devices. However, it's also low-bandwidth, making it ideal for applications that don't send a lot of data, like switches or motion sensors.
 
-Thread uses the same <abbr title="radio frequency">RF</abbr> technology as Zigbee (IEEE 802.15.4) but provides IP connectivity similar to Wi-Fi. Unlike Zigbee, Thread by itself does not allow controlling devices: It is just a communication protocol. To control the Thread devices, a higher-level protocol is required: Matter or Apple HomeKit. Thread devices use the IPv6 standard to communicate both inside and outside the mesh network.
+Thread uses the same <abbr title="radio frequency">RF</abbr> technology as Zigbee (IEEE 802.15.4) but provides IP connectivity similar to Wi-Fi. Unlike Zigbee, Thread by itself does not allow controlling devices: It is just a communication protocol. To control the Thread devices, a higher-level protocol is required: {% term Matter %} or Apple HomeKit. Thread devices use the IPv6 standard to communicate both inside and outside the mesh network.
 
 ### About Thread border routers
 
@@ -67,7 +67,7 @@ Home Assistant can only control OpenThread border routers built with the REST AP
 ### List of Thread border router devices
 
 Currently, the following <abbr title="Thread border router">TBR</abbr> devices are known to work with Home Assistant.
-These border routers may require an iPhone or Android phone for onboarding. What the exact requirements are, depends on the home automation protocol (Matter or Apple HomeKit) that your devices are using. Before buying a border router, check the prerequisites in the corresponding procedures:
+These border routers may require an iPhone or Android phone for onboarding. What the exact requirements are, depends on the home automation protocol ({% term Matter %} or Apple HomeKit) that your devices are using. Before buying a border router, check the prerequisites in the corresponding procedures:
 
 - [Adding a Matter device to Home Assistant](/integrations/matter/#adding-a-matter-device-to-home-assistant)
 - [Adding an Apple HomeKit device through Thread](/integrations/homekit_controller/#adding-a-homekit-device-through-thread)
@@ -117,7 +117,7 @@ The intention of the **Preferred network** in Home Assistant is that it will be 
 
 <div class="note">
 
-The **preferred network** function isn't completely implemented yet. In particular, when adding Matter devices through the companion apps, the preferred network of the mobile device is being used.
+The **preferred network** function isn't completely implemented yet. In particular, when adding {% term Matter %} devices through the companion apps, the preferred network of the mobile device is being used.
 
 </div>
 
@@ -144,7 +144,7 @@ This scenario currently only works in one particular case, under the following c
   - [Enabling Thread on SkyConnect](https://skyconnect.home-assistant.io/procedures/enable-thread/)
   - [Enabling Thread on Yellow](https://yellow.home-assistant.io/procedures/enable-thread/)
 - You have an Android phone and the Home Assistant Companion App. (Note: this does not work with the iOS Companion App).
-- The devices you want to add to the network support Matter. For instructions on how to add Thread-based Matter devices, refer to the section [Adding a Matter device to Home Assistant](/integrations/matter/#adding-a-matter-device-to-home-assistant)
+- The devices you want to add to the network support {% term Matter %}. For instructions on how to add Thread-based {% term Matter %} devices, refer to the section [Adding a Matter device to Home Assistant](/integrations/matter/#adding-a-matter-device-to-home-assistant)
 
 Which TBR are supported mostly depends on (access to) the Thread credentials. And Thread credentials are required during on-boarding/commissioning, which is part of the smart home protocol.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add glossary term refs
- for the terms Thread, Matter, and Thread border router
- depends on #31054 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
