### PR TITLE
Reduce zabbix integration to the zabbix sender part

### DIFF
--- a/source/_integrations/zabbix.markdown
+++ b/source/_integrations/zabbix.markdown
@@ -2,23 +2,17 @@
 title: Zabbix
 description: Instructions on how to integrate Zabbix into Home Assistant.
 ha_category:
-  - Sensor
   - System monitor
 ha_release: 0.37
 ha_iot_class: Local Polling
 ha_domain: zabbix
 ha_platforms:
-  - sensor
 ha_integration_type: integration
 ---
 
-The **Zabbix** {% term integration %} is the main {% term integration %} to connect to a [Zabbix](https://www.zabbix.com/) monitoring instance via the Zabbix API.
+The **Zabbix** {% term integration %} is the main {% term integration %} to publish Home Assistant state changes to [Zabbix](https://www.zabbix.com/).
 
-It is possible to publish Home Assistant state changes to Zabbix. In Zabbix a host has to be created which will contain the Home Assistant states as individual items. These items are automatically created using Zabbix Low-Level Discovery (LLD). In order to make setup in Zabbix easy, you can use this [template](/assets/integrations/zabbix/zbx_template_home_assistant.xml) for the host.
-
-There is currently also support for the following device types within Home Assistant:
-
-- [Sensor](#sensor)
+In Zabbix a host has to be created which will contain the Home Assistant states as individual items. These items are automatically created using Zabbix Low-Level Discovery (LLD). In order to make setup in Zabbix easy, you can use this [template](/assets/integrations/zabbix/zbx_template_home_assistant.xml) for the host.
 
 ## Configuration
 
@@ -28,6 +22,7 @@ To set the Zabbix {% term integration %} up, add the following information to yo
 # Example configuration.yaml entry
 zabbix:
   host: IP_ADDRESS
+  publish_states_host: NAME_OF_HOST_IN_ZABBIX
 ```
 
 {% configuration %}
@@ -35,27 +30,14 @@ host:
   description: Your Zabbix server.
   required: true
   type: string
-path:
-  description: Path to your Zabbix install.
+port:
+  description: Port number of Zabbix server trapper running on the Zabbix server
   required: false
-  type: string
-  default: "`/zabbix/`"
-ssl:
-  description: Set to `true` if your Zabbix installation is using SSL.
-  required: false
-  type: boolean
-  default: false
-username:
-  description: Your Zabbix username.
-  required: false
-  type: string
-password:
-  description: Your Zabbix password.
-  required: false
-  type: string
+  type: integer
+  default: 10051
 publish_states_host:
-  description: The host that will receive the state changes from Home Assistant. It needs to be manually created in Zabbix first and have the template associated with it (see above).
-  required: false
+  description: The name of the host in Zabbix that will receive the state changes from Home Assistant. It needs to be manually created in Zabbix first and have the template associated with it (see above).
+  required: true
   type: string
 exclude:
   type: list
@@ -99,10 +81,6 @@ include:
 # Example configuration.yaml entry
 zabbix:
   host: ZABBIX_HOST
-  path: ZABBIX_PATH
-  ssl: false
-  username: USERNAME
-  password: PASSWORD
   publish_states_host: homeassistant
   exclude:
     domains:
@@ -135,43 +113,3 @@ zabbix:
 {% endraw %}
 
 {% include common-tasks/filters.md %}
-
-## Sensor
-
-The `zabbix` sensor platform let you monitor the current count of active triggers for your [Zabbix](https://www.zabbix.com/) monitoring instance.
-
-<div class='note'>
-You must have the <a href="#configuration">Zabbix integration</a> configured to use those sensors.
-</div>
-
-To set it up, add the following information to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: zabbix
-    triggers:
-      name: Important Hosts Trigger Count
-      hostids: [10051,10081,10084]
-      individual: true
-```
-
-{% configuration %}
-triggers:
-  description: Specifies that this sensor is for Zabbix 'triggers'. In the future there will be other Zabbix sensors.
-  required: true
-  type: string
-name:
-  description: Allows you to specify the name for the Sensor, otherwise the host name, as stored in Zabbix, is used. This is useful when you are specifying a list of hostids to monitor as a single count.
-  required: false
-  type: string
-hostids:
-  description: This is a list of Zabbix hostids that we want to filter our count on.
-  required: false
-  type: string
-individual:
-  description: A 'true'/'false' to specify whether we should show individual sensors when a list of hostids is provided. If false, the sensor state will be the count of all triggers for the specified hosts (or all hosts within the Zabbix instance, if hostids isn't provided).
-  required: false
-  type: boolean
-  default: false
-{% endconfiguration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updated documentation for https://github.com/home-assistant/core/pull/110132 by removing the sensor docs. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/110132
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
