### PR TITLE
Multiprotocol: change link to point to Thread support

### DIFF
--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -137,9 +137,9 @@ This section describes how to add it via Home Assistant's preferred {% term Thre
 - **Thread network**: In order to use HomeKit over Thread, you need a working border router.
   - Make sure your Home Assistant device is on the same network (LAN) as the border router.
   - Make sure the {% term Thread %} network you'd like to use is known by Home Assistant and marked as **Preferred network** in the {% term Thread %} configuration.
-  - If you have a Home Assistant Yellow or Connect ZBT-1, you can enable multiprotocol to set up an Open Thread border router and with that a {% term Thread %} network.
-    - Documentation on [enabling multiprotocol on Yellow](https://yellow.home-assistant.io/guides/enable-multiprotocol/)
-    - Documentation on [enabling multiprotocol on Connect ZBT-1](https://connectzbt1.home-assistant.io/procedures/enable-multiprotocol/)
+  - If you have a Home Assistant Yellow or Connect ZBT-1, you can enable Thread to set up an Open Thread border router and with that a {% term Thread %} network.
+    - Documentation on [enabling Thread on Yellow](https://yellow.home-assistant.io/procedures/enable-thread/)
+    - Documentation on [enabling Thread on Connect ZBT-1](https://connectzbt1.home-assistant.io/procedures/enable-thread/)
 
 #### To add a HomeKit device to a Thread network via Home Assistant
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Multiprotocol: change link to point to Thread support




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated references to enabling Thread on Home Assistant Yellow and Connect ZBT-1 devices.
  - Adjusted related documentation links to reflect changes from "multiprotocol" to "Thread."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->