### PR TITLE
Add button platform to Husqvarna Automower

### DIFF
--- a/source/_integrations/husqvarna_automower.markdown
+++ b/source/_integrations/husqvarna_automower.markdown
@@ -103,7 +103,7 @@ The integration will create the following binary sensors:
 
 ### Button (if available)
 
-The integration will create a button entity for confirming minor mower errors. This entity is disabled by default; you have to enable it manually. The API can't detect if the mower has the capability to confirm minor errors remotely. Before enabling this function, refer to the mower documentation.
+The integration will create a button entity for confirming minor mower errors. This entity is disabled by default. You have to enable it manually. The API can't detect if the mower has the capability to confirm minor errors remotely. Before enabling this function, refer to the mower documentation.
 
 ### Device tracker (if available)
 

--- a/source/_integrations/husqvarna_automower.markdown
+++ b/source/_integrations/husqvarna_automower.markdown
@@ -3,6 +3,7 @@ title: Husqvarna Automower
 description: Instructions on how to integrate Husqvarna Automower lawn mowers into Home Assistant.
 ha_category:
   - Binary sensor
+  - Button
   - Device tracker
   - Lawn Mower
   - Number
@@ -16,6 +17,7 @@ ha_codeowners:
   - '@Thomas55555'
 ha_platforms:
   - binary_sensor
+  - button
   - device_tracker
   - diagnostics
   - lawn_mower
@@ -99,6 +101,10 @@ The integration will create the following binary sensors:
 - Returning to dock  
   *The mower is on its way home to the charging station.*
 
+### Button (if available)
+
+The integration will create a button entity for conforming minor errors of the mower. This entity is disabled by default. You have to enable it manually. It can't be detected with the API if the mower has the capability to conform minor errors remotely. Before enabling this function, refer to the mower documentation.
+
 ### Device tracker (if available)
 
 The integration will create a device tracker entity to show the position of the mower.
@@ -143,14 +149,8 @@ The integration will create the following sensors:
 - Total drive distance
 - Total running time
 - Total searching time
-- Work area (if available). For example: *My lawn*, *Front lawn*, *Back lawn*
 
 ### Switch
 
-#### Enable schedule
-
 The integration will create a switch to enable or disable the schedule of the mower. If the switch is on, the mower will mow according to the schedule. If the switch is off the mower will return to the dock and park until further notice.
 
-#### Avoid (if available)
-
-The integration will create a switch for each stay-out zone defined for your mower. When the switch is on, the mower avoids the corresponding zone. When the switch is off, the mower enters the corresponding zone.

--- a/source/_integrations/husqvarna_automower.markdown
+++ b/source/_integrations/husqvarna_automower.markdown
@@ -103,8 +103,7 @@ The integration will create the following binary sensors:
 
 ### Button (if available)
 
-The integration will create a button entity for confirming minor errors of the mower. This entity is disabled by default. You have to enable it manually. It can't be detected with the API if the mower has the capability to conform minor errors remotely. Before enabling this function, refer to the mower documentation.
-
+The integration will create a button entity for confirming minor errors of the mower. This entity is disabled by default. You have to enable it manually. It can't be detected with the API if the mower has the capability to confirm minor errors remotely. Before enabling this function, refer to the mower documentation.
 ### Device tracker (if available)
 
 The integration will create a device tracker entity to show the position of the mower.

--- a/source/_integrations/husqvarna_automower.markdown
+++ b/source/_integrations/husqvarna_automower.markdown
@@ -103,7 +103,8 @@ The integration will create the following binary sensors:
 
 ### Button (if available)
 
-The integration will create a button entity for confirming minor errors of the mower. This entity is disabled by default. You have to enable it manually. It can't be detected with the API if the mower has the capability to confirm minor errors remotely. Before enabling this function, refer to the mower documentation.
+The integration will create a button entity for confirming minor mower errors. This entity is disabled by default; you have to enable it manually. The API can't detect if the mower has the capability to confirm minor errors remotely. Before enabling this function, refer to the mower documentation.
+
 ### Device tracker (if available)
 
 The integration will create a device tracker entity to show the position of the mower.

--- a/source/_integrations/husqvarna_automower.markdown
+++ b/source/_integrations/husqvarna_automower.markdown
@@ -103,7 +103,7 @@ The integration will create the following binary sensors:
 
 ### Button (if available)
 
-The integration will create a button entity for conforming minor errors of the mower. This entity is disabled by default. You have to enable it manually. It can't be detected with the API if the mower has the capability to conform minor errors remotely. Before enabling this function, refer to the mower documentation.
+The integration will create a button entity for confirming minor errors of the mower. This entity is disabled by default. You have to enable it manually. It can't be detected with the API if the mower has the capability to conform minor errors remotely. Before enabling this function, refer to the mower documentation.
 
 ### Device tracker (if available)
 

--- a/source/_integrations/husqvarna_automower.markdown
+++ b/source/_integrations/husqvarna_automower.markdown
@@ -149,8 +149,14 @@ The integration will create the following sensors:
 - Total drive distance
 - Total running time
 - Total searching time
+- Work area (if available). For example: *My lawn*, *Front lawn*, *Back lawn*
 
 ### Switch
 
+#### Enable schedule
+
 The integration will create a switch to enable or disable the schedule of the mower. If the switch is on, the mower will mow according to the schedule. If the switch is off the mower will return to the dock and park until further notice.
 
+#### Avoid (if available)
+
+The integration will create a switch for each stay-out zone defined for your mower. When the switch is on, the mower avoids the corresponding zone. When the switch is off, the mower enters the corresponding zone.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation to the button platform for the Husqvarna Automower integration. Some mowers allow, that minor errors can be confirmed via the API. This is added with the PR. As the API doesn't have a capability attribute for this, the entity is disabled by default.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/119856
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new Button entity for the `husqvarna_automower` integration, allowing users to manually confirm minor mower errors. This entity is disabled by default and needs to be manually enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->