### PR TITLE
clarify notifications building block page

### DIFF
--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -11,7 +11,7 @@ ha_domain: notify
 ha_integration_type: entity
 ---
 
-The `notify` {% term integration %} makes it possible to send notifications to a wide variety of platforms. To use it you have to setup at least one notification target (notifier), check the [integrations list](/integrations/#notifications) for one that fits your use case.
+The **Notify** {% term integration %} makes it possible to send notifications to a wide variety of platforms. To use it, you have to set up at least one notification target (notifier). Check the [integrations list](/integrations/#notifications) for one that fits your use case.
 
 If you want to send notifications to the Home Assistant web interface, you may use the [Persistent Notification integration](/integrations/persistent_notification/). It is available as an automatically configured notifier. See [its documentation](/integrations/persistent_notification/) for more details.
 
@@ -30,25 +30,25 @@ Once loaded, the `notify` platform will expose a service that can be called to s
 
 ## Usage
 
-The different `notify` integrations you have set up will each show up as a different automation {% term action actions %} / {% term service %} calls that you can use.
+The different **Notify** integrations you have set up will each show up as a different automation {% term action %} or {% term service %} call that you can use.
 
 One notification integration is automatically included, the Persistent Notifications which creates a notification in the sidebar of the web interface of Home Assistant. This can be chosen with the action named "Notifications: Send a persistent notification" which uses the service `notify.persistent_notification`.
 
 Another common notification integration is via the companion app for Android or iPhone. This can be chosen with the action "Send a notification via mobile_app_your_phone_name" which uses the service `notify.mobile_app_your_phone_name`. See the [companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
 
-With any of these integrations, the `message` data input in the automation editor is the main text that will be sent. Other fields are optional, and some integrations support additional `data` or `target` information to customize the action, see their integration pages for more details.
+With any of these integrations, the `message` data input in the automation editor is the main text that will be sent. Other fields are optional, and some integrations support additional `data` or `target` information to customize the action. For more details, refer to their integration documentation.
 
-Be aware that the `notify.notify` service is shorthand for the first notify service the system can find and might not work as intended. Choose a specific service to make sure your message goes to the right place.
+Be aware that the `notify.notify` service is shorthand for the first notify service the system can find. It might not work as intended. Choose a specific service to make sure your message goes to the right place.
 
 Notifications can also be sent using [Notify groups](https://www.home-assistant.io/integrations/group/#notify-groups). These allow you to send notification to multiple devices with a single call, or to update which device is notified by only changing it in a single place.
 
 ### Test if it works
 
-After you setup a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open **{% my developer_services title="Developer tools -> Services" %}** tab from the sidebar. Choose your service from the **Service** dropdown menu depending on the integration you want to test, such as "Notifications: Send a persistent notification" or "Notifications: Send a notification via mobile_app_your_phone_name". Enter your message into the **message** field, and press the **CALL SERVICE** button.
+After you setup a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open {% my developer_services title="**Developer tools** > **Services**" %}** tab from the sidebar. Choose your service from the **Service** dropdown menu depending on the integration you want to test, such as **Notifications: Send a persistent notification** or **Notifications: Send a notification via mobile_app_your_phone_name**. Enter your message into the **message** field, and select the **CALL SERVICE** button.
 
 ### Examples
 
-Select the "Notifications: Send a persistent notification" action under **Developer Tools** on the **Services** tab. Enter a message and test sending it.
+In the **Developer Tools**, on the **Services** tab, select the **Notifications: Send a persistent notification** action. Enter a message and test sending it.
 
 If you switch to view the YAML data under **Developer Tools**, it will appear as below. The same {% term action %} can be chosen in {% term automation %} actions %, whose YAML will appear the same:
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -11,7 +11,7 @@ ha_domain: notify
 ha_integration_type: entity
 ---
 
-The `notify` integration makes it possible to send notifications to a wide variety of platforms. To use it you have to setup at least one notification target (notifier), check the [integrations list](/integrations/#notifications) for one that fits your use case.
+The `notify` {% term integration %} makes it possible to send notifications to a wide variety of platforms. To use it you have to setup at least one notification target (notifier), check the [integrations list](/integrations/#notifications) for one that fits your use case.
 
 If you want to send notifications to the Home Assistant web interface, you may use the [Persistent Notification integration](/integrations/persistent_notification/). It is available as an automatically configured notifier. See [its documentation](/integrations/persistent_notification/) for more details.
 
@@ -30,7 +30,7 @@ Once loaded, the `notify` platform will expose a service that can be called to s
 
 ## Usage
 
-The different `notify` integrations you have set up will each show up as a different automation actions / service calls that you can use.
+The different `notify` integrations you have set up will each show up as a different automation {% term action actions %} / {% term service %} calls that you can use.
 
 One notification integration is automatically included, the Persistent Notifications which creates a notification in the sidebar of the web interface of Home Assistant. This can be chosen with the action named "Send a persistent notification" which uses the service `notify.persistent_notification`.
 
@@ -50,7 +50,7 @@ After you setup a [notifier](/integrations/#notifications), a simple way to test
 
 Select the "Send a persistent notification" action under **Developer Tools** on the **Services** tab. Enter a message and test sending it.
 
-If you switch to view the YAML data under **Developer Tools**, it will appear as below. The same action can be chosen in [automations](/getting-started/automation/). The automation action changed to its YAML view will appear the same:
+If you switch to view the YAML data under **Developer Tools**, it will appear as below. The same {% term action %} can be chosen in {% term automations %}. The automation action changed to its YAML view will appear the same:
 
 {% raw %}
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -44,7 +44,7 @@ Notifications can also be sent using [Notify groups](https://www.home-assistant.
 
 ### Test if it works
 
-After you setup a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open **Developer Tools** from the sidebar and select the **Services** tab. Choose your service from the **Service** dropdown menu depending on the integration you want to test, such as "Send a persistent notification" or "via mobile_app_your_phone_name". Enter your message into the **message** field, and press the **CALL SERVICE** button.
+After you setup a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open **{% my developer_services title="Developer tools -> Services" %}** tab from the sidebar. Choose your service from the **Service** dropdown menu depending on the integration you want to test, such as "Send a persistent notification" or "via mobile_app_your_phone_name". Enter your message into the **message** field, and press the **CALL SERVICE** button.
 
 ### Examples
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -13,7 +13,7 @@ ha_integration_type: entity
 
 The `notify` integration makes it possible to send notifications to a wide variety of platforms. To use it you have to setup at least one notification target (notifier), check the [integrations list](/integrations/#notifications) for one that fits your use case.
 
-If you want to send notifications to the Home Assistant web interface, you may use the [Persistent Notification integration](/integrations/persistent_notification/). The Persistent Notification integration is also available as an automatically configured notifier. See [its documentation](/integrations/persistent_notification/) for more details.
+If you want to send notifications to the Home Assistant web interface, you may use the [Persistent Notification integration](/integrations/persistent_notification/). It is available as an automatically configured notifier. See [its documentation](/integrations/persistent_notification/) for more details.
 
 {% include integrations/building_block_integration.md %}
 
@@ -28,41 +28,69 @@ Once loaded, the `notify` platform will expose a service that can be called to s
 | `target`               |      yes | Some platforms allow specifying a recipient that will receive the notification. See your platform page if it is supported.
 | `data`                 |      yes | On platforms who have extended functionality. See your platform page if it is supported.
 
-The notify integration supports specifying [templates](/docs/configuration/templating/). This will allow you to use the current state of Home Assistant in your notifications.
+## Usage
 
-In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) it could look like this with a customized subject.
+The different `notify` integrations you have set up will each show up as a different automation actions / service calls that you can use.
 
-Be aware that you might want to change the actual service to whatever service you are actually using since `notify.notify` is shorthand for the first notify service the system can find and might therefore not be working as intended.
+One notification integration is automatically included, the Persistent Notifications which creates a notification in the sidebar of the web interface of Home Assistant. This can be chosen with the action named "Send a persistent notification" which uses the service `notify.persistent_notification`.
 
-```yaml
-action:
-  service: notify.notify
-  data:
-    message: "Your message goes here"
-    title: "Custom subject"
-```
+Another common notification integration is via the companion app for Android or iPhone. This can be chosen with the action "Send a notification via mobile_app_your_phone_name" which uses the service `notify.mobile_app_your_phone_name`. See the [app docs](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
+
+With any of these integrations, the `message` data input in the automation editor is the main text that will be sent. Other fields are optional, and some integrations support additional `data` or `target` information to customize the action, see their integration pages for more details.
+
+Be aware that the `notify.notify` is shorthand for the first notify service the system can find and might not work as intended. Choose a specific service to make sure your message goes to the right place.
 
 ### Test if it works
 
-After you setup a [notifier](/integrations/#notifications) a simple way to test if you have set up your notify platform correctly, is to open **Developer Tools** from the sidebar and then select the  **Services** tab. Choose your service from the **Service** dropdown menu, enter the sample below into the **Service Data** field, and press the **CALL SERVICE** button.
+After you setup a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open **Developer Tools** from the sidebar and select the **Services** tab. Choose your service from the **Service** dropdown menu depending on the integration you want to test, such as "Send a persistent notification" or "via mobile_app_your_phone_name". Enter your message into the **message** field, and press the **CALL SERVICE** button.
+
+### Examples
+
+Select the "Send a persistent notification" action under **Developer Tools** on the **Services** tab. Enter a message and test sending it.
+
+If you switch to view the YAML data under **Developer Tools**, it will appear like this:
 
 {% raw %}
 
-```json
-{
-  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"
-}
+```yaml
+service: notify.persistent_notification
+data:
+  message: Can you hear me now?
 ```
 
 {% endraw %}
 
-The automation equivalent would be:
+The same action can be chosen in [automations](/getting-started/automation/). The automation equivalent in its YAML view would be:
+
+{% raw %}
+
+```yaml
+service: notify.persistent_notification
+metadata: {}
+data:
+  message: Can you hear me now?
+```
+
+{% endraw %}
+
+The notify integration supports specifying [templates](/docs/configuration/templating/). This will allow you to use the current state of entities in Home Assistant in your notifications, or use more complex logic to decide the message that is sent.
 
 {% raw %}
 
 ```yaml
 action:
-  service: notify.notify
+  service: notify.persistent_notification
+  data:
+    message: "You have {{ states("todo.shopping_list") }} items on your shopping list."
+```
+
+{% endraw %}
+
+{% raw %}
+
+```yaml
+action:
+  service: notify.persistent_notification
   data:
     message: "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"
 ```

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -38,7 +38,9 @@ Another common notification integration is via the companion app for Android or 
 
 With any of these integrations, the `message` data input in the automation editor is the main text that will be sent. Other fields are optional, and some integrations support additional `data` or `target` information to customize the action, see their integration pages for more details.
 
-Be aware that the `notify.notify` is shorthand for the first notify service the system can find and might not work as intended. Choose a specific service to make sure your message goes to the right place.
+Be aware that the `notify.notify` service is shorthand for the first notify service the system can find and might not work as intended. Choose a specific service to make sure your message goes to the right place.
+
+Notifications can also be sent using [Notify groups](https://www.home-assistant.io/integrations/group/#notify-groups). These allow you to send notification to multiple devices with a single call, or to update which device is notified by only changing it in a single place.
 
 ### Test if it works
 
@@ -48,30 +50,19 @@ After you setup a [notifier](/integrations/#notifications), a simple way to test
 
 Select the "Send a persistent notification" action under **Developer Tools** on the **Services** tab. Enter a message and test sending it.
 
-If you switch to view the YAML data under **Developer Tools**, it will appear like this:
+If you switch to view the YAML data under **Developer Tools**, it will appear as below. The same action can be chosen in [automations](/getting-started/automation/). The automation action changed to its YAML view will appear the same:
 
 {% raw %}
 
 ```yaml
 service: notify.persistent_notification
 data:
-  message: Can you hear me now?
+  message: "Can you hear me now?"
 ```
 
 {% endraw %}
 
-The same action can be chosen in [automations](/getting-started/automation/). The automation equivalent in its YAML view would be:
 
-{% raw %}
-
-```yaml
-service: notify.persistent_notification
-metadata: {}
-data:
-  message: Can you hear me now?
-```
-
-{% endraw %}
 
 The notify integration supports specifying [templates](/docs/configuration/templating/). This will allow you to use the current state of entities in Home Assistant in your notifications, or use more complex logic to decide the message that is sent.
 
@@ -81,7 +72,7 @@ The notify integration supports specifying [templates](/docs/configuration/templ
 action:
   service: notify.persistent_notification
   data:
-    message: "You have {{ states("todo.shopping_list") }} items on your shopping list."
+    message: "You have {{ states('todo.shopping_list') }} items on your shopping list."
 ```
 
 {% endraw %}
@@ -96,3 +87,5 @@ action:
 ```
 
 {% endraw %}
+
+

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -34,7 +34,7 @@ The different `notify` integrations you have set up will each show up as a diffe
 
 One notification integration is automatically included, the Persistent Notifications which creates a notification in the sidebar of the web interface of Home Assistant. This can be chosen with the action named "Send a persistent notification" which uses the service `notify.persistent_notification`.
 
-Another common notification integration is via the companion app for Android or iPhone. This can be chosen with the action "Send a notification via mobile_app_your_phone_name" which uses the service `notify.mobile_app_your_phone_name`. See the [app docs](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
+Another common notification integration is via the companion app for Android or iPhone. This can be chosen with the action "Send a notification via mobile_app_your_phone_name" which uses the service `notify.mobile_app_your_phone_name`. See the [companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
 
 With any of these integrations, the `message` data input in the automation editor is the main text that will be sent. Other fields are optional, and some integrations support additional `data` or `target` information to customize the action, see their integration pages for more details.
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -32,7 +32,7 @@ Once loaded, the `notify` platform will expose a service that can be called to s
 
 The different `notify` integrations you have set up will each show up as a different automation {% term action actions %} / {% term service %} calls that you can use.
 
-One notification integration is automatically included, the Persistent Notifications which creates a notification in the sidebar of the web interface of Home Assistant. This can be chosen with the action named "Send a persistent notification" which uses the service `notify.persistent_notification`.
+One notification integration is automatically included, the Persistent Notifications which creates a notification in the sidebar of the web interface of Home Assistant. This can be chosen with the action named "Notifications: Send a persistent notification" which uses the service `notify.persistent_notification`.
 
 Another common notification integration is via the companion app for Android or iPhone. This can be chosen with the action "Send a notification via mobile_app_your_phone_name" which uses the service `notify.mobile_app_your_phone_name`. See the [companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
 
@@ -44,13 +44,13 @@ Notifications can also be sent using [Notify groups](https://www.home-assistant.
 
 ### Test if it works
 
-After you setup a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open **{% my developer_services title="Developer tools -> Services" %}** tab from the sidebar. Choose your service from the **Service** dropdown menu depending on the integration you want to test, such as "Send a persistent notification" or "via mobile_app_your_phone_name". Enter your message into the **message** field, and press the **CALL SERVICE** button.
+After you setup a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open **{% my developer_services title="Developer tools -> Services" %}** tab from the sidebar. Choose your service from the **Service** dropdown menu depending on the integration you want to test, such as "Notifications: Send a persistent notification" or "Notifications: Send a notification via mobile_app_your_phone_name". Enter your message into the **message** field, and press the **CALL SERVICE** button.
 
 ### Examples
 
-Select the "Send a persistent notification" action under **Developer Tools** on the **Services** tab. Enter a message and test sending it.
+Select the "Notifications: Send a persistent notification" action under **Developer Tools** on the **Services** tab. Enter a message and test sending it.
 
-If you switch to view the YAML data under **Developer Tools**, it will appear as below. The same {% term action %} can be chosen in {% term automations %}. The automation action changed to its YAML view will appear the same:
+If you switch to view the YAML data under **Developer Tools**, it will appear as below. The same {% term action %} can be chosen in {% term automation %} actions %, whose YAML will appear the same:
 
 {% raw %}
 


### PR DESCRIPTION
## Proposed change
Clarifying the notifications page
* reorganize a few sections
* explain how to use a few simple notify services like persistent or mobile_app
* more details for new users how to test and use in automations
* start with simple examples, then with templates after



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- This PR fixes or closes issue: fixes #31781 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
