### PR TITLE
Clarify Calendar and To-Do building block pages

### DIFF
--- a/source/_integrations/calendar.markdown
+++ b/source/_integrations/calendar.markdown
@@ -4,7 +4,8 @@ description: Instructions on how to integrate calendars within Home Assistant.
 ha_release: 0.33
 ha_domain: calendar
 ha_quality_scale: internal
-ha_category: []
+ha_category:
+  - Calendar
 ha_codeowners:
   - '@home-assistant/core'
 ha_integration_type: entity
@@ -16,13 +17,12 @@ dashboard and can be used with automations.
 
 This page does not provide instructions on how to create calendar
 entities. Please see the ["Calendar" category](/integrations/#calendar) on the
-integrations page to find integration offering calendar entities.
+integrations page to find integrations offering calendar entities. For example, [Local Calendar](/integrations/local_calendar/) is a fully local integration to create calendars and events within your Home Assistant instance or other integrations work with other services providing calendar data.
 
 {% include integrations/building_block_integration.md %}
 
-A calendar {% term entity %} has a {% term state %} and attributes representing the next event (only).
-A calendar {% term trigger %} is much more flexible, has fewer limitations, and is
-recommended for automations instead of using the entity state.
+Calendar {% term triggers %} are the best way to automate based on calendar events.
+A calendar {% term entity %} can also be used to automate, but it has a {% term state %} and attributes only representing the next event.
 
 ## Viewing and managing calendars
 

--- a/source/_integrations/calendar.markdown
+++ b/source/_integrations/calendar.markdown
@@ -21,8 +21,6 @@ integrations page to find integrations offering calendar entities. For example, 
 
 {% include integrations/building_block_integration.md %}
 
-Calendar {% term triggers %} are the best way to automate based on calendar events.
-A calendar {% term entity %} can also be used to automate, but it has a {% term state %} and attributes only representing the next event.
 
 ## Viewing and managing calendars
 
@@ -42,6 +40,9 @@ Calendar [Triggers](/docs/automation/trigger) enable {% term automation %} based
 event's start or end. Review the [Automating Home Assistant](/getting-started/automation/)
 getting started guide on automations or the [Automation](/docs/automation/)
 documentation for full details.
+
+Calendar {% term triggers %} are the best way to automate based on calendar events.
+A calendar {% term entity %} can also be used to automate based on its state, but these are limited and attributes only represent the next event.
 
 {% my automations badge %}
 

--- a/source/_integrations/todo.markdown
+++ b/source/_integrations/todo.markdown
@@ -17,6 +17,8 @@ dashboard for tracking items and whether or not they have been completed.
 
 {% include integrations/building_block_integration.md %}
 
+For example, [Local To-do](/integrations/local_todo/) is a fully local integration to create to-do lists and tasks within your Home Assistant instance, [Shopping list](/integrations/shopping_list) specifically for shopping that can be added to with Assist, or other integrations work with online services providing to-do list data.
+
 ## Viewing and managing to-do lists
 
 Each to-do list is represented as its own entity in Home Assistant and can be


### PR DESCRIPTION
## Proposed change
* Add integration category to Calendar so the calendar building block page shows up under the integration list for calendars - matches most other building blocks and their categories
* Add Local Calendar to show the simplest integration to actually implement the building block
* Add Local To-do and Shopping list to To-do for same reason
* Clarify calendar section about trigger to put the "do" part first instead of the "don't"



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
