### PR TITLE
Update octoprint.markdown to add note to log in as the correct user

### DIFF
--- a/source/_integrations/octoprint.markdown
+++ b/source/_integrations/octoprint.markdown
@@ -59,7 +59,7 @@ verify ssl:
 
 ### API key
 For the integration to work, please check that in Octoprint, the [Discovery Plugin](https://docs.octoprint.org/en/master/bundledplugins/discovery.html) is enabled and in the **Settings** -> **Printer Notifications** menu that **Enable popups** is checked.
-The Octoprint integration will attempt to register itself via the [Application Keys Plugin](https://docs.octoprint.org/en/master/bundledplugins/appkeys.html). After submitting the configuration UI in Home Assistant, open the Octoprint UI and click allow on the prompt.
+The Octoprint integration will attempt to register itself via the [Application Keys Plugin](https://docs.octoprint.org/en/master/bundledplugins/appkeys.html). After submitting the configuration UI in Home Assistant, open the Octoprint UI and click allow on the prompt. NOTE: You must be logged into Octoprint as the user which you are adding for the popup access prompt to appear.
 
 ## Binary sensor
 

--- a/source/_integrations/octoprint.markdown
+++ b/source/_integrations/octoprint.markdown
@@ -59,7 +59,7 @@ verify ssl:
 
 ### API key
 For the integration to work, please check that in Octoprint, the [Discovery Plugin](https://docs.octoprint.org/en/master/bundledplugins/discovery.html) is enabled and in the **Settings** -> **Printer Notifications** menu that **Enable popups** is checked.
-The Octoprint integration will attempt to register itself via the [Application Keys Plugin](https://docs.octoprint.org/en/master/bundledplugins/appkeys.html). After submitting the configuration UI in Home Assistant, open the Octoprint UI and click allow on the prompt. NOTE: You must be logged into Octoprint as the user which you are adding for the popup access prompt to appear.
+The Octoprint integration will attempt to register itself via the [Application Keys Plugin](https://docs.octoprint.org/en/master/bundledplugins/appkeys.html). After submitting the configuration UI in Home Assistant, open the Octoprint UI and select **Allow** on the prompt. NOTE: You must be logged into Octoprint as the user which you are adding Home Assistant. Otherwise, the popup access prompt does not appear.
 
 ## Binary sensor
 


### PR DESCRIPTION
To integrate HA and Octoprint, the pop-up only appears when logged in as the user which you are attempting to register.  This may seem logical, but it stumped me and apparently many others from searching for a solution.  Solution found in this comment: https://github.com/home-assistant/core/issues/70152#issuecomment-1100930191

## Proposed change

Add a clear note the HA Octoprint integration documentation to explicitly instruct the user to log into the Octoprint UI as the user that they are attempting to add to HA; the access approval pop-up will not appear otherwise.  In searching for a solution, many others have run into this issue as well (likely since earlier in the same paragraph it instructs you to enable Display Pop-ups which requires you to login as the administrator.)



## Type of change
Documentation only.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
