### PR TITLE
Update template weather docs because of removal of forecast attribute

### DIFF
--- a/source/_integrations/weather.template.markdown
+++ b/source/_integrations/weather.template.markdown
@@ -21,7 +21,7 @@ Output will be converted according to the user's unit system or {% term entity %
 
 To enable a Template Weather provider in your installation, add the following to your `configuration.yaml` file:
 
-(Note, be sure to update my_region in the condition and forecast templates to an appropriate value for your setup).
+(Note, be sure to update my_region in the condition of the template weather configuration and in the template sensor configuration to an appropriate value for your setup).
 
 {% raw %}
 

--- a/source/_integrations/weather.template.markdown
+++ b/source/_integrations/weather.template.markdown
@@ -143,10 +143,6 @@ visibility_unit:
   description: Unit for visibility_template output. Valid options are km, mi, ft, m, cm, mm, in, yd.
   required: false
   type: string
-forecast_template:
-  description: Forecast data.
-  required: false
-  type: template
 forecast_daily_template:
   description: Daily forecast data.
   required: false

--- a/source/_integrations/weather.template.markdown
+++ b/source/_integrations/weather.template.markdown
@@ -34,9 +34,36 @@ weather:
     temperature_template: "{{ states('sensor.temperature') | float }}"
     temperature_unit: "°C"
     humidity_template: "{{ states('sensor.humidity') | float }}"
-    forecast_daily_template: "{{ state_attr('weather.my_region', 'forecast') }}"
+    forecast_daily_template: "{{ state_attr('sensor.daily_weather_forecast', 'forecast') }}"
 ```
 
+{% endraw %}
+
+If you want to use the forecast of another weather integration, you'll need to create a trigger based template sensor and store the forecast in an attribute.
+This is an example on how you can create such a sensor which will update every 3 hours.
+
+{% raw %}
+
+```yaml
+# Example configuration.yaml entry
+template:
+  - trigger:
+      - platform: time_pattern
+        hours: "/3"
+    action:
+      - service: weather.get_forecasts
+        target:
+          entity_id: weather.my_region
+        data:
+          type: daily
+        response_variable: forecast
+    sensor:
+       - unique_id: daily_weather_forecast_template_sensor
+         name: Daily Weather Forecast
+         state: "{{ now() }}"
+         attributes:
+           forecast: "{{ forecast['weather.my_region'].forecast }}"
+```
 {% endraw %}
 
 {% configuration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The old example was still referring to the `forecast` attribute of a weather entity. It also still had `forecast_template` in the configuration variables, which is no longer working.
I also added an example on how to create a template sensor with the forecast.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced configuration instructions for the weather provider.
  - Clarified where configuration variables should be updated.
  - Updated the method for accessing daily forecast data.
  - Added an example YAML configuration for a trigger-based sensor that updates every three hours.
  - Removed an outdated configuration entry for a more streamlined setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->