### PR TITLE
[add] details how StarLine integration works

### DIFF
--- a/source/_integrations/starline.markdown
+++ b/source/_integrations/starline.markdown
@@ -43,6 +43,7 @@ Create a new application in the [StarLine developer profile](https://my.starline
 
 <div class='note'>
 
+The integration makes API calls to StarLine servers to retrieve data. It gets only the latest set of values that are valid for the moment of the API call. It means that integration does not retrieve or store values, StarLine events or parameters between the API calls.
 You can make up to 1000 API calls per day, which means you could make one approximately every 86 seconds.
 By default, the state of integration will be updated every 3 minutes and OBD information will be updated every 3 hours, making 488 calls per day.
 It is not recommended to set an update interval of less than 90 seconds.

--- a/source/_integrations/starline.markdown
+++ b/source/_integrations/starline.markdown
@@ -43,7 +43,7 @@ Create a new application in the [StarLine developer profile](https://my.starline
 
 <div class='note'>
 
-The integration makes API calls to StarLine servers to retrieve data. It gets only the latest set of values that are valid for the moment of the API call. It means that integration does not retrieve or store values, StarLine events or parameters between the API calls.
+The integration makes API calls to StarLine servers to retrieve data. It gets only the latest set of values that are valid for the moment of the API call. This means that the integration does not retrieve or store values, StarLine events, or parameters between the API calls.
 You can make up to 1000 API calls per day, which means you could make one approximately every 86 seconds.
 By default, the state of integration will be updated every 3 minutes and OBD information will be updated every 3 hours, making 488 calls per day.
 It is not recommended to set an update interval of less than 90 seconds.


### PR DESCRIPTION
## Proposed change
The documentation of [StarLine integration](https://www.home-assistant.io/integrations/starline/) currently does not explain and mentions that some information and events from the StarLine servers can be missing and not retrieved by the integration, and this is considered to be a normal situation. This PR adds a notice regarding what data is retrieved and what data is ignored making it crystal clear for the end-users to avoid misunderstanding or confusion during using the integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR is related to: https://github.com/home-assistant/core/issues/108562, https://github.com/home-assistant/core/issues/108563 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
