### PR TITLE
state_object: Context: keywords with backticks

### DIFF
--- a/source/_docs/configuration/state_object.markdown
+++ b/source/_docs/configuration/state_object.markdown
@@ -41,8 +41,8 @@ When an attribute contains spaces, you can retrieve it like this: `state_attr('s
 
 Context is used to tie {% term events %} and {% term states %} together in Home Assistant. Whenever an {% term automation %} or user interaction causes states to change, a new context is assigned. This context will be attached to all events and states that happen as result of the change.
 
-| Field      | Description                                                         |
-| -----      | ------------------------------------------------------------------- |
-| context_id | Unique identifier for the context.                                  |
-| user_id    | Unique identifier of the user that started the change. Will be `None` if action was not started by a user (ie. started by an automation)               |
-| parent_id  | Unique identifier of the parent context that started the change, if available. For example, if an automation is triggered, the context of the trigger will be set as parent.  |
+| Field        | Description                                                         |
+| ------------ | ------------------------------------------------------------------- |
+| `context_id` | Unique identifier for the context.                                  |
+| `user_id`    | Unique identifier of the user that started the change. Will be `None` if action was not started by a user (ie. started by an automation)               |
+| `parent_id`  | Unique identifier of the parent context that started the change, if available. For example, if an automation is triggered, the context of the trigger will be set as parent.  |

--- a/source/_docs/configuration/state_object.markdown
+++ b/source/_docs/configuration/state_object.markdown
@@ -44,5 +44,5 @@ Context is used to tie {% term events %} and {% term states %} together in Home 
 | Field        | Description                                                         |
 | ------------ | ------------------------------------------------------------------- |
 | `context_id` | Unique identifier for the context.                                  |
-| `user_id`    | Unique identifier of the user that started the change. Will be `None` if action was not started by a user (ie. started by an automation)               |
+| `user_id`    | Unique identifier of the user that started the change. Will be `None` if the action was not started by a user (for example, started by an automation).  |
 | `parent_id`  | Unique identifier of the parent context that started the change, if available. For example, if an automation is triggered, the context of the trigger will be set as parent.  |


### PR DESCRIPTION
Same way the keywords are highlighted in other tables on this page.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
