### PR TITLE
Remove link to InfluxDB add-on from integration documentation

### DIFF
--- a/source/_integrations/influxdb.markdown
+++ b/source/_integrations/influxdb.markdown
@@ -17,7 +17,7 @@ related:
     title: Configuration file
 ---
 
-The `influxdb` {% term integration %} makes it possible to transfer all state changes to an external [InfluxDB](https://influxdb.com/) database. See the [official installation documentation](https://docs.influxdata.com/influxdb/v1.7/introduction/installation/) for how to set up an InfluxDB database, or [there is a community add-on](https://community.home-assistant.io/t/community-hass-io-add-on-influxdb/54491) available.
+The `influxdb` {% term integration %} makes it possible to transfer all state changes to an external [InfluxDB](https://influxdb.com/) database. See the [official installation documentation](https://docs.influxdata.com/influxdb/v1.7/introduction/installation/) for how to set up an InfluxDB database.
 
 Additionally, you can now make use of an InfluxDB 2.0 installation with this {% term integration %}. See the [official installation instructions](https://v2.docs.influxdata.com/v2.0/) for how to set up an InfluxDB 2.0 database. Or you can sign up for their [cloud service](https://cloud2.influxdata.com/signup) and connect Home Assistant to that. Note that the configuration is significantly different for a 2.xx installation, the documentation below will note when fields or defaults apply to only a 1.xx installation or a 2.xx installation.
 


### PR DESCRIPTION
Fixes #29193

Removes the reference to the community add-on for InfluxDB from the integration documentation.

- Deletes the paragraph mentioning the community add-on for InfluxDB, aligning the documentation with the current stance on third-party add-ons and ensuring users are directed towards the official installation documentation for setting up InfluxDB.
  

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/home-assistant/home-assistant.io/issues/29193?shareId=1ca35296-f4c6-4fec-82d7-fca729287acd).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated InfluxDB integration documentation to include references and installation instructions for InfluxDB 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->