### PR TITLE
Fix typo in Tedee doc

### DIFF
--- a/source/_integrations/tedee.markdown
+++ b/source/_integrations/tedee.markdown
@@ -28,7 +28,7 @@ This integration interacts with your [Tedee](https://tedee.com) locks by communi
 - You need to have the local API enabled.
 - The bridge firmware needs to be at least version `2.2.18086` for push updates to work without errors.
 
-If you do not own the bridge, you can still add your locks to Home Assistant through the [HomeKit device integration](/integrations/homekit_controller.markdown). Communication will happen over Bluetooth in that case, and features will be limited.
+If you do not own the bridge, you can still add your locks to Home Assistant through the [HomeKit device integration](/integrations/homekit_controller/). Communication will happen over Bluetooth in that case, and features will be limited.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change
Found a wrong link in the Tedee documentation and fixed it.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
None
## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
