### PR TITLE
Add service to 17track to get packages

### DIFF
--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -31,10 +31,10 @@ Although the 17track.net website states that account passwords cannot be longer 
 - Not found
 - In transit
 - Expired
-- Pick up
+- Ready to be picked up
 - Undelivered
 - Delivered
-- Alert
+- Returned
 
 ## Package-level attributes
 
@@ -74,3 +74,23 @@ content: >
 ```
 
 {% endraw %}
+
+## Services
+
+### Service `seventeentrack.get_packages
+
+The `seventeentrack.get_packages` service allows you to query the 17track API for the latest package data.
+
+
+| Service data attribute | Optional | Description                                 |
+|------------------------|----------|---------------------------------------------|
+| `config_entry_id`      | No       | The Id of the 17Track service config entry. |
+| `package_state`        | yes      | A list of the package state.                |
+
+```yaml
+# Example automation action to add a product to the cart by name.
+- service: seventeentrack.get_packages
+  data:
+    config_entry_id: 2b4be47a1fa7c3764f14cf756dc98991
+    package_state: ["Delivered", "In transit"]
+```

--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -77,7 +77,7 @@ content: >
 
 ## Services
 
-### Service `seventeentrack.get_packages
+### Service `seventeentrack.get_packages`
 
 The `seventeentrack.get_packages` service allows you to query the 17track API for the latest package data.
 

--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -84,8 +84,8 @@ The `seventeentrack.get_packages` service allows you to query the 17track API fo
 
 | Service data attribute | Optional | Description                                 |
 |------------------------|----------|---------------------------------------------|
-| `config_entry_id`      | No       | The Id of the 17Track service config entry. |
-| `package_state`        | yes      | A list of the package state.                |
+| `config_entry_id`      | No       | The ID of the 17Track service config entry. |
+| `package_state`        | yes      | A list of the package states.                |
 
 ```yaml
 # Example automation action to add a product to the cart by name.


### PR DESCRIPTION
## Proposed change
Add documentation for the new service call of 17Track to get packages



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/116067
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

