### PR TITLE
Add cutting height for work areas to Husqvarna Automower

### DIFF
--- a/source/_integrations/husqvarna_automower.markdown
+++ b/source/_integrations/husqvarna_automower.markdown
@@ -113,7 +113,14 @@ The integration will create a lawn mower entity to control the mower. This entit
 
 ### Number (if available)
 
-The integration will create a number entity for changing the cutting height of the mower. This entity is disabled by default. You have to enable it manually because it can't be detected with the API if the mower has the capability to change the cutting height remotely. Before enabling this function, consult the handbook of the mower. It's possible that you can use this entity only as sensor but cannot actively change the cutting height.
+#### Cutting height
+
+The integration will create a number entity for changing the cutting height of the mower. This entity is disabled by default. You have to enable it manually. It can't be detected with the API if the mower has the capability to change the cutting height remotely. Before enabling this function, refer to the mower documentation. Depending on the mower, it is possible that you can use this entity only passively as a sensor and not actively to change the cutting height.
+Possible values are 1 (grass stays short) to 9 (grass stays high).
+
+#### Cutting height for work areas
+
+The integration will create a number entity for changing the cutting height for each work area of the mower if your mower supports work areas. Possible values for the cutting heights are 0% (grass stays short) to 100% (grass stays high) of the default cutting height. Note: It's not yet possible to change the default cutting height with Home Assistant.
 
 ### Select (if available)
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add cutting height for work areas to Husqvarna Automower to the number entities.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#116115](https://github.com/home-assistant/core/pull/116115)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
