### PR TITLE
Update analytics.markdown to match core PR 109110

### DIFF
--- a/source/_integrations/analytics.markdown
+++ b/source/_integrations/analytics.markdown
@@ -103,7 +103,11 @@ If your system includes the Supervisor, this will also contain:
     "board": "odroid-n2",
     "version": "{{site.data.version_data.hassos['odroid-n2']}}"
   },
-  "integrations": ["awesome_integration"],
+  "integrations": [
+    "hue",
+    "youtube",
+    "hacs"
+  ],
   "addons": [
       {
           "slug": "awesome_addon",


### PR DESCRIPTION
## Proposed change
Updates references to Analytics integrations to match with https://github.com/home-assistant/core/pull/109110 using the tests in https://github.com/home-assistant/core/blob/dev/tests/components/analytics_insights/test_config_flow.py#L107-L108 (as opposed to placeholders).

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/109110
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
