### PR TITLE
Denon AVR / HEOS Universal Media Player example

### DIFF
--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -144,7 +144,7 @@ For removing a HEOS player from a group you can use the `media_player.unjoin` se
 ## Notes
 
 - Receivers with multiple zones are represented as a single media player. They will be turned on when playback is started, but cannot be turned off by the integration at this time.
-- [Denon AVR](/integrations/denonar/) and HEOS media players can be combined into a [Universal Remote](/integrations/universal/#denon-avr--heos)
+- [Denon AVR](/integrations/denonar/) and HEOS media players can be combined into a [Universal Media Player](/integrations/universal/#denon-avr--heos)
 
 ## Troubleshooing
 

--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -144,6 +144,7 @@ For removing a HEOS player from a group you can use the `media_player.unjoin` se
 ## Notes
 
 - Receivers with multiple zones are represented as a single media player. They will be turned on when playback is started, but cannot be turned off by the integration at this time.
+- Denon and [HEOS](/integrations/heos/) media players can be combined in a [Universal Remote](/integrations/universal/#denon-avr--heos)
 
 ## Troubleshooing
 

--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -144,7 +144,7 @@ For removing a HEOS player from a group you can use the `media_player.unjoin` se
 ## Notes
 
 - Receivers with multiple zones are represented as a single media player. They will be turned on when playback is started, but cannot be turned off by the integration at this time.
-- Denon and [HEOS](/integrations/heos/) media players can be combined in a [Universal Remote](/integrations/universal/#denon-avr--heos)
+- [Denon AVR](/integrations/denonar/) and HEOS media players can be combined into a [Universal Remote](/integrations/universal/#denon-avr--heos)
 
 ## Troubleshooing
 

--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -332,10 +332,10 @@ media_player:
 This media player combines the media players provided by the [Denon AVR](/integrations/denonavr/) and [HEOS](/integrations/heos/) integrations. 
 
 Features:
-* Volume control via Denon entity (might be more fine-granular than HEOS volume control)
-* ON/OFF button via Denon entity (not provided by HEOS media player)
-* Sound mode selector via Denon entity (not provided by HEOS media player)
-* Album art & Metadata via HEOS entity (not provided by Denon media player)
+- Volume control via Denon entity (might be more fine-granular than HEOS volume control)
+- ON/OFF button via Denon entity (not provided by HEOS media player)
+- Sound mode selector via Denon entity (not provided by HEOS media player)
+- Album art & Metadata via HEOS entity (not provided by Denon media player)
 
 The complete configuration is:
 

--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -327,6 +327,61 @@ media_player:
 
 {% endraw %}
 
+### Denon AVR & HEOS
+
+This media player combines the media players provided by the [Denon AVR](/integrations/denonavr/) and [HEOS](/integrations/heos/) integrations. 
+
+Features:
+* Volume control via Denon entity (might be more fine-granular than HEOS volume control)
+* ON/OFF button via Denon entity (not provided by HEOS media player)
+* Sound mode selector via Denon entity (not provided by HEOS media player)
+* Album art & Metadata via HEOS entity (not provided by Denon media player)
+
+The complete configuration is:
+
+{% raw %}
+
+```yaml
+media_player:
+  - platform: universal
+    name: Denon
+    unique_id: denon_universal_remote
+    device_class: receiver
+    children:
+      - media_player.denon_avr_x2700h       # Denon AVR Integration entity
+      - media_player.denon_avr_x2700h_heos  # Denon HEOS Integration entity
+    browse_media_entity: media_player.denon_avr_x2700h_heos
+    commands:
+      turn_off:
+        service: media_player.turn_off
+        data:
+          entity_id: media_player.denon_avr_x2700h
+      turn_on:
+        service: media_player.turn_on
+        data:
+          entity_id: media_player.denon_avr_x2700h
+      volume_up:
+        service: media_player.volume_up
+        data:
+          entity_id: media_player.denon_avr_x2700h
+      volume_down:
+        service: media_player.volume_down
+        data:
+          entity_id: media_player.denon_avr_x2700h
+      select_sound_mode:
+        service: media_player.select_sound_mode
+        target:
+          entity_id: media_player.denon_avr_x2700h
+        data:
+          sound_mode: "{{ sound_mode }}"
+    attributes:
+      sound_mode: media_player.denon_avr_x2700h|sound_mode
+      sound_mode_raw: media_player.denon_avr_x2700h|sound_mode_raw
+      sound_mode_list: media_player.denon_avr_x2700h|sound_mode_list
+```
+
+{% endraw %}
+
 ### Override active children
 
 This example shows how you can use `active_child_template`:


### PR DESCRIPTION
## Proposed change
Added an example for a Universal Media Player combining HEOS and Denon AVR media players.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
I found this useful and currently missing. I feel like the Universal media player wiki page could use more examples.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
