### PR TITLE
Adding UniFi WLAN Password sensor

### DIFF
--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -154,7 +154,7 @@ Get entities reporting the current state of a UniFi Network device.
 
 ### WLAN Password sensor
 
-Provides the current password for a specific WLAN. This sensor serves as a fallback option for retrieving the WLAN password when the QR code is not applicable. It allows users to access the password for various purposes, such as sharing with guests or configuring devices manually.
+Provides the current password for a specific WLAN. It allows users to access the password for various purposes, such as sharing with guests or configuring devices manually. As this exposes the password in clear text it is only recommended to utilize this in scenarios where the QR Code is not sufficient. 
 
 - Entity is disabled by default.
 - This feature requires admin privileges.

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -154,7 +154,7 @@ Get entities reporting the current state of a UniFi Network device.
 
 ### WLAN Password sensor
 
-Provides the current password for a specific WLAN. This sensor allows users to retrieve the WLAN password for various purposes, such as sharing with guests or configuring devices manually.
+Provides the current password for a specific WLAN. This sensor serves as a fallback option for retrieving the WLAN password when the QR code is not applicable. It allows users to access the password for various purposes, such as sharing with guests or configuring devices manually.
 
 - Entity is disabled by default.
 - This feature requires admin privileges.

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -154,7 +154,7 @@ Get entities reporting the current state of a UniFi Network device.
 
 ### WLAN Password sensor
 
-Provides the current password for a specific WLAN configured in a UniFi Network device. This sensor allows users to retrieve the WLAN password for various purposes, such as sharing with guests or configuring devices manually.
+Provides the current password for a specific WLAN. This sensor allows users to retrieve the WLAN password for various purposes, such as sharing with guests or configuring devices manually.
 
 - Entity is disabled by default.
 - This feature requires admin privileges.

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -152,6 +152,13 @@ Get entities reporting the general temperature of a UniFi Network device.
 
 Get entities reporting the current state of a UniFi Network device.
 
+### WLAN Password sensor
+
+Provides the current password for a specific WLAN configured in a UniFi Network device. This sensor allows users to retrieve the WLAN password for various purposes, such as sharing with guests or configuring devices manually.
+
+- Entity is disabled by default.
+- This feature requires admin privileges.
+
 ## Firmware updates
 
 This will show if there are firmware updates available for the UniFi network devices connected to the controller. If the configured user has admin privileges, the firmware upgrades can also be installed directly from Home Assistant.

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -152,7 +152,7 @@ Get entities reporting the general temperature of a UniFi Network device.
 
 Get entities reporting the current state of a UniFi Network device.
 
-### WLAN Password sensor
+### WLAN password sensor
 
 Provides the current password for a specific WLAN. It allows users to access the password for various purposes, such as sharing with guests or configuring devices manually. As this exposes the password in clear text it is only recommended to utilize this in scenarios where the QR Code is not sufficient. 
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I have added a new sensor, WLAN Password, to the UniFi integration. This sensor (disabled by default) allow users to retrieve the password of a WLAN. This addition enhance the functionality of the UniFi integration by providing users with more control over their network configurations.
- Accessibility
It's quite helpful for accessibility purposes. By integrating it into voice assistants like Alexa, users with visual impairments can simply ask for the WLAN password, and the assistant can speak it aloud. This makes accessing the network much easier for everyone, including blind individuals. Additionally, not everyone can scan the QR code at all times.
- Alternative method for accessing the password
Sometimes, you may need the password to enter it manually on a laptop or other devices.
- Guest WLAN security
Imagine an automation that resets the guest password (upcoming feature) every day and displays the new one along with the QR code on a TV in a small business. This setup would prevent people nearby from staying connected indefinitely and ensure that only daily clients use the WiFi.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/114419

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
