### PR TITLE
Add docs for on_change in template trigger

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -132,6 +132,7 @@ These are the properties available for a [Template trigger](/docs/automation/tri
 | Template variable | Data |
 | ---- | ---- |
 | `trigger.platform` | Hardcoded: `template`
+| `trigger.value` | The value returned by the template.
 | `trigger.entity_id` | Entity ID that caused change.
 | `trigger.from_state` | Previous [state object] of entity that caused change.
 | `trigger.to_state` | New [state object] of entity that caused template to change.

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -666,6 +666,23 @@ automation:
 
 The `for` template(s) will be evaluated when the `value_template` becomes 'true'.
 
+If `on_change: true` is set, the template will instead trigger on any change to the template value:
+
+{% raw %}
+
+```yaml
+automation:
+  trigger:
+    - platform: template
+      # Trigger whenever the value of sensor.temperature, rounded to the nearest whole number, changes
+      on_change: true
+      value_template: "{{ states('sensor.temperature') | round }}"
+```
+
+{% endraw %}
+
+The value returned by the template is available as `trigger.value` in the [trigger data](/docs/automation/templating#template).
+
 Templates that do not contain an entity will be rendered once per minute.
 
 <div class='note warning'>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation for https://github.com/home-assistant/core/pull/111312, which adds an `on_change` setting to the teomplate trigger, and puts the value of the template in `trigger.value`.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/111312
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
