### PR TITLE
Add health category for Airthings

### DIFF
--- a/source/_integrations/airthings.markdown
+++ b/source/_integrations/airthings.markdown
@@ -3,6 +3,7 @@ title: Airthings
 description: Instructions on how to integrate Airthings into Home Assistant.
 ha_category:
   - Environment
+  - Health
   - Sensor
 ha_release: '2021.10'
 ha_iot_class: Cloud Polling

--- a/source/_integrations/airthings_ble.markdown
+++ b/source/_integrations/airthings_ble.markdown
@@ -3,6 +3,7 @@ title: Airthings BLE
 description: Instructions on how to set up Airthings Devices over Bluetooth LE.
 ha_category:
   - Environment
+  - Health
   - Sensor
 ha_release: '2022.11'
 ha_iot_class: Local Polling


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds "Health" category to the Airthings integrations, similar to other air quality sensor platforms, such that Airthings shows up when filtering by category:

https://deploy-preview-31437--home-assistant-docs.netlify.app/integrations/#health

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
