### PR TITLE
fix ecobee service data with wrong way to target all thermostats

### DIFF
--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -183,12 +183,12 @@ Delete a vacation on the selected ecobee thermostat.
 
 ### Service `ecobee.resume_program`
 
-Resumes the currently active schedule.
+Resumes the standard active schedule of presets. This cancels any manual temperature settings or selected preset. This will not cancel vacation events, use `delete_vacation`.
 
 | Service data attribute | Optional | Description                                                                                                              |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Use `entity_id: all` to target all. |
-| `resume_all`           | no       | true or false                                                                                                            |
+| `entity_id`            | yes      | String or list of strings that point at `entity_id`s of climate devices to control. Omit to target all ecobee thermostats. |
+| `resume_all`           | no       | `true` will resume the standard schedule. `false` will only cancel the latest active event, which is not used often. |
 
 ### Service `ecobee.set_fan_min_on_time`
 
@@ -196,7 +196,7 @@ Sets the minimum amount of time that the fan will run per hour.
 
 | Service data attribute | Optional | Description                                                                                                              |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Use `entity_id: all` to target all. |
+| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Omit to target all ecobee thermostats. |
 | `fan_min_on_time`      | no       | integer (e.g.,  5)                                                                                                       |
 
 ### Service `ecobee.set_dst_mode`
@@ -205,7 +205,7 @@ Enable/disable automatic daylight savings time.
 
 | Service data attribute | Optional | Description                                                  |
 | ---------------------- | -------- | ------------------------------------------------------------ |
-| `entity_id`            | yes      | ecobee thermostat on which to set daylight savings time mode |
+| `entity_id`            | yes      | ecobee thermostat on which to set daylight savings time mode. Omit to target all ecobee thermostats. |
 | `dst_enabled`          | no       | true or false                                                |
 
 ### Service `ecobee.set_mic_mode`
@@ -214,7 +214,7 @@ Enable/disable Alexa mic (only for ecobee 4).
 
 | Service data attribute | Optional | Description                                    |
 | ---------------------- | -------- | ---------------------------------------------- |
-| `entity_id`            | yes      | ecobee thermostat on which to set the mic mode |
+| `entity_id`            | yes      | ecobee thermostat on which to set the mic mode. Omit to target all ecobee thermostats. |
 | `mic_enabled`          | no       | true or false                                  |
 
 ### Service `ecobee.set_occupancy_modes`
@@ -223,6 +223,6 @@ Enable/disable Smart Home/Away and Follow Me modes.
 
 | Service data attribute | Optional | Description                                       |
 | ---------------------- | -------- | ------------------------------------------------- |
-| `entity_id`            | yes      | ecobee thermostat on which to set occupancy modes |
+| `entity_id`            | yes      | ecobee thermostat on which to set occupancy modes. Omit to target all ecobee thermostats. |
 | `auto_away`            | yes      | true or false                                     |
 | `follow_me`            | yes      | true or false                                     |


### PR DESCRIPTION
## Proposed change
Fix a few services that were saying to use `all` for entity_id, but correct way is to just omit and the library will target all ecobee entities.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- This PR fixes or closes issue: fixes #31718

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
