### PR TITLE
Add documentation for Starlink Sleep configuration

### DIFF
--- a/source/_integrations/starlink.markdown
+++ b/source/_integrations/starlink.markdown
@@ -8,6 +8,7 @@ ha_category:
   - Network
   - Sensor
   - Switch
+  - Time
 ha_release: 2023.2
 ha_iot_class: Local Polling
 ha_config_flow: true
@@ -21,6 +22,7 @@ ha_platforms:
   - diagnostics
   - sensor
   - switch
+  - time
 ha_integration_type: integration
 ha_quality_scale: silver
 ---
@@ -61,7 +63,13 @@ The Starlink integration allows you to integrate your [Starlink](https://www.sta
 ### Switch
 
 - Stowed - Controls whether Dishy is stowed
+- Sleep schedule - Controls whether Starlink will enter a power-saving sleep mode at a predefined schedule
 
 ### Device tracker
 
 - Device location - Tracks the location of Dishy. Note you need to allow location access on the local network via the Starlink app for this to work. This is disabled by default in the Starlink app and is thus disabled by default in Home Assistant.
+
+### Time
+
+- Sleep start - The time at which Starlink will enter sleep mode, if "Sleep Schedule" is enabled
+- Sleep end - The time at which Starlink will exit sleep mode, if "Sleep Schedule" is enabled


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adding documentation for the new Starlink integration feature - configuration of sleep schedule!

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/103057
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
