### PR TITLE
Add raw tags to escape Jinja syntax in example

### DIFF
--- a/source/_integrations/twilio.markdown
+++ b/source/_integrations/twilio.markdown
@@ -74,6 +74,7 @@ The above opens the garage door when the number `+1XXXXXXXXXXX` calls `+1YYYYYYY
 
 An example of an SMS handler:
 
+{% raw %}
 ```yaml
 alias: Twilio incoming
 trigger:
@@ -91,3 +92,4 @@ action:
         incoming twilio message from {{sender}}: {{ message }}
         all event data: {{ trigger.event.data }}
 ```
+{% endraw %}


### PR DESCRIPTION
## Proposed change
The example YAML contains Jinja variables which need to be escaped so they render correctly

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an example of an SMS handler using Twilio to the documentation for better guidance on integrating Twilio services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->