### PR TITLE
Add mention of Open Home Foundation

### DIFF
--- a/source/_includes/asides/about.html
+++ b/source/_includes/asides/about.html
@@ -8,6 +8,7 @@
     <li><a href='https://demo.home-assistant.io'>Try the online demo</a></li>
     <li><a href='https://building.open-home.io/#/portal'>Join our newsletter</a></li>
     <li><a href="https://twitter.com/Home_Assistant">Follow Home Assistant on X</a></li>
+    <li><a href="https://www.openhomefoundation.org/">Home Assistant is part of the Open Home Foundation</a></li>
     {% comment %}
     <li>
       Subscribe to the Home Assistant Newsletter

--- a/source/_includes/site/footer.html
+++ b/source/_includes/site/footer.html
@@ -76,6 +76,7 @@
             <li>
               <a href="https://status.home-assistant.io">System Status</a>
             </li>
+            <li><a href="https://www.openhomefoundation.org/">Home Assistant is part of the Open Home Foundation</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
This pull request updates the Home Assistant website to reflect its affiliation with the Open Home Foundation.

- Adds a new list item in the About section (`source/_includes/asides/about.html`) linking to the Open Home Foundation website, indicating that Home Assistant is part of the foundation.
- Includes a mention of Home Assistant's participation in the Open Home Foundation in the footer section (`source/_includes/site/footer.html`), also with a link to the foundation's website.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/home-assistant/home-assistant.io?shareId=c5d41ff4-e695-4289-9530-ccdf02979381).