### PR TITLE
Add Motionblinds BLE integration documentation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -490,6 +490,7 @@ source/_integrations/monoprice.markdown @etsinko @OnFreund
 source/_integrations/moon.markdown @fabaff @frenck
 source/_integrations/mopeka.markdown @bdraco
 source/_integrations/motion_blinds.markdown @starkillerOG
+source/_integrations/motionblinds_ble.markdown @LennP @jerrybboy
 source/_integrations/motioneye.markdown @dermotduffy
 source/_integrations/mqtt.markdown @emontnemery @jbouwh
 source/_integrations/msteams.markdown @peroyvind

--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -1,0 +1,51 @@
+---
+title: MotionBlinds BLE
+description: Instructions on how to integrate MotionBlinds Bluetooth motors into Home Assistant.
+ha_category:
+  - Cover
+ha_iot_class: Assumed State
+ha_release: 2024.02
+ha_domain: motionblinds_ble
+ha_codeowners:
+  - '@LennP'
+  - '@jerrybboy'
+ha_config_flow: true
+ha_platforms:
+  - cover
+ha_integration_type: integration
+---
+
+This integration adds support for [MotionBlinds](https://motionblinds.com/) Bluetooth motors. Beware that this integration does not work with *Eve MotionBlinds* motors. *Eve MotionBlinds* can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration.
+
+{% include integrations/config_flow.md %}
+
+## Setup
+
+During the setup of a MotionBlinds BLE device, you will be asked what kind of blind your MotionBlind is. There are 8 different blind types:
+
+- **Roller blind**: has the ability to change position and speed.
+- **Honeycomb blind**: has the ability to change position and speed.
+- **Roman blind**: has the ability to change position and speed.
+- **Venetian blind**: has the ability to change position, tilt and speed.
+- **Venetian blind (tilt-only)**: has the ability to change tilt and speed.
+- **Double Roller blind**: has the ability to change position, tilt and speed.
+- **Curtain blind**: has the ability to change position. May need to be calibrated if the end positions are lost, which can be done by using the open/close cover button or the set cover position slider. This will trigger a calibration which will first make the curtain find the end positions after which it will run to the position as indicated by the command that was given.
+- **Vertical blind**: has the ability to change position and tilt. May need to be calibrated if the end positions are lost, which has to be done using the MotionBlinds BLE mobile app.
+
+## Services
+
+Since MotionBlinds BLE motors require a Bluetooth connection to control them, Home Assistant does not get automatic updates of the motor's state by default. Therefore, you can use the [homeassistant.update_entity](https://www.home-assistant.io/docs/scripts/service-calls/#homeassistant-services) service on a MotionBlinds BLE cover entity which will connect to your MotionBlind and update the state of all entities belonging to the device. **However, be aware that doing so may impact battery life.**
+
+This can also be automated using a YAML automation. For instance, the following automation connects to your MotionBlind every 24 hours to update it's state in Home Assistant:
+
+```yaml
+alias: MotionBlinds BLE polling automation
+mode: single
+trigger:
+  - platform: time_pattern
+    hours: "/24"
+action:
+  - service: homeassistant.update_entity
+    target:
+      entity_id: cover.motion_shade
+```

--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate Motionblinds Bluetooth motors into
 ha_category:
   - Cover
 ha_iot_class: Assumed State
-ha_release: 2024.03
+ha_release: 2024.04
 ha_domain: motionblinds_ble
 ha_codeowners:
   - '@LennP'

--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -15,7 +15,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-This integration adds support for [Motionblinds](https://motionblinds.com/) Bluetooth motors. Beware that this integration does not work with *Eve Motionblinds* motors. *Eve Motionblinds* can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration.
+The Motionblinds BLE {% term integration %} adds support for [Motionblinds](https://motionblinds.com/) Bluetooth motors. Beware that this integration does not work with *Eve Motionblinds* motors. *Eve Motionblinds* can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration.
 
 {% include integrations/config_flow.md %}
 
@@ -26,9 +26,9 @@ During the setup of a Motionblinds BLE device, you will be asked what kind of bl
 - **Roller blind**: has the ability to change position and speed.
 - **Honeycomb blind**: has the ability to change position and speed.
 - **Roman blind**: has the ability to change position and speed.
-- **Venetian blind**: has the ability to change position, tilt and speed.
+- **Venetian blind**: has the ability to change position, tilt, and speed.
 - **Venetian blind (tilt-only)**: has the ability to change tilt and speed.
-- **Double Roller blind**: has the ability to change position, tilt and speed.
+- **Double Roller blind**: has the ability to change position, tilt, and speed.
 - **Curtain blind**: has the ability to change position. May need to be calibrated if the end positions are lost, which can be done by using the open/close cover button or the set cover position slider. This will trigger a calibration which will first make the curtain find the end positions after which it will run to the position as indicated by the command that was given.
 - **Vertical blind**: has the ability to change position and tilt. May need to be calibrated if the end positions are lost, which has to be done using the Motionblinds BLE mobile app.
 

--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate MotionBlinds Bluetooth motors into
 ha_category:
   - Cover
 ha_iot_class: Assumed State
-ha_release: 2024.02
+ha_release: 2024.03
 ha_domain: motionblinds_ble
 ha_codeowners:
   - '@LennP'

--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -1,6 +1,6 @@
 ---
-title: MotionBlinds BLE
-description: Instructions on how to integrate MotionBlinds Bluetooth motors into Home Assistant.
+title: Motionblinds BLE
+description: Instructions on how to integrate Motionblinds Bluetooth motors into Home Assistant.
 ha_category:
   - Cover
 ha_iot_class: Assumed State
@@ -15,13 +15,13 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-This integration adds support for [MotionBlinds](https://motionblinds.com/) Bluetooth motors. Beware that this integration does not work with *Eve MotionBlinds* motors. *Eve MotionBlinds* can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration.
+This integration adds support for [Motionblinds](https://motionblinds.com/) Bluetooth motors. Beware that this integration does not work with *Eve Motionblinds* motors. *Eve Motionblinds* can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration.
 
 {% include integrations/config_flow.md %}
 
 ## Setup
 
-During the setup of a MotionBlinds BLE device, you will be asked what kind of blind your MotionBlind is. There are 8 different blind types:
+During the setup of a Motionblinds BLE device, you will be asked what kind of blind your Motionblind is. There are 8 different blind types:
 
 - **Roller blind**: has the ability to change position and speed.
 - **Honeycomb blind**: has the ability to change position and speed.
@@ -30,16 +30,16 @@ During the setup of a MotionBlinds BLE device, you will be asked what kind of bl
 - **Venetian blind (tilt-only)**: has the ability to change tilt and speed.
 - **Double Roller blind**: has the ability to change position, tilt and speed.
 - **Curtain blind**: has the ability to change position. May need to be calibrated if the end positions are lost, which can be done by using the open/close cover button or the set cover position slider. This will trigger a calibration which will first make the curtain find the end positions after which it will run to the position as indicated by the command that was given.
-- **Vertical blind**: has the ability to change position and tilt. May need to be calibrated if the end positions are lost, which has to be done using the MotionBlinds BLE mobile app.
+- **Vertical blind**: has the ability to change position and tilt. May need to be calibrated if the end positions are lost, which has to be done using the Motionblinds BLE mobile app.
 
 ## Services
 
-Since MotionBlinds BLE motors require a Bluetooth connection to control them, Home Assistant does not get automatic updates of the motor's state by default. Therefore, you can use the [homeassistant.update_entity](https://www.home-assistant.io/docs/scripts/service-calls/#homeassistant-services) service on a MotionBlinds BLE cover entity which will connect to your MotionBlind and update the state of all entities belonging to the device. **However, be aware that doing so may impact battery life.**
+Since Motionblinds BLE motors require a Bluetooth connection to control them, Home Assistant does not get automatic updates of the motor's state by default. Therefore, you can use the [homeassistant.update_entity](https://www.home-assistant.io/docs/scripts/service-calls/#homeassistant-services) service on a Motionblinds BLE entity which will connect to your Motionblind and update the state of all entities belonging to the device. **However, be aware that doing so may impact battery life.**
 
-This can also be automated using a YAML automation. For instance, the following automation connects to your MotionBlind every 24 hours to update it's state in Home Assistant:
+This can also be automated using a YAML automation. For instance, the following automation connects to your Motionblind every 24 hours to update it's state in Home Assistant:
 
 ```yaml
-alias: MotionBlinds BLE polling automation
+alias: Motionblinds BLE polling automation
 mode: single
 trigger:
   - platform: time_pattern


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add Motionblinds BLE integration documentation.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/109497
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: -

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards