### PR TITLE
Add telegram id to user id mapping for `telegram_bot`

### DIFF
--- a/source/_integrations/telegram_polling.markdown
+++ b/source/_integrations/telegram_polling.markdown
@@ -34,7 +34,7 @@ allowed_chat_ids:
   required: true
   type: list
 chat_id:
-  description: Telegram chat id. Users would have a positive id and a group would have a negative id.
+  description: Telegram chat id. Users would have a positive id and groups would have a negative id.
   required: true
   type: integer
 user_id:

--- a/source/_integrations/telegram_polling.markdown
+++ b/source/_integrations/telegram_polling.markdown
@@ -38,7 +38,7 @@ chat_id:
   required: true
   type: integer
 user_id:
-  descrition: Home Assistant user id to use as part of the event context.
+  description: Home Assistant user id to use as part of the event context.
   required: false
   type: string
 api_key:

--- a/source/_integrations/telegram_polling.markdown
+++ b/source/_integrations/telegram_polling.markdown
@@ -36,7 +36,7 @@ allowed_chat_ids:
 chat_id:
   description: Telegram chat id. Users would have a positive id and a group would have a negative id.
   required: true
-  type: int
+  type: integer
 user_id:
   descrition: Home Assistant user id to use as part of the event context.
   required: false

--- a/source/_integrations/telegram_polling.markdown
+++ b/source/_integrations/telegram_polling.markdown
@@ -23,8 +23,9 @@ telegram_bot:
   - platform: polling
     api_key: YOUR_API_KEY
     allowed_chat_ids:
-      - 123456789 # example id of a user
-      - -987654321  # example id of a group, starts with a -
+      - chat_id: 123456789 # example id of a user
+        user_id: 3328b4936eccd805bd65063c0562dcd2
+      - chat_id: -987654321  # example id of a group, starts with a -
 ```
 
 {% configuration %}
@@ -32,6 +33,14 @@ allowed_chat_ids:
   description: A list of ids representing the users and group chats that are authorized to interact with the bot.
   required: true
   type: list
+chat_id:
+  description: Telegram chat id. Users would have a positive id and a group would have a negative id.
+  required: true
+  type: int
+user_id:
+  descrition: Home Assistant user id to use as part of the event context.
+  required: false
+  type: string
 api_key:
   description: The API token of your bot.
   required: true

--- a/source/_integrations/telegram_polling.markdown
+++ b/source/_integrations/telegram_polling.markdown
@@ -23,24 +23,15 @@ telegram_bot:
   - platform: polling
     api_key: YOUR_API_KEY
     allowed_chat_ids:
-      - chat_id: 123456789 # example id of a user
-        user_id: 3328b4936eccd805bd65063c0562dcd2
-      - chat_id: -987654321  # example id of a group, starts with a -
+      - 123456789: 3328b4936eccd805bd65063c0562dcd2 # example id of a telegram user that maps to the Home Assistant user
+      - -987654321  # example id of a group, starts with a -
 ```
 
 {% configuration %}
 allowed_chat_ids:
-  description: A list of ids representing the users and group chats that are authorized to interact with the bot.
+  description: A list of ids representing the users and group chats that are authorized to interact with the bot. You can optionally add a mapping to the Home Assistant user ID that would be used as part of the event context. Negative values mean group chats. They can also have mapping to Home Assistant user_id, but the user mapping takes priority.
   required: true
   type: list
-chat_id:
-  description: Telegram chat id. Users would have a positive id and groups would have a negative id.
-  required: true
-  type: integer
-user_id:
-  description: Home Assistant user id to use as part of the event context.
-  required: false
-  type: string
 api_key:
   description: The API token of your bot.
   required: true

--- a/source/_integrations/telegram_webhooks.markdown
+++ b/source/_integrations/telegram_webhooks.markdown
@@ -38,7 +38,7 @@ allowed_chat_ids:
 chat_id:
   description: Telegram chat id. Users would have a positive id and a group would have a negative id.
   required: true
-  type: int
+  type: integer
 user_id:
   descrition: Home Assistant user id to use as part of the event context.
   required: false

--- a/source/_integrations/telegram_webhooks.markdown
+++ b/source/_integrations/telegram_webhooks.markdown
@@ -40,7 +40,7 @@ chat_id:
   required: true
   type: integer
 user_id:
-  descrition: Home Assistant user id to use as part of the event context.
+  description: Home Assistant user id to use as part of the event context.
   required: false
   type: string
 api_key:

--- a/source/_integrations/telegram_webhooks.markdown
+++ b/source/_integrations/telegram_webhooks.markdown
@@ -25,8 +25,9 @@ telegram_bot:
   - platform: webhooks
     api_key: YOUR_API_KEY
     allowed_chat_ids:
-      - 123456789 # example id of a user
-      - -987654321  # example id of a group, starts with a -
+      - chat_id: 123456789 # example id of a user
+        user_id: 3328b4936eccd805bd65063c0562dcd2
+      - chat_id: -987654321  # example id of a group, starts with a -
 ```
 
 {% configuration %}
@@ -34,6 +35,14 @@ allowed_chat_ids:
   description: A list of ids representing the users and group chats that are authorized to interact with the bot.
   required: true
   type: list
+chat_id:
+  description: Telegram chat id. Users would have a positive id and a group would have a negative id.
+  required: true
+  type: int
+user_id:
+  descrition: Home Assistant user id to use as part of the event context.
+  required: false
+  type: string
 api_key:
   description: The API token of your bot.
   required: true

--- a/source/_integrations/telegram_webhooks.markdown
+++ b/source/_integrations/telegram_webhooks.markdown
@@ -36,7 +36,7 @@ allowed_chat_ids:
   required: true
   type: list
 chat_id:
-  description: Telegram chat id. Users would have a positive id and a group would have a negative id.
+  description: Telegram chat id. Users would have a positive id and groups would have a negative id.
   required: true
   type: integer
 user_id:

--- a/source/_integrations/telegram_webhooks.markdown
+++ b/source/_integrations/telegram_webhooks.markdown
@@ -26,7 +26,7 @@ telegram_bot:
     api_key: YOUR_API_KEY
     allowed_chat_ids:
       - 123456789 : 3328b4936eccd805bd65063c0562dcd2 # example id of a telegram user that maps to the Home Assistant user
-      - chat_id: -987654321  # example id of a group, starts with a -
+      - -987654321  # example id of a group, starts with a -
 ```
 
 {% configuration %}

--- a/source/_integrations/telegram_webhooks.markdown
+++ b/source/_integrations/telegram_webhooks.markdown
@@ -25,24 +25,15 @@ telegram_bot:
   - platform: webhooks
     api_key: YOUR_API_KEY
     allowed_chat_ids:
-      - chat_id: 123456789 # example id of a user
-        user_id: 3328b4936eccd805bd65063c0562dcd2
+      - 123456789 : 3328b4936eccd805bd65063c0562dcd2 # example id of a telegram user that maps to the Home Assistant user
       - chat_id: -987654321  # example id of a group, starts with a -
 ```
 
 {% configuration %}
 allowed_chat_ids:
-  description: A list of ids representing the users and group chats that are authorized to interact with the bot.
+  description: A list of ids representing the users and group chats that are authorized to interact with the bot. You can optionally add a mapping to the Home Assistant user ID that would be used as part of the event context. Negative values mean group chats. They can also have mapping to Home Assistant user_id, but the user mapping takes priority.
   required: true
   type: list
-chat_id:
-  description: Telegram chat id. Users would have a positive id and groups would have a negative id.
-  required: true
-  type: integer
-user_id:
-  description: Home Assistant user id to use as part of the event context.
-  required: false
-  type: string
 api_key:
   description: The API token of your bot.
   required: true

--- a/source/_integrations/telegram_webhooks.markdown
+++ b/source/_integrations/telegram_webhooks.markdown
@@ -25,7 +25,7 @@ telegram_bot:
   - platform: webhooks
     api_key: YOUR_API_KEY
     allowed_chat_ids:
-      - 123456789 : 3328b4936eccd805bd65063c0562dcd2 # example id of a telegram user that maps to the Home Assistant user
+      - 123456789: 3328b4936eccd805bd65063c0562dcd2 # example id of a telegram user that maps to the Home Assistant user
       - -987654321  # example id of a group, starts with a -
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add configuration option to map telegram id to home assistant user id to use in the event context.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/117434
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
