### PR TITLE
Glossary: add note that Quick reload is only visible in Advanced Mode

### DIFF
--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -299,7 +299,7 @@
     are normally automatically updated. However, changes made outside of the front
     end will not be reflected in Home Assistant and require a reload.
     To perform a manual reload, go to **Settings** > **System** >
-    **Restart Home Assistant** (top right) > **Quick reload**. More granular
+    **Restart Home Assistant** (top right) > **Quick reload**. If you do not see the **Quick reload** option in the menu, you need to enable **Advanced mode** in your user settings. More granular
     reload options are available in *YAML configuration reloading* section
     in **Developer tools** > **YAML**.
   excerpt: >


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Glossary: add note that Quick reload is only visible in Advanced Mode

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
