### PR TITLE
Add note for local API access

### DIFF
--- a/source/_integrations/freebox.markdown
+++ b/source/_integrations/freebox.markdown
@@ -45,6 +45,12 @@ You can find out your Freebox host and port by opening this address <http://mafr
 The returned JSON should contain an `api_domain` (`host`) and a `https_port` (`port`).
 Please consult the [API documentation](https://dev.freebox.fr/sdk/os/) for more information.
 
+<div class='note warning'>
+
+The `host` (ex: xxxxxxxx.fbxos.fr) and `port` given by <http://mafreebox.freebox.fr/api_version> refers to your Freebox public IP address and may not work if your Home Assistant server is located inside your local LAN. For local API access, you can use alternatively `host` = *mafreebox.freebox.fr* and `port` = *443*.
+
+</div>
+
 ### Initial setup
 
 <div class='note warning'>

--- a/source/_integrations/freebox.markdown
+++ b/source/_integrations/freebox.markdown
@@ -47,7 +47,7 @@ Please consult the [API documentation](https://dev.freebox.fr/sdk/os/) for more 
 
 <div class='note warning'>
 
-The `host` (ex: xxxxxxxx.fbxos.fr) and `port` given by <http://mafreebox.freebox.fr/api_version> refers to your Freebox public IP address and may not work if your Home Assistant server is located inside your local LAN. For local API access, you can use alternatively `host` = *mafreebox.freebox.fr* and `port` = *443*.
+The `host` (ex: xxxxxxxx.fbxos.fr) and `port` given by <http://mafreebox.freebox.fr/api_version> refers to your Freebox public IP address and may not work if your Home Assistant server is located inside your local LAN. For local API access, you can alternatively use `host` = *mafreebox.freebox.fr* and `port` = *443*.
 
 </div>
 


### PR DESCRIPTION
## Proposed change

The current [Freebox documentation ](https://www.home-assistant.io/integrations/freebox#configuration), the `host` (ex: xxxxxxxx.fbxos.fr) and `port` given by <http://mafreebox.freebox.fr/api_version> refers to the Freebox public IP address. With Home Assistant server located inside a local LAN, it results in an error during the setup process because public ip address can not be joined from internal LAN.
For local API access, the added note provide a tip to use alternatively `host` = *mafreebox.freebox.fr* and `port` = *443*.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: None
- Link to parent pull request in the Brands repository: None
- This PR fixes or closes issue: None

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
