### PR TITLE
Document log-json-format option

### DIFF
--- a/source/_docs/tools/hass.markdown
+++ b/source/_docs/tools/hass.markdown
@@ -10,7 +10,8 @@ The command-line part of Home Assistant is `hass`.
 $ hass -h
 usage: hass [-h] [--version] [-c path_to_config_dir] [--safe-mode]
             [--debug] [--open-ui] [--skip-pip] [-v] [--log-rotate-days LOG_ROTATE_DAYS] 
-            [--log-file LOG_FILE] [--log-no-color] [--script ...] [--ignore-os-check]
+            [--log-file LOG_FILE] [--log-json-format] [--log-no-color]
+            [--script ...] [--ignore-os-check]
 
 Home Assistant: Observe, Control, Automate.
 
@@ -27,6 +28,7 @@ optional arguments:
   --log-rotate-days LOG_ROTATE_DAYS
                         Enables daily log rotation and keeps up to the specified days
   --log-file LOG_FILE   Log file to write to. If not set, CONFIG/home-assistant.log is used
+  --log-json-format     Format logs as json. Automatically disable color logs
   --log-no-color        Disable color logs
   --script ...          Run one of the embedded scripts
   --ignore-os-check     Skips validation of operating system


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR documents a new `--log-json-format` option introduced in  https://github.com/home-assistant/core/pull/110487


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/110487
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
