### PR TITLE
Update qBittorrent documentation - add get_torrents and get_all_torrents services

### DIFF
--- a/source/_integrations/qbittorrent.markdown
+++ b/source/_integrations/qbittorrent.markdown
@@ -8,8 +8,8 @@ ha_config_flow: true
 ha_iot_class: Local Polling
 ha_domain: qbittorrent
 ha_codeowners:
-  - '@geoffreylagaisse'
-  - '@finder39'
+  - "@geoffreylagaisse"
+  - "@finder39"
 ha_platforms:
   - sensor
 ha_integration_type: service
@@ -34,3 +34,42 @@ The qBittorrent integration will add the following sensors:
 - `sensor.qbittorrent_active_torrents`: The current active torrents in qBittorrent.
 - `sensor.qbittorrent_inactive_torrents`: The current inactive torrents in qBittorrent.
 - `sensor.qbittorrent_paused_torrents`: The current paused torrents in qBittorrent.
+
+## Services
+
+### Service `qbittorrent.get_torrents`
+
+This service populates [Response Data](/docs/scripts/service-calls#use-templates-to-handle-response-data)
+with a dictionary of torrents based on the provided filter.
+
+| Service data attribute | Optional | Description                                    | Example                                             |
+| ---------------------- | -------- | ---------------------------------------------- | --------------------------------------------------- |
+| `device`               | no       | The device you'd like to check the torrents of | all, active, inactive, paused, downloading, seeding |
+| `torrent_filter`       | no       | The type of torrents you want in the response  | all, active, inactive, paused, downloading, seeding |
+
+```yaml
+service: qbittorrent.get_torrents
+data:
+  filter: "all"
+response_variable: torrents
+```
+
+The response data contains the field `torrents` which contains a dictionary of torrents. The name of the torrents are the keys.
+
+### Service `qbittorrent.get_all_torrents`
+
+This service populates [Response Data](/docs/scripts/service-calls#use-templates-to-handle-response-data)
+with a dictionary of torrents based on the provided filter.
+
+| Service data attribute | Optional | Description                                   | Example                                             |
+| ---------------------- | -------- | --------------------------------------------- | --------------------------------------------------- |
+| `torrent_filter`       | no       | The type of torrents you want in the response | all, active, inactive, paused, downloading, seeding |
+
+```yaml
+service: qbittorrent.get_all_torrents
+data:
+  filter: "all"
+response_variable: all_torrents
+```
+
+The response data contains the field `all_torrents` which contains a dictionary of integrations, which each contain an dictionary of torrents. The name of the torrents are the keys.

--- a/source/_integrations/qbittorrent.markdown
+++ b/source/_integrations/qbittorrent.markdown
@@ -54,7 +54,7 @@ data:
 response_variable: torrents
 ```
 
-The response data contains the field `torrents` which contains a dictionary of torrents. The name of the torrents are the keys.
+The response data contains the field `torrents` which contains a dictionary of torrents. The names of the torrents are the keys.
 
 ### Service `qbittorrent.get_all_torrents`
 
@@ -72,4 +72,4 @@ data:
 response_variable: all_torrents
 ```
 
-The response data contains the field `all_torrents` which contains a dictionary of integrations, which each contain an dictionary of torrents. The name of the torrents are the keys.
+The response data contains the field `all_torrents`, which contains a dictionary of integrations, which each contains a dictionary of torrents. The names of the torrents are the keys.


### PR DESCRIPTION
## Proposed change
Updating the documentation for the QBittorrent integration for changes made in a pull request on core.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/105781
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
