### PR TITLE
docs: advise reboot of system if wyoming integrations are not being discovered

### DIFF
--- a/source/voice_control/voice_remote_local_assistant.markdown
+++ b/source/voice_control/voice_remote_local_assistant.markdown
@@ -26,6 +26,7 @@ For the quickest way to get your local Assist pipeline started, follow these ste
    - Once the add-ons are started, head over to the integrations under {% my integrations title="**Settings** > **Devices & Services**" %}.
      - You should now see Piper and Whisper being discovered by the [Wyoming integration](/integrations/wyoming/).
        ![Whisper and Piper integrations](/images/assist/piper-whisper-install-new-02.png)
+     - If they aren't being discovered, you may need to reboot your system.
    - For each integration, select **Configure**.
      - Once the setup is complete, you should see both Piper and Whisper (and, optionally, also openWakeword) in one integration.
    


### PR DESCRIPTION
As described in https://github.com/home-assistant/home-assistant.io/issues/28770, it is possible that the Wyoming integration is not automatically discovered. In that case, adding it manually results in a pop-up configuration box asking for Host and Port fields, and there is no documentation for this. There are a couple of solutions in that issue, but the only thing that worked for me was rebooting my system. (Home Assistant Operating System 12.1, Core 2024.4.3, Supervisor 2024.04.0, on Raspberry Pi 4B.)

## Proposed change

Update the documentation to recommend restarting Home Assistant if the Wyoming integration is not automatically showing up.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].
