### PR TITLE
Fix duplicated text in SkyConnect FAQ

### DIFF
--- a/source/skyconnect/index.html
+++ b/source/skyconnect/index.html
@@ -192,7 +192,7 @@ frontpage_image: /images/skyconnect/skyconnect-cover.png
   When we launched Home Assistant SkyConnect, we announced our intent to release firmware supporting multiprotocol, which allows the device's Silicon Labs chip to connect to both Zigbee and Thread networks with one radio. <br /><br />
   This experimental firmware has been available since December 2022. Through extensive testing, we have found that although it works in some circumstances, it has technical limitations that lead to a worse user experience. We now do not recommend using this firmware, and it will be experimental for the foreseeable future. Instead, we will focus on making sure the dedicated Zigbee and Thread firmwares for Home Assistant SkyConnect deliver the best experience to users.<br /><br />
   
-  If you currently have the multiprotocol firmware installed but don't actively use it to connect to Thread devices, we recommend that you <a href="https://skyconnect.home-assistant.io/procedures/disable-multiprotocol/">disable multiprotocol</a>. Nothing changes for current users of the multiprotocol firmware who are happy with their experience. The experimental multiprotocol firmware will remain available, but we will not recommend it to new users. <br /><br />
+  If you currently have the multiprotocol firmware installed but don't actively use it to connect to Thread devices, we recommend that you <a href="https://skyconnect.home-assistant.io/procedures/disable-multiprotocol/">disable multiprotocol</a>. <br /><br />
   Nothing changes for current users of the multiprotocol firmware who are happy with their experience. The experimental multiprotocol firmware will remain available, but we will not recommend it to new users.{% enddetails %}
 </div>
 


### PR DESCRIPTION
## Proposed change
Addresses https://github.com/home-assistant/home-assistant.io/pull/32799#discussion_r1608535810 by removing the duplicated text in the SkyConnect FAQ.

I've removed the text from the first paragraph and kept the separate paragraph, as the paragraphs seem to target slightly different user groups (running multiprotocol, but not using Thread vs running multiprotocol _happily_ (maybe with Thread)).
Of course, it can be changed to keep the text in one paragraph if that's preferred.


## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
