### PR TITLE
Update scripts.markdown

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -186,6 +186,7 @@ Delays are useful for temporarily suspending your script and start it at a later
 ```yaml
 # Supports milliseconds, seconds, minutes, hours, days
 # Can be used in combination, at least one required
+# When using milliseconds, consider that delay as *at least* X milliseconds. It won´t be exact.
 # Waits 1 minute
 - delay:
     minutes: 1


### PR DESCRIPTION
Clarification about the inaccuracy of delays that are using milliseconds

## Proposed change
I learned that delays of milliseconds won´t be exact, because the delays are operating at a 1 second resolution. As explained here: https://community.home-assistant.io/t/1-5-second-timer/70688/7

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: fixes # n/a

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that delays specified in milliseconds represent a minimum duration rather than an exact time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->