### PR TITLE
Add dreo integration

### DIFF
--- a/source/_integrations/dreo.markdown
+++ b/source/_integrations/dreo.markdown
@@ -1,0 +1,50 @@
+---
+title: Dreo
+description: Instructions on how to set up Dreo fans within Home Assistant.
+ha_category:
+  - Fan
+ha_release: 0.66
+ha_config_flow: true
+ha_domain: dreo
+ha_platforms:
+  - fan
+ha_integration_type: integration
+---
+
+The `**Dreo** integration enables you to control smart switches and outlets connected to the Dreo App.
+
+The devices must be added to the Dreo App before this integration can discover them.
+
+The following platforms are supported:
+
+- **fan**
+
+## Supported devices
+
+This integration supports devices controllable by the Dreo App.  The following devices are supported by this integration:
+
+### Fans
+
+- DR-HTF001S: Tower Fan
+- DR-HTF002S: Tower Fan
+- DR-HTF004S: Tower Fan
+- DR-HTF005S: Tower Fan
+- DR-HTF007S: Tower Fan
+- DR-HTF008S: Tower Fan
+- DR-HTF009S: Tower Fan
+- DR-HTF010S: Tower Fan
+
+## Prerequisite
+
+Before you can use this integration, all devices must be registered with the
+Dreo App. Once registration is complete,  Added dreo integration in Home Assistant.
+
+## Fan exposed attributes
+
+Dreo Tower Fan will expose the following details depending on the features supported by the model:
+
+| Attribute | Description                                                  | Example |
+| --------- | ------------------------------------------------------------ | ------- |
+| `mode`    | The current mode the device is in. (DR-HTF001S/002S/004S/005S/007S/008S/009S/010S) | manual  |
+| `speed`   | The current speed setting of the device. (DR-HTF001S/002S/004S/005S/007S/008S/009S/010S) | 1       |
+| oscillate | The current oscillate setting of the device. (DR-HTF001S/002S/004S/005S/007S/008S/009S/010S) | true    |


### PR DESCRIPTION
Add documentation for Dreo fan

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/119075
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/5487
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
