### PR TITLE
Fix URL typo in ambient_network docs

### DIFF
--- a/source/_integrations/ambient_network.markdown
+++ b/source/_integrations/ambient_network.markdown
@@ -21,7 +21,7 @@ Similar to the [Ambient Weather Station](https://www.home-assistant.io/integrati
 integration, this integration gathers sensor data from individual weather stations.
 However, in contrast to the [Ambient Weather Station](https://www.home-assistant.io/integrations/ambient_station/)
 integration, which exclusively enables owners to fetch data solely from their owned stations, this
-integration directly pulls public data from <https://ambientwether.net/> without requiring an API key,
+integration directly pulls public data from <https://ambientweather.net> without requiring an API key,
 albeit with a reduced dataset (for example, excluding indoor sensors).
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change

Correct a typo in Ambient Network's URL - it's missing an `a`.

Targeting `rc` branch as this integration (`ambient_network`) is currently in 2024.5 beta.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A
- Related: #30347

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
