### PR TITLE
List Prusa MK2.5/MK3 as supported

### DIFF
--- a/source/_integrations/prusalink.markdown
+++ b/source/_integrations/prusalink.markdown
@@ -18,16 +18,17 @@ ha_platforms:
 ha_dhcp: true
 ---
 
-The PrusaLink integration allows you to monitor your [Prusa 3D printer](https://www.prusa3d.com) and its progress with your Home Assistant installation. This integration works with Prusa MINI/MINI+, Prusa MK3.9/MK4 and Prusa XL. It does not work with the older Raspberry Pi based Prusa Link printers.
+The PrusaLink integration allows you to monitor your [Prusa 3D printer](https://www.prusa3d.com) and its progress with your Home Assistant installation. This integration works with Prusa MINI/MINI+, Prusa MK3.9/MK4, Prusa XL and with the older Raspberry Pi based Prusa MK2.5/MK3.
 
-This integration has been updated to utilize the latest v1 API endpoints, which require firmware version 4.7.0 or later. If you own a Prusa MINI/MINI+, please make sure your printer is running firmware 5.1.0 or a more recent version. Firmware versions 4.7.x and 5.0.x are not available for this model.
+This integration has been updated to utilize the latest v1 API endpoints, which require firmware version 4.7.0 or later. If you own a Prusa MINI/MINI+, please make sure your printer is running firmware 5.1.0 or a more recent version. Firmware versions 4.7.x and 5.0.x are not available for this model. For Prusa MK2.5/MK3, this integration requires PrusaLink version 0.7.2 or later.
 
 Firmware update guides can be found here:
 
  - [Prusa MINI/MINI+](https://help.prusa3d.com/article/firmware-updating-mini-mini_124784)
  - [Prusa MK3.9/MK4/XL](https://help.prusa3d.com/article/how-to-update-firmware-mk4-xl_453086)
+ - [Prusa MK2.5/MK3](https://help.prusa3d.com/guide/how-to-update-prusalink-mk2-5-s-mk3-s-_650837)
 
-To obtain the hostname, username, and password:
+To obtain the hostname, username, and password on Prusa MINI/MINI+/MK3.9/MK4/XL:
 
  - On your printer, navigate to **Settings** > **Network** > **PrusaLink**.
  - Find the device's **IP address**. Alternatively, you can look for the printer's IP address or hostname on your router.
@@ -39,3 +40,4 @@ To obtain the hostname, username, and password:
 ## Related topics
 
 - [PrusaLink documentation](https://help.prusa3d.com/article/prusa-connect-and-prusalink-explained_302608)
+- [PrusaLink installation guide for Prusa MK3](https://help.prusa3d.com/guide/prusalink-and-prusa-connect-setup-mk3-s-_221744)

--- a/source/_integrations/prusalink.markdown
+++ b/source/_integrations/prusalink.markdown
@@ -18,7 +18,7 @@ ha_platforms:
 ha_dhcp: true
 ---
 
-The **PrusaLink integration allows you to monitor your [Prusa 3D printer](https://www.prusa3d.com) and its progress with your Home Assistant installation. This integration works with Prusa MINI/MINI+, Prusa MK3.9/MK4, Prusa XL, and with the older Raspberry Pi-based Prusa MK2.5/MK3.
+The **PrusaLink** {% term integration %} allows you to monitor your [Prusa 3D printer](https://www.prusa3d.com) and its progress with your Home Assistant installation. This integration works with Prusa MINI/MINI+, Prusa MK3.9/MK4, Prusa XL, and with the older Raspberry Pi-based Prusa MK2.5/MK3.
 
 This integration has been updated to utilize the latest v1 API endpoints, which require firmware version 4.7.0 or later. If you own a Prusa MINI/MINI+, please make sure your printer is running firmware 5.1.0 or a more recent version. Firmware versions 4.7.x and 5.0.x are not available for this model. For Prusa MK2.5/MK3, this integration requires PrusaLink version 0.7.2 or later.
 

--- a/source/_integrations/prusalink.markdown
+++ b/source/_integrations/prusalink.markdown
@@ -18,7 +18,7 @@ ha_platforms:
 ha_dhcp: true
 ---
 
-The PrusaLink integration allows you to monitor your [Prusa 3D printer](https://www.prusa3d.com) and its progress with your Home Assistant installation. This integration works with Prusa MINI/MINI+, Prusa MK3.9/MK4, Prusa XL and with the older Raspberry Pi based Prusa MK2.5/MK3.
+The PrusaLink integration allows you to monitor your [Prusa 3D printer](https://www.prusa3d.com) and its progress with your Home Assistant installation. This integration works with Prusa MINI/MINI+, Prusa MK3.9/MK4, Prusa XL, and with the older Raspberry Pi based Prusa MK2.5/MK3.
 
 This integration has been updated to utilize the latest v1 API endpoints, which require firmware version 4.7.0 or later. If you own a Prusa MINI/MINI+, please make sure your printer is running firmware 5.1.0 or a more recent version. Firmware versions 4.7.x and 5.0.x are not available for this model. For Prusa MK2.5/MK3, this integration requires PrusaLink version 0.7.2 or later.
 
@@ -28,16 +28,24 @@ Firmware update guides can be found here:
  - [Prusa MK3.9/MK4/XL](https://help.prusa3d.com/article/how-to-update-firmware-mk4-xl_453086)
  - [Prusa MK2.5/MK3](https://help.prusa3d.com/guide/how-to-update-prusalink-mk2-5-s-mk3-s-_650837)
 
-To obtain the hostname, username, and password on Prusa MINI/MINI+/MK3.9/MK4/XL:
+## Obtaining hostname, username, and password
+
+### Prusa MINI/MINI+/MK3.9/MK4/XL
 
  - On your printer, navigate to **Settings** > **Network** > **PrusaLink**.
  - Find the device's **IP address**. Alternatively, you can look for the printer's IP address or hostname on your router.
  - Note that for some models, the username may not be visible, as it is hardcoded to `maker`.
  - Depending on your model, the password entry may not be called **Password**, but **API key**.
 
+### Prusa MK2.5/MK3
+
+ - The device's **IP address** is displayed on the printer LCD after PrusaLink starts up. Alternatively, you can look for the printer's IP address or hostname on your router.
+ - Use the **username** and **password** you entered during the initial PrusaLink setup (not the API key).
+
 {% include integrations/config_flow.md %}
 
 ## Related topics
 
 - [PrusaLink documentation](https://help.prusa3d.com/article/prusa-connect-and-prusalink-explained_302608)
-- [PrusaLink installation guide for Prusa MK3](https://help.prusa3d.com/guide/prusalink-and-prusa-connect-setup-mk3-s-_221744)
+- [PrusaLink installation guide for Prusa MK3 with Raspberry Pi Zero W](https://help.prusa3d.com/guide/prusalink-and-prusa-connect-setup-mk3-s-_221744)
+- [PrusaLink installation guide for Prusa MK2.5/MK3 with Raspberry Pi 3/4](https://help.prusa3d.com/guide/prusalink-prusa-connect-with-rpi-3-4-usb-mk2-5-s-mk3-s-_469341)

--- a/source/_integrations/prusalink.markdown
+++ b/source/_integrations/prusalink.markdown
@@ -18,7 +18,7 @@ ha_platforms:
 ha_dhcp: true
 ---
 
-The PrusaLink integration allows you to monitor your [Prusa 3D printer](https://www.prusa3d.com) and its progress with your Home Assistant installation. This integration works with Prusa MINI/MINI+, Prusa MK3.9/MK4, Prusa XL, and with the older Raspberry Pi based Prusa MK2.5/MK3.
+The **PrusaLink integration allows you to monitor your [Prusa 3D printer](https://www.prusa3d.com) and its progress with your Home Assistant installation. This integration works with Prusa MINI/MINI+, Prusa MK3.9/MK4, Prusa XL, and with the older Raspberry Pi-based Prusa MK2.5/MK3.
 
 This integration has been updated to utilize the latest v1 API endpoints, which require firmware version 4.7.0 or later. If you own a Prusa MINI/MINI+, please make sure your printer is running firmware 5.1.0 or a more recent version. Firmware versions 4.7.x and 5.0.x are not available for this model. For Prusa MK2.5/MK3, this integration requires PrusaLink version 0.7.2 or later.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documents added support for Prusa MK3 and MK2.5 printers in the existing PrusaLink integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/114210
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #31582

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
