### PR TITLE
Add H5103 and H5105 to govee-ble

### DIFF
--- a/source/_integrations/govee_ble.markdown
+++ b/source/_integrations/govee_ble.markdown
@@ -33,7 +33,9 @@ The Govee BLE integration will automatically discover devices once the [Bluetoot
 - [H5100 Hygrometer Thermometer](https://us.govee.com/collections/thermo-hydrometer/products/govee-h5100-mini-hygrometer-thermometer-sensors)
 - H5101 Hygrometer Thermometer
 - H5102 Hygrometer Thermometer
+- H5103 Hygrometer Thermometer
 - [H5104 Hygrometer Thermometer](https://us.govee.com/products/goveelife-bluetooth-hygrometer-thermometer-h5104-white)
+- H5105 Hygrometer Thermometer
 - H5106 Hygrometer Thermometer and Air Quality Monitor
 - H5108 Hygrometer Thermometer
 - [H5177/5178 Bluetooth Thermo-Hygrometer](https://us.govee.com/collections/thermo-hydrometer/products/bluetooth-thermo-hygrometer)


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

These devices previously worked in 2024.1 but regressed in dev because they were detected as other models even though they were not supported. They stopped working in `dev` with the lib bump when the H5106 was added because they would get detected as an H5106.

govee-ble 0.31.0 fixes that so we can move them to the supported list


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/109235
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
