### PR TITLE
Allow manual delete of stale Unifi device from UI

### DIFF
--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -167,6 +167,18 @@ Provides the current password for a specific WLAN. It allows users to access the
 
 This will show if there are firmware updates available for the UniFi network devices connected to the controller. If the configured user has admin privileges, the firmware upgrades can also be installed directly from Home Assistant.
 
+
+## Removing devices
+
+By default Home Assistant does not remove old device configurations, even if they are not present in Unifi network anymore. This can lead to an accumulation of older network clients.
+
+To manually remove a device, go to the Device Info page and select "Delete" from the Device Info menu.
+
+Only devices which have not been seen since the startup or reload of the Unifi integration can be removed.
+
+![4d4ca937-17bb-4902-9949-2ea83e3c2c0c](https://github.com/home-assistant/home-assistant.io/assets/21991867/c926f5c7-18af-47b5-b888-30cc8511d76a)
+
+
 ## Debugging integration
 
 If you have problems with the UniFi Network application or {% term integration %} you can add debug prints to the log.

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -170,11 +170,11 @@ This will show if there are firmware updates available for the UniFi network dev
 
 ## Removing devices
 
-By default Home Assistant does not remove old device configurations, even if they are not present in Unifi network anymore. This can lead to an accumulation of older network clients.
+By default Home Assistant does not remove old device configurations, even if they are not present in UniFi network anymore. This can lead to an accumulation of older network clients.
 
 To manually remove a device, go to the Device Info page and select "Delete" from the Device Info menu.
 
-Only devices which have not been seen since the startup or reload of the Unifi integration can be removed.
+Only devices which have not been seen since the startup or reload of the UniFi integration can be removed.
 
 ![4d4ca937-17bb-4902-9949-2ea83e3c2c0c](https://github.com/home-assistant/home-assistant.io/assets/21991867/c926f5c7-18af-47b5-b888-30cc8511d76a)
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -168,13 +168,13 @@ Provides the current password for a specific WLAN. It allows users to access the
 This will show if there are firmware updates available for the UniFi network devices connected to the controller. If the configured user has admin privileges, the firmware upgrades can also be installed directly from Home Assistant.
 
 
-## Removing devices
+## Removing a device in Home Assistant
 
-By default Home Assistant does not remove old device configurations, even if they are not present in UniFi network anymore. This can lead to an accumulation of older network clients.
+Integration populates both UniFi devices as well as network clients into Home Assistant. In certain edge cases entities are left lingering even if they are not present in UniFi network anymore. This can lead to an accumulation of entries in the device registry.
 
-To manually remove a device, go to the Device Info page and select "Delete" from the Device Info menu.
+To manually remove a device entry, go to the Device Info page and select "Delete" from the Device Info menu.
 
-Only devices which have not been seen since the startup or reload of the UniFi integration can be removed.
+Only clients/devices which are no longer known by UniFi since the startup or reload of the UniFi integration can be removed.
 
 ![4d4ca937-17bb-4902-9949-2ea83e3c2c0c](https://github.com/home-assistant/home-assistant.io/assets/21991867/c926f5c7-18af-47b5-b888-30cc8511d76a)
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Allow manual delete of stale Unifi device from UI


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
https://github.com/home-assistant/core/pull/115267 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
