### PR TITLE
Added documentation for JVC Projector Binary Sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -382,7 +382,7 @@ source/_integrations/jellyfin.markdown @j-stienstra @ctalkington
 source/_integrations/jewish_calendar.markdown @tsvi
 source/_integrations/juicenet.markdown @jesserockz
 source/_integrations/justnimbus.markdown @kvanzuijlen
-source/_integrations/jvc_projector.markdown @SteveEasley
+source/_integrations/jvc_projector.markdown @SteveEasley @msavazzi
 source/_integrations/kaiterra.markdown @Michsior14
 source/_integrations/kaleidescape.markdown @SteveEasley
 source/_integrations/keba.markdown @dannerph

--- a/source/_integrations/jvc_projector.markdown
+++ b/source/_integrations/jvc_projector.markdown
@@ -62,4 +62,4 @@ The JVC Projector remote platform will create a [Remote](/integrations/remote/) 
 ### Binary sensor
 
 The status reported is:
-- Power on is True when projector is in status "on", "warming"
+- **Power on** is **True** when the projector is either in status **on** or **warming**.

--- a/source/_integrations/jvc_projector.markdown
+++ b/source/_integrations/jvc_projector.markdown
@@ -46,9 +46,20 @@ The JVC Projector remote platform will create a [Remote](/integrations/remote/) 
 - `lens_control`
 - `setting_memory`
 - `gamma_settings`
+- `hdmi_1`
+- `hdmi_2`
+- `mode_1`
+- `mode_2`
+- `mode_3`
+- `lens_ap`
+- `gamma`
+- `color_temp`
+- `natural`
+- `cinema`
+- `anamo`
+- `3d_format`
 
 ### Binary sensor
 
-The following sensor types are supported:
-
+The status reported is:
 - Power on is True when projector is in status "on", "warming"

--- a/source/_integrations/jvc_projector.markdown
+++ b/source/_integrations/jvc_projector.markdown
@@ -12,6 +12,7 @@ ha_codeowners:
 ha_domain: jvc_projector
 ha_platforms:
   - remote
+  - binary_sensor
 ha_integration_type: device
 ---
 

--- a/source/_integrations/jvc_projector.markdown
+++ b/source/_integrations/jvc_projector.markdown
@@ -8,6 +8,7 @@ ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:
   - '@SteveEasley'
+  - '@msavazzi'
 ha_domain: jvc_projector
 ha_platforms:
   - remote
@@ -44,15 +45,9 @@ The JVC Projector remote platform will create a [Remote](/integrations/remote/) 
 - `lens_control`
 - `setting_memory`
 - `gamma_settings`
-- `hdmi_1`
-- `hdmi_2`
-- `mode_1`
-- `mode_2`
-- `mode_3`
-- `lens_ap`
-- `gamma`
-- `color_temp`
-- `natural`
-- `cinema`
-- `anamo`
-- `3d_format`
+
+### Binary sensor
+
+The following sensor types are supported:
+
+- Power on is True when projector is in status "on", "warming"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added description of Binary Sensor for JVC Projector integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/108668
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
