### PR TITLE
Add event platform to rfxtrx docs

### DIFF
--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -105,7 +105,7 @@ The RFXtrx integration supports Siemens/LightwaveRF and Somfy RTS roller shutter
 
 #### Events
 
-The RFXtrx integration will expose event entities for remotes controlling lights as well security devices.
+The RFXtrx integration will expose event entities for remotes controlling lights as well as security devices.
 
 #### Lights
 

--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -105,7 +105,7 @@ The RFXtrx integration supports Siemens/LightwaveRF and Somfy RTS roller shutter
 
 #### Events
 
-The RFXtrx integration will expose event entities for remotes controlling lights as well as security devices.
+The RFXtrx integration will expose event entities for remotes controlling lights as well security devices.
 
 #### Lights
 

--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to integrate RFXtrx into Home Assistant.
 ha_category:
   - Binary sensor
   - Cover
+  - Event
   - Hub
   - Light
   - Sensor
@@ -21,6 +22,7 @@ ha_platforms:
   - binary_sensor
   - cover
   - diagnostics
+  - event
   - light
   - sensor
   - siren
@@ -33,6 +35,7 @@ The RFXtrx integration supports RFXtrx devices by [RFXCOM](http://www.rfxcom.com
 There is currently support for the following device types within Home Assistant:
 
 - [Cover](#covers)
+- [Event](#events)
 - [Light](#lights)
 - [Switch](#switches)
 - [Sensor](#sensors)
@@ -99,6 +102,10 @@ In the options menu, select *Enable automatic add* to enable automatic addition 
 #### Covers
 
 The RFXtrx integration supports Siemens/LightwaveRF and Somfy RTS roller shutters that communicate in the frequency range of 433.92 MHz.
+
+#### Events
+
+The RFXtrx integration will expose event entities for remotes controlling lights as well as security devices.
 
 #### Lights
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add mention of event entities for rfxtrx devices.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/111526
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
