### PR TITLE
Fix links to device class and customizing entities

### DIFF
--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -4,7 +4,7 @@ module Jekyll
       'action'       => '/docs/scripts/',
       'device_class' => '/integrations/homeassistant/#device-class',
       'template'     => '/docs/configuration/templating/',
-      'icon'         => '/docs/configuration/customizing-devices/#icon',
+      'icon'         => /integrations/homeassistant/#icon',
       'selector'     => '/docs/blueprint/selectors/',
     }
 

--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -4,7 +4,7 @@ module Jekyll
       'action'       => '/docs/scripts/',
       'device_class' => '/integrations/homeassistant/#device-class',
       'template'     => '/docs/configuration/templating/',
-      'icon'         => /integrations/homeassistant/#icon',
+      'icon'         => '/integrations/homeassistant/#icon',
       'selector'     => '/docs/blueprint/selectors/',
     }
 

--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -1,17 +1,17 @@
 module Jekyll
   class ConfigurationBlock < Liquid::Block
     TYPE_LINKS = {
-      'action' => '/docs/scripts/',
+      'action'       => '/docs/scripts/',
       'device_class' => '/integrations/homeassistant/#device-class',
-      'template' => '/docs/configuration/templating/',
-      'icon' => '/docs/configuration/customizing-devices/#icon',
-      'selector' => '/docs/blueprint/selectors/'
+      'template'     => '/docs/configuration/templating/',
+      'icon'         => '/docs/configuration/customizing-devices/#icon',
+      'selector'     => '/docs/blueprint/selectors/',
     }
 
-    TYPES = %w[
-      action boolean string integer float time template
-      device_class icon map list date datetime any
-      selector
+    TYPES = [
+      'action', 'boolean', 'string', 'integer', 'float', 'time', 'template',
+      'device_class', 'icon', 'map', 'list', 'date', 'datetime', 'any',
+      'selector',
     ]
 
     MIN_DEFAULT_LENGTH = 30
@@ -22,7 +22,7 @@ module Jekyll
     end
 
     def slug(key)
-      key.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+      key.downcase.strip.gsub(' ', '-').gsub(/[^\w\-]/, '')
     end
 
     def type_class(type)
@@ -30,14 +30,18 @@ module Jekyll
     end
 
     def type_link(type, component: nil)
-      type = type.split(',') if type.include? ','
+      if type.include? ','
+        type = type.split(',')
+      end
 
-      return (type.map { |t| type_link(t, component:) }).join(' | ') if type.is_a? Array
+      if type.is_a? Array
+        return (type.map { |t| type_link(t, component: component) }).join(' | ')
+      end
 
       type.strip!
       if TYPE_LINKS.include? type.downcase
-        url = format(TYPE_LINKS[type.downcase], component:)
-        format('<a href="%s">%s</a>', url, type)
+        url = TYPE_LINKS[type.downcase] % {component: component}
+        "<a href=\"%s\">%s</a>" % [url, type]
       else
         type
       end
@@ -45,107 +49,104 @@ module Jekyll
 
     def required_value(value)
       if value === true
-        'Required'
+        "Required"
       elsif value === false
-        'Optional'
+        "Optional"
       else
         value.strip.titlecase
       end
     end
 
     def render_config_vars(vars:, component:, platform:, converter:, classes: nil, parent_type: nil)
-      result = []
+      result = Array.new
       result << "<div class='#{classes}'>"
 
       result << vars.map do |key, attr|
-        markup = []
+        markup = Array.new
         # There are spaces around the "{key}", to improve double-click selection in Chrome.
         markup << "<div class='config-vars-item'><div class='config-vars-label'><a name='#{slug(key)}' class='title-link' href='\##{slug(key)}'></a> <span class='config-vars-label-name'> #{key} </span>"
 
         if attr.key? 'type'
 
           # Check if the type (or list of types) are valid
-          if attr['type'].is_a? Array
+          if attr['type'].kind_of? Array
             attr['type'].each do |type|
-              unless TYPES.include? type
-                raise ArgumentError, "Configuration type '#{type}' for key '#{key}' is not a valid type in the documentation."\
-                ' See: https://developers.home-assistant.io/docs/documenting/create-page#configuration'
-              end
+              raise ArgumentError, "Configuration type '#{type}' for key '#{key}' is not a valid type in the documentation."\
+              " See: https://developers.home-assistant.io/docs/documenting/create-page#configuration" unless \
+                TYPES.include? type
             end
           else
-            unless TYPES.include? attr['type']
-              raise ArgumentError, "Configuration type '#{attr['type']}' for key '#{key}' is not a valid type in the documentation."\
-              ' See: https://developers.home-assistant.io/docs/documenting/create-page#configuration'
-            end
+            raise ArgumentError, "Configuration type '#{attr['type']}' for key '#{key}' is not a valid type in the documentation."\
+            " See: https://developers.home-assistant.io/docs/documenting/create-page#configuration" unless \
+              TYPES.include? attr['type']
           end
 
-          markup << "<span class='config-vars-type'>#{type_link(attr['type'], component:)}</span>"
+          markup << "<span class='config-vars-type'>#{type_link(attr['type'], component: component)}</span>"
         else
           # Type is missing, which is required (unless we are in a list or template)
           raise ArgumentError, "Configuration key '#{key}' is missing a type definition" \
-            unless %w[list template].include? parent_type
+            unless ['list', 'template'].include? parent_type
         end
 
-        defaultValue = ''
+        defaultValue = ""
         isDefault = false
-        if attr.key? 'default' and !attr['default'].to_s.empty?
+        if attr.key? 'default' and not attr['default'].to_s.empty?
           isDefault = true
           defaultValue = converter.convert(attr['default'].to_s)
         elsif attr['type'].to_s.include? 'boolean'
           # If the type is a boolean, a default key is required
           raise ArgumentError, "Configuration key '#{key}' is a boolean type and"\
-            ' therefore, requires a default.'
+            " therefore, requires a default."
         end
 
         if attr.key? 'required'
           # Check if required is a valid value
-          unless [true, false, 'inclusive', 'exclusive'].include? attr['required']
-            raise ArgumentError, "Configuration key '#{key}' required field must be specified as: "\
-              'true, false, inclusive or exclusive.'
-          end
+          raise ArgumentError, "Configuration key '#{key}' required field must be specified as: "\
+            "true, false, inclusive or exclusive."\
+            unless [true, false, 'inclusive', 'exclusive'].include? attr['required']
 
           isTrue = attr['required'].to_s == 'true'
           startSymbol = isTrue ? ' ' : ' ('
           endSymbol = isTrue ? '' : ')'
           showDefault = isDefault && (defaultValue.length <= MIN_DEFAULT_LENGTH)
-          shortDefaultValue = ''
+          shortDefaultValue = ""
           if showDefault
             shortDefaultValue = defaultValue
-            shortDefaultValue.slice!('<p>')
-            shortDefaultValue.slice!('</p>')
+            shortDefaultValue.slice!("<p>")
+            shortDefaultValue.slice!("</p>")
             shortDefaultValue = shortDefaultValue.strip
-            shortDefaultValue = ', default: ' + shortDefaultValue
+            shortDefaultValue = ", default: " + shortDefaultValue
           end
 
-          markup << "<span class='config-vars-required'>#{startSymbol}<span class='#{attr['required']}'>#{required_value(attr['required'])}</span><span class='default'>#{shortDefaultValue}</span>#{endSymbol}</span>"
+          markup << "<span class='config-vars-required'>#{startSymbol}<span class='#{attr['required'].to_s}'>#{required_value(attr['required'])}</span><span class='default'>#{shortDefaultValue}</span>#{endSymbol}</span>"
         end
 
         markup << "</div><div class='config-vars-description-and-children'>"
 
-        raise ArgumentError, "Configuration key '#{key}' is missing a description." unless attr.key? 'description'
-
-        markup << "<span class='config-vars-description'>#{converter.convert(attr['description'].to_s)}</span>"
-
-        # Description is missing
+        if attr.key? 'description'
+          markup << "<span class='config-vars-description'>#{converter.convert(attr['description'].to_s)}</span>"
+        else
+          # Description is missing
+          raise ArgumentError, "Configuration key '#{key}' is missing a description."
+        end
 
         if isDefault && defaultValue.length > MIN_DEFAULT_LENGTH
           markup << "<div class='config-vars-default'>\nDefault: #{defaultValue}</div>"
         end
-        markup << '</div>'
+        markup << "</div>"
 
         # Check for nested configuration variables
         if attr.key? 'keys'
           markup << render_config_vars(
-            vars: attr['keys'], component:,
-            platform:, converter:,
-            classes: 'nested', parent_type: attr['type']
-          )
+            vars: attr['keys'], component: component,
+            platform: platform, converter: converter,
+            classes: 'nested', parent_type: attr['type'])
         end
 
-        markup << '</div>'
+        markup << "</div>"
       end
 
-      result << '</div>'
+      result << "</div>"
       result.join
     end
 
@@ -174,10 +175,10 @@ module Jekyll
             <a href="/docs/configuration/" target="_blank">Looking for your configuration file?</a>
           </div>
           #{render_config_vars(
-            vars:,
-            component:,
-            platform:,
-            converter:
+            vars: vars,
+            component: component,
+            platform: platform,
+            converter: converter
           )}
         </div>
       MARKUP

--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -30,4 +30,4 @@ To change the entity ID and friendly name of supported entities, follow these st
 
    ![Edit entity ID in automation.](/images/docs/configuration/edit_entity-id_in_automation.png)
 
-If your entity is not supported, or you cannot customize what you need via this method, you need to edit the settings in your [`configuration.yaml` file](/docs/configuration/). For a detailed description of the entity configuration variables, refer to the [Home Assistant Core integration documentation](/integrations/homeassistant/).
+If your entity is not supported, or you cannot customize what you need via this method, you need to edit the settings in your [`configuration.yaml` file](/docs/configuration/). For a detailed description of the entity configuration variables and device class information, refer to the [Home Assistant Core integration documentation](/integrations/homeassistant/).

--- a/source/_redirects
+++ b/source/_redirects
@@ -263,8 +263,8 @@ layout: null
 /draw_assist /voice_control/s3-box-customize/#to-draw-your-own-images
 /projects/thirteen-usd-voice-remote/ /voice_control/thirteen-usd-voice-remote/
 /docs/backend/updater /integrations/analytics
-docs/configuration/customizing-devices/#device-class /integrations/homeassistant/#device-class
-docs/configuration/customizing-devices/#customizing-entities /integrations/homeassistant/#editing-the-entity-settings-in-yaml
+/docs/configuration/customizing-devices/#device-class /integrations/homeassistant/#device-class
+/docs/configuration/customizing-devices/#customizing-entities /integrations/homeassistant/#editing-the-entity-settings-in-yaml
 /docs/ecosystem/ios/ https://companion.home-assistant.io/
 /docs/ecosystem/ios/devices_file https://companion.home-assistant.io/
 /docs/ecosystem/ios/integration https://companion.home-assistant.io/docs/integrations/integrations

--- a/source/_redirects
+++ b/source/_redirects
@@ -263,6 +263,7 @@ layout: null
 /draw_assist /voice_control/s3-box-customize/#to-draw-your-own-images
 /projects/thirteen-usd-voice-remote/ /voice_control/thirteen-usd-voice-remote/
 /docs/backend/updater /integrations/analytics
+docs/configuration/customizing-devices/#device-class /integrations/homeassistant/#device-class
 /docs/ecosystem/ios/ https://companion.home-assistant.io/
 /docs/ecosystem/ios/devices_file https://companion.home-assistant.io/
 /docs/ecosystem/ios/integration https://companion.home-assistant.io/docs/integrations/integrations

--- a/source/_redirects
+++ b/source/_redirects
@@ -264,6 +264,7 @@ layout: null
 /projects/thirteen-usd-voice-remote/ /voice_control/thirteen-usd-voice-remote/
 /docs/backend/updater /integrations/analytics
 docs/configuration/customizing-devices/#device-class /integrations/homeassistant/#device-class
+docs/configuration/customizing-devices/#customizing-entities /integrations/homeassistant/#editing-the-entity-settings-in-yaml
 /docs/ecosystem/ios/ https://companion.home-assistant.io/
 /docs/ecosystem/ios/devices_file https://companion.home-assistant.io/
 /docs/ecosystem/ios/integration https://companion.home-assistant.io/docs/integrations/integrations


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fix links to device class and customizing entities
- add redirect
- addresses issue raised in #32480


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #32480

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
