### PR TITLE
Add fallback for missing integration_type

### DIFF
--- a/source/integrations.json
+++ b/source/integrations.json
@@ -10,7 +10,7 @@ layout: none
     "description": "{{ integration.description }}",
     "quality_scale": "{{integration.ha_quality_scale}}",
     "iot_class": "{{integration.ha_iot_class}}",
-    "integration_type": "{{integration.ha_integration_type | default: 'hub'}}",
+    "integration_type": "{{integration.ha_integration_type | default: 'hub'}}"
   }{%- if forloop.last -%}{%- else -%},{%- endif -%}
 {%- endif -%}
 {%- endfor %}

--- a/source/integrations.json
+++ b/source/integrations.json
@@ -10,7 +10,7 @@ layout: none
     "description": "{{ integration.description }}",
     "quality_scale": "{{integration.ha_quality_scale}}",
     "iot_class": "{{integration.ha_iot_class}}",
-    "integration_type": "{{integration.ha_integration_type}}"
+    "integration_type": "{{integration.ha_integration_type | default: 'hub'}}",
   }{%- if forloop.last -%}{%- else -%},{%- endif -%}
 {%- endif -%}
 {%- endfor %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Blank integration types are breaking the analytics insights integration, and as the documentation states there is a. default ("hub"), I think it make sense to add that here as a fallback as well.

Ref https://developers.home-assistant.io/docs/creating_integration_manifest#integration-type

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
