### PR TITLE
matrix: End to End encryption documentation

### DIFF
--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -89,6 +89,49 @@ In order to prevent infinite loops when reacting to commands, you have to use a 
 
 </div>
 
+### End to End Encryption
+
+End to end encryption is automatically enabled in supported rooms. Devices in the room must be trusted before messages can be sent to them. If you are having issues receiving a message and an unverified device error, you will need to trust the device using the `trust_blacklist_device` service.
+
+There are three different ways you can trust or blacklist devices.
+
+#### Trust or blacklist by user id and device id
+
+```yaml
+service: matrix.trust_blacklist_device
+data:
+  user_id: "@test_user:matrix.org"
+  device_id: "@test_user:matrix.org"
+  # If set to true, this will blacklist the device of
+  # trusting it. By default, this is true if unspecified
+  blacklist: false
+```
+
+#### Trust or blacklist all known devices for a user id
+
+```yaml
+service: matrix.trust_blacklist_device
+data:
+  user_id: "@test_user:matrix.org"
+  apply_all_user_devices: true
+  # If set to true, this will blacklist the device of
+  # trusting it. By default, this is true if unspecified
+  blacklist: false
+```
+
+#### Trust or blacklist all known devices
+
+This will trust all devices known regardless of user id.
+
+```yaml
+service: matrix.trust_blacklist_device
+data:
+  apply_all_devices: true
+  # If set to true, this will blacklist the device of
+  # trusting it. By default, this is true if unspecified
+  blacklist: false
+```
+
 ### Event data
 
 If a command is triggered, a `matrix_command` event is fired. The event contains the name of the command in the `name` field.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document matrix end to end encryption


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/112538
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
