### PR TITLE
Add section about default dashboards

### DIFF
--- a/source/_includes/asides/dashboards_navigation.html
+++ b/source/_includes/asides/dashboards_navigation.html
@@ -6,7 +6,7 @@
     <ul class="divided sidebar-menu">
       <li>{% active_link /dashboards/ Introduction %}</li>
       <li>
-        {% active_link /dashboards/dashboards/ Multiple Dashboards %}
+        {% active_link /dashboards/dashboards/ Multiple dashboards %}
       </li>
       <li>
         {% active_link /dashboards/views/ Views %}

--- a/source/dashboards/dashboards.markdown
+++ b/source/dashboards/dashboards.markdown
@@ -5,16 +5,40 @@ description: "Multiple powerful and configurable dashboards in Home Assistant."
 
 You can define multiple dashboards in Home Assistant. Each dashboard can be added to the sidebar. This makes it possible to create separate control dashboards for each individual part of your house.
 
-You can manage your dashboards via the user interface. Go to {% my lovelace_dashboards title="**Settings** > **Dashboards**" %}. Here you can see all defined dashboards and create new ones.
+You can manage your dashboards via the user interface. Go to {% my lovelace_dashboards title="**Settings** > **Dashboards**" %}. Here you can see some of the defined dashboards and create new ones.
 
 <p class='img'>
 <img src='/images/dashboards/dashboard-manage-01.png' alt='Screenshot of the dashboard list'>
 Screenshot of the Dashboard list.
 </p>
 
-## Using YAML for the default dashboard
+## Home Assistant default dashboards
 
-To change the default dashboard, create a new file `ui-lovelace.yaml` in your configuration directory and add the following section to your `configuration.yaml` and restart Home Assistant:
+Home Assistant ships with 5 predefined dashboards:
+
+- Overview
+- Energy
+- Map
+- Logbook
+- History
+
+Not all of predefined dashboards are listed under {% my lovelace_dashboards title="**Settings** > **Dashboards**" %}. **Map**, **Logbook**, and **History**, are powered by their respective integrations.
+
+### Map panel
+
+The predefined **Map** dashboard is powered by the [Map integration](/integrations/map/). If you see a [person](/integrations/person/) on the map, it means you have connected a device that allows [presence detection](/integrations/#presence-detection). This is the case for example if you have the [Home Assistant Companion App](https://companion.home-assistant.io/) on your phone and allowed location tracking.
+
+### Logbook panel
+
+The predefined **Logbook** dashboard is powered by the [Logbook integration](/integrations/logbook/). To control which events to show or filter out, refer to the documentation of the Logbook integration.
+
+### History panel
+
+The predefined **History** dashboard is powered by the [History integration](/integrations/logbook/). To learn about the data sources used and how to export data, refer to the documentation of the History integration.
+
+## Using YAML for the Overview dashboard
+
+To change the **Overview** dashboard, create a new file `ui-lovelace.yaml` in your configuration directory and add the following section to your `configuration.yaml` and restart Home Assistant:
 
 ```yaml
 lovelace:
@@ -197,3 +221,9 @@ views:
         content: >
           Welcome to your **dashboard**.
 ```
+
+## Related topics
+
+- [Logbook integration](/integrations/logbook/)
+- [Map integration](/integrations/map/)
+- [History integration](/integrations/history/)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add section about default dashboards
- inspired by #31697 
- the person looked in the logbook card docs under dashboard, instead of the logbook integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
