### PR TITLE
Add event entities to Folder watcher

### DIFF
--- a/source/_integrations/folder_watcher.markdown
+++ b/source/_integrations/folder_watcher.markdown
@@ -7,6 +7,8 @@ ha_iot_class: Local Polling
 ha_config_flow: true
 ha_release: 0.67
 ha_quality_scale: internal
+ha_platforms:
+  - event
 ha_domain: folder_watcher
 ha_integration_type: integration
 ---
@@ -27,6 +29,11 @@ Configured folders must be added to [allowlist_external_dirs](/integrations/home
 
 Pattern matching using [fnmatch](https://docs.python.org/3.6/library/fnmatch.html) can be used to limit filesystem monitoring to only files which match the configured patterns.
 As example to monitor specific file, as example YAML and text-files add `*.yaml` and `*.txt`.
+
+## Entities
+
+This integration will besides the events also create `event` entities for the respective events that can happen.
+These entities can be used for automations instead of using the respective event.
 
 ## Automations
 

--- a/source/_integrations/folder_watcher.markdown
+++ b/source/_integrations/folder_watcher.markdown
@@ -15,7 +15,7 @@ ha_integration_type: integration
 
 The **Folder watcher** {% term integration %} adds [Watchdog](https://pythonhosted.org/watchdog/) file system monitoring.
 
-It creates Event entities for these monitored event types:
+It creates event entities for these monitored event types:
 
 - `closed`
 - `created`
@@ -45,7 +45,7 @@ When the `event_type` is `moved`, the file details are for the source file and d
 - `dest_file`: The name of the moved file (e.g. "world.txt")
 - `dest_folder`: The folder moved path (e.g. "/hello")
 
-Automations can be triggered on filesystem events data using a template. The following automation will send a notification with the name and folder of new files added to that folder:
+Automations can be triggered on file system events data using a template. The following automation will send a notification with the name and folder of new files added to that folder:
 
 {% raw %}
 

--- a/source/_integrations/folder_watcher.markdown
+++ b/source/_integrations/folder_watcher.markdown
@@ -13,7 +13,9 @@ ha_domain: folder_watcher
 ha_integration_type: integration
 ---
 
-The **Folder watcher** {% term integration %} adds [Watchdog](https://pythonhosted.org/watchdog/) file system monitoring, publishing events on the Home Assistant bus on the creation/deletion/modification of files within configured folders. The monitored `event_type` are:
+The **Folder watcher** {% term integration %} adds [Watchdog](https://pythonhosted.org/watchdog/) file system monitoring.
+
+It creates Event entities for these monitored event types:
 
 - `closed`
 - `created`
@@ -30,14 +32,9 @@ Configured folders must be added to [allowlist_external_dirs](/integrations/home
 Pattern matching using [fnmatch](https://docs.python.org/3.6/library/fnmatch.html) can be used to limit filesystem monitoring to only files which match the configured patterns.
 As example to monitor specific file, as example YAML and text-files add `*.yaml` and `*.txt`.
 
-## Entities
-
-This integration will besides the events also create `event` entities for the respective events that can happen.
-These entities can be used for automations instead of using the respective event.
-
 ## Automations
 
-The elements the events contain are:
+The attributes the event entities contain are:
 - `event_type`: matching the `event_type` of the filter (one of `created`, `moved`, `modified`, `deleted`, `closed`)
 - `path`: The full path to the file (e.g. "/hello/world.txt")
 - `file`: The name of the file (e.g. "world.txt")
@@ -48,7 +45,7 @@ When the `event_type` is `moved`, the file details are for the source file and d
 - `dest_file`: The name of the moved file (e.g. "world.txt")
 - `dest_folder`: The folder moved path (e.g. "/hello")
 
-Automations can be triggered on filesystem event data using a template. The following automation will send a notification with the name and folder of new files added to that folder:
+Automations can be triggered on filesystem events data using a template. The following automation will send a notification with the name and folder of new files added to that folder:
 
 {% raw %}
 
@@ -57,17 +54,15 @@ Automations can be triggered on filesystem event data using a template. The foll
 automation:
   alias: "New file alert"
   trigger:
-    platform: event
-    event_type: folder_watcher
-    event_data:
-      event_type: created
+    platform: state
+    entity_id: event.created
   action:
     service: notify.notify
     data:
       title: New image captured!
-      message: "Created {{ trigger.event.data.file }} in {{ trigger.event.data.folder }}"
+      message: "Created {{ trigger.to_state.attributes.file }} in {{ trigger.to_state.attributes.folder }}"
       data:
-        file: "{{ trigger.event.data.path }}"
+        file: "{{ trigger.to_state.attributes.file }}"
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds event entities to Folder watcher


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/116526
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
