### PR TITLE
Add config flow to One-Time Password (OTP) integration

### DIFF
--- a/source/_integrations/otp.markdown
+++ b/source/_integrations/otp.markdown
@@ -10,6 +10,7 @@ ha_quality_scale: internal
 ha_domain: otp
 ha_platforms:
   - sensor
+ha_config_flow: true
 ha_integration_type: integration
 related:
   - docs: /docs/configuration/

--- a/source/_integrations/otp.markdown
+++ b/source/_integrations/otp.markdown
@@ -18,29 +18,7 @@ related:
 
 The `otp` {% term integration %} generates One-Time Passwords according to [RFC6238](https://tools.ietf.org/html/rfc6238) that is compatible with most OTP generators available, including Google Authenticator. You can use this when building custom security solutions and want to use "rolling codes", that change every 30 seconds.
 
-## Configuration
-
-To enable the OTP {% term integration %}, add the following lines to your {% term "`configuration.yaml`" %} file.
-{% include integrations/restart_ha_after_config_inclusion.md %}
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: otp
-    token: SHARED_SECRET_TOKEN
-```
-
-{% configuration %}
-name:
-  description: Name of the sensor to use in the frontend.
-  required: false
-  default: OTP Sensor
-  type: string
-token:
-  description: The shared secret you use in your OTP generator (e.g., Google Authenticator on your phone).
-  required: true
-  type: string
-{% endconfiguration %}
+{% include integrations/config_flow.md %}
 
 ## Generating a token
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Remove configuration.yaml set up instructions and add config flow instructions

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/118493
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
