### PR TITLE
Documentation change for PR 115739

### DIFF
--- a/source/_integrations/squeezebox.markdown
+++ b/source/_integrations/squeezebox.markdown
@@ -15,7 +15,9 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The Squeezebox integration allows you to control a [Logitech Squeezebox](https://en.wikipedia.org/wiki/Squeezebox_%28network_music_player%29) music player from Home Assistant. This lets you control Squeezebox hardware like the Classic, Transporter, Duet, Boom, Radio and Touch and of software players like [Squeezelite](https://github.com/ralph-irving/squeezelite), [SoftSqueeze](http://softsqueeze.sourceforge.net/), [SqueezePlayer](https://play.google.com/store/apps/details?id=de.bluegaspode.squeezeplayer) and [SqueezeSlave](https://forums.slimdevices.com/showthread.php?93607-ANNOUNCE-Squeezeslave-1-2-released).
+The Squeezebox integration allows you to control a [Logitech Squeezebox](https://en.wikipedia.org/wiki/Squeezebox_%28network_music_player%29) music player from Home Assistant. Today, the Logitech Media Server is also known as the [Lyrion Music Server](https://lyrion.org/).  
+
+This lets you control Squeezebox hardware like the Classic, Transporter, Duet, Boom, Radio and Touch and software players like [Squeezelite](https://github.com/ralph-irving/squeezelite), [SoftSqueeze](http://softsqueeze.sourceforge.net/), [SqueezePlayer](https://play.google.com/store/apps/details?id=de.bluegaspode.squeezeplayer) and [SqueezeSlave](https://forums.slimdevices.com/showthread.php?93607-ANNOUNCE-Squeezeslave-1-2-released).
 
 {% include integrations/config_flow.md %}
 
@@ -70,7 +72,7 @@ This can work with title search and basically any thing. The same wouldn't have 
 
 ### Service `call_query`
 
-Call a custom Squeezebox JSON-RPC API. The result of the query will be stored in the 'query_result' attribute of the player.
+Call a custom Squeezebox JSON-RPC API. The result of the query will be stored in the 'query_result' attribute of the player as an object, and in the 'query_result_json' attribute as a json string.  The 'query_result_json' attribute may be useful when, for example, calling this service from the [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest/)
 
 See documentation for this interface on `http://HOST:PORT/html/docs/cli-api.html?player=` where HOST and PORT are the host name and port for your Logitech Media Server.
 

--- a/source/_integrations/squeezebox.markdown
+++ b/source/_integrations/squeezebox.markdown
@@ -72,7 +72,7 @@ This can work with title search and basically any thing. The same wouldn't have 
 
 ### Service `call_query`
 
-Call a custom Squeezebox JSON-RPC API. The result of the query will be stored in the 'query_result' attribute of the player as an object, and in the 'query_result_json' attribute as a json string.  The 'query_result_json' attribute may be useful when, for example, calling this service from the [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest/)
+Call a custom Squeezebox JSON-RPC API. The result of the query will be stored in the 'query_result' attribute of the player as an object, and also in the 'query_result_json' attribute as a json string.  The 'query_result_json' attribute may be useful when, for example, calling this service from the [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest/)
 
 See documentation for this interface on `http://HOST:PORT/html/docs/cli-api.html?player=` where HOST and PORT are the host name and port for your Logitech Media Server.
 


### PR DESCRIPTION
## Proposed change
<!-- 
Documentation change for PR 115739.  Add reference to new query_result_json attribute and mention new Lyrion Music Server naming for LMS.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
PR 115739 adds a new attribute query_result_json.  This doc change references that new functionality.  Also, we mention the new forthcoming name change for the entire Logitech Media Server ecosystem to Lyrion Music Server.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/115739
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
