### PR TITLE
Add dyad support to Roborock

### DIFF
--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -41,7 +41,7 @@ Once you log in with your Roborock account, the integration will automatically d
 {% include integrations/config_flow.md %}
 
 
-## Robovac Entities
+## Robovac entities
 
 Roborock devices have a variety of features that are supported on some devices but not on others. Only entities that your device supports will be added to your integration.
 
@@ -133,9 +133,9 @@ Reset air filter - The air filter is expected to be replaced every 150 hours.
 You can see all the maps within your Roborock account. Keep in mind that they are device-specific. The maps require the cloud API to communicate as the maps are seemingly stored on the cloud. If someone can figure out a way around this - contributions are always welcome.
 
 
-## Dyad Entities
+## Dyad entities
 
-Roborock wet/dry vacuums currently expose some entities through a MQTT connection - it is currently cloud dependent.
+Roborock wet/dry vacuums currently expose some entities through an MQTT connection - it is currently cloud dependent.
 
 ### Sensor
 
@@ -143,13 +143,13 @@ Status - The current status of your vacuum. This typically describes the action 
 
 Battery - The current charge of your device.
 
-Filter time left - how long until Roborock recommends cleaning/replacing your filter
+Filter time left - how long until Roborock recommends cleaning/replacing your filter.
 
-Brush time left - how long until Roborock recommends cleaning/replacing your brush
+Brush time left - how long until Roborock recommends cleaning/replacing your brush.
 
 Error - the current error of the device - if one exists - "None" otherwise.
 
-Total cleaning time - how long you have cleaned with your wet/dry vac
+Total cleaning time - how long you have cleaned with your wet/dry vacuum.
 
 
 ## FAQ

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -41,7 +41,7 @@ Once you log in with your Roborock account, the integration will automatically d
 {% include integrations/config_flow.md %}
 
 
-## Entities
+## Robovac Entities
 
 Roborock devices have a variety of features that are supported on some devices but not on others. Only entities that your device supports will be added to your integration.
 
@@ -131,6 +131,25 @@ Reset air filter - The air filter is expected to be replaced every 150 hours.
 ### Image
 
 You can see all the maps within your Roborock account. Keep in mind that they are device-specific. The maps require the cloud API to communicate as the maps are seemingly stored on the cloud. If someone can figure out a way around this - contributions are always welcome.
+
+
+## Dyad Entities
+
+Roborock wet/dry vacuums currently expose some entities through a Mqtt connection - it is currently cloud dependent.
+
+### Sensor
+
+Status - The current status of your vacuum. This typically describes the action that is currently being run. For example, 'drying' or 'charging'.
+
+Battery - The current charge of your device.
+
+Filter time left - how long until Roborock recommends cleaning/replacing your filter
+
+Brush time left - how long until Roborock recommends cleaning/replacing your brush
+
+Error - the current error of the device - if one exists - "None" otherwise.
+
+Total cleaning time - how long you have cleaned with your wet/dry vac
 
 
 ## FAQ

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -135,7 +135,7 @@ You can see all the maps within your Roborock account. Keep in mind that they ar
 
 ## Dyad Entities
 
-Roborock wet/dry vacuums currently expose some entities through a Mqtt connection - it is currently cloud dependent.
+Roborock wet/dry vacuums currently expose some entities through a MQTT connection - it is currently cloud dependent.
 
 ### Sensor
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This adds support for Roborock [Dyad](https://us.roborock.com/pages/roborock-dyad) wet/dry vacs.

For now - they only communicate through Mqtt - and not a local transport like the robot vacuums do. I am hoping to figure this out, but without direct access to one, it is a pretty hard challenge to get local control working.

Starting with just some of the read only parameters.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/115331
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
