### PR TITLE
Update password reset command and serial console setup instructions

### DIFF
--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -58,7 +58,7 @@ Use this procedure only if the following conditions are met:
 2. Once you have opened the Home Assistant command line, enter the following command:
    - Note: `existing_user` is a placeholder. Replace it with your user name.
    - Note: `new_password` is a placeholder. Replace it with your new password.
-   - **Command**: `auth reset --username existing_user --password new_password`
+   - **Command**: `ha auth reset --username existing_user --password new_password`
    - **Troubleshooting**: If you see the message `zsh: command not found: auth`, you likely did not enter the command in the serial console connected to the device itself, but in the terminal within Home Assistant.
 3. You can now log in to Home Assistant using this new password.
 
@@ -138,3 +138,13 @@ For Windows or macOS you will need third party software. Below are some options.
 
 - Windows: <https://www.diskinternals.com/linux-reader/> (read-only access to the SD)
 - macOS: <https://osxfuse.github.io/>
+
+### Serial console setup on Windows
+
+If you are using a Home Assistant Yellow and need to set up a serial console on Windows, follow these steps:
+
+1. Connect the USB cable to the Home Assistant Yellow and your Windows computer.
+2. Download and install the [CP210x Universal Windows Driver](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers?tab=downloads) from Silicon Labs.
+3. Open Device Manager to find the COM port number assigned to your device.
+4. Use a terminal program like PuTTY to connect to the serial console. Use the COM port number found in step 3, set the baud rate to 115200, data bits to 8, stop bits to 1, and parity to None.
+5. You should now have access to the Home Assistant command line interface through the serial console.


### PR DESCRIPTION
Fixes #32920

Updates the password reset instructions and serial console setup guide in the locked out documentation.

- Corrects the password reset command to include the `ha` prefix, ensuring accuracy in the documentation for users attempting to reset their password via the console.
- Adds detailed instructions for setting up a serial console on Windows, including the installation of the CP210x Universal Windows Driver, addressing the issue of unrecognized devices and facilitating access to the Home Assistant command line interface for troubleshooting and configuration.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/home-assistant/home-assistant.io/issues/32920?shareId=cd005d83-c7dd-4a36-a75a-a46cf57c6c6a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the command for resetting authentication in Home Assistant to `ha auth reset`.
  - Added a new section on setting up a serial console on Windows for Home Assistant Yellow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->