### PR TITLE
Fix Motionblinds brand name consistency in virtual integrations

### DIFF
--- a/source/_integrations/amp_motorization.markdown
+++ b/source/_integrations/amp_motorization.markdown
@@ -1,15 +1,15 @@
 ---
 title: AMP Motorization
-description: Connect and control your AMP Motorization devices using the Motion Blinds integration
+description: Connect and control your AMP Motorization devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: amp_motorization
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/amp_motorization.markdown
+++ b/source/_integrations/amp_motorization.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/bliss_automation.markdown
+++ b/source/_integrations/bliss_automation.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/bliss_automation.markdown
+++ b/source/_integrations/bliss_automation.markdown
@@ -1,15 +1,15 @@
 ---
 title: Bliss Automation
-description: Connect and control your Bliss Automation devices using the Motion Blinds integration
+description: Connect and control your Bliss Automation devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: bliss_automation
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/bloc_blinds.markdown
+++ b/source/_integrations/bloc_blinds.markdown
@@ -1,15 +1,15 @@
 ---
 title: Bloc Blinds
-description: Connect and control your Bloc Blinds devices using the Motion Blinds integration
+description: Connect and control your Bloc Blinds devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: bloc_blinds
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/bloc_blinds.markdown
+++ b/source/_integrations/bloc_blinds.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/brel_home.markdown
+++ b/source/_integrations/brel_home.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/brel_home.markdown
+++ b/source/_integrations/brel_home.markdown
@@ -1,15 +1,15 @@
 ---
 title: Brel Home
-description: Connect and control your Brel Home devices using the Motion Blinds integration
+description: Connect and control your Brel Home devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: brel_home
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/diaz.markdown
+++ b/source/_integrations/diaz.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/diaz.markdown
+++ b/source/_integrations/diaz.markdown
@@ -1,15 +1,15 @@
 ---
 title: Diaz
-description: Connect and control your Diaz devices using the Motion Blinds integration
+description: Connect and control your Diaz devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: diaz
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/dooya.markdown
+++ b/source/_integrations/dooya.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/dooya.markdown
+++ b/source/_integrations/dooya.markdown
@@ -1,15 +1,15 @@
 ---
 title: Dooya
-description: Connect and control your Dooya devices using the Motion Blinds integration
+description: Connect and control your Dooya devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: dooya
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/gaviota.markdown
+++ b/source/_integrations/gaviota.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/gaviota.markdown
+++ b/source/_integrations/gaviota.markdown
@@ -1,15 +1,15 @@
 ---
 title: Gaviota
-description: Connect and control your Gaviota devices using the Motion Blinds integration
+description: Connect and control your Gaviota devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: gaviota
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/havana_shade.markdown
+++ b/source/_integrations/havana_shade.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/havana_shade.markdown
+++ b/source/_integrations/havana_shade.markdown
@@ -1,15 +1,15 @@
 ---
 title: Havana Shade
-description: Connect and control your Havana Shade devices using the Motion Blinds integration
+description: Connect and control your Havana Shade devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: havana_shade
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/hurrican_shutters_wholesale.markdown
+++ b/source/_integrations/hurrican_shutters_wholesale.markdown
@@ -1,15 +1,15 @@
 ---
 title: Hurrican Shutters Wholesale
-description: Connect and control your Hurrican Shutters Wholesale devices using the Motion Blinds integration
+description: Connect and control your Hurrican Shutters Wholesale devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: hurrican_shutters_wholesale
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/hurrican_shutters_wholesale.markdown
+++ b/source/_integrations/hurrican_shutters_wholesale.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/inspired_shades.markdown
+++ b/source/_integrations/inspired_shades.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/inspired_shades.markdown
+++ b/source/_integrations/inspired_shades.markdown
@@ -1,15 +1,15 @@
 ---
 title: Inspired Shades
-description: Connect and control your Inspired Shades devices using the Motion Blinds integration
+description: Connect and control your Inspired Shades devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: inspired_shades
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/ismartwindow.markdown
+++ b/source/_integrations/ismartwindow.markdown
@@ -1,15 +1,15 @@
 ---
 title: iSmartWindow
-description: Connect and control your iSmartWindow devices using the Motion Blinds integration
+description: Connect and control your iSmartWindow devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: ismartwindow
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/ismartwindow.markdown
+++ b/source/_integrations/ismartwindow.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/martec.markdown
+++ b/source/_integrations/martec.markdown
@@ -1,15 +1,15 @@
 ---
 title: Martec
-description: Connect and control your Martec devices using the Motion Blinds integration
+description: Connect and control your Martec devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: martec
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/martec.markdown
+++ b/source/_integrations/martec.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/raven_rock_mfg.markdown
+++ b/source/_integrations/raven_rock_mfg.markdown
@@ -1,15 +1,15 @@
 ---
 title: Raven Rock MFG
-description: Connect and control your Raven Rock MFG devices using the Motion Blinds integration
+description: Connect and control your Raven Rock MFG devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: raven_rock_mfg
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/raven_rock_mfg.markdown
+++ b/source/_integrations/raven_rock_mfg.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/screenaway.markdown
+++ b/source/_integrations/screenaway.markdown
@@ -1,15 +1,15 @@
 ---
 title: ScreenAway
-description: Connect and control your ScreenAway devices using the Motion Blinds integration
+description: Connect and control your ScreenAway devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: screenaway
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/screenaway.markdown
+++ b/source/_integrations/screenaway.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/smart_blinds.markdown
+++ b/source/_integrations/smart_blinds.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/smart_blinds.markdown
+++ b/source/_integrations/smart_blinds.markdown
@@ -1,15 +1,15 @@
 ---
-title: Smart Blinds
-description: Connect and control your Smart Blinds devices using the Motion Blinds integration
+title: Smartblinds
+description: Connect and control your Smartblinds devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: smart_blinds
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/smart_home.markdown
+++ b/source/_integrations/smart_home.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/smart_home.markdown
+++ b/source/_integrations/smart_home.markdown
@@ -1,15 +1,15 @@
 ---
 title: Smart Home
-description: Connect and control your Smart Home devices using the Motion Blinds integration
+description: Connect and control your Smart Home devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: smart_home
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/uprise_smart_shades.markdown
+++ b/source/_integrations/uprise_smart_shades.markdown
@@ -9,7 +9,7 @@ ha_supporting_domain: motion_blinds
 ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - "@starkillerOG"
+  - '@starkillerOG'
 ha_config_flow: true
 ha_platforms:
   - cover

--- a/source/_integrations/uprise_smart_shades.markdown
+++ b/source/_integrations/uprise_smart_shades.markdown
@@ -1,15 +1,15 @@
 ---
 title: Uprise Smart Shades
-description: Connect and control your Uprise Smart Shades devices using the Motion Blinds integration
+description: Connect and control your Uprise Smart Shades devices using the Motionblinds integration
 ha_category:
   - Cover
 ha_domain: uprise_smart_shades
 ha_integration_type: virtual
 ha_supporting_domain: motion_blinds
-ha_supporting_integration: Motion Blinds
+ha_supporting_integration: Motionblinds
 ha_release: 2020.12
 ha_codeowners:
-  - '@starkillerOG'
+  - "@starkillerOG"
 ha_config_flow: true
 ha_platforms:
   - cover


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Corrects the name of **Motionblinds** and **Smartblinds** for all virtual integrations of motion_blinds.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
