### PR TITLE
Update SkyConnect marketing website

### DIFF
--- a/source/skyconnect/index.html
+++ b/source/skyconnect/index.html
@@ -76,10 +76,10 @@ frontpage_image: /images/skyconnect/skyconnect-cover.png
       <div class="banner-overlay-header">Available now</div>
       <div class="banner-overlay-content">
         The Home Assistant SkyConnect is the easiest way to add Zigbee support
-        to your Home Assistant instance and make it Matter-over-Thread-ready.
+        to your Home Assistant instance.
         <br /><br />
-        A future firmware update will bring Thread support; allowing SkyConnect
-        to be used for Matter-over-Thread devices
+        We will soon add Thread support; allowing your Home Assistant SkyConnect
+        to be used to connect to Thread-based Matter devices.
       </div>
     </div>
     <div class="material-card text box">
@@ -122,27 +122,6 @@ frontpage_image: /images/skyconnect/skyconnect-cover.png
       <span>Automatically detected by Home Assistant</span>
     </div>
   </div>
-</div>
-
-<div class="material-card text multi-pan">
-  <h1>Concurrent Zigbee and Thread on a single chip</h1>
-  <p>
-    Out of the box the Home Assistant SkyConnect will support only Zigbee. We're
-    working on a firmware update that makes it possible to run both Zigbee and
-    Thread at the same time. Thread is the mesh networking protocol that powers
-    Matter, the new standard for smart home devices.
-  </p>
-  <p>
-    Once available, Home Assistant SkyConnect will run part of the software that
-    normally runs inside Zigbee and Thread chips inside Home Assistant add-ons.
-    These add-ons will be installed and updated automatically without requiring
-    user interaction.
-  </p>
-  <p style="margin-bottom: 0">
-    We will make this multi-protocol set-up first available for Home Assistant
-    OS installations. We will be looking into making this available for Home
-    Assistant Supervised and Home Assistant Container installations afterwards.
-  </p>
 </div>
 
 <div class="sub-title">Specifications</div>
@@ -196,26 +175,14 @@ frontpage_image: /images/skyconnect/skyconnect-cover.png
 
 <h1 class="sub-title">FAQs</h1>
 <div class="faq-list">
-  {% details "Why start with Home Assistant OS support for multi-protocol?" %} A
-  standalone Zigbee or standalone Thread stick works by turning radio signals
-  into radio packets and then processing those radio packets and making that
-  available over a serial port.<br /><br />
-  With multi-protocol, the processing of the radio packets is moved into Linux
-  daemons. This means we run one daemon to split the radio packets into Zigbee
-  and Thread streams, one daemon to process the Zigbee radio packets and one
-  daemon to process the Thread radio packets.<br /><br />
-  To make this all work together, we need to strictly manage the version of the
-  firmware on the stick and the three different Linux daemons. The easiest way
-  for us to do this is using Home Assistant add-ons in a known host environment,
-  which is Home Assistant OS. {% enddetails %} {% details "Why include a USB
-  extension cable?" %} USB 3.0 ports (the ones with blue on the inside)
-  are known to cause significant noise and radio interference to any 2.4Ghz
-  wireless devices. This includes Zigbee and Thread. If you do not use the
-  extension cable, it may not work at all, and if it does, it could be flaky at
-  best with intermittent problems (issues with pairing, device dropouts, unreachable
-  devices, timeout errors, etc).
+  {% details "Why include a USB extension cable?" %} USB 3.0 ports (the ones with blue on the inside) are known to cause significant noise and radio interference to any 2.4Ghz  wireless devices. This includes Zigbee and Thread. If you do not use the extension cable, it may not work at all, and if it does, it could be flaky at best with intermittent problems (issues with pairing, device dropouts, unreachable devices, timeout errors, etc).
   <br><br>
   <a href="https://www.youtube.com/watch?v=tHqZhNcFEvA">See demo on YouTube.</a> {% enddetails %}
+  {% details "Which use case do you recommend for Home Assistant SkyConnect?" %}
+  Our current recommendation for Home Assistant SkyConnect is to use the Zigbee firmware to power your Zigbee network. This solution offers a great experience out-of-the-box.<br /><br />
+  As part of our efforts to bring Matter to Home Assistant, we're now focused on ensuring that the Thread experience will catch up and become a first-class citizen, making it easy to connect to your Thread-based Matter devices in Home Assistant without a third-party Thread border router. The Thread firmware is already fully functional under the hood, but we still have some work to do to make the experience of using Thread-based devices in Home Assistant feel good. Once the experience has improved, we will recommend using this Thread firmware to power your Thread network as an alternative to using third-party Thread border routers from Apple or Google.{% enddetails %}
+  {% details "What is the current state of multiprotocol support?" %} When we launched Home Assistant SkyConnect, we announced our intent to release a firmware supporting multiprotocol, which allows the Silicon Labs chip to connect to both Zigbee and Thread networks with one radio. This experimental firmware has been available since December 2022. It integrates the Silicon Labs SDK, which adds this support for multiprotocol. During the further development and testing of the multiprotocol firmware, we have concluded that while Silicon Labs' multiprotocol works, it comes with technical limitations. These limitations mean users will not have the best experience compared to using dedicated Zigbee and Thread radios. That is why we do not recommend using this firmware, and it will remain an experimental feature of Home Assistant SkyConnect. If you currently have the multiprotocol firmware installed but don't actively use it to connect to Thread devices, we recommend that you <a href="https://skyconnect.home-assistant.io/procedures/disable-multiprotocol/">disable multiprotocol</a>.<br /><br />
+  Nothing changes for current users of the multiprotocol firmware who are happy with their experience. The experimental multiprotocol firmware will remain available, but we will not recommend it to new users. Instead, we will focus on making sure the dedicated Zigbee and Thread firmwares for Home Assistant SkyConnect deliver the best experience to users.{% enddetails %}
 </div>
 
 <div style="margin-top: 24px; text-align: center; font-size: .8rem;">


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update the SkyConnect marketing page to reflect our latest recommendation which is to use pure Zigbee or pure Thread firmware. The multi-pan firmware remains available and FAQ has been updated to mention this. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
