### PR TITLE
Modbus, configuration without entities

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -339,7 +339,7 @@ modbus:
 
 modbus entities are grouped below each modbus communication entry.
 
-**REMARK** Each modbus device must have at least 1 entity defined.
+**REMARK** Each modbus device must have at least 1 entity defined, otherwise the integration will not be loaded.
 
 Experience has shown that a modbus configuration without entities leads to instability issues.
 

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -341,10 +341,6 @@ modbus entities are grouped below each modbus communication entry.
 
 **REMARK** Each modbus device must have at least 1 entity defined, otherwise the integration will not be loaded.
 
-Experience has shown that a modbus configuration without entities leads to instability issues.
-
-The normal use case for the integration is to have entities, however there are some special cases and custom components that used the modbus integration without entities. The solution to these special cases is to add a dummy entity.
-
 Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
 All modbus entities have the following parameters:

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -339,9 +339,15 @@ modbus:
 
 modbus entities are grouped below each modbus communication entry.
 
-All modbus entities have the following parameters:
+**REMARK** Each modbus device must have at least 1 entity defined.
+
+Experience has shown that a modbus configuration without entities leads to instability issues.
+
+The normal use case for the integration is to have entities, however there are some special cases and custom components that used the modbus integration without entities. The solution to these special cases is to add a dummy entity.
 
 Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
+
+All modbus entities have the following parameters:
 
 {% configuration %}
 address:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The modbus integration do not allow a configuration of a device without at least a single entity.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
https://github.com/home-assistant/core/pull/113516
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
