### PR TITLE
Added sync flag for verify section of Switch and Light

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1220,7 +1220,7 @@ lights:
           "
           required: false
           default: false
-          type: bool
+          type: boolean
 
 {% endconfiguration %}
 
@@ -1544,7 +1544,7 @@ switches:
           "
           required: false
           default: false
-          type: bool
+          type: boolean
 
 {% endconfiguration %}
 

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1214,10 +1214,7 @@ lights:
           default: "Same as `command_off`"
           type: integer
         sync:
-          description: "Keep the output synced with HA state.
-          It will cause a signal update on modbus if verify will report a different status of light respect the current one.
-          No action will be performed if verify confirm the current state
-          "
+          description: "Synchronizes the output with the Home Assistant state. If the 'verify' reports a status different from the current one, a signal update on Modbus is performed. No action is taken if the 'verify' confirms the current state."
           required: false
           default: false
           type: boolean
@@ -1538,10 +1535,7 @@ switches:
           default: "Same as `command_off`"
           type: integer
         sync:
-          description: "Keep the output synced with HA state.
-          It will cause a signal update on modbus if verify will report a different status of switch respect the current one.
-          No action will be performed if verify confirm the current state
-          "
+          description: "Synchronizes the output with the Home Assistant state. If the 'verify' reports a status different from the current one, a signal update on Modbus is performed. No action is taken if the 'verify' confirms the current state."
           required: false
           default: false
           type: boolean

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1213,6 +1213,14 @@ lights:
           required: false
           default: "Same as `command_off`"
           type: integer
+        sync:
+          description: "Keep the output synced with HA state.
+          It will cause a signal update on modbus if verify will report a different status of light respect the current one.
+          No action will be performed if verify confirm the current state
+          "
+          required: false
+          default: false
+          type: bool
 
 {% endconfiguration %}
 
@@ -1529,6 +1537,14 @@ switches:
           required: false
           default: "Same as `command_off`"
           type: integer
+        sync:
+          description: "Keep the output synced with HA state.
+          It will cause a signal update on modbus if verify will report a different status of switch respect the current one.
+          No action will be performed if verify confirm the current state
+          "
+          required: false
+          default: false
+          type: bool
 
 {% endconfiguration %}
 


### PR DESCRIPTION
## Proposed change
Added sync flag for switch and light documentation to describe the behavior introduced with PR xxx on core repository


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/119485
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `sync` parameter to the `lights` and `switches` configurations in the Modbus integration. This feature ensures synchronization with Home Assistant (HA) state, updating the Modbus side if discrepancies are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->