### PR TITLE
Document new zwave js services get_lock_usercode and get_lock_usercodes

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -427,6 +427,50 @@ This service will set the configuration of a lock.
 | `twist_assist`       | no       | Enable Twist Assist.   |
 | `block_to_block`       | no       | Enable block-to-block functionality.   |
 
+### Service `zwave_js.get_lock_usercode`
+
+This service will get the usercode for a lock at code slot X.
+
+| Service Data Attribute | Required | Description                                          |
+| ---------------------- | -------- | ---------------------------------------------------- |
+| `entity_id`            | no       | Lock entity or list of entities to get the usercode. |
+| `code_slot`            | yes      | The code slot to get the usercode for.               |
+
+#### Response data
+
+The response data is a dictionary containing the usercode as a string.
+
+```json
+{
+  "usercode": "1234"
+}
+```
+
+### Service `zwave_js.get_lock_usercodes`
+
+This service will get all the usercodes for a lock.
+
+| Service Data Attribute | Required | Description                                          |
+| ---------------------- | -------- | ---------------------------------------------------- |
+| `entity_id`            | no       | Lock entity or list of entities to get the usercode. |
+
+#### Response data
+
+The response data is a dictionary of code slots to usercodes, both represented as strings.
+
+Only code slots that have set usercodes are present in the dictionary.
+
+```json
+{
+  "usercodes": {
+    "1": "1234",
+    "2": "5678",
+    "9": "abcd",
+    "10": "efgh"
+  }
+}
+```
+
 ### Service `zwave_js.set_lock_usercode`
 
 This service will set the usercode of a lock to X at code slot Y.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds documentation for new Z-Wave JS services `get_lock_usercode` and `get_lock_usercodes`.

For details, see https://github.com/home-assistant/core/pull/119714

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/119714
- Fulfills feature request: https://community.home-assistant.io/t/z-wave-js-get-lock-usercode/731489

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `zwave_js.get_lock_usercode` service to retrieve the usercode for a specified code slot on a lock.
  - Added `zwave_js.get_lock_usercodes` service to retrieve all usercodes for a lock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->