### PR TITLE
Update Octoprint documentation

### DIFF
--- a/source/_integrations/octoprint.markdown
+++ b/source/_integrations/octoprint.markdown
@@ -59,7 +59,9 @@ verify ssl:
 
 ### API key
 For the integration to work, please check that in Octoprint, the [Discovery Plugin](https://docs.octoprint.org/en/master/bundledplugins/discovery.html) is enabled and in the **Settings** -> **Printer Notifications** menu that **Enable popups** is checked.
-The Octoprint integration will attempt to register itself via the [Application Keys Plugin](https://docs.octoprint.org/en/master/bundledplugins/appkeys.html). After submitting the configuration UI in Home Assistant, open the Octoprint UI and select **Allow** on the prompt. NOTE: You must be logged into Octoprint as the user which you are adding Home Assistant. Otherwise, the popup access prompt does not appear.
+The Octoprint integration will attempt to register itself via the [Application Keys Plugin](https://docs.octoprint.org/en/master/bundledplugins/appkeys.html). After submitting the configuration UI in Home Assistant, log in to Octoprint as the user whose credentials you just entered in Home Assistant, and select **Allow** on the prompt.
+
+NOTE: You *must* be logged into Octoprint as the user which you are adding to Home Assistant. If you log in to Octoprint as any other user, you will not see the prompt to allow access.
 
 ## Binary sensor
 


### PR DESCRIPTION
Make it clearer that for the Octoprint integration, you must be logged in as the user you're adding.

## Proposed change
Edit Octoprint documentation to make an important technical detail clearer.


## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions for Octoprint integration to clarify the importance of logging in as the user being added to Home Assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->