### PR TITLE
Shelly add custom TCP port support

### DIFF
--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -83,9 +83,9 @@ Shelly generation 2 and 3 devices not battery-powered can act as a Bluetooth pro
 
 ## Range Extender Support
 
-Shelly generation 2 and 3 devices not battery-powered can act as a Range Extender.
-Devices of the same generations can be configured via those Range Extender specifying a custom TCP port during configuration flow.
-Currently only static IP or DHCP reserved IP are supported for the main device.
+Shelly generation 2 and 3 devices that are not battery-powered can act as a Range Extender.
+Devices of the same generations can be configured via those Range Extenders specifying a custom TCP port during the configuration flow.
+Currently, only static IP or DHCP reserved IP are supported for the main device.
 
 ## Entity naming (generation 1)
 

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -81,6 +81,12 @@ Shelly generation 2 and 3 devices not battery-powered can act as a Bluetooth pro
 
 {% include integrations/option_flow.md %}
 
+## Range Extender Support
+
+Shelly generation 2 and 3 devices not battery-powered can act as a Range Extender.
+Devices of the same generations can be configured via those Range Extender specifying a custom TCP port during configuration flow.
+Currently only static IP or DHCP reserved IP are supported for the main device.
+
 ## Entity naming (generation 1)
 
 The integration uses `Device Name` to name its entities if the device has only one relay or no relays at all.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add support for Shelly Range Extender via custom TCP port


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/110860
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
