### PR TITLE
Document group state changes when in cases with one specific state

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -409,7 +409,7 @@ When a group contains entities from domains that have multiple `on` states, the 
 - More than one of these `on` states are actively used.
 - The entities only use `on` and `off`.
 
-If for example a group has multiple `vacuum` entities, that are all `cleaning`, the group state `on` state will be `cleaning`, of if multiple `lock` entities are `unlocked`, the group `on` state will be `unlocked`.
+If for example a group has multiple `vacuum` entities, that are all `cleaning`, the group state `on` state will be `cleaning`, or if multiple `lock` entities are `unlocked`, the group `on` state will be `unlocked`.
 
 It is possible to create a group that the system cannot calculate a group state. Groups with entities from unsupported domains will always have an unknown state.
 

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -405,7 +405,9 @@ When member entities all have a single `on` and `off` state, the group state wil
 | person         | home     | not_home |
 | media_player   | ok       | problem  |
 
-When a group contains entities from domains that have multiple `on` states, and more than one of these `on` states are actively used, or only use `on` and `off`, the group state will be `on` or `off`.
+When a group contains entities from domains that have multiple `on` states, the **group** state will be `on` or `off` if one of the following is true:
+- More than one of these `on` states are actively used.
+- The entities only use `on` and `off`.
 
 If for example a group has multiple `vacuum` entities, that are all `cleaning`, the group state `on` state will be `cleaning`, of if multiple `lock` entities are `unlocked`, the group `on` state will be `unlocked`.
 

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -405,7 +405,9 @@ When member entities all have a single `on` and `off` state, the group state wil
 | person         | home     | not_home |
 | media_player   | ok       | problem  |
 
-When a group contains entities from domains that have multiple `on` states or only use `on` and `off`, the group state will be `on` or `off`.
+When a group contains entities from domains that have multiple `on` states, and more than one of these `on` states are actively used, or only use `on` and `off`, the group state will be `on` or `off`.
+
+If for example a group has multiple `vacuum` entities, that are all `cleaning`, the group state `on` state will be `cleaning`, of if multiple `lock` entities are `unlocked`, the group `on` state will be `unlocked`.
 
 It is possible to create a group that the system cannot calculate a group state. Groups with entities from unsupported domains will always have an unknown state.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document group state changes when in cases with one specific state

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/115866
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
