### PR TITLE
Correct fan to switch

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1489,9 +1489,9 @@ switches:
         coils:
           description: "write_coils is called."
     verify:
-      description: "Read from Modbus device to verify fan.
+      description: "Read from Modbus device to verify switch.
         If used without attributes, it uses the toggle register configuration.
-        If omitted, no verification is done, but the state of the fan is set with each toggle."
+        If omitted, no verification is done, but the state of the switch is set with each toggle."
       required: false
       type: map
       keys:


### PR DESCRIPTION


## Proposed change

The docs related to a switch incorrectly mentioned fans.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [c] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

None

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the description for reading from a Modbus device to verify a switch instead of a fan.
  - Added clarification on the verification process for the switch state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->