### PR TITLE
Add Alarm Clock documentation

### DIFF
--- a/source/_integrations/alarm_clock.markdown
+++ b/source/_integrations/alarm_clock.markdown
@@ -1,0 +1,132 @@
+---
+title: Alarm Clock
+description: Instructions on how to integrate alarm clocks into Home Assistant.
+ha_category:
+  - Automation
+  - Helper
+ha_release: 2024.6
+ha_quality_scale: internal
+ha_domain: alarm_clock
+ha_integration_type: helper
+---
+
+The `alarm_clock` integration aims to simplify the use of alarm clocks in Home Assistant.
+Alarm clocks can be used to trigger events at a specific time of day.
+They can be set to repeat on specific days of the week, or only once.
+Alarm clocks can be created as a helper and can be utilized by integrations, such as smart alarm clocks.
+
+When an alarm clock starts, changes, finishes, or gets canceled, the corresponding events are fired.
+Listening these events allows you to set your smart wake up light directly form home assistant, or gradually turn up the lights in your bedroom when it's time to wake up.
+
+## Configuration
+
+The preferred way to configure alarm clock helpers is via the user interface at **{% my helpers title="Settings > Devices & Services > Helpers" %}** and click the add button; next choose the {% my config_flow_start domain=page.ha_domain title=page.title %} option.
+
+To be able to add Helpers via the user interface you should have `default_config:` in your {% term "`configuration.yaml`" %}, it should already be there by default unless you removed it. If you removed `default_config:` from your configuration, you must add `timer:` to your `configuration.yaml` first, then you can use the UI.
+
+Alarm clocks can also be configured via configuration.yaml:
+To add an alarm clock to your installation, add the following to your {% term "`configuration.yaml`" %} file:
+
+```yaml
+# Example configuration.yaml entry
+alarm_clock:
+  work:
+    alarm_time: "08:00:00",
+    repeat_days: ["mon", "tue", "wed", "thu", "fri"]
+```
+
+{% configuration %}
+"[alias]":
+  description: Alias for the alarm clock. Multiple entries are allowed.
+  required: true
+  type: map
+  keys:
+    name:
+      description: Friendly name of the timer.
+      required: false
+      type: string
+    icon:
+      description: Set a custom icon for the entity.
+      required: false
+      type: icon
+    alarm_time:
+      description: Time of day to trigger the alarm.
+      required: true
+      type: time
+    repeat_days:
+      description: When set to an array of days, the alarm will repeat on those days unless turned off. If left empty, the alarm will trigger once and then turn off automatically.
+      required: false
+      type: list
+      default: []
+{% endconfiguration %}
+
+Pick an icon from [Material Design Icons](https://pictogrammers.com/library/mdi/) to use for your alarm clock and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.
+
+## Possible states
+
+| State | Description |
+| ----- | ----------- |
+| `on` | The alarm clock is turned on and will trigger at the next possible time. |
+| `off` | The alarm clock is turned off and will not trigger. |
+
+## Events
+
+|           Event | Description |
+| --------------- | ----------- |
+| `alarm_clock.started` | Fired when the alarm clock is turned on |
+| `alarm_clock.finished` | Fired when the alarm clock triggers |
+| `alarm_clock.cancelled` | Fired when the alarm clock is canceled |
+| `alarm_clock.changed` | Fired when the alarm clock's time is changed |
+
+## Services
+
+### Service `alarm_clock.turn_on`
+
+Turn on the alarm clock. If a new `alarm_time` is provided, this will update the time of the alarm.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |      no  | Name of the entity to take action, e.g., `alarm_clock.alarm0`. |
+| `alarm_time`           |      yes | Alarm time in `hh:mm:ss` format. |
+
+### Service `alarm_clock.turn_off`
+
+Turn off the alarm clock.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |      no  | Name of the entity to take action, e.g., `alarm_clock.alarm0`. |
+
+### Service `alarm_clock.reload`
+
+Reload `alarm_clock`'s configuration without restarting Home Assistant itself. This service takes no service data attributes.
+
+### Use the service
+
+Navigate to **Developer Tools** -> **Services** and select the `alarm_clock.turn_on` service, then click the **Fill Example Data** button. Now change the `entity_id` and `alarm_time` and click **Call Service** button.
+
+## Examples
+
+Gradually turn on the bedroom lights when the alarm is triggered.
+
+```yaml
+mode: single
+trigger:
+  - platform: event
+    event_type: alarm_clock.finished
+condition: []
+action:
+  - service: light.turn_on
+    metadata: {}
+    data:
+      brightness_pct: 1
+    target:
+      entity_id: light.bedroom_lights
+  - service: light.turn_on
+    metadata: {}
+    data:
+      transition: 600
+      brightness_pct: 100
+    target:
+      entity_id: light.bedroom_lights
+```

--- a/source/_integrations/alarm_clock.markdown
+++ b/source/_integrations/alarm_clock.markdown
@@ -16,7 +16,7 @@ They can be set to repeat on specific days of the week, or only once.
 Alarm clocks can be created as a helper and can be utilized by integrations, such as smart alarm clocks.
 
 When an alarm clock starts, changes, finishes, or gets canceled, the corresponding events are fired.
-Listening these events allows you to set your smart wake up light directly form home assistant, or gradually turn up the lights in your bedroom when it's time to wake up.
+Listening these events allows you to set your smart wake up light directly from Home Assistant, or gradually turn up the lights in your bedroom when it's time to wake up.
 
 ## Configuration
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add an alarm clock helper that can be used to set alarms. This can be used also by various integrations that provide alarms such as:
https://github.com/theneweinstein/somneo
https://github.com/lukas-clarke/eight_sleep

Without this integration, other integrations need to set up one alarm clock using several individual entities:
- Switch entity for turning on/off the alarm
- Time entity for the alarm's time
- Select entity for choosing between days. However, this only supports one selection. Therefore a text entity might be used but is really clumsy.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/117755
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/5481
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
