### PR TITLE
add notes about using and configuring SwitchBot entities

### DIFF
--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -49,9 +49,6 @@ Some SwitchBot devices need to be configured within the app before being control
 
 {% include integrations/config_flow.md %}
 
-
-
-
 ## Supported devices
 
 - [Color Bulb (WoBulb)](https://switch-bot.com/pages/switchbot-color-bulb)

--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -45,7 +45,7 @@ If you have multiple devices of the same type, you need to get the BTLE MAC addr
 
 Please note, device names configured in the SwitchBot app are not transferred into Home Assistant.
 
-Some SwitchBot devices need to be configured within the app before controlling them from Home Assistant, such as calibrating the cover open/close limits or pairing two covers to move together.
+Some SwitchBot devices need to be configured within the app before being controlled by Home Assistant, such as calibrating the cover open/close limits or pairing two covers to move together.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -45,10 +45,11 @@ If you have multiple devices of the same type, you need to get the BTLE MAC addr
 
 Please note, device names configured in the SwitchBot app are not transferred into Home Assistant.
 
+Some SwitchBot devices need to be configured within the app before controlling them from Home Assistant, such as calibrating the cover open/close limits or pairing two covers to move together.
+
 {% include integrations/config_flow.md %}
 
-SwitchBot devices are added to Home Assistant according to their domain, such as Curtains under the cover domain. For more information how to use these in automations, see the buliding block integration that domain, such as [cover](/integrations/cover/).
-Some SwitchBot devices need to be configured within the app before controlling them from Home Assistant, such as adjusting the cover open/close limits or pairing two covers to move together.
+
 
 
 ## Supported devices

--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -47,6 +47,10 @@ Please note, device names configured in the SwitchBot app are not transferred in
 
 {% include integrations/config_flow.md %}
 
+SwitchBot devices are added to Home Assistant according to their domain, such as Curtains under the cover domain. For more information how to use these in automations, see the buliding block integration that domain, such as [cover](/integrations/cover/).
+Some SwitchBot devices need to be configured within the app before controlling them from Home Assistant, such as adjusting the cover open/close limits or pairing two covers to move together.
+
+
 ## Supported devices
 
 - [Color Bulb (WoBulb)](https://switch-bot.com/pages/switchbot-color-bulb)


### PR DESCRIPTION
## Proposed change
Adding a paragraph to clarify some general details about actually using switchbot entities, since each of them shows up under its own domain and there is not any documentation on this page about the triggers and services available for each of those domain entities. 
Plus a note that some switchbot devices have to be set up within the app first.


## Type of change


- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- This PR fixes or closes issue: fixes #31550

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
