### PR TITLE
Remove Chipolo One Spot from iBeacon compatibility list

### DIFF
--- a/source/_integrations/ibeacon.markdown
+++ b/source/_integrations/ibeacon.markdown
@@ -69,7 +69,6 @@ To get the Estimated distance sensor to work, in most cases, it has to be calibr
 - [Blue Charm Beacons BC08-MultiBeacon](https://bluecharmbeacons.com/product/blue-charm-beacons-bluetooth-ble-ibeacon-bc08-multibeacon-w-motion-sensor-and-button-trigger-ble-5-0/)
 - Blue Charm Beacons BC037G-GeoPattern-iBeacon (discontinued)
 - Blue Charm Beacons BC037S-SmoothPattern-iBeacon (discontinued)
-- [Chipolo ONE Spot](https://chipolo.net/de/products/chipolo-one-spot)
 - [Blue SLIM ID](https://elainnovation.com/en/product/blue-slim-id-en/)
 - [Feasycom FSC-BP103B](https://www.feasycom.com/bluetooth-ibeacon-da14531)
 - [Feasycom FSC-BP104D](https://www.feasycom.com/dialog-da14531-bluetooth-low-energy-beacon)


### PR DESCRIPTION
## Proposed change
Remove the Chipolo One Spot from the iBeacon compatibility list because it does not use the iBeacon protocol. Chipolo One Spot appear as items in Apple's Find My network using their proprietary bluetooth tracking protocol.

After buying 4 of these devices which did not appear as iBeacons, I contacted Chipolo support and asked if the One Spot used the iBeacon protocol. Their reply was as follows:

> Chipolo Spot models have a dynamic ID that changes periodically to ensure anonymity.
> For the application you are talking about, I believe you would need it to have a static ID.
> They also do not advertise the ID all the time, they only do when they are paired but are not connected to the owners mobile device.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [X] Removed stale or deprecated documentation.

## Additional information
- This PR closes issue: #30084
- Original PR which added this change implies that an actual test of a Chipolo One Spot connecting as an iBeacon was never performed: https://github.com/home-assistant/home-assistant.io/pull/25462

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].