### PR TITLE
Documentation for device trackers in tplink_omada

### DIFF
--- a/source/_integrations/tplink_omada.markdown
+++ b/source/_integrations/tplink_omada.markdown
@@ -59,3 +59,16 @@ Controller versions 5.1.0 and later are supported.
 - WAN Port Connect/Disconnect switches
 - LAN Port PoE activity sensor
 - Firmware Update
+
+### Device Trackers
+
+The integration can track Wi-Fi devices connected to access points managed by the TP-Link Omada controller.
+This feature is disabled by default. Use the Options panel to enable Device Trackers. You can select which
+clients to track from the list of known clients.
+
+Two types of trackers are supported:
+
+- Scanners - Track presence based on network connectivity.
+- Trackers - Track an approximate location based on the name of the nearest Wi-Fi access point.
+
+Note that the TP-Link Omada controller takes a few minutes to detect when a client disconnects from the Wi-Fi network.

--- a/source/_integrations/tplink_omada.markdown
+++ b/source/_integrations/tplink_omada.markdown
@@ -60,7 +60,7 @@ Controller versions 5.1.0 and later are supported.
 - LAN Port PoE activity sensor
 - Firmware Update
 
-### Device Trackers
+### Device trackers
 
 The integration can track Wi-Fi devices connected to access points managed by the TP-Link Omada controller. All known Wi-Fi clients will be initially created in a disabled state. You then need to enable the entities that you want to track.
 

--- a/source/_integrations/tplink_omada.markdown
+++ b/source/_integrations/tplink_omada.markdown
@@ -62,13 +62,8 @@ Controller versions 5.1.0 and later are supported.
 
 ### Device Trackers
 
-The integration can track Wi-Fi devices connected to access points managed by the TP-Link Omada controller.
-This feature is disabled by default. Use the Options panel to enable Device Trackers. You can select which
-clients to track from the list of known clients.
+The integration can track Wi-Fi devices connected to access points managed by the TP-Link Omada controller. All known Wi-Fi clients will be initially created in a disabled state. You then need to enable the entities that you want to track.
 
-Two types of trackers are supported:
+If you want to increase the polling frequency of client updates, follow [these instructions](https://www.home-assistant.io/common-tasks/general/#defining-a-custom-polling-interval). You only need to request a refresh from one of the tracked devices, all of the tracked devices will be refreshed at the same time.
 
-- Scanners - Track presence based on network connectivity.
-- Trackers - Track an approximate location based on the name of the nearest Wi-Fi access point.
-
-Note that the TP-Link Omada controller takes a few minutes to detect when a client disconnects from the Wi-Fi network.
+Note: The TP-Link Omada controller takes a few minutes to detect when a client disconnects from the Wi-Fi network, even with more regular polling updates.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation for the addition of device trackers in TP-Link Omada integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#115601](https://github.com/home-assistant/core/pull/115601)
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: fixes N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
