### PR TITLE
Add Yale Smart Alarm smoke detector temp sensors

### DIFF
--- a/source/_integrations/yale_smart_alarm.markdown
+++ b/source/_integrations/yale_smart_alarm.markdown
@@ -55,6 +55,6 @@ The lock platform requires a code for unlocking but no code for locking.
 
 ## Sensor
 
-Provides support for Smoke detector temperature sensors
+Provides support for smoke detector temperature sensors.
 
 The {% term integration %} can be configured to provide a default code that is used if no code is supplied and the number of digits required.

--- a/source/_integrations/yale_smart_alarm.markdown
+++ b/source/_integrations/yale_smart_alarm.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Binary sensor
   - Button
   - Lock
+  - Sensor
 ha_release: 0.78
 ha_iot_class: Cloud Polling
 ha_config_flow: true
@@ -18,6 +19,7 @@ ha_platforms:
   - button
   - diagnostics
   - lock
+  - sensor
 ha_integration_type: integration
 ---
 
@@ -29,6 +31,7 @@ There is currently support for the following device types within Home Assistant:
 - Binary sensor
 - Button
 - Lock
+- Sensor
 
 {% include integrations/config_flow.md %}
 
@@ -49,5 +52,9 @@ Provides support for pressing the panic button to trigger the alarm. Be careful 
 ## Lock
 
 The lock platform requires a code for unlocking but no code for locking.
+
+## Sensor
+
+Provides support for Smoke detector temperature sensors
 
 The {% term integration %} can be configured to provide a default code that is used if no code is supplied and the number of digits required.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds support for smoke detector temp sensors in Yale Smart Alarm


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/116306
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
