### PR TITLE
Add known issues section to Verisure

### DIFF
--- a/source/_integrations/verisure.markdown
+++ b/source/_integrations/verisure.markdown
@@ -83,7 +83,7 @@ automation:
 | auto | Lock was locked/unlocked automatically by Verisure rule |
 | remote | Lock was locked/unlocked automatically by Verisure App |
 
-## Limitations and Known Issues
+## Limitations and known issues
 
 Some users have reported that this integration currently doesn't work in the following countries:
 

--- a/source/_integrations/verisure.markdown
+++ b/source/_integrations/verisure.markdown
@@ -87,7 +87,7 @@ automation:
 
 Some users have reported that this integration currently doesn't work in the following countries:
 
-* France
-* Ireland
-* Italy 
-* Sweden
+- France
+- Ireland
+- Italy 
+- Sweden

--- a/source/_integrations/verisure.markdown
+++ b/source/_integrations/verisure.markdown
@@ -82,3 +82,12 @@ automation:
 | code | Lock was unlocked by exterior code |
 | auto | Lock was locked/unlocked automatically by Verisure rule |
 | remote | Lock was locked/unlocked automatically by Verisure App |
+
+## Limitations and Known Issues
+
+Some users have reported that this integration currently doesn't work in the following countries:
+
+* France
+* Ireland
+* Italy 
+* Sweden


### PR DESCRIPTION
## Proposed change

Adds a Known Issues section to Verisure integration and adds the information that the integration doesn't work for some specific countries.

The idea for this change originated from the discussion in https://github.com/home-assistant/core/issues/99507

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Closes #31590
- Related to https://github.com/home-assistant/core/issues/99507

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
