### PR TITLE
Skyconnect integration rename skyconnect

### DIFF
--- a/source/_integrations/homeassistant_sky_connect.markdown
+++ b/source/_integrations/homeassistant_sky_connect.markdown
@@ -1,6 +1,6 @@
 ---
-title: Home Assistant Connect&nbsp;ZBT-1
-description: Home Assistant SkyConnect provides hardware information for the hardware configuration page.
+title: Home Assistant Connect ZBT-1
+description: Home Assistant Connect ZBT-1 provides hardware information for the hardware configuration page.
 ha_release: 2022.9
 ha_category:
   - Other
@@ -11,10 +11,10 @@ ha_integration_type: hardware
 ha_config_flow: true
 ---
 
-The Home Assistant SkyConnect integration provides hardware information for the hardware configuration page.
+The Home Assistant Connect ZBT-1 integration provides hardware information for the hardware configuration page.
 
-For documentation on the Home Assistant SkyConnect, please visit the [documentation page](https://skyconnect.home-assistant.io/documentation/).
-If you are looking to buy one, please visit the [product page](https://home-assistant.io/skyconnect)
+For documentation on the Home Assistant Connect ZBT-1, please visit the [documentation page](https://connectzbt1.home-assistant.io/documentation/).
+If you are looking to buy one, please visit the [product page](https://home-assistant.io/connectzbt1)
 
 ## Configuration
 

--- a/source/_integrations/homeassistant_sky_connect.markdown
+++ b/source/_integrations/homeassistant_sky_connect.markdown
@@ -1,5 +1,5 @@
 ---
-title: Home Assistant SkyConnect
+title: Home Assistant Connect&nbsp;ZBT-1
 description: Home Assistant SkyConnect provides hardware information for the hardware configuration page.
 ha_release: 2022.9
 ha_category:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
SkyConnect integration: rename SkyConnect to Connect ZBT-1
Note: can only be merged after the domain of the docs website has been renamed. Otherwise, the links will be dead
Todo: check if `ha_domain: homeassistant_sky_connect` will be renamed

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
