### PR TITLE
Remove "NOTSET" logging level

### DIFF
--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -115,7 +115,6 @@ Possible log severity levels, listed in order from most severe to least severe, 
 - warn
 - info
 - debug
-- notset
 
 ### Log filters
 


### PR DESCRIPTION
## Proposed change

The `logging.NOTSET` level has special meaning in Python and when used results in confusing behavior. Looking at the previous listing of levels a admin not familiar with Python might reasonably assume setting `homeassistant.components.command_line` to `notset` would get them all possible log messages. In fact, it results in no more log messages and thus less log messages than setting `homeassistant.components.command_line` to `debug`.

Better not to list it as an available level. If it needs to be mentioned at all, it should be a special mention that describes the effect it has.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
