### PR TITLE
Update panasonic_viera.markdown

### DIFF
--- a/source/_integrations/panasonic_viera.markdown
+++ b/source/_integrations/panasonic_viera.markdown
@@ -166,5 +166,6 @@ The list with all known valid keys can be found [here](https://github.com/floria
 - TX-P50GT30Y
 - TX-P50GT60E
 - TX-65HZ1000W
+  TX-65HZ1500
 
 If your model is not on the list, give it a test. If everything works correctly, then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.io/blob/current/source/_integrations/panasonic_viera.markdown).

--- a/source/_integrations/panasonic_viera.markdown
+++ b/source/_integrations/panasonic_viera.markdown
@@ -166,6 +166,6 @@ The list with all known valid keys can be found [here](https://github.com/floria
 - TX-P50GT30Y
 - TX-P50GT60E
 - TX-65HZ1000W
-  TX-65HZ1500
+- TX-65HZ1500
 
 If your model is not on the list, give it a test. If everything works correctly, then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.io/blob/current/source/_integrations/panasonic_viera.markdown).


### PR DESCRIPTION
added Tx-65Hz1500 because it works without problems.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added the `TX-65HZ1500` key to the list of known valid keys for Panasonic Viera models in the integration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->