### PR TITLE
Added Automation example for the Radio Browser Intigration

### DIFF
--- a/source/_integrations/radio_browser.markdown
+++ b/source/_integrations/radio_browser.markdown
@@ -24,7 +24,7 @@ To start the Radio Browser, in Home Assistant, go to **Media** > **Radio Browser
 
 ## Automation
 
-You can also use the Radio Browser in automations. When creating an automation, use the **Play Media** action to pick a station from the directory. This allows you for example, to create
+You can also use the Radio Browser in automations. When creating an automation, use the **Play Media** action to pick a station from the directory. This allows you, for example, to create
 an automation that starts playing your favorite radio station on your Cast devices. 
 
 The easiest way to find `media_content_id` is to set up the automation via the UI and then switch to the YAML mode. See [Media Player](/integrations/media_player) for more options.

--- a/source/_integrations/radio_browser.markdown
+++ b/source/_integrations/radio_browser.markdown
@@ -22,6 +22,30 @@ in Home Assistant.
 To start the Radio Browser, in Home Assistant, go to **Media** > **Radio Browser** and select the speaker.
 ![Starting the radio browser](/images/integrations/radio_browser/radio_browser.png)
 
+## Automation
+
 You can also use the Radio Browser in automations. When creating an automation, use the **Play Media** action to pick a station from the directory. This allows you for example to create
-an automation that starts playing your favorite radio station on your
-Cast devices.
+an automation that starts playing your favorite radio station on your Cast devices. 
+
+The easiest way to find `media_content_id` is to set up the automation via the UI and then switch to the YAML mode. See [Media Player](/integrations/media_player) for more options.
+
+```yaml
+service: media_player.play_media
+target:
+  entity_id: media_player.example
+data:
+  media_content_id: media-source://radio_browser/963ccae5-0601-11e8-ae97-52543be04c81
+  media_content_type: audio/mpeg
+metadata:
+  title: Deutschlandfunk [MP3 128k]
+  thumbnail: >-
+    http://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png
+  media_class: music
+  children_media_class: null
+  navigateIds:
+    - {}
+    - media_content_type: app
+      media_content_id: media-source://radio_browser
+    - media_content_type: music
+      media_content_id: media-source://radio_browser/popular
+```

--- a/source/_integrations/radio_browser.markdown
+++ b/source/_integrations/radio_browser.markdown
@@ -27,7 +27,7 @@ To start the Radio Browser, in Home Assistant, go to **Media** > **Radio Browser
 You can also use the Radio Browser in automations. When creating an automation, use the **Play Media** action to pick a station from the directory. This allows you, for example, to create
 an automation that starts playing your favorite radio station on your Cast devices. 
 
-If you want to use a YAML for the Automation you would look like this: 
+If you want to use a YAML for the automation, you would look like this:
 
 ```yaml
 service: media_player.play_media

--- a/source/_integrations/radio_browser.markdown
+++ b/source/_integrations/radio_browser.markdown
@@ -27,7 +27,7 @@ To start the Radio Browser, in Home Assistant, go to **Media** > **Radio Browser
 You can also use the Radio Browser in automations. When creating an automation, use the **Play Media** action to pick a station from the directory. This allows you, for example, to create
 an automation that starts playing your favorite radio station on your Cast devices. 
 
-The easiest way to find `media_content_id` is to set up the automation via the UI and then switch to the YAML mode. See [Media Player](/integrations/media_player) for more options.
+If you want to use a YAML for the Automation you would look like this: 
 
 ```yaml
 service: media_player.play_media
@@ -36,16 +36,6 @@ target:
 data:
   media_content_id: media-source://radio_browser/963ccae5-0601-11e8-ae97-52543be04c81
   media_content_type: audio/mpeg
-metadata:
-  title: Deutschlandfunk [MP3 128k]
-  thumbnail: >-
-    http://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png
-  media_class: music
-  children_media_class: null
-  navigateIds:
-    - {}
-    - media_content_type: app
-      media_content_id: media-source://radio_browser
-    - media_content_type: music
-      media_content_id: media-source://radio_browser/popular
 ```
+
+See [Media Player](/integrations/media_player) for more options.

--- a/source/_integrations/radio_browser.markdown
+++ b/source/_integrations/radio_browser.markdown
@@ -24,7 +24,7 @@ To start the Radio Browser, in Home Assistant, go to **Media** > **Radio Browser
 
 ## Automation
 
-You can also use the Radio Browser in automations. When creating an automation, use the **Play Media** action to pick a station from the directory. This allows you for example to create
+You can also use the Radio Browser in automations. When creating an automation, use the **Play Media** action to pick a station from the directory. This allows you for example, to create
 an automation that starts playing your favorite radio station on your Cast devices. 
 
 The easiest way to find `media_content_id` is to set up the automation via the UI and then switch to the YAML mode. See [Media Player](/integrations/media_player) for more options.
@@ -32,7 +32,7 @@ The easiest way to find `media_content_id` is to set up the automation via the U
 ```yaml
 service: media_player.play_media
 target:
-  entity_id: media_player.example
+  entity_id: media_player.YOUR_MEDIA_PLAYER
 data:
   media_content_id: media-source://radio_browser/963ccae5-0601-11e8-ae97-52543be04c81
   media_content_type: audio/mpeg


### PR DESCRIPTION
## Proposed change

I saw the two issues https://github.com/home-assistant/home-assistant.io/issues/32099,  https://github.com/home-assistant/home-assistant.io/issues/31610 & https://github.com/home-assistant/home-assistant.io/issues/31736 and had myself a bit of trouble setting up the integration without an example.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #31610, #32099 &  #31736

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


---
_edit:_ added https://github.com/home-assistant/home-assistant.io/issues/31736 to the list of Issues
