### PR TITLE
add sidebar section on integrations to list platforms that they use

### DIFF
--- a/source/_includes/site/sidebar.html
+++ b/source/_includes/site/sidebar.html
@@ -53,9 +53,9 @@
   {%- if page.ha_platforms.first -%}
   <section class="aside-module grid__item one-whole lap-one-half">
     <div class='section'>
-      <h1 class="title delta">Platforms</h1>
-      This integration creates entities from the following platforms.
-      See these general pages for details on using their triggers and actions in automations:
+      <h1 class="title delta">Related building blocks</h1>
+      This integration uses the following integrations as building blocks.
+      For details on using their triggers and actions in automations, refer to their documentation:
     </div>
     <div class='section'>
       <ul class='unstyled'>

--- a/source/_includes/site/sidebar.html
+++ b/source/_includes/site/sidebar.html
@@ -61,7 +61,7 @@
       <ul class='unstyled'>
       {%- for platform in page.ha_platforms -%}
         <li>
-          <a href='/integrations/{{ platform }}'>{{ platform | capitalize }}</a>
+          <a href='/integrations/{{ platform }}'>{{ platform | capitalize | replace: "_", " " }}</a>
         </li>
       {%- endfor -%}
       </ul>

--- a/source/_includes/site/sidebar.html
+++ b/source/_includes/site/sidebar.html
@@ -50,11 +50,37 @@
     {%- endunless -%}
   {% endif %} 
 
+  {%- if page.ha_platforms.first -%}
+  <section class="aside-module grid__item one-whole lap-one-half">
+    <div class='section'>
+      <h1 class="title delta">Platforms</h1>
+      This integration creates entities from the following platforms.
+      See these general pages for details on using their triggers and actions in automations:
+    </div>
+    <div class='section'>
+      <ul class='unstyled'>
+      {%- for platform in page.ha_platforms -%}
+        <li>
+          <a href='/integrations/{{ platform }}'>{{ platform | capitalize }}</a>
+        </li>
+      {%- endfor -%}
+      </ul>
+    </div>
+  </section>
+  {%- endif -%}
+
   {%- if page.ha_category.first -%}
     <section class="aside-module grid__item one-whole lap-one-half">
       <div class='section'>
         <h1 class="title delta">Categories</h1>
-        <ul class='divided'>
+        {% if page.ha_integration_type == "integration" %}
+          Find other integrations in these categories:
+        {% else %}
+          Search for integrations built from this:
+        {% endif %}
+      </div>
+      <div class='section'>
+        <ul class='unstyled'>
         {%- for category in page.ha_category -%}
           <li>
             <a href='/integrations/#{{ category | slugify }}'>{{ category }}</a>


### PR DESCRIPTION
## Proposed change

This PR adds a section in the sidebar for integration pages that lists the platforms that it uses. This metadata is already included on all integrations, but isn't being used in the docs. Now this list links to the building block integration for that domain (switch, light, fan, etc.), where the general info like service calls are found. Lists were also compacted to match the TOC and save space, and added a short description to each section.

### Why

Many specific integration pages lack any information about how to actually use the entities that it creates under different domains. This is by design, they're specific instances of the building blocks / platforms and we wouldn't want to repeat the information from the building block page and have it get out of date. However, it leaves many pages without any information about how to actually use it, and it's up to who writes each page to link or describe much of the usage details. There are links to the categories listing, but users won't intuit how to find the platform / building block from there in a large list.

As an example, the Switchbot page has a lot of details about some specific quirks about some types of devices it adds, but there is no mention anywhere of how to just make my curtains open. This was frustrating to me as a new user and I see lots of forum posts and issues here about the same. I've added a few recently myself like to Local Calendar to To-Do, but a better solution is to automate it with data we already have.



My hope is that this makes a standardized and automatic way for every integration to at least include a simple list and link to the platforms.


### Notes

In many cases it does look goofy to have a double listing of Platforms and Categories. But some distinctions that I've found that require it, and think it's useful to keep both:
* Some categories aren't platforms, like Hub, 3D Printer, Car...
* Some aren't easy to convert, like notify vs Notifications, todo vs To-do List
* Some integrations have a lot of differences in their platform vs category lists, not sure if intentional, like ESPHome
These feel like a separate problem that can be addressed later.

I tried looking through a lot of integrations and building blocks to make sure this works with all of the current data. I found a few weird ones like Switch has a platform of Light listed, but generally everything I looked at made sense with my addition. Working on another PR to fix a couple errors in the platform lists.


I'm very open to feedback if you think this is useful or could be improved on.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.
- [X] Sidebar that affects all Integration pages!



## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
