### PR TITLE
Remove deprecated `color_mode` flag, adjust `brightness` description for MQTT json light

### DIFF
--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -40,7 +40,7 @@ When a state topic is not available, the light will work in optimistic mode. In 
 Optimistic mode can be forced, even if the `state_topic` is available. Try to enable it, if experiencing incorrect light operation.
 
 Home Assistant internally assumes that a light's state corresponds to a defined `color_mode`.
-The state of MQTT lights with default schema and support for both color and color temperature will set the `color_mode` according to the last received valid color or color temperature. Optionally, a `color_mode_state_topic` can be configured for explicit control of the `color_mode`
+The state of MQTT lights with default schema and support for both color and color temperature will set the `color_mode` according to the last received valid color or color temperature. Optionally, a `color_mode_state_topic` can be configured for explicit control of the `color_mode`.
 
 ```yaml
 # Example configuration.yaml entry
@@ -563,7 +563,7 @@ availability_topic:
   required: false
   type: string
 brightness:
-  description: Flag that defines if the light supports brightness.
+  description: Flag that defines if light supports brightness when the `rgb`, `rgbw` or `rgbww` color mode is supported.
   required: false
   type: boolean
   default: false
@@ -572,11 +572,6 @@ brightness_scale:
   required: false
   type: integer
   default: 255
-color_mode:
-  description: Flag that defines if the light supports color modes.
-  required: false
-  type: boolean
-  default: false
 command_topic:
   description: The MQTT topic to publish commands to change the light’s state.
   required: true
@@ -715,7 +710,7 @@ state_topic:
   required: false
   type: string
 supported_color_modes:
-  description: A list of color modes supported by the list. This is required if `color_mode` is `True`. Possible color modes are `onoff`, `brightness`, `color_temp`, `hs`, `xy`, `rgb`, `rgbw`, `rgbww`, `white`. Note that if `onoff` **or** `brightness` are used, that must be the _only_ value in the list.
+  description: A list of color modes supported by the list. Possible color modes are `onoff`, `brightness`, `color_temp`, `hs`, `xy`, `rgb`, `rgbw`, `rgbww`, `white`. Note that if `onoff` **or** `brightness` are used, that must be the _only_ value in the list.
   required: false
   type: list
 unique_id:
@@ -758,7 +753,6 @@ mqtt:
       state_topic: "home/rgb1"
       command_topic: "home/rgb1/set"
       brightness: true
-      color_mode: true
       supported_color_modes: ["rgb"]
 ```
 
@@ -775,7 +769,6 @@ mqtt:
       state_topic: "home/rgb1"
       command_topic: "home/rgb1/set"
       brightness: true
-      color_mode: true
       supported_color_modes: ["brightness"]
 ```
 
@@ -793,7 +786,6 @@ mqtt:
       command_topic: "home/light/set"
       brightness: true
       brightness_scale: 4095
-      color_mode: true
       supported_color_modes: ["brightness"]
 ```
 
@@ -817,7 +809,6 @@ mqtt:
       name: mqtt_json_hs_light
       state_topic: "home/light"
       command_topic: "home/light/set"
-      color_mode: true
       supported_color_modes: ["hs"]
 ```
 
@@ -847,7 +838,6 @@ mqtt:
       state_topic: "home/rgbw1"
       command_topic: "home/rgbw1/set"
       brightness: true
-      color_mode: true
       supported_color_modes: ["rgbw"]
 ```
 

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -563,7 +563,7 @@ availability_topic:
   required: false
   type: string
 brightness:
-  description: Flag that defines if light supports brightness when the `rgb`, `rgbw` or `rgbww` color mode is supported.
+  description: Flag that defines if light supports brightness when the `rgb`, `rgbw`, or `rgbww` color mode is supported.
   required: false
   type: boolean
   default: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove deprecated `color_mode` flag, adjust `brightness` description for MQTT json light

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/111676
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
