### PR TITLE
Rename Motionblinds BLE integration to Motionblinds Bluetooth

### DIFF
--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -1,5 +1,5 @@
 ---
-title: Motionblinds BLE
+title: Motionblinds Bluetooth
 description: Instructions on how to integrate Motionblinds Bluetooth motors into Home Assistant.
 ha_category:
   - Cover
@@ -37,7 +37,7 @@ During the setup of a Motionblinds Bluetooth motor, you will be asked what kind 
 
 ## Entities
 
-The following entities are available for a Motionblinds BLE device:
+The following entities are available for a Motionblinds Bluetooth device:
 
 - [Cover](https://www.home-assistant.io/integrations/cover/) entity: depending on the blind that was chosen during the setup, this entity has a slider that makes it possible to change position and tilt, and buttons that allow you to open the blind, close the blind, tilt it open, tilt it closed and stop it.
 - [Button](https://www.home-assistant.io/integrations/button/) entities:
@@ -54,7 +54,7 @@ Since Motionblinds Bluetooth motors require a Bluetooth connection to control th
 This can also be automated using a YAML automation. For instance, the following automation connects to your Motionblind every 24 hours to update its state in Home Assistant:
 
 ```yaml
-alias: Motionblinds BLE polling automation
+alias: Motionblinds Bluetooth polling automation
 mode: single
 trigger:
   - platform: time_pattern


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Rename Motionblinds BLE integration to Motionblinds Bluetooth


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/114584
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
