### PR TITLE
Better describe HomeKit bridge ip_address option

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -98,7 +98,7 @@ homekit:
       type: string
       default: '`Home Assistant Bridge`'
     ip_address:
-      description: The local network IP address. Only necessary if the default from Home Assistant does not work.
+      description: The HAP binding address. The bridge will advertise itself through the interface with this IP address, so it must be local to the machine (For Docker users, you cannot put your host IP here, because it's different from the container address and no advertisement will be generated). Only necessary if the default from Home Assistant does not work.
       required: false
       type: string
     mode:


### PR DESCRIPTION
## Proposed change
I think the documentation of the option isn't clear enough about what it does under the hood, so I described it a bit more.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: none
- Link to parent pull request in the Brands repository: none
- This PR fixes or closes issue: fixes none

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
