### PR TITLE
Add Yale Unity Entrance Lock to Yale Access Bluetooth

### DIFF
--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -37,6 +37,7 @@ Devices must have a Yale Access module installed to function with this {% term i
 - YRD420 (Yale Assure Lock 2)
 - YRD450 (Yale Assure Lock 2 Key Free)
 - YUR/SSDL/1/SIL (Yale Unity Screen Door Lock - Australia)
+- YUR/DEL/1/SIL (Yale Unity Entrance Lock - Australia)
 - IES-D210W-G0 (Yale Smart Safe)
 - YRSM-1 (Yale Smart Safe)
 - ASL-05 (August WiFi Smart Lock - Gen 4)


### PR DESCRIPTION
Add Yale Unity Entrance Lock (YUR/DEL/1/SIL) to the supported devices list

## Proposed change
<!-- 
    I propose a change to add the Yale Unity Entrance Lock to the Yale Access Bluetooth integration documentation. 
-->

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    I have this lock integrated into my Home Assistant instance and it works reliably, supporting lock states, battery levels and the action of locking and unlocking the lock.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #31083

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
