### PR TITLE
Document new arming_states in manual alarm control panel

### DIFF
--- a/source/_integrations/manual.markdown
+++ b/source/_integrations/manual.markdown
@@ -73,7 +73,7 @@ disarm_after_trigger:
   type: boolean
   default: false
 arming_states:
-  description: Limit the supported arming states
+  description: Limit the supported arming states.
   required: false
   type: list
   default: armed_away, armed_home, armed_night, armed_vacation, armed_custom_bypass

--- a/source/_integrations/manual.markdown
+++ b/source/_integrations/manual.markdown
@@ -72,6 +72,11 @@ disarm_after_trigger:
   required: false
   type: boolean
   default: false
+arming_states:
+  description: Limit the supported arming states
+  required: false
+  type: list
+  default: armed_away, armed_home, armed_night, armed_vacation, armed_custom_bypass
 armed_custom_bypass/armed_home/armed_away/armed_night/armed_vacation/disarmed/triggered:
   description: State specific settings
   required: false
@@ -132,6 +137,7 @@ be used for example to sound the siren for a shorter time during the night.
 
 In the configuration example below:
 
+- The only arming states allowed are `armed_away` and `armed_home`.
 - The `disarmed` state never triggers the alarm.
 - The `armed_home` state will leave no time to leave the building or disarm the alarm.
 - The other states will give 30 seconds to leave the building before triggering the alarm, and 20 seconds to disarm the alarm when coming back.
@@ -145,6 +151,9 @@ alarm_control_panel:
     arming_time: 30
     delay_time: 20
     trigger_time: 4
+    arming_states:
+      - armed_away
+      - armed_home
     disarmed:
       trigger_time: 0
     armed_home:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
SSIA


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/119122
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `arming_states` field in the alarm control panel configuration to specify and limit supported arming states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->