### PR TITLE
Add override_event_timestamp option to influxdb integration

### DIFF
--- a/source/_integrations/influxdb.markdown
+++ b/source/_integrations/influxdb.markdown
@@ -213,6 +213,11 @@ component_config_glob:
       type: [string, list]
       description: The list of attribute names to ignore when reporting to InfluxDB. Will be merged with the default `ignore_attributes` list when processing a state change event for a particular entity.
       required: false
+override_event_timestamp:
+  description: Use the `override_event_timestamp` attribute (RFC3339 format) as the timestamp if available; otherwise, use the event-fired timestamp. This is useful for sensors where sampling time differs from transmission time.
+  required: false
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 ## Configure filter


### PR DESCRIPTION
## Proposed change
Allow the sensor to override the event-fired timestamp sent to InfluxDB with an RFC3339 timestamp in the override_event_timestamp attribute. This feature is enabled with a boolean configuration named override_event_timestamp, which has a default value of False. This feature is helpful for sensors where sampling time differs from transmission time.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [Add feature to influxdb integration allowing user to override event timestamp with a timestamp attribute #117865 ](https://github.com/home-assistant/core/pull/117865)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
