### PR TITLE
NUT: Mention that add-on specific hostname has to be used when connecting to add-on server

### DIFF
--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -22,6 +22,9 @@ The Network UPS Tools (NUT) integration allows you to monitor and manage a UPS (
 
 {% include integrations/config_flow.md %}
 
+## Connecting to Add-on instance
+If you are using [NUT add-on](https://github.com/hassio-addons/addon-nut) to run the server, you have to use the add-on specific hostname for the connection. It can be found on the add-on status page and looks like this: `a0d7b954-nut`.
+
 ## Example Resources
 
 Given the following example output from NUT (your variables may differ):


### PR DESCRIPTION
## Proposed change
When NUT integration is used with NUT add-on server, it is necessary to use the add-on/container hostname to connect the integration to it as it won't be found automatically. 

The current documentation of the integration doesn't mention this, and the integration itself has hostname `localhost` as the default. The add-on's documentation mentions this but just in one sentence and with "can" rather than "should" or "must". This confused multiple users (including me) and led to several comments in tickets, e.g. [here](https://github.com/home-assistant/core/issues/75765#issuecomment-1336600731) or [here](https://github.com/home-assistant/core/issues/55888#issuecomment-1179123795). So I'm making the integration manual more explicit about this.

## Type of change
One new small section in the NUT integration documentation.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- [NUT Add-on documentation](https://github.com/hassio-addons/addon-nut/blob/main/nut/DOCS.md)
- I made a similar update for the add-on itself: hassio-addons/addon-nut/pull/341

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
