### PR TITLE
Resolve terminology links causing new table rows

### DIFF
--- a/plugins/terminology_tooltip.rb
+++ b/plugins/terminology_tooltip.rb
@@ -34,7 +34,7 @@ module Jekyll
         
         if glossary.key?("link")
           rendered_link = Liquid::Template.parse(glossary["link"]).render(context).strip
-          link = "<br><a class='terminology-link' href='#{rendered_link}' target='_blank'>[Learn more]</a>"
+          link = "<small><a class='terminology-link' href='#{rendered_link}' target='_blank'>[Learn more]</a></small>"
         end
 
         tooltip = "<span class='terminology-tooltip'>#{definition}#{link || ""}</span>"


### PR DESCRIPTION
Related to PR #32640, this will prevent the terminology links from causing new table rows which was done because they add  a `<br>`. By making them `<small>` instead, they'll stay inline but not be too in the way.

Before:
![CleanShot 2024-05-08 at 17 51 29](https://github.com/home-assistant/home-assistant.io/assets/16113535/4f1ae186-2ec6-4957-8072-5a7d09edf404)

After:
![CleanShot 2024-05-08 at 17 51 01](https://github.com/home-assistant/home-assistant.io/assets/16113535/f9af6883-782c-4602-8f90-0b86073e7e5e)
