### PR TITLE
service-calls: added info that target values should be lower-cased

### DIFF
--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -28,7 +28,7 @@ Instead of targeting an entity, you can also target an {% term area %} or {% ter
 This is done with the `target` key.
 
 A `target` is a map that contains at least one of the following: `area_id`, `device_id`, `entity_id`.
-Each of these can be a list.
+Each of these can be a list. The values should be lower-cased.
 
 The following example uses a single service call to turn on the lights in the
 living room area, 2 additional light devices and 2 additional light entities:


### PR DESCRIPTION
Added info about values case–(in)sensitivity.

I was surprised when my `area_id` did not work, only later to notice, that the value is case–sensitive. Apparently, it is different from `entity_id`, which is case–insensitive.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.