### PR TITLE
Denon AVR docs: add port information

### DIFF
--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -112,7 +112,7 @@ Known supported devices:
 
 If your model is not on the list then give it a test, if everything works correctly then add it to the list by clicking on the **Edit** link at the bottom of this page.
 
-If you are using VLANs, the Home Assistant needs access to the following port on the AVR: 23, 8080 and 60006 (all TCP).
+If you are using VLANs, Home Assistant needs access to the following ports on the AVR: 23, 8080 and 60006 (all TCP).
 
 <div class='note warning'>
 If you have something else using the IP controller for your Denon AVR 3808CI, such as your URC controller, it will not work! There is either a bug or security issue with some models where only one device could be controlling the IP functionality.

--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -112,6 +112,8 @@ Known supported devices:
 
 If your model is not on the list then give it a test, if everything works correctly then add it to the list by clicking on the **Edit** link at the bottom of this page.
 
+If you are using VLANs, the Home Assistant needs access to the following port on the AVR: 23, 8080 and 60006 (all TCP).
+
 <div class='note warning'>
 If you have something else using the IP controller for your Denon AVR 3808CI, such as your URC controller, it will not work! There is either a bug or security issue with some models where only one device could be controlling the IP functionality.
 </div>

--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -112,7 +112,7 @@ Known supported devices:
 
 If your model is not on the list then give it a test, if everything works correctly then add it to the list by clicking on the **Edit** link at the bottom of this page.
 
-If you are using VLANs, Home Assistant needs access to the following ports on the AVR: 23, 8080 and 60006 (all TCP).
+If you are using VLANs, Home Assistant needs access to the following ports on the AVR: 23, 8080, and 60006 (all TCP).
 
 <div class='note warning'>
 If you have something else using the IP controller for your Denon AVR 3808CI, such as your URC controller, it will not work! There is either a bug or security issue with some models where only one device could be controlling the IP functionality.


### PR DESCRIPTION
## Proposed change
I have added port information for [Denon AVR integration](https://www.home-assistant.io/integrations/denonavr/), so users of VLANs in their network can adjust firewall rules accordingly.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
None.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards