### PR TITLE
Revert "Document scan_interval support for RESTful switch"

### DIFF
--- a/source/_integrations/switch.rest.markdown
+++ b/source/_integrations/switch.rest.markdown
@@ -96,11 +96,6 @@ verify_ssl:
   required: false
   type: boolean
   default: true
-scan_interval:
-  description: Define the frequency for calling the REST endpoint to get the current state in seconds.
-  required: false
-  type: integer
-  default: 30
 {% endconfiguration %}
 
 <div class='note warning'>


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#31330

Reverts this change, as this is not a property of this integration at all.

Platform specific options are documented here:

<https://www.home-assistant.io/docs/configuration/platform_options/#scan-interval>

See also the source, which doesn't have it:

https://github.com/home-assistant/core/blob/845071f8f0b1297073d3314c5d465de7787faa17/homeassistant/components/rest/switch.py#L66-L86

../Frenck

/CC: @c0ffeeca7 @holysoles