### PR TITLE
Homeassistant integration: update device type section

### DIFF
--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -191,16 +191,23 @@ initial_state:
 
 ### Device class
 
+A device class represents a group of device types. The way a specific device class is shown in the user interface depends on the platform that is using it. For example, binary sensor and cover both support the device class "window". While for the binary sensor the window can only be open or closed, for cover, a window can also be tilted. For a given platform, the device class controls how the device is shown in the user interface. For example: humidifier has two device classes, humidifier and dehumidifier. If the device class is set to `humidifier`, the UI shows **Humidifying**. If it is set to `dehumidifier`, it shows **Drying**.
+
 Device class is currently supported by the following platforms:
 
-- [Binary sensor](/integrations/binary_sensor/)
-- [Button](/integrations/button/)
-- [Cover](/integrations/cover/)
-- [Humidifier](/integrations/humidifier/)
-- [Media player](/integrations/media_player/)
-- [Number](/integrations/number/)
-- [Sensor](/integrations/sensor/)
-- [Switch](/integrations/switch/)
+- [Binary sensor](/integrations/binary_sensor/#device-class)
+- [Button](/integrations/button/#device-class)
+- [Cover](/integrations/cover/#device-class)
+- [Event](/integrations/event/#device-class)
+- [Humidifier](/integrations/humidifier/#device-class)
+- [Media player](/integrations/media_player/#device-class)
+- [Number](/integrations/number/#device-class)
+- [Sensor](/integrations/sensor#device-class)
+- [Switch](/integrations/switch/#device-class)
+- [Update](/integrations/update/#device-class)
+- [Valve](/integrations/valve/#device-class)
+
+For a list of the supported device classes, refer to the documentation of the platform.
 
 ### Manual customization
 

--- a/source/_integrations/update.markdown
+++ b/source/_integrations/update.markdown
@@ -49,7 +49,7 @@ information on the update state:
 - `release_summary`: A summary of the release notes for the update available.
 - `release_url`: A link to the full release announcement for the update available.
 
-## Device classes
+## Device class
 
 The way these update entities are displayed in the frontend depend on their
 device classes. The following device classes are supported for switches:


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Homeassistant integration: update device type section
- Add intro section
- Update list of platforms supporting device types
- point links to device type section
- streamline spelling of "Device class" title
- partially addresses #32480


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
