### PR TITLE
Add documentation for Ecovacs position sensors

### DIFF
--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -74,6 +74,9 @@ Additionally, **depending on your model**, the integration provides the followin
     - `Area`: Total cleaned area
     - `Cleanings`: The number of cleanings
     - `Time`: The total cleaning time
+  - `Position`: The following position entities will be created.
+    - `Last Position`: The last bot position (JSON object with X and Y)
+    - `Charger Position`: The charger position (JSON object with X and Y)
 - **Switch**:
   - `Advanced mode`: Enable advanced mode. Disabled by default.
   - `Border switch`: Enable border switch. Disabled by default.
@@ -123,6 +126,23 @@ template:
 
 {% endraw %}
 
+### Handling positions updates
+
+To force the update of Last position and Charger position use the update_positions command on the vacuum entity_
+
+{% raw %}
+
+```yaml
+# Example update_positions command service call
+service: vacuum.send_command
+target:
+  entity_id: vacuum.my_vacuum_id
+data:
+  command: update_positions
+```
+
+{% endraw %}
+
 ### Handling errors
 
 The vacuum entity has an `error` attribute that will contain the _most recent_ error message that came from the vacuum. There is not a comprehensive list of all error messages, so you may need to do some experimentation to determine the error messages that your vacuum can send.
@@ -143,6 +163,7 @@ Finally, if a vacuum becomes unavailable (usually due to being idle and off its 
 ## Self-hosted configuration
 
 Depending on your setup of the self-hosted instance, you can connect to the server using the following settings:
+
 - `Username`: Enter the email address configured in your instance. If authentication is disabled, you can enter any valid email address.
 - `Password`: Enter the password configured in your instance. If authentication is disabled, you can enter any string (series of characters).
 - `REST URL`: http://`SELF_HOSTED_INSTANCE`:8007

--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -128,7 +128,7 @@ template:
 
 ### Handling positions updates
 
-To force the update of Last position and Charger position use the update_positions command on the vacuum entity_
+To force the update of Last position and Charger position use the update_positions command on the vacuum entity.
 
 {% raw %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for Ecovacs position sensors

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/117697
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
