### PR TITLE
Correct in-page links on concepts-terminology.markdown

### DIFF
--- a/source/getting-started/concepts-terminology.markdown
+++ b/source/getting-started/concepts-terminology.markdown
@@ -6,13 +6,13 @@ Now you're in Home Assistant, let's look at the most important concepts.
 
 ## Integrations
 
-Integrations are pieces of software that allow Home Assistant to connect to other software and platforms. For example, a product by Philips called Hue would use the Philips Hue {% term integration %} and allow Home Assistant to talk to the hardware controller Hue Bridge. Any Home Assistant compatible {% term devices %} connected to the Hue Bridge would appear in Home Assistant as [devices](#devices--entities).
+Integrations are pieces of software that allow Home Assistant to connect to other software and platforms. For example, a product by Philips called Hue would use the Philips Hue {% term integration %} and allow Home Assistant to talk to the hardware controller Hue Bridge. Any Home Assistant compatible {% term devices %} connected to the Hue Bridge would appear in Home Assistant as [devices](#devices).
 
 ![Integrations](/images/getting-started/integrations-new.png)
 
 For a full list of compatible {% term integrations %}, refer to the [integrations](/integrations) documentation.
 
-Once an {% term integration %} has been added, the hardware and/or data are represented in Home Assistant as [devices and entities](#devices--entities).
+Once an {% term integration %} has been added, the hardware and/or data are represented in Home Assistant as [devices and entities](#devices).
 
 ## Entities
 


### PR DESCRIPTION
## Proposed change
These documentation links broke when the headers changed in 8381ef1. 


## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase:  [N/A]
- Link to parent pull request in the Brands repository:  [N/A]
- This PR fixes or closes issue: fixes #  [N/A]

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
