### PR TITLE
Add Comelit humidifier/dehumidifier info

### DIFF
--- a/source/_integrations/comelit.markdown
+++ b/source/_integrations/comelit.markdown
@@ -12,6 +12,7 @@ ha_iot_class: Local Polling
 ha_platforms:
   - alarm_control_panel
   - climate
+  - humidifier
   - cover
   - light
   - sensor
@@ -23,7 +24,7 @@ The Comelit SimpleHome integration allows you to control your [Comelit home auto
 
 There is support for the following platform types within Home Assistant:
 
-- **Comelit Serial Bridge** - allows local control for light, cover, irrigation, climate and "other" devices; creates power sensors.
+- **Comelit Serial Bridge** - allows local control for light, cover, irrigation, climate, humidifier/dehumidifier and "other" devices; creates power sensors.
 - **Comelit VEDO System** - allows local control of the alarm system.
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
List Comelit humidifier/dehumidifier as supported


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#111203](https://github.com/home-assistant/core/pull/111203)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
