### PR TITLE
Create awattar.markdown

### DIFF
--- a/source/_integrations/awattar.markdown
+++ b/source/_integrations/awattar.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to integrate aWATTar prices within Home Assista
 ha_category:
   - Energy
   - Sensor
+ha_release: 2024.4
 ha_iot_class: Cloud Polling
 ha_config_flow: true
 ha_codeowners:

--- a/source/_integrations/awattar.markdown
+++ b/source/_integrations/awattar.markdown
@@ -1,0 +1,48 @@
+---
+title: aWATTar
+description: Instructions on how to integrate aWATTar prices within Home Assistant.
+ha_category:
+  - Energy
+  - Sensor
+ha_iot_class: Cloud Polling
+ha_config_flow: true
+ha_codeowners:
+ha_domain: awattar
+ha_platforms:
+  - diagnostics
+  - sensor
+ha_integration_type: integration
+---
+
+The aWATTar integration integrates the [aWATTar](https://www.awattar.at) API platform 
+with Home Assistant.
+
+The integration makes it possible to retrieve the dynamic energy prices
+from aWATTar in order to gain insight into the price trend of the day and
+to adjust your consumption accordingly.
+
+## Sensors
+
+The aWATTar integration creates a number of sensor entities for electricity prices and 
+prices for various timeslot sizes.
+
+The prices for the following day are available every day around **14:00 UTC time**. 
+Depending on the time of day you either get prices until end of this day (before 14:00) or 
+prices until end of next day.
+
+Either way you get the following sensors for the integration:
+
+- The `current` and `next hour` price
+- Average electricity price of the period (either end of this day or end of next day)
+- Lowest energy price of the period
+- Highest energy price of the period
+
+For timespans from 2 to 6 hours you get the information when the price is lowest:
+
+- Time of Day when the timeslot begins
+- Average price you would have to pay within this timeslot
+
+With this you can easily create an automation to start consumption for a given period at 
+the lowest possible price to e.g. heat up the boiler or charge a battery.
+
+The API is free of charge and gets polled every hour.


### PR DESCRIPTION
Documentation for aWATTar integration

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/112511
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/5269
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
