### PR TITLE
Update xiaomi_ble documentation

### DIFF
--- a/source/_integrations/xiaomi_ble.markdown
+++ b/source/_integrations/xiaomi_ble.markdown
@@ -20,15 +20,11 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-Integrates devices that implement the Xiaomi Mijia BLE MiBeacon protocol and the BLE protocols implemented in the MiScales and the MiFora plant sensor. The integration listens to Bluetooth broadcasts that the device makes by itself, allowing it to track the latest sensor values or events without waking the device up for polling.  This method conserves battery lifetime.
+Integrates devices that use the Xiaomi Mijia BLE MiBeacon protocol and the BLE protocols implemented in the MiScales and the MiFora plant sensor. This integration does not support Xiaomi BLE Mesh devices. The integration listens to Bluetooth broadcasts that the device makes by itself, allowing it to track the latest sensor values or events without waking the device up for polling (except HHCCJCY01, see note below). This method conserves battery lifetime.
 
 The integration automatically discovers devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional. The entities are added after the values are first received. This means that entities might show up later if the corresponding values are broadcasted at a lower interval (for example, battery).
 
 {% include integrations/config_flow.md %}
-
-## Supported devices
-
-From the devices that support the Xiaomi Mijia BLE MiBeacon protocol, currently locks are not implemented yet. This integration also does not support Xiaomi BLE Mesh devices.
 
 ## Encryption
 
@@ -63,3 +59,5 @@ Flower Care firmware update steps:
 - Wait for the synchronization of the sensor to finish, and a dialog asking for a firmware update should appear (this might take a few minutes)
 - The installed and latest firmware version can be verified by selecting the plant -> three-dot menu -> Hardware settings -> Hardware update
 - The Flower Care account and app are not required any further for this integration to work
+
+Also note that the battery level of the plant sensor can only be retrieved by connecting to the device (reading characteristics), while the other sensor data is broadcasted passively. To prevent battery drainage, a connection is made only once a day. Connecting to the device also requires that the device has a good signal strength.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update xiaomi_ble documentation for the added locks and some small changes.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/111156
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/111139

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
