### PR TITLE
Remove API Key instructions from Hydrawise docs

### DIFF
--- a/source/_integrations/hydrawise.markdown
+++ b/source/_integrations/hydrawise.markdown
@@ -28,15 +28,6 @@ There is currently support for the following device types within Home Assistant:
 - [Sensor](#sensor)
 - [Switch](#switch)
 
-## Prerequisites
-
-To set up the Hydrawise integration, you must first obtain an API Key.
-
-1. Login at [https://app.hydrawise.com](https://app.hydrawise.com).
-2. Go to **Account Details** under the **My Account** menu (in the upper-right-hand corner).
-3. Under the **Account Settings** section, copy the **API Key**.
-   1. If no API Key is present, select the **Generate API Key** button.
-
 {% include integrations/config_flow.md %}
 
 ## Binary sensor


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove the prerequisites section from the Hydrawise docs that discuss the need to obtain an API Key. This is no longer necessary with https://github.com/home-assistant/core/pull/106904 as you can now simply authenticate using username & password.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
