### PR TITLE
Below/above is lower/higher than, *equal excluded*

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -215,7 +215,7 @@ automation:
 
 ## Numeric state trigger
 
-Fires when the numeric value of an entity's state (or attribute's value if using the `attribute` property, or the calculated value if using the `value_template` property) **crosses** a given threshold. On state change of a specified entity, attempts to parse the state as a number and fires if the value is changing from above to below or from below to above the given threshold.
+Fires when the numeric value of an entity's state (or attribute's value if using the `attribute` property, or the calculated value if using the `value_template` property) **crosses** a given threshold (equal excluded). On state change of a specified entity, attempts to parse the state as a number and fires if the value is changing from above to below or from below to above the given threshold (equal excluded).
 
 <div class='note'>
 Crossing the threshold means that the trigger only fires if the state wasn't previously within the threshold.

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -165,7 +165,7 @@ condition:
 
 ## Numeric state condition
 
-This type of condition attempts to parse the state of the specified entity or the attribute of an entity as a number, and triggers if the value matches the thresholds.
+This type of condition attempts to parse the state of the specified entity or the attribute of an entity as a number, and triggers if the value matches the thresholds (strictly below/above, so equal excluded).
 
 If both `below` and `above` are specified, both tests have to pass.
 


### PR DESCRIPTION


## Proposed change
I was wondering myself and spent some time searching for the answer and I had to look at the code...

So I suggest to make this more explicit in the doc :) I hope my wording is clear enough.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Related issue: https://github.com/home-assistant/core/issues/7170

- Confirmed by code:
https://github.com/home-assistant/core/blob/cee3be5f7af8f7300921c10cd57b1852ed19d7be/homeassistant/helpers/condition.py#L446-L452
- Confirmed in test (added by https://github.com/home-assistant/core/pull/7857/):
https://github.com/home-assistant/core/blob/cee3be5f7af8f7300921c10cd57b1852ed19d7be/tests/components/homeassistant/triggers/test_numeric_state.py#L329

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Clarified the behavior of the `Numeric state condition` to specify that it triggers only if the value is strictly below or above the thresholds, excluding equality.
  - Updated the description of the `Numeric state trigger` in the automation context to ensure it fires only when the state transitions from above to below or below to above the threshold, excluding equal values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->