### PR TITLE
Update yeelight.markdown

### DIFF
--- a/source/_integrations/yeelight.markdown
+++ b/source/_integrations/yeelight.markdown
@@ -161,7 +161,6 @@ Per default, the bulb limits the number of requests per minute to 60, a limitati
 Before trying to control your light through Home Assistant, you have to set up your bulb using the Yeelight app. ( [Android](https://play.google.com/store/apps/details?id=com.yeelight.cherry&hl=fr), [IOS](https://itunes.apple.com/us/app/yeelight/id977125608?mt=8) ).
 In the bulb property, you have to enable "LAN Control" (previously called "Developer mode"). LAN Control may only be available with the latest firmware installed on your bulb.  Firmware can be updated in the application after connecting the bulb.
 Determine your bulb IP (using router, software, ping...).
-~~Information on how to enable "LAN Control" can be found [here](https://www.yeelight.com/faqs/lan_control).~~
 Currently, there is no official way to change LAN mode. However, some methods might be found here:
 - [Desktop app](https://community.home-assistant.io/t/the-easiest-method-to-enable-lan-developer-mode-on-xiaomi-bulb/727360)
 - CLI using the python-miio library: [1](https://community.home-assistant.io/t/integrate-mi-smart-led-bulb-easy-steps/312174), [2](https://community.home-assistant.io/t/integrate-mi-smart-led-bulb-warm-white-xmbgdp01ylk/290404)

--- a/source/_integrations/yeelight.markdown
+++ b/source/_integrations/yeelight.markdown
@@ -161,7 +161,10 @@ Per default, the bulb limits the number of requests per minute to 60, a limitati
 Before trying to control your light through Home Assistant, you have to set up your bulb using the Yeelight app. ( [Android](https://play.google.com/store/apps/details?id=com.yeelight.cherry&hl=fr), [IOS](https://itunes.apple.com/us/app/yeelight/id977125608?mt=8) ).
 In the bulb property, you have to enable "LAN Control" (previously called "Developer mode"). LAN Control may only be available with the latest firmware installed on your bulb.  Firmware can be updated in the application after connecting the bulb.
 Determine your bulb IP (using router, software, ping...).
-Information on how to enable "LAN Control" can be found [here](https://www.yeelight.com/faqs/lan_control).
+~~Information on how to enable "LAN Control" can be found [here](https://www.yeelight.com/faqs/lan_control).~~
+Currently, there is no official way to change LAN mode. However, some methods might be found here:
+- [Desktop app](https://community.home-assistant.io/t/the-easiest-method-to-enable-lan-developer-mode-on-xiaomi-bulb/727360)
+- CLI using the python-miio library: [1](https://community.home-assistant.io/t/integrate-mi-smart-led-bulb-easy-steps/312174), [2](https://community.home-assistant.io/t/integrate-mi-smart-led-bulb-warm-white-xmbgdp01ylk/290404)
 
 </div>
 


### PR DESCRIPTION
## Proposed change
Update information about enabling LAN mode for Xiaomi bulbs. 
The old text is just been strikethrough, maybe there is a better way to mark the official guide website as deprecated.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated information on enabling "LAN Control" for Yeelight bulbs, noting the absence of an official method and suggesting alternative approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->