### PR TITLE
Elaborate on instructions for home assistant deployed using docker container

### DIFF
--- a/source/_integrations/weatherflow.markdown
+++ b/source/_integrations/weatherflow.markdown
@@ -60,4 +60,22 @@ Additionally the following diagnostic sensors are available:
 
 ## Networking notes
 
-This {% term integration %} relies on the ability of Home Assistant to receive `UDP` traffic on port `50222`. You may run into trouble if you have a more complex network setup utilizing either VLANs or multiple subnets.
+This {% term integration %} relies on the ability of Home Assistant to receive `UDP` traffic on port `50222`. You may run into trouble if you have a more complex network setup utilizing either VLANs or multiple subnets. If you are deploying Home Assistant via a Docker container, make sure to run using host networking mode or expose port `50222` as `UDP`. For example.:
+
+```
+docker run -d \
+   ...
+  --network=host \
+  ghcr.io/home-assistant/home-assistant:stable
+```
+
+or
+
+```
+docker run -d \
+   ...
+  -p 50222:50222/udp \
+  ghcr.io/home-assistant/home-assistant:stable
+```
+
+Failing to run host networking or exposing port `50222` as `UDP` will result in the error `Config flow could not be loaded: Unknown error`.


### PR DESCRIPTION
Elaborate on instructions for home assistant deployed using docker container

## Proposed change
Documentation update describing how weatherflow integration needs to be configured when home assistant is run from a docker container.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/101423

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Updated instructions for deploying Home Assistant via a Docker container with specific networking configurations for proper UDP communication on port 50222.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->