### PR TITLE
Docs: add glossary ref to configuration.yaml term definition

### DIFF
--- a/source/_docs/authentication/multi-factor-auth.markdown
+++ b/source/_docs/authentication/multi-factor-auth.markdown
@@ -24,7 +24,7 @@ Home Assistant generates a secret key which is synchronized with an app on your 
 
 #### Setting up TOTP
 
-Enable TOTP in your `configuration.yaml` like this:
+Enable TOTP in your {% term "`configuration.yaml`" %} like this:
 
 ```yaml
 homeassistant:
@@ -64,7 +64,7 @@ The Notify MFA module uses the [notify integration](/integrations/notify/) to se
 
 #### Setting up MFA notify
 
-Add Notify MFA to your `configuration.yaml` file like this:
+Add Notify MFA to your {% term "`configuration.yaml`" %} file like this:
 
 ```yaml
 homeassistant:

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -44,7 +44,7 @@ User details are stored in the `[your config]/.storage`  directory. All password
 
 Users can be managed in Home Assistant by the owner. Go to the configuration panel and click on _{% my users %}_.
 
-This is the entry in `configuration.yaml` for Home Assistant auth:
+This is the entry in {% term "`configuration.yaml`" %} for Home Assistant auth:
 
 ```yaml
 homeassistant:
@@ -52,7 +52,7 @@ homeassistant:
     - type: homeassistant
 ```
 
-If you don't specify any `auth_providers` section in the `configuration.yaml` file then this provider will be set up automatically.
+If you don't specify any `auth_providers` section in the {% term "`configuration.yaml`" %} file then this provider will be set up automatically.
 
 ### Trusted networks
 
@@ -72,7 +72,7 @@ You cannot trust a network that you are using in any [trusted_proxies](/integrat
 
 </div>
 
-Here is an example in `configuration.yaml` to set up Trusted Networks:
+Here is an example in {% term "`configuration.yaml`" %} to set up Trusted Networks:
 
 ```yaml
 homeassistant:

--- a/source/_docs/automation/editor.markdown
+++ b/source/_docs/automation/editor.markdown
@@ -39,4 +39,4 @@ Automations created or edited via the user interface are activated immediately a
 
 ## Troubleshooting missing automations
 
-When you're creating automations using the GUI and they don't appear in the UI, make sure that you add back `automation: !include automations.yaml` from the default configuration to your `configuration.yaml`.
+When you're creating automations using the GUI and they don't appear in the UI, make sure that you add back `automation: !include automations.yaml` from the default configuration to your {% term "`configuration.yaml`" %}.

--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -91,4 +91,4 @@ Learn more about blueprints by [reading our tutorial on creating a blueprint](/d
 
 ## Troubleshooting missing automations
 
-When you're creating automations using blueprints and they don't appear in the UI, make sure that you add back `automation: !include automations.yaml` from the default configuration to your `configuration.yaml`.
+When you're creating automations using blueprints and they don't appear in the UI, make sure that you add back `automation: !include automations.yaml` from the default configuration to your {% term "`configuration.yaml`" %}.

--- a/source/_docs/automation/yaml.markdown
+++ b/source/_docs/automation/yaml.markdown
@@ -7,7 +7,7 @@ Automations are created in Home Assistant via the UI, but are stored in a YAML f
 
 The UI will write your automations to `automations.yaml`. This file is managed by the UI and should not be edited manually.
 
-It is also possible to write your automations directly inside `configuration.yaml` or other YAML files. You can do this by adding a labeled `automation` block to your `configuration.yaml`:
+It is also possible to write your automations directly inside {% term "`configuration.yaml`" %} or other YAML files. You can do this by adding a labeled `automation` block to your `configuration.yaml`:
 
 ```yaml
 # The configuration required for the UI to work
@@ -128,7 +128,7 @@ Mode | Description
 
 ## YAML example
 
-Example of a YAML based automation that you can add to `configuration.yaml`.
+Example of a YAML based automation that you can add to {% term "`configuration.yaml`" %}.
 
 {% raw %}
 

--- a/source/_docs/blueprint/tutorial.markdown
+++ b/source/_docs/blueprint/tutorial.markdown
@@ -137,7 +137,7 @@ For more information on blueprint inputs, refer to the documentation of the [blu
 
 With the bare minimum metadata added, your blueprint is ready to use.
 
-Open your `configuration.yaml` and add the following:
+Open your {% term "`configuration.yaml`" %} and add the following:
 
 ```yaml
 automation tutorial:

--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -19,7 +19,7 @@ The package configuration can include: `switch`, `light`, `automation`, `groups`
 
 It can be specified inline or in a separate YAML file using `!include`.
 
-Inline example, main `configuration.yaml`:
+Inline example, main {% term "`configuration.yaml`" %}:
 
 ```yaml
 homeassistant:
@@ -34,7 +34,7 @@ homeassistant:
           ...
 ```
 
-Include example, main `configuration.yaml`:
+Include example, main {% term "`configuration.yaml`" %}:
 
 ```yaml
 homeassistant:
@@ -74,7 +74,7 @@ Integrations inside packages can only specify platform entries using configurati
 
 ## Create a packages folder
 
-One way to organize packages is to create a folder named "packages" in your Home Assistant configuration directory. In the packages directory, you can store any number of packages in a YAML file. This entry in your `configuration.yaml` will load all YAML-files in this _packages_ folder and its subfolders:
+One way to organize packages is to create a folder named "packages" in your Home Assistant configuration directory. In the packages directory, you can store any number of packages in a YAML file. This entry in your {% term "`configuration.yaml`" %} will load all YAML-files in this _packages_ folder and its subfolders:
 
 ```yaml
 homeassistant:

--- a/source/_docs/configuration/secrets.markdown
+++ b/source/_docs/configuration/secrets.markdown
@@ -8,13 +8,13 @@ related:
     title: Splitting the configuration
 ---
 
-The `configuration.yaml` file is a plain-text file, thus it is readable by anyone who has access to the file. The file contains passwords and API tokens which need to be redacted if you want to share your configuration. By using `!secret` you can remove any private information from your configuration files. This separation can also help you to keep easier track of your passwords and API keys, as they are all stored at one place and no longer spread across the `configuration.yaml` file or even multiple YAML files if you [split up your configuration](/docs/configuration/splitting_configuration/).
+The {% term "`configuration.yaml`" %} file is a plain-text file, thus it is readable by anyone who has access to the file. The file contains passwords and API tokens which need to be redacted if you want to share your configuration. By using `!secret` you can remove any private information from your configuration files. This separation can also help you to keep easier track of your passwords and API keys, as they are all stored at one place and no longer spread across the {% term "`configuration.yaml`" %} file or even multiple YAML files if you [split up your configuration](/docs/configuration/splitting_configuration/).
 
 ## Using `secrets.yaml`
 
 The workflow for moving private information to `secrets.yaml` is very similar to the [splitting of the configuration](/docs/configuration/splitting_configuration/). Create a `secrets.yaml` file in your Home Assistant [configuration directory](/docs/configuration/).
 
-The entries for password and API keys in the `configuration.yaml` file usually looks like the example below.
+The entries for password and API keys in the {% term "`configuration.yaml`" %} file usually looks like the example below.
 
 ```yaml
 rest:
@@ -45,7 +45,7 @@ rest_password: "YOUR_PASSWORD"
 When you start splitting your configuration into multiple files, you might end up with configuration in sub folders. Secrets will be resolved in this order:
 
 - A `secrets.yaml` located in the same folder as the YAML file referencing the secret,
-- next, parent folders will be searched for a `secrets.yaml` file with the secret, stopping at the folder with the main `configuration.yaml`.
+- next, parent folders will be searched for a `secrets.yaml` file with the secret, stopping at the folder with the main {% term "`configuration.yaml`" %}.
 
 To see where secrets are being loaded from, you can either add an option to your `secrets.yaml` file or use the `check_config` script. The latter is only available for {% term "Home Assistant Core" %} installations given it's available through [`hass`](/docs/tools/hass/).
 

--- a/source/_docs/configuration/splitting_configuration.markdown
+++ b/source/_docs/configuration/splitting_configuration.markdown
@@ -10,7 +10,7 @@ related:
     title: Using packages to organize configuration files
 ---
 
-So you've been using Home Assistant for a while now and your `configuration.yaml` file brings people to tears because it has become so large. Or, you simply want to start off with the distributed approach. Here's how to split the `configuration.yaml` into more manageable (read: human-readable) pieces.
+So you've been using Home Assistant for a while now and your {% term "`configuration.yaml`" %} file brings people to tears because it has become so large. Or, you simply want to start off with the distributed approach. Here's how to split the {% term "`configuration.yaml`" %} into more manageable (read: human-readable) pieces.
 
 ## Example configuration files for inspiration
 
@@ -22,7 +22,7 @@ As commenting code doesn't always happen, please read on to learn in detail how 
 
 In this section, we are going use some example configuration files and look at their structure and format in more detail.
 
-Now you might think that the `configuration.yaml` will be replaced during the splitting process. However, it will in fact remain, albeit in a much less cluttered form.
+Now you might think that the {% term "`configuration.yaml`" %} will be replaced during the splitting process. However, it will in fact remain, albeit in a much less cluttered form.
 
 ### The core configuration file
 

--- a/source/_docs/configuration/troubleshooting.markdown
+++ b/source/_docs/configuration/troubleshooting.markdown
@@ -17,7 +17,7 @@ If you have incorrect entries in your configuration files you can use the config
 
 ### Problems with the configuration
 
-One of the most common problems with Home Assistant is an invalid `configuration.yaml` or other configuration file.
+One of the most common problems with Home Assistant is an invalid {% term "`configuration.yaml`" %} or other configuration file.
 
 - Home Assistant provides a CLI that allows you to see how it interprets them, each installation type has its own section in the common-tasks about this:
   - [Operating System](/common-tasks/os/#configuration-check)
@@ -25,7 +25,7 @@ One of the most common problems with Home Assistant is an invalid `configuration
   - [Core](/common-tasks/core/#configuration-check)
   - [Supervised](/common-tasks/supervised/#configuration-check)
 
-- The configuration files, including `configuration.yaml` must be UTF-8 encoded. If you see error like `'utf-8' codec can't decode byte`, edit the offending configuration and re-save it as UTF-8.
+- The configuration files, including {% term "`configuration.yaml`" %} must be UTF-8 encoded. If you see error like `'utf-8' codec can't decode byte`, edit the offending configuration and re-save it as UTF-8.
 - You can verify your configuration's YAML structure using [this online YAML parser](https://yaml-online-parser.appspot.com/) or [YAML Validator](https://codebeautify.org/yaml-validator/).
 - To learn more about the quirks of YAML, read [YAML IDIOSYNCRASIES](https://docs.saltproject.io/en/latest/topics/troubleshooting/yaml_idiosyncrasies.html) by SaltStack (the examples there are specific to SaltStack, but do explain YAML issues well).
 
@@ -126,7 +126,7 @@ After you download logs, you will also want to download the diagnostics for the 
 
 ### Handling unexpected restarts or crashes
 
-Suppose you find that Home Assistant unexpectedly restarts or crashes; it's likely that you have a misbehaving integration impacting system stability. Home Assistant has a built-in debug option that can help find implementation errors. It can also block many unsafe thread operations from crashing the system. Enabling debug has a slight performance impact on the system and is not recommended for long-term use. To enable debug, add the following to your `configuration.yaml`:
+Suppose you find that Home Assistant unexpectedly restarts or crashes; it's likely that you have a misbehaving integration impacting system stability. Home Assistant has a built-in debug option that can help find implementation errors. It can also block many unsafe thread operations from crashing the system. Enabling debug has a slight performance impact on the system and is not recommended for long-term use. To enable debug, add the following to your {% term "`configuration.yaml`" %}:
 
 ```yaml
 homeassistant:

--- a/source/_docs/energy/faq.markdown
+++ b/source/_docs/energy/faq.markdown
@@ -31,7 +31,7 @@ To accomplish such, you can use the [utility_meter integration](/integrations/ut
 
 ## The energy dashboard is not visible
 
-If you do not see the Energy dashboard in the sidebar, make sure you have not removed [`default_config:`](/integrations/default_config/) from your `configuration.yaml`. If you have, you will need to add the `energy:` integration manually.
+If you do not see the Energy dashboard in the sidebar, make sure you have not removed [`default_config:`](/integrations/default_config/) from your {% term "`configuration.yaml`" %}. If you have, you will need to add the `energy:` integration manually.
 
 ## Troubleshooting missing entities
 

--- a/source/_docs/quality_scale.markdown
+++ b/source/_docs/quality_scale.markdown
@@ -9,7 +9,7 @@ The Integration Quality Scale scores each integration based on the code quality 
 
 ## No score
 
-This integration passes the bare minimum requirements. That's the level of most integrations when they are introduced into Home Assistant. It doesn't mean that they are bad or buggy, just that you need to configure them with an entry in your `configuration.yaml` file.
+This integration passes the bare minimum requirements. That's the level of most integrations when they are introduced into Home Assistant. It doesn't mean that they are bad or buggy, just that you need to configure them with an entry in your {% term "`configuration.yaml`" %} file.
 
 ## Silver 🥈
 

--- a/source/_docs/tools/check_config.markdown
+++ b/source/_docs/tools/check_config.markdown
@@ -6,7 +6,7 @@ related:
     title: Validating the configuration
 ---
 
-Test any changes to your `configuration.yaml` file before launching Home Assistant. This script allows you to test changes without the need to restart Home Assistant.
+Test any changes to your {% term "`configuration.yaml`" %} file before launching Home Assistant. This script allows you to test changes without the need to restart Home Assistant.
 
 ```bash
 hass --script check_config

--- a/source/_docs/tools/dev-tools.markdown
+++ b/source/_docs/tools/dev-tools.markdown
@@ -32,7 +32,7 @@ It is almost the same as the option under **Settings** > three dot menu (top rig
 
 ### Reloading the YAML configuration
 
-For configuration changes to become effective, the configuration must be reloaded. Most integrations in Home Assistant (that do not interact with {% term devices %} or {% term services %}) can reload changes made to their configuration in `configuration.yaml` without needing to restart Home Assistant.
+For configuration changes to become effective, the configuration must be reloaded. Most integrations in Home Assistant (that do not interact with {% term devices %} or {% term services %}) can reload changes made to their configuration in {% term "`configuration.yaml`" %} without needing to restart Home Assistant.
 
 1. Go to {% my server_controls title="**Developer Tools** > **YAML**" %} and scroll down to the YAML configuration reloading section (alternatively, hit ["c"](/docs/tools/quick-bar/) anywhere in the UI and search for "reload").
    - You are presented with a list of integrations, such as **Automations** or **Conversation**.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Docs: add glossary ref to configuration.yaml term definition

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
