### PR TITLE
Documents for adding to/from/not_to/not_from to template trigger

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -132,6 +132,7 @@ These are the properties available for a [Template trigger](/docs/automation/tri
 | Template variable | Data |
 | ---- | ---- |
 | `trigger.platform` | Hardcoded: `template`
+| `trigger.value` | The value returned by the template.
 | `trigger.entity_id` | Entity ID that caused change.
 | `trigger.from_state` | Previous [state object] of entity that caused change.
 | `trigger.to_state` | New [state object] of entity that caused template to change.

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -635,6 +635,56 @@ This is achieved by having the template result in a true boolean expression (for
 
 With template triggers you can also evaluate attribute changes by using is_state_attr (like `{% raw %}{{ is_state_attr('climate.living_room', 'away_mode', 'off') }}{% endraw %}`)
 
+Alternatively, if one of more of `from`, `to`, `not_from`, or `not_to` are given, the trigger will fire on any matching value change.
+
+{% raw %}
+
+```yaml
+automation:
+  trigger:
+    - platform: template
+      value_template: "{% states('device_tracker.paulus') %}"
+      from: away
+      to: home
+```
+
+{% endraw %}
+
+Just like state triggers, `to`/`from`/`not_to`/`not_from` can accept a list...
+
+{% raw %}
+
+```yaml
+automation:
+  trigger:
+    - platform: template
+      value_template: "{% states("input_number.value") %}"
+      to:
+        - "3"
+        - "14"
+```
+
+{% endraw %}
+
+... or `*` can be used to match any value.
+
+{% raw %}
+
+```yaml
+automation:
+  trigger:
+    - platform: template
+      value_template: "{% states("input_number.value") %}"
+      # Triggers whenever input_number.value changes
+      to: "*"
+```
+
+{% endraw %}
+
+If `to`/`not_to` is provided without `from`/`not_from`, the automation will trigger whenever the template updates to return a valid value, no matter what the previous value was. If `from`/`not_from` is provided without `to`/`not_to`, the aotmation will trigger whenever the template updates from a valid value, no matter what the new value is.
+
+You can also use templates with the `for` option.
+
 {% raw %}
 
 ```yaml
@@ -649,8 +699,6 @@ automation:
 
 {% endraw %}
 
-You can also use templates in the `for` option.
-
 {% raw %}
 
 ```yaml
@@ -664,7 +712,7 @@ automation:
 
 {% endraw %}
 
-The `for` template(s) will be evaluated when the `value_template` becomes 'true'.
+The `for` template(s) will be evaluated when the `value_template` becomes 'true', or matches the to/from/not_to/not_from options.
 
 Templates that do not contain an entity will be rendered once per minute.
 
@@ -673,6 +721,8 @@ Templates that do not contain an entity will be rendered once per minute.
 Use of the `for` option will not survive Home Assistant restart or the reload of automations. During restart or reload, automations that were awaiting `for` the trigger to pass, are reset.
 
 If for your use case this is undesired, you could consider using the automation to set an [`input_datetime`](/integrations/input_datetime) to the desired time and then use that [`input_datetime`](/integrations/input_datetime) as an automation trigger to perform the desired actions at the set time.
+
+After triggering, the value returned by the template is available at `trigger.value`
 
 </div>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update documents for template trigger to reflect the changes in https://github.com/home-assistant/core/pull/110664


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/110664
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
