### PR TITLE
docs(command_line): Commands missing template type

### DIFF
--- a/source/_integrations/command_line.markdown
+++ b/source/_integrations/command_line.markdown
@@ -43,7 +43,7 @@ command_line:
         command:
           description: The action to take to get the value.
           required: true
-          type: string
+          type: template
         command_timeout:
           description: Defines number of seconds for command timeout.
           required: false
@@ -154,7 +154,7 @@ command_line:
         command:
           description: The action to take.
           required: true
-          type: string
+          type: template
         command_timeout:
           description: Defines number of seconds for command timeout.
           required: false
@@ -168,7 +168,7 @@ command_line:
         command:
           description: The action to take to get the value.
           required: true
-          type: string
+          type: template
         command_timeout:
           description: Defines number of seconds for command timeout
           required: false


### PR DESCRIPTION
## Proposed change

Fix the reference documentation for the `command` fields that are missing the `template` type.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].
