### PR TITLE
Clarify google translate how to use preferred speak service

### DIFF
--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -41,11 +41,11 @@ You can also use supported BCP 47 tags like the below or the 2-2 digit format fo
 | es-us   | es       | com    |
 
 
-## Service Speak
+## Service speak
 
 The `tts.speak` service is the modern way to use Google translate TTS action. Add the `speak` action, select the entity for your Google translate TTS (it's named for the language you created it with), select the media player entity or group to send the TTS audio to, and enter the message to speak.
 
-For more options about `speak`, see the Speak section on the main [TTS](https://www.home-assistant.io/integrations/tts/#service-speak) building block page.
+For more options about `speak`, see the Speak section on the main [TTS](/integrations/tts/#service-speak) building block page.
 
 In YAML, your action will look like this:
 ```yaml
@@ -57,7 +57,7 @@ data:
   message: Hello, can you hear me now?
 ```
 
-## Service say (Legacy)
+## Service say (legacy)
 
 <div class='note'>
 

--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -40,7 +40,24 @@ You can also use supported BCP 47 tags like the below or the 2-2 digit format fo
 | es-es   | es       | es     |
 | es-us   | es       | com    |
 
-## Service say
+
+## Service Speak
+
+The `tts.speak` service is the modern way to use Google translate TTS action. Add the `speak` action, select the entity for your Google translate TTS (it's named for the language you created it with), select the media player entity or group to send the TTS audio to, and enter the message to speak.
+
+For more options about `speak`, see the Speak section on the main [TTS](https://www.home-assistant.io/integrations/tts/#service-speak) building block page.
+
+In YAML, your action will look like this:
+```yaml
+service: tts.speak
+target:
+  entity_id: tts.google_en_com
+data:
+  media_player_entity_id: media_player.giant_tv
+  message: Hello, can you hear me now?
+```
+
+## Service say (Legacy)
 
 <div class='note'>
 


### PR DESCRIPTION
## Proposed change
Google translate TTS page has a bunch of examples showing the legacy `say` service, but nothing about the modern `speak`.
Clarifying to make it more obvious that `speak` is modern
Description how to create an action in UI (not just YAML block)
Add YAML example
Clarify that it's build off the TTS building block and more info is found there



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.



## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
