### PR TITLE
Make explicit clear what domains are supported with old style groups

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -378,22 +378,33 @@ icon:
 
 Old style groups can calculate group state with entities from the following domains:
 
+- `alert`
 - `alarm_control_panel`
+- `automation`
 - `binary_sensor`
+- `calendar`
 - `climate`
 - `cover`
 - `device_tracker`
 - `fan`
 - `humidifier`
+- `input_boolean`
 - `light`
 - `lock`
 - `media_player`
 - `person`
 - `plant`
 - `remote`
+- `script`
 - `switch`
 - `vacuum`
 - `water_heater`
+
+<div class='note info'>
+
+Platform domains other than these are not supported to be used with old style groups, nor will they be supported in the future.
+
+</div>
 
 When member entities all have a single `on` and `off` state, the group state will be calculated as follows:
 

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -402,7 +402,7 @@ Old style groups can calculate group state with entities from the following doma
 
 <div class='note info'>
 
-Platform domains other than these are not supported to be used with old style groups, nor will they be supported in the future.
+Platform domains other than these are not supported to be used with old style groups, nor will other domains be supported in the future.
 
 </div>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Make explicit clear what domains are supported with old style groups. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: #https://github.com/home-assistant/core/pull/116318
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
