### PR TITLE
Adding UniFi WLAN regenerate password button

### DIFF
--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -64,19 +64,6 @@ It is recommended that you run the UniFi Network application in a dedicated virt
 
 The Button entities will only be available and usable if the integration has a UniFi Network account with administrator privileges.
 
-### Device Restart
-- **Function**: Initiates a restart command for UniFi devices.
-- **Usage**: Useful for remotely rebooting UniFi devices such as access points or switches.
-
-### PoE Power Cycle
-- **Function**: Power cycles a specific PoE port on UniFi devices.
-- **Usage**: Helpful for troubleshooting or resetting devices connected to PoE ports.
-
-### WLAN Change Password
-- **Function**: Generates a new password for a WLAN. **Unfortunately, the user cannot specify the new password; it will be randomly generated with 18 characters, consisting of lowercase letters, uppercase letters, digits, and special characters.**
-- **Usage**: Allows for easy rotation of WLAN passwords for improved security.
-
-
 ### Power cycle PoE
 
 Use the **Power cycle PoE** button entity to power cycle one specific PoE port to cause the connected device to restart.
@@ -84,6 +71,9 @@ Use the **Power cycle PoE** button entity to power cycle one specific PoE port t
 ### Restart UniFi device
 
 Use the **Restart UniFi device** button entity to restart the entire UniFi device. In case the device is a PoE switch, the PoE supply is not affected.
+
+### WLAN Change Password
+Use the **WLAN Change Password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **Unfortunately, the user cannot specify the new password; it will be randomly generated with 18 characters, consisting of lowercase letters, uppercase letters, digits, and special characters.**
 
 ## Image
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -64,6 +64,19 @@ It is recommended that you run the UniFi Network application in a dedicated virt
 
 The Button entities will only be available and usable if the integration has a UniFi Network account with administrator privileges.
 
+### Device Restart
+- **Function**: Initiates a restart command for UniFi devices.
+- **Usage**: Useful for remotely rebooting UniFi devices such as access points or switches.
+
+### PoE Power Cycle
+- **Function**: Power cycles a specific PoE port on UniFi devices.
+- **Usage**: Helpful for troubleshooting or resetting devices connected to PoE ports.
+
+### WLAN Change Password
+- **Function**: Generates a new password for a WLAN. **Unfortunately, the user cannot specify the new password; it will be randomly generated with 18 characters, consisting of lowercase letters, uppercase letters, digits, and special characters.**
+- **Usage**: Allows for easy rotation of WLAN passwords for improved security.
+
+
 ### Power cycle PoE
 
 Use the **Power cycle PoE** button entity to power cycle one specific PoE port to cause the connected device to restart.

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -73,7 +73,7 @@ Use the **Power cycle PoE** button entity to power cycle one specific PoE port t
 Use the **Restart UniFi device** button entity to restart the entire UniFi device. In case the device is a PoE switch, the PoE supply is not affected.
 
 ### WLAN Regenerate Password
-Use the **WLAN Regenerate Password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **Unfortunately, the user cannot specify the new password; it will be randomly generated using the python function `secrets.token_urlsafe(15)`. This function generates a 20-character password comprised of lowercase letters, uppercase letters, and digits. The number '15' in the function represents the number of bytes, with each byte equivalent to approximately 1.3 characters when base64 encoded.**
+Use the **WLAN Regenerate Password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **Unfortunately, the user cannot specify the new password; it will be randomly generated with 20 characters, consisting of lowercase letters, uppercase letters, and digits.**
 
 ## Image
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -73,7 +73,7 @@ Use the **Power cycle PoE** button entity to power cycle one specific PoE port t
 Use the **Restart UniFi device** button entity to restart the entire UniFi device. In case the device is a PoE switch, the PoE supply is not affected.
 
 ### WLAN regenerate password
-Use the **WLAN regenerate password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **Unfortunately, the user cannot specify the new password; it will be randomly generated with 20 characters, consisting of lowercase letters, uppercase letters, and digits.**
+Use the **WLAN regenerate password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). Use the **WLAN regenerate password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **It will be randomly generated with 20 characters, consisting of lowercase letters, uppercase letters, and digits.**
 
 ## Image
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -72,8 +72,8 @@ Use the **Power cycle PoE** button entity to power cycle one specific PoE port t
 
 Use the **Restart UniFi device** button entity to restart the entire UniFi device. In case the device is a PoE switch, the PoE supply is not affected.
 
-### WLAN Change Password
-Use the **WLAN Change Password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **Unfortunately, the user cannot specify the new password; it will be randomly generated with 18 characters, consisting of lowercase letters, uppercase letters, and digits.**
+### WLAN Regenerate Password
+Use the **WLAN Regenerate Password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **Unfortunately, the user cannot specify the new password; it will be randomly generated using the python function `secrets.token_urlsafe(15)`. This function generates a 20-character password comprised of lowercase letters, uppercase letters, and digits. The number '15' in the function represents the number of bytes, with each byte equivalent to approximately 1.3 characters when base64 encoded.**
 
 ## Image
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -72,8 +72,8 @@ Use the **Power cycle PoE** button entity to power cycle one specific PoE port t
 
 Use the **Restart UniFi device** button entity to restart the entire UniFi device. In case the device is a PoE switch, the PoE supply is not affected.
 
-### WLAN Regenerate Password
-Use the **WLAN Regenerate Password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **Unfortunately, the user cannot specify the new password; it will be randomly generated with 20 characters, consisting of lowercase letters, uppercase letters, and digits.**
+### WLAN regenerate password
+Use the **WLAN regenerate password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **Unfortunately, the user cannot specify the new password; it will be randomly generated with 20 characters, consisting of lowercase letters, uppercase letters, and digits.**
 
 ## Image
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -73,7 +73,7 @@ Use the **Power cycle PoE** button entity to power cycle one specific PoE port t
 Use the **Restart UniFi device** button entity to restart the entire UniFi device. In case the device is a PoE switch, the PoE supply is not affected.
 
 ### WLAN Change Password
-Use the **WLAN Change Password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **Unfortunately, the user cannot specify the new password; it will be randomly generated with 18 characters, consisting of lowercase letters, uppercase letters, digits, and special characters.**
+Use the **WLAN Change Password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **Unfortunately, the user cannot specify the new password; it will be randomly generated with 18 characters, consisting of lowercase letters, uppercase letters, and digits.**
 
 ## Image
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I have added a new button, WLAN regenerate password, to the UniFi integration. This button (disabled by default) allow users to generate new password for a WLAN. This addition enhance the functionality of the UniFi integration by providing users with more control over their network configurations.
It will be randomly generated with 20 characters, consisting of lowercase letters, uppercase letters, and digits.

- Guest WLAN security
Imagine an automation that resets the guest password every day and displays the new one along with the QR code on a TV in a small business. This setup would prevent people nearby from staying connected indefinitely and ensure that only daily clients use the WiFi.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/114422

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
