### PR TITLE
Remove deprecated yaml config section of Habitica

### DIFF
--- a/source/_integrations/habitica.markdown
+++ b/source/_integrations/habitica.markdown
@@ -12,6 +12,7 @@ ha_platforms:
 ha_codeowners:
   - '@ASMfreaK'
   - '@leikoilja'
+  - '@tr4nt0r'
 ha_config_flow: true
 ha_integration_type: integration
 ---
@@ -45,27 +46,6 @@ Tasks: allows you to view and monitor your tasks from [Habitica](https://habitic
 At runtime you will be able to use API for each respective user by their Habitica's username.
 You can override this by passing `name` key, this value will be used instead of the username.
 If you are hosting your own instance of Habitica, you can specify a URL to it in `url` key.
-
-{% configuration %}
-api_user:
-  description: "Habitica's API user ID. This value can be grabbed from [account setting](https://habitica.com/user/settings/api)"
-  required: true
-  type: string
-api_key:
-  description: "Habitica's API password (token). This value can be grabbed from [account setting](https://habitica.com/user/settings/api) by pressing 'Show API token'"
-  required: true
-  type: string
-name:
-  description: "Override for Habitica's username. Will be used for service calls"
-  required: false
-  type: string
-  default: Deduced at startup
-url:
-  description: "URL to your Habitica instance, if you are hosting your own"
-  required: false
-  type: string
-  default: https://habitica.com
-{% endconfiguration %}
 
 ### API Service Parameters
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Removes the yaml configuration section as it is deprecated

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/116374
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
