### PR TITLE
Remove invalid anchor link on Yardian page

### DIFF
--- a/source/_integrations/yardian.markdown
+++ b/source/_integrations/yardian.markdown
@@ -19,7 +19,7 @@ The **Yardian** {% term integration %} allows you to control your [Yardian Smart
 
 There is currently support for the following platform within Home Assistant:
 
-- [Switch](#switch) - Allows you to view the status of zones and control them.
+- Switch - Allows you to view the status of zones and control them.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change

Removes an invalid anchor link on the Yardian integration page. 

This link was previously pointing to YAML configuration for the switch platform, but that has been removed, as the integration switched to a UI config flow.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
