### PR TITLE
Add MikroTik BT5 integration documentation

### DIFF
--- a/source/_integrations/mikrotik_bt5.markdown
+++ b/source/_integrations/mikrotik_bt5.markdown
@@ -1,0 +1,29 @@
+---
+title: MikroTik BT5
+description: Instructions on how to integrate MikroTik BT5 devices into Home Assistant.
+ha_category:
+  - Sensor
+ha_bluetooth: true
+ha_release: 2024.6
+ha_iot_class: Local Push
+ha_codeowners:
+  - '@anrijs'
+ha_domain: mikrotik_bt5
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_integration_type: integration
+---
+
+Integrates [MikroTik](https://mikrotik.com/) bluetooth tags into Home Assistant.
+
+{% include integrations/config_flow.md %}
+
+The MikroTik BT5 integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
+
+## Supported devices
+
+- [MikroTik TG-BT5-IN](https://mikrotik.com/product/tg_bt5_in/)
+- [MikroTik TB-BT5-OUT](https://mikrotik.com/product/tg_bt5_out/)
+
+  The MikroTik BT5 integration requires that your MikroTik BT5 devices has MikroTik Beacon enabled. This can be done within the settings portion of the MikroTik Beacon Manager mobile application on both Android and iOS.

--- a/source/_integrations/mikrotik_bt5.markdown
+++ b/source/_integrations/mikrotik_bt5.markdown
@@ -15,7 +15,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-Integrates [MikroTik](https://mikrotik.com/) bluetooth tags into Home Assistant.
+Integrates [MikroTik](https://mikrotik.com/) Bluetooth tags into Home Assistant.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/mikrotik_bt5.markdown
+++ b/source/_integrations/mikrotik_bt5.markdown
@@ -23,7 +23,7 @@ The MikroTik BT5 integration will automatically discover devices once the [Bluet
 
 ## Supported devices
 
-- [MikroTik TG-BT5-IN](https://mikrotik.com/product/tg_bt5_in/)
-- [MikroTik TB-BT5-OUT](https://mikrotik.com/product/tg_bt5_out/)
+- [MikroTik TG-BT5-IN](https://mikrotik.com/product/tg_bt5_in/) (acceleration and battery charge)
+- [MikroTik TB-BT5-OUT](https://mikrotik.com/product/tg_bt5_out/) (temperature, acceleration and battery charge)
 
   The MikroTik BT5 integration requires that your MikroTik BT5 devices have MikroTik Beacon enabled. This can be done within the settings portion of the MikroTik Beacon Manager mobile application on both Android and iOS.

--- a/source/_integrations/mikrotik_bt5.markdown
+++ b/source/_integrations/mikrotik_bt5.markdown
@@ -26,4 +26,4 @@ The MikroTik BT5 integration will automatically discover devices once the [Bluet
 - [MikroTik TG-BT5-IN](https://mikrotik.com/product/tg_bt5_in/)
 - [MikroTik TB-BT5-OUT](https://mikrotik.com/product/tg_bt5_out/)
 
-  The MikroTik BT5 integration requires that your MikroTik BT5 devices has MikroTik Beacon enabled. This can be done within the settings portion of the MikroTik Beacon Manager mobile application on both Android and iOS.
+  The MikroTik BT5 integration requires that your MikroTik BT5 devices have MikroTik Beacon enabled. This can be done within the settings portion of the MikroTik Beacon Manager mobile application on both Android and iOS.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds documentation for the MikroTik BT5 integration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/117354
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/5456
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
