### PR TITLE
add current room sensor to Roborock

### DIFF
--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -70,6 +70,8 @@ Water shortage - States if the water box is low on water - 'Ok' if it has not de
 
 ### Sensor
 
+Current room - What room your vacuum is currently in according to the last map update. It gives your vacuums last known location in your current selected map similar to the app.
+
 Cleaning area - How much area the vacuum has cleaned in its current run.  If the vacuum is not currently cleaning, how much area it has cleaned during its last run.
 
 Cleaning time - How long the vacuum has been cleaning for. If the vacuum is not currently cleaning, how long it cleaned for in its last run.

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -70,7 +70,7 @@ Water shortage - States if the water box is low on water - 'Ok' if it has not de
 
 ### Sensor
 
-Current room - What room your vacuum is currently in according to the last map update. It gives your vacuums last known location in your current selected map similar to the app.
+Current room—The room your vacuum is currently in according to the last map update. Similar to the app, this gives your vacuum's last known location in your current selected map.
 
 Cleaning area - How much area the vacuum has cleaned in its current run.  If the vacuum is not currently cleaning, how much area it has cleaned during its last run.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Current room describes what room the robot is currently in in the selected map. If the user has the wrong map selected, then it will say wherever the robot was last seen in that map, same as it does in the app.




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/115326
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
