### PR TITLE
Add data point type option to `knx.telegram` trigger

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -164,7 +164,7 @@ The `knx.telegram` trigger can be used to trigger automations on incoming or out
 
 <div class='note'>
 
-This trigger is also provided as a device trigger by the `KNX Interface` device. It supports setting the options in the automation builder UI, but doesn't support setting a specific DPT (`type`) to decode the payload as it always relies on project data.
+This trigger is also provided as a device trigger by the `KNX Interface` device. It supports setting the options in the automation builder UI, but doesn't support setting a specific <abbr title="data point type">DPT</abbr> (`type`) to decode the payload as it always relies on project data.
 
 </div>
 
@@ -174,7 +174,7 @@ destination:
   type: [string, list]
   required: false
 type:
-  description: If set, the payload will be decoded as given DPT in the trigger data. When not set, the DPT is sorced from project data. KNX sensor types are valid values [KNX Sensor](#sensor) (e.g., "2byte_float" or "percent").
+  description: If set, the payload will be decoded as given DPT in the trigger data. When not set, the DPT is sourced from project data. KNX sensor types are valid values [KNX Sensor](#sensor) (e.g., "2byte_float" or "percent").
   type: [string, integer]
   required: false
 group_value_write:

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -164,7 +164,7 @@ The `knx.telegram` trigger can be used to trigger automations on incoming or out
 
 <div class='note'>
 
-This trigger is also provided as a device trigger by the `KNX Interface` device. It supports setting the options in the automation builder UI.
+This trigger is also provided as a device trigger by the `KNX Interface` device. It supports setting the options in the automation builder UI, but doesn't support setting a specific DPT (`type`) to decode the payload as it always relies on project data.
 
 </div>
 
@@ -172,6 +172,10 @@ This trigger is also provided as a device trigger by the `KNX Interface` device.
 destination:
   description: A group address or a list of group addresses the trigger should listen on. If not set, or an empty list, the trigger will listen on all group addresses.
   type: [string, list]
+  required: false
+type:
+  description: If set, the payload will be decoded as given DPT in the trigger data. When not set, the DPT is sorced from project data. KNX sensor types are valid values [KNX Sensor](#sensor) (e.g., "2byte_float" or "percent").
+  type: [string, integer]
   required: false
 group_value_write:
   description: If set to `false`, the trigger will not fire on GroupValueWrite telegrams.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add data point type option to `knx.telegram` trigger


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/117463
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
