### PR TITLE
Customizing entities: move YAML config docs

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -1,6 +1,10 @@
 ---
 title: "Customizing entities"
 description: "Simple customization for entities."
+related:
+  - docs: /integrations/homeassistant/
+  - docs: /docs/configuration/
+    title: Home Assistant Core integration documentation
 ---
 
 ## Changing the entity ID
@@ -14,116 +18,4 @@ You can use the UI to change the entity ID and friendly name of supported entiti
 ![Settings for entity.](/images/docs/configuration/customizing-entity.png)
 4. Select *Update*
 
-If your entity is not supported, or you cannot customize what you need via this method, please see below for more options.
-
-## Customizing entities
-
-By default, all of your devices will be visible and have a default icon determined by their domain. You can customize the look and feel of your front page by altering some of these parameters. This can be done by overriding attributes of specific entities.
-
-### Possible values
-
-{% configuration customize %}
-friendly_name:
-  description: Name of the entity as displayed in the UI.
-  required: false
-  type: string
-entity_picture:
-  description: URL to use as picture for entity.
-  required: false
-  type: string
-icon:
-  description: "Any icon from [Material Design Icons](https://pictogrammers.com/library/mdi/). Prefix name with `mdi:`, ie `mdi:home`. Note: Newer icons may not yet be available in the current Home Assistant release."
-  required: false
-  type: string
-assumed_state:
-  description: For switches with an assumed state two buttons are shown (turn off, turn on) instead of a switch. By setting `assumed_state` to `false` you will get the default switch icon.
-  required: false
-  type: boolean
-  default: true
-device_class:
-  description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below). It does not set the `unit_of_measurement`.
-  required: false
-  type: device_class
-  default: None
-unit_of_measurement:
-  description: Defines the units of measurement, if any. This will also influence the graphical presentation in the history visualization as continuous value. Sensors with missing `unit_of_measurement` are showing as discrete values.
-  required: false
-  type: string
-  default: None
-initial_state:
-  description: Sets the initial state for automations, `on` or `off`.
-  required: false
-  type: boolean
-  default: None
-{% endconfiguration %}
-
-### Device class
-
-Device class is currently supported by the following platforms:
-
-- [Binary sensor](/integrations/binary_sensor/)
-- [Button](/integrations/button/)
-- [Cover](/integrations/cover/)
-- [Humidifier](/integrations/humidifier/)
-- [Media player](/integrations/media_player/)
-- [Number](/integrations/number/)
-- [Sensor](/integrations/sensor/)
-- [Switch](/integrations/switch/)
-
-### Manual customization
-
-<div class='note'>
-
-If you implement `customize`, `customize_domain`, or `customize_glob` you must make sure it is done inside of `homeassistant:` or it will fail.
-
-</div>
-
-```yaml
-homeassistant:
-  name: Home
-  unit_system: metric
-  # etc
-
-  customize:
-    # Add an entry for each entity that you want to overwrite.
-    thermostat.family_room:
-      entity_picture: https://example.com/images/nest.jpg
-      friendly_name: Nest
-    switch.wemo_switch_1:
-      friendly_name: Toaster
-      entity_picture: /local/toaster.jpg
-    switch.wemo_switch_2:
-      friendly_name: Kitchen kettle
-      icon: mdi:kettle
-    switch.rfxtrx_switch:
-      assumed_state: false
-    media_player.my_media_player:
-      source_list:
-        - Channel/input from my available sources
-  # Customize all entities in a domain
-  customize_domain:
-    light:
-      icon: mdi:home
-    automation:
-      initial_state: "on"
-  # Customize entities matching a pattern
-  customize_glob:
-    "light.kitchen_*":
-      icon: mdi:description
-    "scene.month_*_colors":
-      icon: mdi:other
-```
-
-### Reloading customize
-
-Home Assistant offers a service to reload the core configuration while Home Assistant is running. This allows you to change your customize section and see your changes being applied without having to restart Home Assistant.
-
-To reload customizations, navigate to Developer Tools > YAML and then press the "Reload Location & Customizations" button. If you don't see this, enable Advanced Mode on your user profile page first.
-
-You can also use the [Quick bar](/docs/tools/quick-bar/#command-palette), and choose "Reload Location & Customizations".
-
-Alternatively, you can reload via service call. Navigate to Developer Tools > Services tab, select `homeassistant.reload_core_config` from the dropdown and press the "Call Service" button.
-
-<div class='note warning'>
-New customize information will be applied the next time the state of the entity gets updated.
-</div>
+If your entity is not supported, or you cannot customize what you need via this method, you need to edit the settings in your [`configuration.yaml` file](/docs/configuration/).For a detailed description of the entity configuration variables, refer to the [Home Assistant Core integration documentation](/integrations/homeassistant/).

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -15,6 +15,7 @@ related:
   - docs: /docs/configuration/basic/
     title: Basic information
   - docs: /docs/configuration/
+  - docs: /docs/configuration/customizing-devices/
 ---
 
 The **Home Assistant Core** {% term integration %} provides generic implementations like the generic `homeassistant.turn_on`.
@@ -138,7 +139,12 @@ country:
 
 ## Editing the entity settings in YAML
 
+The Home Assistant Core integration is also responsible for the entity settings.
 By default, all of your devices will be visible and have a default icon determined by their domain. You can customize the look and feel of your front page by altering some of these parameters. This can be done by overriding attributes of specific entities.
+
+Most of these settings can be changed from the UI. For the detailed steps, refer to [Customizing entites](/docs/configuration/customizing-devices/).
+
+If you prefer editing in YAML, you can define your general settings in the [`configuration.yaml` file](/docs/configuration/).
 
 ### Possible values
 

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -136,6 +136,104 @@ country:
   type: string
 {% endconfiguration %}
 
+## Editing the entity settings in YAML
+
+By default, all of your devices will be visible and have a default icon determined by their domain. You can customize the look and feel of your front page by altering some of these parameters. This can be done by overriding attributes of specific entities.
+
+### Possible values
+
+{% configuration customize %}
+friendly_name:
+  description: Name of the entity as displayed in the UI.
+  required: false
+  type: string
+entity_picture:
+  description: URL to use as picture for entity.
+  required: false
+  type: string
+icon:
+  description: "Any icon from [Material Design Icons](https://pictogrammers.com/library/mdi/). Prefix name with `mdi:`, ie `mdi:home`. Note: Newer icons may not yet be available in the current Home Assistant release."
+  required: false
+  type: string
+assumed_state:
+  description: For switches with an assumed state two buttons are shown (turn off, turn on) instead of a switch. By setting `assumed_state` to `false` you will get the default switch icon.
+  required: false
+  type: boolean
+  default: true
+device_class:
+  description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below). It does not set the `unit_of_measurement`.
+  required: false
+  type: device_class
+  default: None
+unit_of_measurement:
+  description: Defines the units of measurement, if any. This will also influence the graphical presentation in the history visualization as continuous value. Sensors with missing `unit_of_measurement` are showing as discrete values.
+  required: false
+  type: string
+  default: None
+initial_state:
+  description: Sets the initial state for automations, `on` or `off`.
+  required: false
+  type: boolean
+  default: None
+{% endconfiguration %}
+
+### Device class
+
+Device class is currently supported by the following platforms:
+
+- [Binary sensor](/integrations/binary_sensor/)
+- [Button](/integrations/button/)
+- [Cover](/integrations/cover/)
+- [Humidifier](/integrations/humidifier/)
+- [Media player](/integrations/media_player/)
+- [Number](/integrations/number/)
+- [Sensor](/integrations/sensor/)
+- [Switch](/integrations/switch/)
+
+### Manual customization
+
+<div class='note'>
+
+If you implement `customize`, `customize_domain`, or `customize_glob` you must make sure it is done inside of `homeassistant:` or it will fail.
+
+</div>
+
+```yaml
+homeassistant:
+  name: Home
+  unit_system: metric
+  # etc
+
+  customize:
+    # Add an entry for each entity that you want to overwrite.
+    thermostat.family_room:
+      entity_picture: https://example.com/images/nest.jpg
+      friendly_name: Nest
+    switch.wemo_switch_1:
+      friendly_name: Toaster
+      entity_picture: /local/toaster.jpg
+    switch.wemo_switch_2:
+      friendly_name: Kitchen kettle
+      icon: mdi:kettle
+    switch.rfxtrx_switch:
+      assumed_state: false
+    media_player.my_media_player:
+      source_list:
+        - Channel/input from my available sources
+  # Customize all entities in a domain
+  customize_domain:
+    light:
+      icon: mdi:home
+    automation:
+      initial_state: "on"
+  # Customize entities matching a pattern
+  customize_glob:
+    "light.kitchen_*":
+      icon: mdi:description
+    "scene.month_*_colors":
+      icon: mdi:other
+```
+
 ## Services
 
 The `homeassistant` integration provides services for controlling Home Assistant itself, as well as generic controls for any entity.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Customizing entities: move YAML config docs
- to Home Assistant Core integration docs

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
