### PR TITLE
Jewish Calendar: Document Services

### DIFF
--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -14,7 +14,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The Jewish Calendar (`jewish_calendar`) integration displays a variety of information related to the Jewish Calendar as a variety of sensors.
+The Jewish Calendar (`jewish_calendar`) integration displays a variety of information about the current day related to the Jewish Calendar as a variety of sensors, and offers services to return information about other days.
 
 ## Configuration
 
@@ -157,3 +157,56 @@ jewish_calendar:
   diaspora: true
   havdalah_minutes_after_sunset: 50
 ```
+
+## Services
+
+The Jewish Calendar integration also includes four services that return Hebrew calendar and Zmanim information about specific day(s).
+
+### Common Attributes
+
+All of these services return the same fields, based on which of the following `include_*` attributes you pass to the service. If you set multiple attributes to true, it will return all of thise fields.
+
+| Service data attribute     | Description                                                                   |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `include_hebrew_date_info` | True to return Hebrew year, month, day, and related calendar information.     |
+| `include_holiday_info`     | True to return information about the holiday that falls on this date, if any. |
+| `include_zmanim`           | True to return the day's zmanim timestamps.                                   |
+
+### Service jewish_calendar.for_gregorian_date
+
+Return Jewish Calendar information for the specified Gregorian date.
+
+| Service data attribute | Optional | Description                                                                                                                                                                                                                            |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `date`                 | yes      | Look up the specified date or time.  If you pass a date with a time, it will be evaluated relative to sunset, returning the following day if after sunset (not candle lighting). Defaults to today (relative to midnight, not sunset). |
+
+### Service jewish_calendar.for_hebrew_date
+
+Return Jewish Calendar information for the specified Hebrew date.
+
+| Service data attribute | Optional | Description                                                                                                                                          |
+| ---------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `year`                 | yes      | The year of the date to return.  Omit this to return the specified date in the current Hebrew year (eg, a Yahrzeit).                                 |
+| `month`                | no       | The month of the date to return.  You must specify Adar I or Adar II in case the year is a leap year; in non-leap years, they will both return Adar. |
+| `day`                  | no       | The day of month of the date to return.                                                                                                              |
+
+### Service jewish_calendar.for_next_holiday
+
+Return Jewish Calendar information for the next holiday on or after a given date, optionally filtered to specific type(s) of holiday.
+
+| Service data attribute | Optional | Description                                                                                                                                                                                                                                  |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `date`                 | yes      | Get a holiday the specified date or time.  If you pass a date with a time, it will be evaluated relative to sunset, returning the following day if after sunset (not candle lighting). Defaults to today (relative to midnight, not sunset). |
+| `types`                | yes      | The categories of holidays to return, from the `Type` column [above](#holiday-sensor).  If omitted, returns any holiday.                                                                                                                     |
+
+### Service jewish_calendar.get_holidays
+
+Return Jewish Calendar information for holiday(s) in a given year.  Exactly one of `types` or `holidays` is required to filter holidays to return.
+
+Note: Unlike the other services, this returns results for multiple days, wrapped in an array named `holidays`.
+
+| Service data attribute | Optional | Description                                                                                               |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `year`                 | yes      | Return holidays in the specified year.  Defaults to the current Hebrew year.                              |
+| `types`                | yes      | The categories of holidays to return, from the `Type` column [above](#holiday-sensor).                    |
+| `holidays`             | yes      | The name(s) of holidays to return, from the `English` or `Hebrew` names columns [above](#holiday-sensor). |

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -183,6 +183,15 @@ Return Jewish Calendar information for the specified Gregorian date.
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `date`                 | yes      | Look up the specified date or time.  If you pass a date with a time, it will be evaluated relative to sunset, returning the following day if after sunset (not candle lighting). Defaults to today (relative to midnight, not sunset). |
 
+### Service {% my developer_call_service service="jewish_calendar.get_gregorian_date_range" %}
+
+Return Jewish Calendar information for a range of Gregorian dates.
+
+| Service data attribute | Optional | Description                                                                                                                                                                                                                 |
+| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `date`                 | yes      | The first day to return.  If you pass a date with a time, it will be evaluated relative to sunset, returning the following day if after sunset (not candle lighting). Defaults to today (relative to midnight, not sunset). |
+| `number_of_days`       | no       | The number of days to return, including `date`.                                                                                                                                                                             |
+
 ### Service {% my developer_call_service service="jewish_calendar.get_hebrew_date" %}
 
 Return Jewish Calendar information for the specified Hebrew date.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document https://github.com/home-assistant/core/pull/111986

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/111986
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
