### PR TITLE
Update modbus.markdown

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -274,7 +274,7 @@ modbus:
     baudrate: 9600
     bytesize: 8
     method: rtu
-    parity: E
+    parity: N
     stopbits: 1
 ```
 
@@ -289,7 +289,7 @@ modbus:
     baudrate: 9600
     bytesize: 8
     method: rtu
-    parity: E
+    parity: N
     stopbits: 1
 
     delay: 0
@@ -331,7 +331,7 @@ modbus:
     baudrate: 9600
     bytesize: 8
     method: rtu
-    parity: E
+    parity: N
     stopbits: 1
 ```
 


### PR DESCRIPTION
changed parity bit by default in examples

## Proposed change
<!-- 
Most of modbus devices hasn't parity bit 
so by default it is "N" parameter, but in your examples by default you use uncommon "E" parameter
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

