### PR TITLE
Snippet on reloading HA after configuration change

### DIFF
--- a/source/_includes/integrations/reload_ha_after_config_inclusion.md
+++ b/source/_includes/integrations/reload_ha_after_config_inclusion.md
@@ -1,0 +1,1 @@
+"After changing the {% term configuration.yaml %} file, [restart Home Assistant](/docs/configuration/#reloading-the-configuration-to-apply-changes) to apply the changes. To view the changes, go to {% my entities title="**Settings** > **Devices & services** > **Entities**" %}.

--- a/source/_includes/integrations/reload_ha_after_config_inclusion.md
+++ b/source/_includes/integrations/reload_ha_after_config_inclusion.md
@@ -1,1 +1,1 @@
-"After changing the {% term configuration.yaml %} file, [restart Home Assistant](/docs/configuration/#reloading-the-configuration-to-apply-changes) to apply the changes. To view the changes, go to {% my entities title="**Settings** > **Devices & services** > **Entities**" %}.
+After changing the {% term configuration.yaml %} file, [restart Home Assistant](/docs/configuration/#reloading-the-configuration-to-apply-changes) to apply the changes. To view the changes, go to {% my entities title="**Settings** > **Devices & services** > **Entities**" %}.


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Snippet on reloading HA after configuration change
- depends on #32619
- to be used in integrations that require manual editing of the configuration.yaml file.
- inspired by #32505

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
