### PR TITLE
2024.5: Add LG Netcast breaking changes in release notes

### DIFF
--- a/source/_posts/2024-05-01-release-20245.markdown
+++ b/source/_posts/2024-05-01-release-20245.markdown
@@ -471,7 +471,7 @@ sidebar, has moved to the integration page in
 
 Turn on action for turning the TV on via a custom script
 within `configuration.yaml` has been changed to use a custom automation trigger
-`lg_netcast.turn_on` or a device trigger that can be setup from the UI.
+`lg_netcast.turn_on` or a device trigger that can be set up from the UI.
 
 ([@splinter98] - [#104913]) ([documentation](/integrations/lg_netcast))
 

--- a/source/_posts/2024-05-01-release-20245.markdown
+++ b/source/_posts/2024-05-01-release-20245.markdown
@@ -400,6 +400,19 @@ sidebar, has moved to the integration page in
 
 {% enddetails %}
 
+{% details "LG Netcast" %}
+
+Turn on action for turning the TV on via a custom script
+within `configuration.yaml` has been changed to use a custom automation trigger
+`lg_netcast.turn_on` or a device trigger that can be setup from the UI.
+
+([@splinter98] - [#104913]) ([documentation](/integrations/lg_netcast))
+
+[@splinter98]: https://github.com/splinter98
+[#104913]: https://github.com/home-assistant/core/pull/104913
+
+{% enddetails %}
+
 {% details "Netatmo" %}
 
 The state of the Netatmo wind and gust direction sensor provided by


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Looks like the breaking change from https://github.com/home-assistant/core/pull/104913 is lost.

P.S. [The documentaion PR](https://github.com/home-assistant/home-assistant.io/pull/30110) was also not merged, but changes from core have already been released.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
