### PR TITLE
Fixed typo in lawn_mower.mqtt.markdown

### DIFF
--- a/source/_integrations/lawn_mower.mqtt.markdown
+++ b/source/_integrations/lawn_mower.mqtt.markdown
@@ -210,7 +210,7 @@ The example below shows how to use a single command topic with a command templat
 ```yaml
 # Example configuration.yaml entry
 mqtt:
-  - alarm_control_panel:
+  - lawn_mower:
       name: "Lawn Mower Plus"
       activity_state_topic: "lawn_mower_plus/state"
       activity_value_template: "{{ value_json.activity }}" 


### PR DESCRIPTION
## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
