### PR TITLE
Rename strict connection statig page to guard page

### DIFF
--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -133,7 +133,7 @@ The strict connection mode specifies how the Home Assistant instance should reac
 
 The following modes are supported:
 - `disabled`: Strict connection mode is disabled, and all unauthenticated requests are allowed (Same as before `2024.5`).
-- `static_page`: Home Assistant will answer any unauthenticated requests with a static page, informing the user about the strict connection mode.
+- `guard_page`: Home Assistant will answer any unauthenticated requests with a guard page, informing the user about the strict connection mode.
 - `drop_connection`: Home Assistant will drop/close the connection for any unauthenticated requests, similar to when no Home Assistant instance is running.
 
 If activated, Home Assistant will not even show the login page. To log in on a new device, the user needs to ask the instance admin for a temporary link. The instance admin can generate the link by calling the service `http.create_temporary_strict_connection_url`.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Rename strict connection statig page to guard page


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/116085
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
