### PR TITLE
Address brand filter review comments

### DIFF
--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -34,7 +34,7 @@ regenerate: false
       <a href='#all' class="btn">All ({{tot}})</a>
       <div class="featured">
         <a href='#featured' class="btn">Featured</a>
-        <a href='#works-with-home-assistant' class="btn">Partners</a>
+        <a href='#works-with-home-assistant' class="btn">Partner brands</a>
       </div>
       <div class="version_select">Added in: <select name="versions">
           <option value="#"></option>
@@ -213,7 +213,7 @@ allComponents.pop(); // remove placeholder element at the end
             return comp.featured;
           };
 
-        } else if (hash === '#works-with-home-assistant' || hash === '') {
+        } else if (hash === '#works-with-home-assistant') {
           // only show those partners of the Works with Home Assistant program
           filter = function (comp) {
             return comp.wwha;


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Addresses the review comment by @edenhaus in https://github.com/home-assistant/home-assistant.io/pull/31019#pullrequestreview-1841372390

Also changes it from "Partners" to "Partener brands", as was requested/suggested on Discord.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
