### PR TITLE
Add service waze_travel_time.get_travel_times

### DIFF
--- a/source/_integrations/waze_travel_time.markdown
+++ b/source/_integrations/waze_travel_time.markdown
@@ -25,6 +25,89 @@ Notes:
 - The string inputs for `Substring *` allow you to force the {% term integration %} to use a particular route or avoid a particular route in its time travel calculation. These inputs are case insensitive and matched against the description of the route.
 - When using the `Avoid Toll Roads?`, `Avoid Subscription Roads?` and `Avoid Ferries?` options, be aware that Waze will sometimes still route you over toll roads or ferries if a valid vignette/subscription is assumed. Default behavior is that Waze will route you over roads having subscription options. It is therefor best is to set both `Avoid Toll Roads?` and `Avoid Subscription Roads?` or `Avoid Ferries?` if needed and experiment to ensure the desired outcome.
 
+## Service `waze_travel_time.get_travel_times`
+
+This service populates [response data](/docs/scripts/service-calls#use-templates-to-handle-response-data)
+with route alternatives and travel times between two locations.
+
+| Service data attribute | Optional | Description | Example |
+| ---------------------- | -------- | ----------- | --------|
+| `origin` | no | The origin of the route | "51.330436, 3.802043" |
+| `destination` | no | he destination of the route | "51.330436, 3.802043" |
+| `region` | no | The region. Controls which waze server is used. | "us" |
+| `units` | yes | Which unit system to use | metric |
+| `vehicle_type` | yes | Which vehicle to use | "car" |
+| `incl_filter` | yes | Which streetnames must be part of the route | "A321" |
+| `excl_filter` | yes | Which streetnames must not be part of the route | "A321" |
+| `realtime` | yes | Use realtime or statistical data | True |
+| `avoid_toll_roads` | yes | Whether to avoid toll roads | True |
+| `avoid_ferries` | yes | Whether to avoid ferries | True |
+| `avoid_subscription_roads` | yes | Whether to avoid subscription roads | True |
+
+```yaml
+service: waze_travel_time.get_travel_times
+data:
+  origin: "51.330436, 3.802043"
+  destination: "51.445677, 3.749929"
+  region: "eu"
+response_variable: routes
+```
+
+{% details "Example service response" %}
+
+```yaml
+waze_travel_time.get_travel_times:
+  routes:
+    - duration: 16.15
+      distance: 13.942
+      name: B455 - Boelckestraße Wiesbaden
+      street_names:
+        - Eleonorenstraße
+        - Wiesbadener Straße
+        - L3482 - Wiesbadener Straße
+        - Otto-Suhr-Ring
+        - Boelckestraße
+        - B455 - Boelckestraße
+        - A66 > Frankfurt am Main / Köln
+        - A66
+        - AS 8 Wallau
+        - L3017
+        - Diedenberger Straße
+        - L3017 - Diedenberger Straße
+        - K785 - Diedenberger Straße
+        - Hessenstraße
+        - Robert-Bosch-Straße
+        - Nassaustraße
+        - Johannes-Gutenberg-Straße
+    - duration: 16.9
+      distance: 15.319
+      name: L3482 - Wiesbadener Landstraße Wiesbaden
+      street_names:
+        - Eleonorenstraße
+        - Wiesbadener Straße
+        - L3482 - Wiesbadener Straße
+        - Wiesbadener Landstraße
+        - L3482 - Wiesbadener Landstraße
+        - Kasteler Straße
+        - L3482 - Kasteler Straße
+        - Mainzer Straße
+        - K650 - Mainzer Straße
+        - "> A66 / Wiesbaden-Stadtmitte"
+        - A66 > Frankfurt / Hannover
+        - A66
+        - AS 8 Wallau
+        - L3017
+        - Diedenberger Straße
+        - L3017 - Diedenberger Straße
+        - K785 - Diedenberger Straße
+        - Hessenstraße
+        - Robert-Bosch-Straße
+        - Nassaustraße
+        - Johannes-Gutenberg-Straße
+```
+
+{% enddetails %}
+
 ## Defining a custom polling interval
 
 {% include common-tasks/define_custom_polling.md %}

--- a/source/_integrations/waze_travel_time.markdown
+++ b/source/_integrations/waze_travel_time.markdown
@@ -33,13 +33,13 @@ with route alternatives and travel times between two locations.
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
 | `origin` | no | The origin of the route | "51.330436, 3.802043" |
-| `destination` | no | he destination of the route | "51.330436, 3.802043" |
+| `destination` | no | The destination of the route | "51.330436, 3.802043" |
 | `region` | no | The region. Controls which waze server is used. | "us" |
 | `units` | yes | Which unit system to use | metric |
 | `vehicle_type` | yes | Which vehicle to use | "car" |
-| `incl_filter` | yes | Which streetnames must be part of the route | "A321" |
-| `excl_filter` | yes | Which streetnames must not be part of the route | "A321" |
-| `realtime` | yes | Use realtime or statistical data | True |
+| `incl_filter` | yes | Which street names must be part of the route | "A321" |
+| `excl_filter` | yes | Which street names must not be part of the route | "A321" |
+| `realtime` | yes | Use real-time or statistical data | True |
 | `avoid_toll_roads` | yes | Whether to avoid toll roads | True |
 | `avoid_ferries` | yes | Whether to avoid ferries | True |
 | `avoid_subscription_roads` | yes | Whether to avoid subscription roads | True |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds the service `waze_travel_time.get_travel_times` it returns all possible routes for a given origin->destination, including duration, distance, route.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/108170
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
