### PR TITLE
add is charging sensor docs

### DIFF
--- a/source/_integrations/permobil.markdown
+++ b/source/_integrations/permobil.markdown
@@ -46,5 +46,5 @@ A total of 13 sensors are available:
   The highest number of adjustments ever recorded in a single day.
 - **Longest distance traveled**
   The largest distance traveled ever recorded in a single day.
-- **Is Charging**
+- **Is charging**
   Binary sensor that is true when the Permobil wheelchair is charging.

--- a/source/_integrations/permobil.markdown
+++ b/source/_integrations/permobil.markdown
@@ -20,7 +20,7 @@ The **MyPermobil** integration allows you to view various sensors with informati
 
 ## Sensors
 
-A total of 12 sensors are available:
+A total of 13 sensors are available:
 
 - **Battery charge**
   The current battery state of the wheelchair as a percentage.
@@ -46,3 +46,5 @@ A total of 12 sensors are available:
   The highest number of adjustments ever recorded in a single day.
 - **Longest distance traveled**
   The largest distance traveled ever recorded in a single day.
+- **Is Charging**
+  Binary sensor that is true when the Permobil wheelchair is charging.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add docs for the new "is charging" sensor.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
~https://github.com/home-assistant/core/pull/110820~ 
https://github.com/home-assistant/core/pull/112130
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
