### PR TITLE
Signal Messenger: add text_mode and improve docs

### DIFF
--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -20,6 +20,7 @@ The `signal_messenger` {% term integration %} uses the [Signal Messenger REST AP
 
 ## Setup
  
+### Requirements
 The requirements are:
 
 - You need to set up the Signal Messenger REST API. 
@@ -29,7 +30,7 @@ The requirements are:
 Please follow those [instructions](https://github.com/bbernhard/signal-cli-rest-api/blob/master/doc/HOMEASSISTANT.md), to set up the Signal Messenger REST API. 
 
 
-## Configuration
+### Configuration Variables
 
 To send Signal Messenger notifications with Home Assistant, add the following to your {% term "`configuration.yaml`" %} file.
 {% include integrations/restart_ha_after_config_inclusion.md %}
@@ -44,11 +45,6 @@ notify:
     recipients: # one or more recipients
       - "RECIPIENT1"
 ```
-
-Both phone numbers and Signal Messenger groups can be added to the `recipients`list. However, it's not possible to mix phone numbers and Signal Messenger groups in a single notifier. If you would like to send messages to individual phone numbers and Signal Messenger groups, separate notifiers need to be created.
-
-To obtain the Signal Messenger group ids, follow [this guide]( https://github.com/bbernhard/signal-cli-rest-api/blob/master/doc/HOMEASSISTANT.md).
-
 {% configuration %}
 name:
   description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
@@ -60,22 +56,30 @@ url:
   required: true
   type: string
 number:
-  description: The sender number.
+  description: The sender number, [see Sender/recipient formats](#senderrecipient-formats).
   required: true
   type: string
 recipients:
-  description: A list of recipients (either phone numbers or Signal Messenger group ids).
+  description: A list of recipients (either phone numbers or Signal Messenger group ids [see Sender/recipient formats](#senderrecipient-formats)).
   required: true
-  type: string
+  type: list
 {% endconfiguration %}
 
+### Sender/recipient formats
+Both phone numbers and Signal Messenger groups can be added to the `recipients`list. However, it's not possible to mix phone numbers and Signal Messenger groups in a single notifier. If you would like to send messages to individual phone numbers and Signal Messenger groups, separate notifiers need to be created.
+
+Phone numbers shall include the international code "+XX" format.
+
+To obtain the Signal Messenger group ids, follow [this guide]( https://github.com/bbernhard/signal-cli-rest-api/blob/master/doc/HOMEASSISTANT.md).
 
 
-## Examples
+
+## Notification Service
+### Examples
 
 A few examples on how to use this integration as actions in automations.
 
-### Text message
+#### Text message
 
 ```yaml
 ...
@@ -85,7 +89,7 @@ action:
     message: "That's an example that sends a simple text message to the recipients specified in the configuration.yaml"
 ```
 
-### Text message with an attachment
+#### Text message with an attachment
 
 This example assumes you have an image stored in the default `www`-folder in Home Assistant Operating System.
 
@@ -101,7 +105,7 @@ action:
         - "/config/www/surveillance_camera.jpg"
 ```
 
-### Text message with an attachment from a URL
+#### Text message with an attachment from a URL
 
 To attach files from outside of Home Assistant, the URLs must be added to the [`allowlist_external_urls`](/integrations/homeassistant/#allowlist_external_urls) list.
 

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -70,38 +70,6 @@ recipients:
 {% endconfiguration %}
 
 
-## Sending messages to Signal to trigger events
-
-You can use Signal Messenger REST API as a Home Assistant trigger. In this example, we will make a simple chatbot. If you write anything to your Signal account linked to Signal Messenger REST API, the automation gets triggered, with the condition that the number (attribute source) is correct, to take action by sending a Signal notification back with a "Message received!".
-
-To accomplish this, make sure the addon's `mode` parameter is set to `native` or `normal`, and edit the configuration of Home Assistant, adding a [RESTful resource](/integrations/rest/) as follows:
-
-```yaml
-- resource: "http://127.0.0.1:8080/v1/receive/<number>"
-  headers:
-    Content-Type: application/json
-  sensor:
-    - name: "Signal message received"
-      value_template: "{{ value_json[0].envelope.dataMessage.message }}" #this will fetch the message
-      json_attributes_path: $[0].envelope
-      json_attributes:
-        - source #using attributes you can get additional information, in this case, the phone number.
-  ```
-You can create an automation as follows:
-
-```yaml
-...
-trigger:
-  - platform: state
-    entity_id:
-      - sensor.signal_message_received
-    attribute: source
-    to: "<yournumber>"
-action:
-  - service: notify.signal
-    data:
-      message: "Message received!"
-```
 
 ## Examples
 
@@ -149,4 +117,36 @@ action:
       verify_ssl: false
       urls:
         - "http://homeassistant.local/api/frigate/notifications/<event-id>/thumbnail.jpg"
+```
+## Triggering events based on Signal message reception
+
+You can use Signal Messenger REST API as a Home Assistant trigger. In this example, we will make a simple chatbot. If you write anything to your Signal account linked to Signal Messenger REST API, the automation gets triggered, with the condition that the number (attribute source) is correct, to take action by sending a Signal notification back with a "Message received!".
+
+To accomplish this, make sure the addon's `mode` parameter is set to `native` or `normal`, and edit the configuration of Home Assistant, adding a [RESTful resource](/integrations/rest/) as follows:
+
+```yaml
+- resource: "http://127.0.0.1:8080/v1/receive/<number>"
+  headers:
+    Content-Type: application/json
+  sensor:
+    - name: "Signal message received"
+      value_template: "{{ value_json[0].envelope.dataMessage.message }}" #this will fetch the message
+      json_attributes_path: $[0].envelope
+      json_attributes:
+        - source #using attributes you can get additional information, in this case, the phone number.
+  ```
+You can create an automation as follows:
+
+```yaml
+...
+trigger:
+  - platform: state
+    entity_id:
+      - sensor.signal_message_received
+    attribute: source
+    to: "<yournumber>"
+action:
+  - service: notify.signal
+    data:
+      message: "Message received!"
 ```

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -86,9 +86,14 @@ A few examples on how to use this integration as actions in automations.
 action:
   service: notify.NOTIFIER_NAME
   data:
-    message: "That's an example that sends a simple text message to the recipients specified in the configuration.yaml"
+    message: "That's an example that sends a simple text message to the recipients specified in the configuration.yaml. If text mode is 'styled', you can use *italic*, **bold** or ~strikethrough~ ."
+    ## Optional
+    data:
+      text_mode: styled
 ```
-
+| Attribute   | Optional | Default |Description                                                                                                                                                                                          |
+| ----------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text_mode` | *optional* | normal | Accepted values are `normal` or ` styled`. If set to `styled`, additional text formatting is enabled (*`*italic*`*, **`**bold**`**, and ~~`~strikethrough~`~~). |
 #### Text message with an attachment
 
 This example assumes you have an image stored in the default `www`-folder in Home Assistant Operating System.
@@ -103,13 +108,18 @@ action:
     data:
       attachments:
         - "/config/www/surveillance_camera.jpg"
+      text_mode: styled
 ```
 
+| Data attribute   | Optional | Default |Description                                                                                                                                                                                          |
+| ----------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `attachments` | **required** | -  | List of paths of files to be attached. |
+| `text_mode` | *optional* | normal | Accepted values are `normal` or ` styled`. If set to `styled`, additional text formatting is enabled (*`*italic*`*, **`**bold**`**, and ~~`~strikethrough~`~~). |
 #### Text message with an attachment from a URL
 
 To attach files from outside of Home Assistant, the URLs must be added to the [`allowlist_external_urls`](/integrations/homeassistant/#allowlist_external_urls) list.
 
-Note there is a 50MB size limit for attachments retrieved via URLs. You can also set `verify_ssl` to `false` to ignore SSL errors (default `true`).
+Note there is a 50MB size limit for attachments retrieved via URLs. 
 
 ```yaml
 ...
@@ -121,7 +131,15 @@ action:
       verify_ssl: false
       urls:
         - "http://homeassistant.local/api/frigate/notifications/<event-id>/thumbnail.jpg"
+      text_mode: styled
 ```
+| Data attribute   | Optional | Default |Description                                                                                                                                                                                          |
+| ----------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `urls` | **required** | -  | List of URLs of files to be attached. |
+| `verify_ssl` | *optional* | true  | Accepted values are `true`, `false`. You can set it to `false` to ignore SSL errors. |
+| `text_mode` | *optional* | normal | Accepted values are `normal` or ` styled`. If set to `styled`, additional text formatting is enabled (*`*italic*`*, **`**bold**`**, and ~~`~strikethrough~`~~). |
+
+
 ## Triggering events based on Signal message reception
 
 You can use Signal Messenger REST API as a Home Assistant trigger. In this example, we will make a simple chatbot. If you write anything to your Signal account linked to Signal Messenger REST API, the automation gets triggered, with the condition that the number (attribute source) is correct, to take action by sending a Signal notification back with a "Message received!".

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -117,10 +117,6 @@ action:
 | `text_mode` | *optional* | normal | Accepted values are `normal` or ` styled`. If set to `styled`, additional text formatting is enabled (*`*italic*`*, **`**bold**`**, and ~~`~strikethrough~`~~). |
 #### Text message with an attachment from a URL
 
-To attach files from outside of Home Assistant, the URLs must be added to the [`allowlist_external_urls`](/integrations/homeassistant/#allowlist_external_urls) list.
-
-Note there is a 50MB size limit for attachments retrieved via URLs. 
-
 ```yaml
 ...
 action:
@@ -138,6 +134,11 @@ action:
 | `urls` | **required** | -  | List of URLs of files to be attached. |
 | `verify_ssl` | *optional* | true  | Accepted values are `true`, `false`. You can set it to `false` to ignore SSL errors. |
 | `text_mode` | *optional* | normal | Accepted values are `normal` or ` styled`. If set to `styled`, additional text formatting is enabled (*`*italic*`*, **`**bold**`**, and ~~`~strikethrough~`~~). |
+
+**Notes:**
+- To attach files from outside of Home Assistant, the URLs must be reachable and added to the [`allowlist_external_urls`](/integrations/homeassistant/#allowlist_external_urls) list.
+
+- There is a 50MB size limit for attachments retrieved via URLs. 
 
 
 ## Triggering events based on Signal message reception

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -77,7 +77,7 @@ To obtain the Signal Messenger group ids, follow [this guide]( https://github.co
 ## Notification Service
 ### Examples
 
-A few examples on how to use this integration as actions in automations.
+A few examples on how to use this integration to send notifications from automations..
 
 #### Text message
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding documentation of new [`text_mode` option](https://github.com/home-assistant/core/pull/117148) and improves overall Signal Messenger docs.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/117148
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
