### PR TITLE
Update Android TV Remote documentation that you can launch any app by its application ID/package name

### DIFF
--- a/source/_integrations/androidtv_remote.markdown
+++ b/source/_integrations/androidtv_remote.markdown
@@ -32,21 +32,29 @@ For a quick introduction on how to get started with Android TV Remote, check out
 
 This {% term integration %} adds a `media_player` with basic playback and volume controls. The media player provides volume information and display name of current active app on the Android TV. Due to API limitations, the integration will not display the playback status. It is recommended to use this integration together with [Google Cast integration](/integrations/cast/). Two media players can be combined into one using the [Universal Media Player](/integrations/universal/) integration. See [Using with Google Cast](#using-with-google-cast) section for more details.
 
-Using the `media_player.play_media` service, you can launch applications via `Deep Links` and switch channels. Only `url` and `channel` media types are supported.
+Using the `media_player.play_media` service, you can launch applications and switch channels. Only `url` and `channel` media types are supported.
 
 ### Launching apps
 
-You can pass any URL to the device. Using `Deep Links`, you can launch some applications.
+If the Android TV device has the Google Play Store, you can directly launch any app by passing the package name.
+The app doesn't need to exist in the Google Play Store.
+If it exists, you can find the app's package name in the URL of the app's Google Play Store listing.
+For example, if the URL of an app page is `play.google.com/store/apps/details?id=com.example.app123`, the app's package name is `com.example.app123`.
+The package name is also displayed in the media player card when you launch the application on the device.
 
-Examples of some `Deep Links` for popular applications:
+Alternatively, if the device doesn't have the Google Play Store or if you want to open an app in a specific section, you can pass deep links supported by some applications.
 
-| App | URL |
-| --- | --- |
-| YouTube | `https://www.youtube.com` or `vnd.youtube://` or `vnd.youtube.launch://`
-| Netflix | `https://www.netflix.com/title` or `netflix://`
-| Prime Video | `https://app.primevideo.com`
-| Disney+ | `https://www.disneyplus.com`
-| Plex | `plex://`
+Examples of package names and deep links for popular applications:
+
+| App | Package name | Deep link |
+| --- | --- | --- |
+| YouTube | `com.google.android.youtube.tv` | `https://www.youtube.com` or `vnd.youtube://` or `vnd.youtube.launch://`
+| Netflix | `com.netflix.ninja` | `https://www.netflix.com/title` or `netflix://`
+| Prime Video | `com.amazon.amazonvideo.livingroom` | `https://app.primevideo.com`
+| Disney+ | `com.disney.disneyplus` | `https://www.disneyplus.com`
+| Plex | `com.plexapp.android` | `plex://`
+| Kodi | `org.xbmc.kodi` | N/A
+| Twitch | `tv.twitch.android.app` | `twitch://home` `[home,stream,game,video,clip,search,browse,channel,user]`
 
 Examples:
 
@@ -55,7 +63,7 @@ Examples:
 service: media_player.play_media
 data:
   media_content_type: url
-  media_content_id: https://www.netflix.com/title
+  media_content_id: com.netflix.ninja
 target:
   entity_id: media_player.living_room_tv
 ```
@@ -130,6 +138,7 @@ media_player:
 
 The remote allows you to send key commands to your Android TV device with the `remote.send_command` service.
 The entity has the `current_activity` attribute that shows the current foreground app on the Android TV.
+You can pass the package name shown in this `current_activity` as `activity` in the `remote.turn_on` service to launch that app.
 
 {% details "List of the most common commands" %}
 
@@ -213,7 +222,7 @@ Other:
 
 {% enddetails %}
 
-If `activity` is specified in `remote.turn_on` it will open the specified URL in the associated app. See [Launching apps section](#launching-apps).
+If `activity` is specified in `remote.turn_on` it will open the specified URL or package name. See [Launching apps section](#launching-apps).
 
 Examples of service calls:
 
@@ -491,7 +500,7 @@ cards:
           action: call-service
           service: remote.turn_on
           data:
-            activity: https://www.netflix.com/title
+            activity: com.netflix.ninja
           target:
             entity_id: remote.living_room_tv
         hold_action:
@@ -503,7 +512,7 @@ cards:
           action: call-service
           service: remote.turn_on
           data:
-            activity: https://app.primevideo.com
+            activity: com.amazon.amazonvideo.livingroom
           target:
             entity_id: remote.living_room_tv
         hold_action:
@@ -515,7 +524,7 @@ cards:
           action: call-service
           service: remote.turn_on
           data:
-            activity: https://www.disneyplus.com
+            activity: com.disney.disneyplus
           target:
             entity_id: remote.living_room_tv
         hold_action:

--- a/source/_integrations/androidtv_remote.markdown
+++ b/source/_integrations/androidtv_remote.markdown
@@ -36,17 +36,17 @@ Using the `media_player.play_media` service, you can launch applications and swi
 
 ### Launching apps
 
-If the Android TV device has the Google Play Store, you can directly launch any app by passing the package name.
+If the Android TV device has the Google Play Store, you can directly launch any app by its application ID/package name.
 The app doesn't need to exist in the Google Play Store.
-If it exists, you can find the app's package name in the URL of the app's Google Play Store listing.
-For example, if the URL of an app page is `play.google.com/store/apps/details?id=com.example.app123`, the app's package name is `com.example.app123`.
-The package name is also displayed in the media player card when you launch the application on the device.
+If it exists, you can find the application ID in the URL of the app's Google Play Store listing.
+For example, if the URL of an app page is `play.google.com/store/apps/details?id=com.example.app123`, the application ID is `com.example.app123`.
+The application ID is also displayed in the media player card when you launch the application on the device.
 
 Alternatively, if the device doesn't have the Google Play Store or if you want to open an app in a specific section, you can pass deep links supported by some applications.
 
-Examples of package names and deep links for popular applications:
+Examples of application IDs and deep links for popular applications:
 
-| App | Package name | Deep link |
+| App | App ID | Deep link |
 | --- | --- | --- |
 | YouTube | `com.google.android.youtube.tv` | `https://www.youtube.com` or `vnd.youtube://` or `vnd.youtube.launch://`
 | Netflix | `com.netflix.ninja` | `https://www.netflix.com/title` or `netflix://`
@@ -138,7 +138,7 @@ media_player:
 
 The remote allows you to send key commands to your Android TV device with the `remote.send_command` service.
 The entity has the `current_activity` attribute that shows the current foreground app on the Android TV.
-You can pass the package name shown in this `current_activity` as `activity` in the `remote.turn_on` service to launch that app.
+You can pass the application ID shown in this `current_activity` as `activity` in the `remote.turn_on` service to launch that app.
 
 {% details "List of the most common commands" %}
 

--- a/source/_integrations/androidtv_remote.markdown
+++ b/source/_integrations/androidtv_remote.markdown
@@ -222,7 +222,7 @@ Other:
 
 {% enddetails %}
 
-If `activity` is specified in `remote.turn_on` it will open the specified URL or package name. See [Launching apps section](#launching-apps).
+If `activity` is specified in `remote.turn_on` it will open the specified URL or the application with the given package name. See [Launching apps section](#launching-apps).
 
 Examples of service calls:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
SSIA


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/116906
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
