### PR TITLE
S3-BOX-3: change on-device wake word procedure

### DIFF
--- a/source/voice_control/s3-box-customize.markdown
+++ b/source/voice_control/s3-box-customize.markdown
@@ -180,7 +180,7 @@ If your images have transparency, you can define the background color in the con
 
 ## Customizing on-device wake words (microWakeWord)
 
-If you are running the latest version of ESPHome on your device, you can already process your wake word on your S3-BOX (instead of running it on the Home Assistant server). This is done using the [microWakeWord](https://github.com/kahrendt/microWakeWord) model. By default, the wake word then is *Okay Nabu*. If you want to change the on-device wake word to *Hey Jarvis* or *Alexa*, follow these steps.
+You can update the firmware to process your wake word on your S3-BOX-3, instead of running it on the Home Assistant server. This is done using the [microWakeWord](https://github.com/kahrendt/microWakeWord) model. The currently supported on-device wake words are *Okay Nabu*, *Hey Jarvis*, or *Alexa*.
 
 ### Prerequisites
 
@@ -188,12 +188,12 @@ If you are running the latest version of ESPHome on your device, you can already
 - Successfully [installed ESPHome on the S3-BOX-3](/voice_control/s3_box_voice_assistant/)
 - ESPHome 2024.2 or later
 - Home Assistant server with at least 2&nbsp;GB of RAM
-  - The firmware needs to be compiled on the server before it is installed on the S3-BOX-*.
+  - The firmware needs to be compiled on the server before it is installed on the S3-BOX-3.
   - Compiling requires a bit of RAM.
 
-(It also works on the, now discontinued, S3-BOX and S3-BOX-Lite)_
+*(It also works on the (now discontinued) S3-BOX and S3-BOX-Lite)*
 
-### To customize the S3-BOX-* with on-device wake words
+### To customize the S3-BOX-3 with on-device wake words
 
 1. If you haven't done so already, [adopt the device in the ESPHome add-on](#adopting-the-device-in-the-esphome-add-on).
 2. In Home Assistant, go to [**Settings** > **Add-ons** > **ESPHome**](https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome), and **Open Web UI**.
@@ -212,8 +212,15 @@ If you are running the latest version of ESPHome on your device, you can already
 
 5. Save the changes and in the top right corner, select **Install**.
    - Depending on your environment, the installation process can take a while. (On Home Assistant Green, for example, it takes about 45 minutes.)
-   - On Home Assistant Green, for example, it takes about 45 minutes.86. Once the installation is complete, you can see the new image on the S3-BOX-3.
-6.  - Now, speak a command to test the new setting. For example, *OK Nabu, turn on the light*.
+   - On Home Assistant Green, for example, it takes about 45 minutes.
+   - Once the installation is complete, you can see the new image on the S3-BOX-3.
+6. Select the **ESPHome** integration. Under **Devices**, you should see the **ESP32-S3-BOX** listed.
+    - On the ESP32-S3-BOX-3 entry, select **Device** to open the device page.
+    - Under **Wake word engine location**, select **On device**.
+
+      ![ESP32-S3-BOX-3 on device wake word processing](/images/assist/wake_word_engine_location.png)
+
+7.  - Now, speak a command to test the new setting. For example, *OK Nabu, turn on the light*.
 
 ## Related topics
 

--- a/source/voice_control/s3-box-customize.markdown
+++ b/source/voice_control/s3-box-customize.markdown
@@ -180,12 +180,12 @@ If your images have transparency, you can define the background color in the con
 
 ## Customizing on-device wake words (microWakeWord)
 
-You can update the firmware to process your wake word on your S3-BOX-3, instead of running it on the Home Assistant server. This is done using the [microWakeWord](https://github.com/kahrendt/microWakeWord) model. 
+You can also change the on-device wake word (microWakeWord) that is used on your S3-BOX-3.
 
 Do the following steps if one of the following options apply:
 
 - **Option 1**: Your first installation of the S3-BOX-3 is ESPHome 2024.2. In this case, it already supports the on-device wake word *Hey Jarvis*. Follow these steps only if you want to change the wake word. The currently supported on-device wake words are *Okay Nabu*, *Hey Jarvis*, or *Alexa*.
-- **Option 2**: You have an existing S3-BOX-3 running an older version of ESPHome. In this case, the S3-BOX-3 is not updated automatically to support on-device wake word. Follow these steps if you want to enable on-device wake word.
+- **Option 2**: You have an existing S3-BOX-3 running an older version of ESPHome. In this case, the S3-BOX-3 is not updated automatically to support on-device wake word. Follow these steps if you want update the firmware to process your wake word on your S3-BOX-3, instead of running it on the Home Assistant server. This is done using the [microWakeWord](https://github.com/kahrendt/microWakeWord) model.
 
 ### Prerequisites
 

--- a/source/voice_control/s3-box-customize.markdown
+++ b/source/voice_control/s3-box-customize.markdown
@@ -180,7 +180,7 @@ If your images have transparency, you can define the background color in the con
 
 ## Customizing on-device wake words (microWakeWord)
 
-You can also change the on-device wake word (microWakeWord) that is used on your S3-BOX-3.
+You can change the on-device wake word (microWakeWord) that is used on your S3-BOX-3.
 
 Do the following steps if one of the following options apply:
 

--- a/source/voice_control/s3-box-customize.markdown
+++ b/source/voice_control/s3-box-customize.markdown
@@ -185,7 +185,7 @@ You can change the on-device wake word (microWakeWord) that is used on your S3-B
 Do the following steps if one of the following options apply:
 
 - **Option 1**: Your first installation of the S3-BOX-3 is ESPHome 2024.2. In this case, it already supports the on-device wake word *Hey Jarvis*. Follow these steps only if you want to change the wake word. The currently supported on-device wake words are *Okay Nabu*, *Hey Jarvis*, or *Alexa*.
-- **Option 2**: You have an existing S3-BOX-3 running an older version of ESPHome. In this case, the S3-BOX-3 is not updated automatically to support on-device wake word. Follow these steps if you want update the firmware to process your wake word on your S3-BOX-3, instead of running it on the Home Assistant server. This is done using the [microWakeWord](https://github.com/kahrendt/microWakeWord) model.
+- **Option 2**: You have an existing S3-BOX-3 running an older version of ESPHome. In this case, the S3-BOX-3 is not updated automatically to support on-device wake word. Follow these steps if you want to update the firmware to process your wake word on your S3-BOX-3, instead of running it on the Home Assistant server. This is done using the [microWakeWord](https://github.com/kahrendt/microWakeWord) model.
 
 ### Prerequisites
 

--- a/source/voice_control/s3-box-customize.markdown
+++ b/source/voice_control/s3-box-customize.markdown
@@ -184,8 +184,8 @@ You can update the firmware to process your wake word on your S3-BOX-3, instead 
 
 Do the following steps if one of the following options apply:
 
-- **Option 1**: If your first installation of the S3-BOX-3 is ESPHome 2024.2, it already supports the on-device wake word *Hey Jarvis*. Follow these steps if you want to change the wake word. The currently supported on-device wake words are *Okay Nabu*, *Hey Jarvis*, or *Alexa*.
-- **Option 2**: If you have an existing S3-BOX-3 running an older version of ESPHome and you want to enable on-device wake word.
+- **Option 1**: Your first installation of the S3-BOX-3 is ESPHome 2024.2. In this case, it already supports the on-device wake word *Hey Jarvis*. Follow these steps only if you want to change the wake word. The currently supported on-device wake words are *Okay Nabu*, *Hey Jarvis*, or *Alexa*.
+- **Option 2**: You have an existing S3-BOX-3 running an older version of ESPHome. In this case, the S3-BOX-3 is not updated automatically to support on-device wake word. Follow these steps if you want to enable on-device wake word.
 
 ### Prerequisites
 

--- a/source/voice_control/s3-box-customize.markdown
+++ b/source/voice_control/s3-box-customize.markdown
@@ -180,7 +180,12 @@ If your images have transparency, you can define the background color in the con
 
 ## Customizing on-device wake words (microWakeWord)
 
-You can update the firmware to process your wake word on your S3-BOX-3, instead of running it on the Home Assistant server. This is done using the [microWakeWord](https://github.com/kahrendt/microWakeWord) model. The currently supported on-device wake words are *Okay Nabu*, *Hey Jarvis*, or *Alexa*.
+You can update the firmware to process your wake word on your S3-BOX-3, instead of running it on the Home Assistant server. This is done using the [microWakeWord](https://github.com/kahrendt/microWakeWord) model. 
+
+Do the following steps if one of the following options apply:
+
+- **Option 1**: If your first installation of the S3-BOX-3 is ESPHome 2024.2, it already supports the on-device wake word *Hey Jarvis*. Follow these steps if you want to change the wake word. The currently supported on-device wake words are *Okay Nabu*, *Hey Jarvis*, or *Alexa*.
+- **Option 2**: If you have an existing S3-BOX-3 running an older version of ESPHome and you want to enable on-device wake word.
 
 ### Prerequisites
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
S3-BOX-3: change on-device wake word procedure
- to reflect latest changes is firmware
- on-device wake word is supported for first installations using ESPHome 2024.2
- It is not automatically installed if you already have an S3-BOX running an older version.
- In this case, you need to change the config manually to enable on-device wake word.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
