### PR TITLE
Notify entity platform

### DIFF
--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -62,7 +62,7 @@ To test the entity platform service select the `notify.send_message` service, se
 
 Under {% my developer_services title="**Developer Tools** > **Services**" %}, select the **Notifications: Send a notification message** action. Select some target entity's using the entity selectors, enter a message and test sending it.
 
-If you switch to view the YAML data under **Developer Tools**, it will appear as below. The same {% term action %} can be chosen in {% term automation %} actions %, whose YAML will appear the same:
+If you switch to view the YAML data under **Developer Tools**, it will appear as below. The same {% term action %} can be chosen in {% term automation %}. The YAML will appear the same:
 
 {% raw %}
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -19,7 +19,7 @@ If you want to send notifications to the Home Assistant web interface, you may u
 
 ## Service
 
-Once loaded, the `notify` platform will expose a service that can be called to send notifications.
+The legacy `notify` platform will expose a generic `notify` service that can be called to send notifications.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -34,7 +34,17 @@ The different **Notify** integrations you have set up will each show up as a dif
 
 One notification integration is automatically included, the Persistent Notifications which creates a notification in the sidebar of the web interface of Home Assistant. This can be chosen with the action named "Notifications: Send a persistent notification" which uses the service `notify.persistent_notification`.
 
-Another common notification integration is via the companion app for Android or iPhone. This can be chosen with the action "Send a notification via mobile_app_your_phone_name" which uses the service `notify.mobile_app_your_phone_name`. See the [companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
+## Notify entity service
+
+Integrations can also implement the notify entity platform. Entity platform implementations will replace the legacy notify service in time. There is an entity platform service `sens_message` to allow you to send notification messages to multiple notify entities.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `message`              |       no | Body of the notification.
+
+## Companion app notifications
+
+A common notification integration is via the companion app for Android or iPhone. This can be chosen with the action "Send a notification via mobile_app_your_phone_name" which uses the service `notify.mobile_app_your_phone_name`. See the [companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
 
 With any of these integrations, the `message` data input in the automation editor is the main text that will be sent. Other fields are optional, and some integrations support additional `data` or `target` information to customize the action. For more details, refer to their integration documentation.
 
@@ -46,7 +56,40 @@ Notifications can also be sent using [Notify groups](https://www.home-assistant.
 
 After you setup a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open {% my developer_services title="**Developer tools** > **Services**" %}** tab from the sidebar. Choose your service from the **Service** dropdown menu depending on the integration you want to test, such as **Notifications: Send a persistent notification** or **Notifications: Send a notification via mobile_app_your_phone_name**. Enter your message into the **message** field, and select the **CALL SERVICE** button.
 
-### Examples
+To test the entity platform service select the `notify.send_message` service, select one or more of `entity`, `device`, `area` or `label` and supply a `message`.
+
+### Example with the entity platform notify service
+
+In the **Developer Tools**, on the **Services** tab, select the **Notifications: Send a notification message** action. Select some target entity's using the entity selectors, enter a message and test sending it.
+
+If you switch to view the YAML data under **Developer Tools**, it will appear as below. The same {% term action %} can be chosen in {% term automation %} actions %, whose YAML will appear the same:
+
+{% raw %}
+
+```yaml
+service: notify.send_message
+data:
+  entity_id: notify.my_direct_message_notifier
+  message: "You have an update!"
+```
+
+{% endraw %}
+
+The notify integration supports specifying [templates](/docs/configuration/templating/). This will allow you to use the current state of entities in Home Assistant in your notifications, or use more complex logic to decide the message that is sent.
+
+{% raw %}
+
+```yaml
+action:
+  service: notify.send_message
+  data:
+    entity_id: notify.my_direct_message_notifier
+    message: "You have {{ states('todo.shopping_list') }} items on your shopping list."
+```
+
+{% endraw %}
+
+### Examples with the legacy notify service
 
 In the **Developer Tools**, on the **Services** tab, select the **Notifications: Send a persistent notification** action. Enter a message and test sending it.
 
@@ -61,8 +104,6 @@ data:
 ```
 
 {% endraw %}
-
-
 
 The notify integration supports specifying [templates](/docs/configuration/templating/). This will allow you to use the current state of entities in Home Assistant in your notifications, or use more complex logic to decide the message that is sent.
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -36,7 +36,7 @@ One notification integration is automatically included, the Persistent Notificat
 
 ## Notify entity service
 
-Integrations can also implement the notify entity platform. Entity platform implementations will replace the legacy notify service in time. There is an entity platform service `sens_message` to allow you to send notification messages to multiple notify entities.
+Integrations can also implement the notify entity platform. Entity platform implementations will replace the legacy notify service in time. There is an entity platform service `send_message` which allows you to send notification messages to multiple notify entities.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -60,7 +60,7 @@ To test the entity platform service select the `notify.send_message` service, se
 
 ### Example with the entity platform notify service
 
-In the **Developer Tools**, on the **Services** tab, select the **Notifications: Send a notification message** action. Select some target entity's using the entity selectors, enter a message and test sending it.
+Under {% my developer_services title="**Developer Tools** > **Services**" %}, select the **Notifications: Send a notification message** action. Select some target entity's using the entity selectors, enter a message and test sending it.
 
 If you switch to view the YAML data under **Developer Tools**, it will appear as below. The same {% term action %} can be chosen in {% term automation %} actions %, whose YAML will appear the same:
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -44,7 +44,7 @@ Integrations can also implement the notify entity platform. Entity platform impl
 
 ## Companion app notifications
 
-A common notification integration is via the companion app for Android or iPhone. This can be chosen with the action "Send a notification via mobile_app_your_phone_name" which uses the service `notify.mobile_app_your_phone_name`. See the [companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
+A common notification integration is via the Home Assistant Companion app for Android or iPhone. This can be chosen with the action "Send a notification via mobile_app_your_phone_name", which uses the service `notify.mobile_app_your_phone_name`. Refer to the [Companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
 
 With any of these integrations, the `message` data input in the automation editor is the main text that will be sent. Other fields are optional, and some integrations support additional `data` or `target` information to customize the action. For more details, refer to their integration documentation.
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -56,7 +56,7 @@ Notifications can also be sent using [Notify groups](https://www.home-assistant.
 
 After you setup a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open {% my developer_services title="**Developer tools** > **Services**" %}** tab from the sidebar. Choose your service from the **Service** dropdown menu depending on the integration you want to test, such as **Notifications: Send a persistent notification** or **Notifications: Send a notification via mobile_app_your_phone_name**. Enter your message into the **message** field, and select the **CALL SERVICE** button.
 
-To test the entity platform service select the `notify.send_message` service, select one or more of `entity`, `device`, `area` or `label` and supply a `message`.
+To test the entity platform service, select the `notify.send_message` service, and select one or more of `entity`, `device`, `area`, or `label`. Then, supply a `message`.
 
 ### Example with the entity platform notify service
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add notify entity platform and `send_message` service.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/110950
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
