### PR TITLE
Allow unix timestamp values for DATE and TIMESTAMP device classes in MQTT

### DIFF
--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -1,6 +1,6 @@
 ---
 title: "MQTT Sensor"
-description: "Instructions on how to integrate MQTT sensors within Home Assistant."
+description: "Instructions on how to integrate MQTT sensors within Home Assistant TEST."
 ha_category:
   - Sensor
 ha_release: 0.7
@@ -185,7 +185,7 @@ state_class:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for timestamp or date the following values are expected: datetime object, e.g. `2021-11-18T20:25:00+00:00` or `2021-11-18, or unix timestamp, e.g. `1707265443.323565`.
+  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`.
   required: true
   type: string
 unique_id:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -185,7 +185,7 @@ state_class:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for timestamp or date the following values are expected: datetime object (e.g. `2021-11-18T20:25:00+00:00` or `2021-11-18`) or unix timestamp (e.g. `1707265443.323565`).
+  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`.
   required: true
   type: string
 unique_id:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -185,7 +185,7 @@ state_class:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for timestamp or date the following values are expected, datetime object (e.g. 2021-11-18T20:25:00+00:00 or 2021-11-18) or unix timestamp (e.g. 1707265443.323565).
+  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for `timestamp` or `date` the following values are expected, datetime object (e.g. `2021-11-18T20:25:00+00:00` or `2021-11-18`) or unix timestamp (e.g. `1707265443.323565`).
   required: true
   type: string
 unique_id:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -185,7 +185,7 @@ state_class:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`.
+  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for timestamp or date the following values are expected: datetime object (e.g.: `2021-11-18T20:25:00+00:00` or `2021-11-18`) or unix timestamp (e.g.: `1707265443.323565`).
   required: true
   type: string
 unique_id:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -185,7 +185,7 @@ state_class:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for `timestamp` or `date` the following values are expected, datetime object (e.g. `2021-11-18T20:25:00+00:00` or `2021-11-18`) or unix timestamp (e.g. `1707265443.323565`). For unix timestamp, the value must be UTC..
+  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for `timestamp` or `date` the following values are expected, datetime object (e.g. `2021-11-18T20:25:00+00:00` or `2021-11-18`) or unix timestamp (e.g. `1707265443.323565`).
   required: true
   type: string
 unique_id:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -185,7 +185,7 @@ state_class:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`.
+  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for timestamp or date the following values are expected: datetime object, e.g. `2021-11-18T20:25:00+00:00` or `2021-11-18, or unix timestamp, e.g. `1707265443.323565`.
   required: true
   type: string
 unique_id:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -185,7 +185,7 @@ state_class:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for `timestamp` or `date` the following values are expected, datetime object (e.g. `2021-11-18T20:25:00+00:00` or `2021-11-18`) or unix timestamp (e.g. `1707265443.323565`).
+  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for `timestamp` or `date` the following values are expected, datetime object (e.g. `2021-11-18T20:25:00+00:00` or `2021-11-18`) or unix timestamp (e.g. `1707265443.323565`). For unix timestamp, the value must be UTC..
   required: true
   type: string
 unique_id:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -185,7 +185,7 @@ state_class:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for timestamp or date the following values are expected: datetime object (e.g.: `2021-11-18T20:25:00+00:00` or `2021-11-18`) or unix timestamp (e.g.: `1707265443.323565`).
+  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for timestamp or date the following values are expected: datetime object (e.g. `2021-11-18T20:25:00+00:00` or `2021-11-18`) or unix timestamp (e.g. `1707265443.323565`).
   required: true
   type: string
 unique_id:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -1,6 +1,6 @@
 ---
 title: "MQTT Sensor"
-description: "Instructions on how to integrate MQTT sensors within Home Assistant TEST."
+description: "Instructions on how to integrate MQTT sensors within Home Assistant."
 ha_category:
   - Sensor
 ha_release: 0.7
@@ -185,7 +185,7 @@ state_class:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`.
+  description: The MQTT topic subscribed to receive sensor values. If `device_class`, `state_class`, `unit_of_measurement` or `suggested_display_precision` is set, and a numeric value is expected, an empty value `''` will be ignored and will not update the state, a `'null'` value will set the sensor to an `unknown` state. The `device_class` can be `null`. When the device class is defined for timestamp or date the following values are expected, datetime object (e.g. 2021-11-18T20:25:00+00:00 or 2021-11-18) or unix timestamp (e.g. 1707265443.323565).
   required: true
   type: string
 unique_id:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Allow unix timestamp values for DATE and TIMESTAMP device classes in MQTT


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/109773
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
