### PR TITLE
Fix Pushbullet sensor anchor link

### DIFF
--- a/source/_integrations/pushbullet.markdown
+++ b/source/_integrations/pushbullet.markdown
@@ -18,7 +18,7 @@ ha_config_flow: true
 
 There is currently support for the following device types within Home Assistant:
 
-- [Sensor](#sensor)
+- [Sensor](#sensors)
 - [Notifications](#notifications)
 
 <div class='note'>


### PR DESCRIPTION
## Proposed change
This fixes an invalid anchor link for the "Sensor" device type on the Pushbullet integration page.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
