### PR TITLE
uptimerobot: note for people using new dashboard as default

### DIFF
--- a/source/_integrations/uptimerobot.markdown
+++ b/source/_integrations/uptimerobot.markdown
@@ -23,7 +23,7 @@ The **UptimeRobot** {% term integration %} provides entities to get the status f
 
 {% include integrations/config_flow.md %}
 
-To get your API key, go to [My Settings](https://uptimerobot.com/dashboard#mySettings) on the UptimeRobot website, at the bottom you will find your "Main API Key".
+To get your API key, go to [My Settings](https://old.uptimerobot.com/dashboard#mySettings) on the UptimeRobot website, at the bottom you will find your "Main API Key".
 
 > **NOTE**  
 > If you get redirected to the [new dashboard](https://dashboard.uptimerobot.com), you won't be able to find the API key.  

--- a/source/_integrations/uptimerobot.markdown
+++ b/source/_integrations/uptimerobot.markdown
@@ -25,4 +25,8 @@ The **UptimeRobot** {% term integration %} provides entities to get the status f
 
 To get your API key, go to [My Settings](https://uptimerobot.com/dashboard#mySettings) on the UptimeRobot website, at the bottom you will find your "Main API Key".
 
+> **NOTE**  
+> If you get redirected to the [new dashboard](https://dashboard.uptimerobot.com), you won't be able to find the API key.  
+> Go to [Account Details](https://dashboard.uptimerobot.com/account/details) and **disable** `Use New Interface as Default`. You'll now be able to use the previous link to My Settings and create the key.
+
 All the data will be fetched from [UptimeRobot](https://uptimerobot.com).

--- a/source/_integrations/uptimerobot.markdown
+++ b/source/_integrations/uptimerobot.markdown
@@ -25,8 +25,4 @@ The **UptimeRobot** {% term integration %} provides entities to get the status f
 
 To get your API key, go to [My Settings](https://old.uptimerobot.com/dashboard#mySettings) on the UptimeRobot website, at the bottom you will find your "Main API Key".
 
-> **NOTE**  
-> If you get redirected to the [new dashboard](https://dashboard.uptimerobot.com), you won't be able to find the API key.  
-> Go to [Account Details](https://dashboard.uptimerobot.com/account/details) and **disable** `Use New Interface as Default`. You'll now be able to use the previous link to My Settings and create the key.
-
 All the data will be fetched from [UptimeRobot](https://uptimerobot.com).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

As covered by the title, uptimerobot new interface does not expose API keys so one has to disable it to be able to use the old one.

Took me some time to realize that, thought it would be worth adding it to docs

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
