### PR TITLE
Matter on Android: add troubleshooting information

### DIFF
--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -179,7 +179,9 @@ This guide describes how to add a new device. This will use the Bluetooth connec
 
 <lite-youtube videoid="Fk0n0r0eKcE" videotitle="Add Matter device via Android app in Home Assistant"></lite-youtube>
 
-### Troubleshooting the installation via Android Companion app
+### Troubleshooting the installation
+
+Check these steps if you are experiencing issues when trying to add a Matter device using the Home Assistant Companion app on your Android phone.
 
 #### Symptom
 

--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -80,7 +80,6 @@ One of the great features of Matter is the so-called _Multi Fabric_ feature: you
 
 For devices where Home Assistant provides a native integration (with local API), Matter may not be the best option. Matter, being a universal standard, might not have the nitty-gritty features that come with a product-specific protocol. A good example is Philips Hue: the communication over Matter only provides the basic controls over lights, while the official [Hue integration](/integrations/hue) brings all Hue unique features like (dynamic) scenes, entertainment mode, etc.
 
-
 ## Supported installation types
 
 It is recommended to run the Matter add-on on Home Assistant OS. This is currently the only supported option. Other installation types are without support and at your own risk.
@@ -179,6 +178,20 @@ This guide describes how to add a new device. This will use the Bluetooth connec
 7. Your device is now ready to use.
 
 <lite-youtube videoid="Fk0n0r0eKcE" videotitle="Add Matter device via Android app in Home Assistant"></lite-youtube>
+
+### Troubleshooting the installation via Android Companion app
+
+#### Symptom
+
+While trying to add the Matter device, I get an error stating that *Matter is currently unavailable*. 
+
+#### Remedy
+
+This could mean that not all required Matter modules that are needed by the Home Assistant Companion App have been downloaded yet. Try the following steps:
+
+1. Wait up to 24 hours for the Google Play services to download the necessary Matter modules. For more information, refer to this [Troubleshooting Guide from Google](https://developers.home.google.com/matter/verify-services).
+2. If this did not work, try reinstalling the Home Assistant Companion app.
+
 
 ## Sharing a device from another platform with Home Assistant
 

--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -191,9 +191,10 @@ While trying to add the Matter device, I get an error stating that *Matter is cu
 
 This could mean that not all required Matter modules that are needed by the Home Assistant Companion App have been downloaded yet. Try the following steps:
 
-1. Wait up to 24 hours for the Google Play services to download the necessary Matter modules. For more information, refer to this [Troubleshooting Guide from Google](https://developers.home.google.com/matter/verify-services).
+1. Wait up to 24 hours for the Google Play services to download the necessary Matter modules.
 2. If this did not work, try reinstalling the Home Assistant Companion app.
-
+3. If this did not work, try installing the Google Home app. Technically this is not required, but it might trigger another installation attempt of the Matter modules.
+4. Refer to this [Troubleshooting Guide from Google](https://developers.home.google.com/matter/verify-services).
 
 ## Sharing a device from another platform with Home Assistant
 


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Matter on Android: add troubleshooting information
- Adding a Matter device via Home Assistant Companion app on Android:
- Add troubleshooting information on what to do when the Matter modules are unavailable
- Addresses feedback from #31700

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #31700

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
