### PR TITLE
[withings] Add note about 2nd config entry

### DIFF
--- a/source/_integrations/withings.markdown
+++ b/source/_integrations/withings.markdown
@@ -57,6 +57,8 @@ Withings will validate (with HTTP HEAD) these requirements each time you save yo
 
 {% enddetails %}
 
+Note: You will only need one developer account; the same account and credentials are used for each Withings config.
+
 {% include integrations/config_flow.md %}
 
 ## Data updates

--- a/source/_integrations/withings.markdown
+++ b/source/_integrations/withings.markdown
@@ -57,7 +57,7 @@ Withings will validate (with HTTP HEAD) these requirements each time you save yo
 
 {% enddetails %}
 
-Note: You will only need one developer account; the same account and credentials are used for each Withings config.
+Note: You will only need one developer account; the same account and credentials are used for each Withings configuration.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change

When adding a second Withings integration, you don't need another developer account and oauth credentials. I added a note to clarify this for anyone doing the same thing.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #30637

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
