### PR TITLE
Document scan_interval support for RESTful switch

### DIFF
--- a/source/_integrations/switch.rest.markdown
+++ b/source/_integrations/switch.rest.markdown
@@ -96,6 +96,11 @@ verify_ssl:
   required: false
   type: boolean
   default: true
+scan_interval:
+  description: Define the refrequency to call the REST endpoint to get the current state in seconds.
+  required: false
+  type: integer
+  default: 30
 {% endconfiguration %}
 
 <div class='note warning'>

--- a/source/_integrations/switch.rest.markdown
+++ b/source/_integrations/switch.rest.markdown
@@ -97,7 +97,7 @@ verify_ssl:
   type: boolean
   default: true
 scan_interval:
-  description: Define the refrequency to call the REST endpoint to get the current state in seconds.
+  description: Define the frequency for calling the REST endpoint to get the current state in seconds.
   required: false
   type: integer
   default: 30


### PR DESCRIPTION
## Proposed change
Document that the RESTful switch supports the `scan_interval` for fetching entity state on a configurable basis like for the REST integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  N/A
- Link to parent pull request in the Brands repository:  N/A
- This PR fixes or closes issue: #31329 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
