### PR TITLE
Update nws.markdown to match current behavior

### DIFF
--- a/source/_integrations/nws.markdown
+++ b/source/_integrations/nws.markdown
@@ -25,6 +25,6 @@ According to the [API documentation](https://www.weather.gov/documentation/servi
 
 Providing a METAR station code is optional, and if not supplied, the closest station to the latitude and longitude will be chosen. A list of nearby stations is printed to the log with level `DEBUG` if no station is supplied. Stations can also be found on the [NOAA website](https://www.cnrfc.noaa.gov/metar.php). Codes with only three characters, for example, `ADW` should be prefixed with the letter K, `KADW`.
 
-Two weather entities are created for each entry in the configuration: one for day and night forecasts and one for hourly forecasts. The hourly forecast entity is disabled after configuration but can be enabled by the user. The time supplied for each forecast is the start time for the forecast. Sensors are also created as disabled entities after configuration and can be enabled by the user.
+One weather entity is created for each entry in the configuration for day and night forecasts. The time supplied for each forecast is the start time for the forecast. Hourly forecast data can be obtained using the weather.get_forecast service. Sensors are also created as disabled entities after configuration and can be enabled by the user.
 
 Details about the API are available in the [NWS API documentation](https://www.weather.gov/documentation/services-web-api). The [pynws](https://github.com/MatthewFlamm/pynws) library is used to retrieve data.

--- a/source/_integrations/nws.markdown
+++ b/source/_integrations/nws.markdown
@@ -25,7 +25,7 @@ According to the [API documentation](https://www.weather.gov/documentation/servi
 
 Providing a METAR station code is optional, and if not supplied, the closest station to the latitude and longitude will be chosen. A list of nearby stations is printed to the log with level `DEBUG` if no station is supplied. Stations can also be found on the [NOAA website](https://www.cnrfc.noaa.gov/metar.php). Codes with only three characters, for example, `ADW` should be prefixed with the letter K, `KADW`.
 
-One weather entity is created for each entry in the configuration with hourly and day/night forecasts, which can be obtained through the `weather.get_forecasts` service. The time supplied for each forecast is the start time for the forecast. Sensors are also created as disabled entities after configuration and can be enabled by the user.
+One weather entity is created for each entry in the configuration. Hourly and day/night forecasts are provided through the `weather.get_forecasts` service. The time supplied for each forecast is the start time for the forecast. Sensors are also created as disabled entities after configuration and can be enabled by the user.
 
 Details about the API are available in the [NWS API documentation](https://www.weather.gov/documentation/services-web-api). The [pynws](https://github.com/MatthewFlamm/pynws) library is used to retrieve data.
 

--- a/source/_integrations/nws.markdown
+++ b/source/_integrations/nws.markdown
@@ -25,6 +25,8 @@ According to the [API documentation](https://www.weather.gov/documentation/servi
 
 Providing a METAR station code is optional, and if not supplied, the closest station to the latitude and longitude will be chosen. A list of nearby stations is printed to the log with level `DEBUG` if no station is supplied. Stations can also be found on the [NOAA website](https://www.cnrfc.noaa.gov/metar.php). Codes with only three characters, for example, `ADW` should be prefixed with the letter K, `KADW`.
 
-One weather entity is created for each entry in the configuration for day and night forecasts. The time supplied for each forecast is the start time for the forecast. Hourly forecast data can be obtained using the weather.get_forecast service. Sensors are also created as disabled entities after configuration and can be enabled by the user.
+One weather entity is created for each entry in the configuration for day and night forecasts. The time supplied for each forecast is the start time for the forecast. Hourly forecast data can be obtained using the `weather.get_forecasts` service. Sensors are also created as disabled entities after configuration and can be enabled by the user.
 
 Details about the API are available in the [NWS API documentation](https://www.weather.gov/documentation/services-web-api). The [pynws](https://github.com/MatthewFlamm/pynws) library is used to retrieve data.
+
+Details about the `weather.get_forecasts` service are available in the [`weather` documentation](https://www.home-assistant.io/integrations/weather/).

--- a/source/_integrations/nws.markdown
+++ b/source/_integrations/nws.markdown
@@ -25,7 +25,7 @@ According to the [API documentation](https://www.weather.gov/documentation/servi
 
 Providing a METAR station code is optional, and if not supplied, the closest station to the latitude and longitude will be chosen. A list of nearby stations is printed to the log with level `DEBUG` if no station is supplied. Stations can also be found on the [NOAA website](https://www.cnrfc.noaa.gov/metar.php). Codes with only three characters, for example, `ADW` should be prefixed with the letter K, `KADW`.
 
-One weather entity is created for each entry in the configuration for day and night forecasts. The time supplied for each forecast is the start time for the forecast. Hourly forecast data can be obtained using the `weather.get_forecasts` service. Sensors are also created as disabled entities after configuration and can be enabled by the user.
+One weather entity is created to provide forecasts for each entry in the configuration. The time supplied for each forecast is the start time for the forecast. Hourly forecast data can be obtained using the `weather.get_forecasts` service. Sensors are also created as disabled entities after configuration and can be enabled by the user.
 
 Details about the API are available in the [NWS API documentation](https://www.weather.gov/documentation/services-web-api). The [pynws](https://github.com/MatthewFlamm/pynws) library is used to retrieve data.
 

--- a/source/_integrations/nws.markdown
+++ b/source/_integrations/nws.markdown
@@ -25,7 +25,7 @@ According to the [API documentation](https://www.weather.gov/documentation/servi
 
 Providing a METAR station code is optional, and if not supplied, the closest station to the latitude and longitude will be chosen. A list of nearby stations is printed to the log with level `DEBUG` if no station is supplied. Stations can also be found on the [NOAA website](https://www.cnrfc.noaa.gov/metar.php). Codes with only three characters, for example, `ADW` should be prefixed with the letter K, `KADW`.
 
-One weather entity is created to provide forecasts for each entry in the configuration. The time supplied for each forecast is the start time for the forecast. Hourly forecast data can be obtained using the `weather.get_forecasts` service. Sensors are also created as disabled entities after configuration and can be enabled by the user.
+One weather entity is created for each entry in the configuration with hourly and day/night forecasts, which can be obtained through the `weather.get_forecasts` service. The time supplied for each forecast is the start time for the forecast. Sensors are also created as disabled entities after configuration and can be enabled by the user.
 
 Details about the API are available in the [NWS API documentation](https://www.weather.gov/documentation/services-web-api). The [pynws](https://github.com/MatthewFlamm/pynws) library is used to retrieve data.
 


### PR DESCRIPTION
## Proposed change
Update documentation to reflect my understanding of the latest changes mentioned in the "Backward-incompatible changes" section of the 2024.4 release notes.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: [#112503](https://github.com/home-assistant/core/pull/112503)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #29256

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards