### PR TITLE
Improve Generic x86-64 Installation Documentation

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -140,7 +140,9 @@ To write the HAOS image to the boot medium on your x86-64 hardware, there are 2 
 
 ### Method 2: Installing HAOS directly from a boot medium
 
-<div class='note warning'>Use this method only if Method 1 does not work for you.</div>
+<div class='note warning'>
+Use this method only if Method 1 does not work for you.
+</div>
 
 #### Required material
 
@@ -205,8 +207,8 @@ To write the HAOS image to the boot medium on your x86-64 hardware, there are 2 
 *Select and copy the URL or use the "copy" button that appear when you hover it.*
 
 5. Paste the URL into your browser to start the download.
-6. Extract the archive.
-7. Select **Flash from file** and select the image you just downloaded.
+6. Extract the file you just downloaded.
+7. Select **Flash from file** and select the image you just extracted.
    - Do not use **Flash from URL**. It does not work on some systems.
 
   ![Screenshot of the Etcher software showing flash from URL selected.](/images/installation/etcher1_file.png)

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -140,7 +140,7 @@ To write the HAOS image to the boot medium on your x86-64 hardware, there are 2 
 
 ### Method 2: Installing HAOS directly from a boot medium
 
-Use this method only if Method 1 does not work for you.
+<div class='note warning'>Use this method only if Method 1 does not work for you.</div>
 
 #### Required material
 
@@ -205,15 +205,16 @@ Use this method only if Method 1 does not work for you.
 *Select and copy the URL or use the "copy" button that appear when you hover it.*
 
 5. Paste the URL into your browser to start the download.
-6. Select **Flash from file** and select the image you just downloaded.
+6. Extract the archive.
+7. Select **Flash from file** and select the image you just downloaded.
    - Do not use **Flash from URL**. It does not work on some systems.
 
   ![Screenshot of the Etcher software showing flash from URL selected.](/images/installation/etcher1_file.png)
-7. **Select target**.
+8. **Select target**.
 ![Screenshot of the Etcher software showing the select target button highlighted.](/images/installation/etcher3.png)
-8. Select the boot medium ({{site.installation.types[page.installation_type].installation_media}}) you want to use for your installation.
+9. Select the boot medium ({{site.installation.types[page.installation_type].installation_media}}) you want to use for your installation.
 ![Screenshot of the Etcher software showing the targets available.](/images/installation/etcher4.png)
-9. Select **Flash!** to start writing the image.
+10. Select **Flash!** to start writing the image.
    - If the operation fails, decompress the .xz file and try again.
 ![Screenshot of the Etcher software showing the Flash button highlighted.](/images/installation/etcher5.png)
    - When Balena Etcher has finished writing the image, you will see a confirmation.


### PR DESCRIPTION
## Proposed change
Generic x86-64 method 2 has a warning to do method 1 first, but it wasn't highlighted as a warning.
It was also missing the extract step which made it fail.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a warning note in Method 2 of HAOS installation, advising users to use this method only if Method 1 fails.
  - Included steps for extracting the archive before flashing the image.
  - Renumbered the subsequent steps for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Here is the changed page on the netifly build: https://deploy-preview-33241--home-assistant-docs.netlify.app/installation/generic-x86-64#method-2-installing-haos-directly-from-a-boot-medium