### PR TITLE
Add more info to Motionblinds BLE integration

### DIFF
--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -17,13 +17,14 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The Motionblinds BLE {% term integration %} adds support for [Motionblinds](https://motionblinds.com/) Bluetooth motors. Beware that this integration does not work with *Eve Motionblinds* motors. *Eve Motionblinds* can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration.
+This {% term integration %} adds support for [Motionblinds](https://motionblinds.com/) Bluetooth motors. Want to motorize your existing blinds? This can be done with Motionblinds motor CMD-03 which is available through the following stores: [Hornbach](https://www.hornbach.com/), [Coolblue](https://www.coolblue.nl/),[Proshop](https://www.proshop.com/),[Raamdecoratie.com](https://www.raamdecoratie.com/),[Robbshop.com](https://www.robbshop.nl/). Made-to-measure window coverings with Motionblinds are available through a worldwide reseller network which can be found [here](https://motionblinds.com/stores/)
+Beware that this integration does not work with Eve Motionblinds motors. Eve Motionblinds can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration or the [Matter] (https://www.home-assistant.io/integrations/matter/) integration.
 
 {% include integrations/config_flow.md %}
 
 ## Setup
 
-During the setup of a Motionblinds BLE device, you will be asked what kind of blind your Motionblind is. There are 8 different blind types:
+During the setup of a Motionblinds Bluetooth motor, you will be asked what kind of blind you have. There are 8 different blind types:
 
 - **Roller blind**: has the ability to change position and speed.
 - **Honeycomb blind**: has the ability to change position and speed.
@@ -32,7 +33,7 @@ During the setup of a Motionblinds BLE device, you will be asked what kind of bl
 - **Venetian blind (tilt-only)**: has the ability to change tilt and speed.
 - **Double Roller blind**: has the ability to change position, tilt, and speed.
 - **Curtain blind**: has the ability to change position. May need to be calibrated if the end positions are lost, which can be done by using the open/close cover button or the set cover position slider. This will trigger a calibration which will first make the curtain find the end positions after which it will run to the position as indicated by the command that was given.
-- **Vertical blind**: has the ability to change position and tilt. May need to be calibrated if the end positions are lost, which has to be done using the Motionblinds BLE mobile app.
+- **Vertical blind**: has the ability to change position and tilt. May need to be calibrated if the end positions are lost, which must be done using the Motionblinds Bluetooth app.
 
 ## Entities
 
@@ -44,11 +45,11 @@ The following entities are available for a Motionblinds BLE device:
   -  Disconnect button: allows you to disconnect the blind.
   -  Favorite button: allows you to move the blind to the favorite position.
 - [Select](https://www.home-assistant.io/integrations/select/) entities:
-  -  Speed select: allows you to change the speed of the motor to low, medium, or high. Available for all blinds except a curtain blind and a vertical blind.
+  -  Speed select: allows you to change the speed of the motor to low, medium, or high. Available for all blinds except curtain blinds and vertical blinds.
 
 ## Services
 
-Since Motionblinds BLE motors require a Bluetooth connection to control them, Home Assistant does not get automatic updates of the motor's state by default. Therefore, you can use the [homeassistant.update_entity](https://www.home-assistant.io/docs/scripts/service-calls/#homeassistant-services) service on a Motionblinds BLE entity which will connect to your Motionblind and update the state of all entities belonging to the device. **However, be aware that doing so may impact battery life.**
+Since Motionblinds Bluetooth motors require a Bluetooth connection to control them, Home Assistant does not get automatic updates of the motor's state by default. Therefore, you can use the [homeassistant.update_entity](https://www.home-assistant.io/docs/scripts/service-calls/#homeassistant-services) service on any entity belonging to a Motionblinds Bluetooth device, which will connect to your Motionblinds Bluetooth motor and update the state of all entities belong to that device. However, be aware that doing so may impact battery life.
 
 This can also be automated using a YAML automation. For instance, the following automation connects to your Motionblind every 24 hours to update it's state in Home Assistant:
 

--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -18,7 +18,7 @@ ha_integration_type: integration
 ---
 
 This {% term integration %} adds support for [Motionblinds](https://motionblinds.com/) Bluetooth motors. Want to motorize your existing blinds? This can be done with Motionblinds motor CMD-03 which is available through the following stores: [Hornbach](https://www.hornbach.com/), [Coolblue](https://www.coolblue.nl/),[Proshop](https://www.proshop.com/),[Raamdecoratie.com](https://www.raamdecoratie.com/),[Robbshop.com](https://www.robbshop.nl/). Made-to-measure window coverings with Motionblinds are available through a worldwide reseller network which can be found [here](https://motionblinds.com/stores/)
-Beware that this integration does not work with Eve Motionblinds motors. Eve Motionblinds can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration or the [Matter] (https://www.home-assistant.io/integrations/matter/) integration.
+Beware that this integration does not work with Eve Motionblinds motors. Eve Motionblinds can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration or the [Matter](https://www.home-assistant.io/integrations/matter/) integration.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -17,7 +17,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-This {% term integration %} adds support for [Motionblinds](https://motionblinds.com/) Bluetooth motors. Want to motorize your existing blinds? This can be done with Motionblinds motor CMD-03 which is available through the following stores: [Hornbach](https://www.hornbach.com/), [Coolblue](https://www.coolblue.nl/), [Proshop](https://www.proshop.com/), [Raamdecoratie.com](https://www.raamdecoratie.com/), [Robbshop.com](https://www.robbshop.nl/). Made-to-measure window coverings with Motionblinds are available through a worldwide reseller network which can be found [here](https://motionblinds.com/stores/).
+This {% term integration %} adds support for [Motionblinds](https://motionblinds.com/) Bluetooth motors. Want to motorize your existing blinds? This can be done with Motionblinds motor CMD-03. Made-to-measure window coverings with Motionblinds are available through a worldwide reseller network.
 Beware that this integration does not work with Eve Motionblinds motors. Eve Motionblinds can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration or the [Matter](https://www.home-assistant.io/integrations/matter/) integration.
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -51,7 +51,7 @@ The following entities are available for a Motionblinds BLE device:
 
 Since Motionblinds Bluetooth motors require a Bluetooth connection to control them, Home Assistant does not get automatic updates of the motor's state by default. Therefore, you can use the [homeassistant.update_entity](https://www.home-assistant.io/docs/scripts/service-calls/#homeassistant-services) service on any entity belonging to a Motionblinds Bluetooth device, which will connect to your Motionblinds Bluetooth motor and update the state of all entities belong to that device. However, be aware that doing so may impact battery life.
 
-This can also be automated using a YAML automation. For instance, the following automation connects to your Motionblind every 24 hours to update it's state in Home Assistant:
+This can also be automated using a YAML automation. For instance, the following automation connects to your Motionblind every 24 hours to update its state in Home Assistant:
 
 ```yaml
 alias: Motionblinds BLE polling automation

--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -17,7 +17,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-This {% term integration %} adds support for [Motionblinds](https://motionblinds.com/) Bluetooth motors. Want to motorize your existing blinds? This can be done with Motionblinds motor CMD-03 which is available through the following stores: [Hornbach](https://www.hornbach.com/), [Coolblue](https://www.coolblue.nl/),[Proshop](https://www.proshop.com/),[Raamdecoratie.com](https://www.raamdecoratie.com/),[Robbshop.com](https://www.robbshop.nl/). Made-to-measure window coverings with Motionblinds are available through a worldwide reseller network which can be found [here](https://motionblinds.com/stores/)
+This {% term integration %} adds support for [Motionblinds](https://motionblinds.com/) Bluetooth motors. Want to motorize your existing blinds? This can be done with Motionblinds motor CMD-03 which is available through the following stores: [Hornbach](https://www.hornbach.com/), [Coolblue](https://www.coolblue.nl/), [Proshop](https://www.proshop.com/), [Raamdecoratie.com](https://www.raamdecoratie.com/), [Robbshop.com](https://www.robbshop.nl/). Made-to-measure window coverings with Motionblinds are available through a worldwide reseller network which can be found [here](https://motionblinds.com/stores/).
 Beware that this integration does not work with Eve Motionblinds motors. Eve Motionblinds can be added to Home Assistant using the [HomeKit Device](https://www.home-assistant.io/integrations/homekit_controller/) integration or the [Matter](https://www.home-assistant.io/integrations/matter/) integration.
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds more information about Motionblinds Bluetooth motors to the Motionblinds BLE integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/109497
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
