### PR TITLE
Add note about Cloud Pub/Sub billing changes that do not apply to nest

### DIFF
--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -44,7 +44,7 @@ The Nest Smart Device Management (SDM) API **requires a US$5 fee**. Before buyin
 
 <div class='note'>
 
-The Google Nest integration uses a Cloud Pub/Sub subscription with a 15 minute retention by default. The Google Cloud Pub/sub billing changes effective June 30, 2024 do not apply (only applies to subscriptions with a 24-hour retention). See the [Pub/Sub console](https://console.cloud.google.com/cloudpubsub/subscription/list) to view your subscriptions if you previously created one manually.
+The Google Nest integration uses a Cloud Pub/Sub subscription with a 15-minute retention period by default. The Google Cloud Pub/Sub billing changes, effective June 30, 2024, do not apply. The billing changes only apply to subscriptions with a 24-hour retention period. See the [Pub/Sub console](https://console.cloud.google.com/cloudpubsub/subscription/list) to view your subscriptions if you previously created one manually.
 
 </div>
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -42,6 +42,12 @@ The Nest Smart Device Management (SDM) API **requires a US$5 fee**. Before buyin
 
 </div>
 
+<div class='note'>
+
+The Google Nest integration uses a Cloud Pub/Sub subscription with a 15 minute retention by default. The Google Cloud Pub/sub billing changes effective June 30, 2024 do not apply (only applies to subscriptions with a 24-hour retention). See the [Pub/Sub console](https://console.cloud.google.com/cloudpubsub/subscription/list) to view your subscriptions.
+
+</div>
+
 <lite-youtube videoid="RwZmQ7QfhsM" videotitle="Finally! A WORKING NEST Integration with Home Assistant using Oauth!" posterquality="maxresdefault"></lite-youtube>
 
 ## Configuration

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -44,7 +44,7 @@ The Nest Smart Device Management (SDM) API **requires a US$5 fee**. Before buyin
 
 <div class='note'>
 
-The Google Nest integration uses a Cloud Pub/Sub subscription with a 15 minute retention by default. The Google Cloud Pub/sub billing changes effective June 30, 2024 do not apply (only applies to subscriptions with a 24-hour retention). See the [Pub/Sub console](https://console.cloud.google.com/cloudpubsub/subscription/list) to view your subscriptions.
+The Google Nest integration uses a Cloud Pub/Sub subscription with a 15 minute retention by default. The Google Cloud Pub/sub billing changes effective June 30, 2024 do not apply (only applies to subscriptions with a 24-hour retention). See the [Pub/Sub console](https://console.cloud.google.com/cloudpubsub/subscription/list) to view your subscriptions if you previously created one manually.
 
 </div>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add note about Cloud Pub/Sub billing changes indicating that they do not apply to nest.

Users today received an email from Google Cloud that subscriptions with a retention period of over 24 hours may incur billing. Nest uses a 15 minute rention period by default, so these charges do not apply. Add a link so users know how to check their subscription retention.

This has come up a couple times in the community forum and discord.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
