### PR TITLE
Add pulse functionality to modbus switches

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1051,6 +1051,16 @@ fans:
       required: false
       default: 0x00
       type: integer
+    pulse:
+      description: "Send a pulse instead of an on or off command, the pulse wil first send the on command and after the pulse delay value it wil subsequently send the off command."
+      required: false
+      default: false
+      type: boolean
+    pulse_delay:
+      description: "The delay value in milliseconds when using pulse."
+      required: false
+      default: 50
+      type: integer
     write_type:
       description: Type of write request.
       required: false
@@ -1125,6 +1135,17 @@ modbus:
         address: 14
         write_type: coil
         verify:
+      - name: "Fan3"
+        slave: 2
+        address: 15
+        write_type: coil
+        pulse: true
+        pulse_delay: 100
+        verify:
+            input_type: coil
+            adress: 8192
+            state_on: 1
+            state_off: 0
       - name: "Register1"
         address: 11
         command_on: 1
@@ -1157,6 +1178,16 @@ lights:
       description: "Value to write to turn off the light."
       required: false
       default: 0x00
+      type: integer
+    pulse:
+      description: "Send a pulse instead of an on or off command, the pulse wil first send the on command and after the pulse delay value it wil subsequently send the off command."
+      required: false
+      default: false
+      type: boolean
+    pulse_delay:
+      description: "The delay value in milliseconds when using pulse."
+      required: false
+      default: 50
       type: integer
     write_type:
       description: "Type of write request."
@@ -1233,6 +1264,17 @@ modbus:
         address: 14
         write_type: coil
         verify:
+      - name: "light3"
+        slave: 2
+        address: 15
+        write_type: coil
+        pulse: true
+        pulse_delay: 100
+        verify:
+            input_type: coil
+            adress: 8192
+            state_on: 1
+            state_off: 0
       - name: "Register1"
         address: 11
         command_on: 1
@@ -1470,6 +1512,16 @@ switches:
       required: false
       default: 0x00
       type: integer
+    pulse:
+      description: "Send a pulse instead of an on or off command, the pulse wil first send the on command and after the pulse delay value it wil subsequently send the off command."
+      required: false
+      default: false
+      type: boolean
+    pulse_delay:
+      description: "The delay value in milliseconds when using pulse."
+      required: false
+      default: 50
+      type: integer
     write_type:
       description: Type of write request.
       required: false
@@ -1574,6 +1626,17 @@ modbus:
         address: 14
         write_type: coil
         verify:
+      - name: Switch3
+        slave: 2
+        address: 15
+        write_type: coil
+        pulse: true
+        pulse_delay: 100
+        verify:
+            input_type: coil
+            adress: 8192
+            state_on: 1
+            state_off: 0
       - name: Register1
         address: 11
         command_on: 1


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This change will add pulse boolean and pulse_delay in milliseconds to the modbus switch configuration.
The purpose of this change is to make it possible to send a ON and OFF pulse signal to the modbus adress instead of staying ON or OFF.
This way it is possible to on or off pulse relays in the plc hardware.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).e
- [] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

[](https://github.com/home-assistant/core/pull/117808)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
