### PR TITLE
Mention securitas-direct-new-api on Verisure page

### DIFF
--- a/source/_integrations/verisure.markdown
+++ b/source/_integrations/verisure.markdown
@@ -85,9 +85,11 @@ automation:
 
 ## Limitations and known issues
 
-Some users have reported that this integration currently doesn't work in the following countries:
+Some users have reported that this integration currently doesn't work in the following countries because of two-factor authentication:
 
 - France
 - Ireland
 - Italy 
 - Sweden
+
+Instead, users in these countries can use the [`securitas-direct-new-api`](https://github.com/guerrerotook/securitas-direct-new-api) available via HACS.


### PR DESCRIPTION
## Proposed change

The Verisure integration doesn't work for several countries where two factor authentication is required. This commit points users to an integration on HACS which does work.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

Closes https://github.com/home-assistant/core/issues/99507

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `verisure` integration documentation to specify that the integration does not work in certain countries due to two-factor authentication. Provided alternative instructions for affected users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->