### PR TITLE
Fix links from includes

### DIFF
--- a/source/_includes/feedback.html
+++ b/source/_includes/feedback.html
@@ -1,6 +1,6 @@
 {% unless page.feedback == false  or page.layout == "landingpage"  %}
-<div class="material-card text feedback" id="feedback_section">
-  <h4><a href="#feedback_section" class="title-link"><b> Help us to improve our documentation</b></a></h4>
+<div class="material-card text feedback">
+  <h4><a href="#feedback_section" class="title-link" name="feedback_section"></a><b> Help us to improve our documentation</b></h4>
   Suggest an edit to this page, or provide/view feedback for this page.
   <div class="links">
     <a

--- a/source/_includes/related.html
+++ b/source/_includes/related.html
@@ -8,8 +8,8 @@
 {% endif %}
 {%- endfor -%}
 {% if related_topics and related_topics.size != 0 %}
-<div class="text related-topics" id="related-topics">
-  <h2>Related topics</h2>
+<div class="text related-topics">
+  <h2><a class="title-link" href="#related-topics" name="related-topics"></a>Related topics</h2>
   <ul>
     {% assign site_part = "pages,documents" | split: "," %}
     {%- for related in related_topics -%}
@@ -33,8 +33,8 @@
 </div>
 {% endif %}
 {% if related_links and related_links.size != 0 %}
-<div class="text related-links" id="related-links">
-  <h2>Related links</h2>
+<div class="text related-links">
+  <h2><a class="title-link" href="#related-links" name="related-links"></a>Related links</h2>
   <ul>
     {% for link in related_links %}
     <li><a href="{{ link.url }}" class="link" target="_blank">{{ link.title | default: link.url }}</a></li>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Currently, the content produced by these will hide the container of the content if one selects the anchor of it.
This PR moves the names of those to the a tag instead of the container. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
