### PR TITLE
Azure DevOps new build sensors

### DIFF
--- a/source/_integrations/azure_devops.markdown
+++ b/source/_integrations/azure_devops.markdown
@@ -24,13 +24,13 @@ Azure DevOps instance in Home Assistant.
 This integration provides a sensor for Azure DevOps:
 
 - Latest build - The build number of the latest build.
-- Latest build id - The id of the latest build.
+- Latest build id - The ID of the latest build.
 - Latest build reason - The reason the build was triggered.
 - Latest build result - The build result.
 - Latest build source branch - The source git branch.
 - Latest build source version - This is the version i.e. the tag if set, or the commit.
 - Latest build status - The build status.
-- Latest build queue time - The time that the build was queued.
-- Latest build start time - The time the build actually started.
-- Latest build finish time - The time the build finished.
-- Latest build URL - The URL to the build. 
+- Latest build queue time - How long the latest build was queued.
+- Latest build start time - The time when the latest build actually started.
+- Latest build finish time - The time when the latest build finished.
+- Latest build URL - The URL to the latest build. 

--- a/source/_integrations/azure_devops.markdown
+++ b/source/_integrations/azure_devops.markdown
@@ -33,4 +33,4 @@ This integration provides a sensor for Azure DevOps:
 - Latest build queue time - The time that the build was queued.
 - Latest build start time - The time the build actually started.
 - Latest build finish time - The time the build finished.
-- Latest build url - The URL to the build. 
+- Latest build URL - The URL to the build. 

--- a/source/_integrations/azure_devops.markdown
+++ b/source/_integrations/azure_devops.markdown
@@ -23,4 +23,14 @@ Azure DevOps instance in Home Assistant.
 
 This integration provides a sensor for Azure DevOps:
 
-- Latest build - This includes attributes with additional info about the build.
+- Latest build - The build number of the latest build.
+- Latest build id - The id of the latest build.
+- Latest build reason - The reason the build was triggered.
+- Latest build result - The build result.
+- Latest build source branch - The source git branch.
+- Latest build source version - This is the version i.e. the tag if set, or the commit.
+- Latest build status - The build status.
+- Latest build queue time - The time that the build was queued.
+- Latest build start time - The time the build actually started.
+- Latest build finish time - The time the build finished.
+- Latest build url - The URL to the build. 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
https://github.com/home-assistant/core/pull/114948


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/114948
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
