### PR TITLE
OpenWeatherMap remove obsolete forecast sensors

### DIFF
--- a/source/_integrations/openweathermap.markdown
+++ b/source/_integrations/openweathermap.markdown
@@ -44,8 +44,8 @@ For more details, set limits on your usage to avoid charges at [OpenWeatherMap S
 
 <div class='note'>
 
-If you register an new API key with OpenWeatherMap, it will be activated automatically, this typically takes between 10 minutes and 2 hours
-after your successful registration. Keep in mind when configuring this integration, that you new API key might
+If you register a new API key with OpenWeatherMap, it will be activated automatically, this typically takes between 10 minutes and 2 hours
+after your successful registration. Keep in mind when configuring this integration, that your new API key might
 not be activated yet. Recent policy changes limit the API access for new registered users with a free plan, they should select the `hourly` mode. The other modes require a paid subscription plan. Invalid API-key errors might occur if your API key is used with the other modes.
 
 </div>
@@ -61,7 +61,7 @@ not be activated yet. Recent policy changes limit the API access for new registe
 | Mode      | API version, `v2.5` (deprecated), `v3.0` new API version. |
 | Language  | Language for receiving data (only for `sensor`)           |
 
-A `sensor` entity will be created for each supported condition. Their ids will follow the format:
+A `sensor` entity will be created for each supported condition. Their IDs will follow the format:
 
 `sensor.<integration name>_<monitored condition>`
 
@@ -94,21 +94,6 @@ The Weather entity provides data only in English. Home Assistant automatically t
 | `weather`                | A human-readable description of the [weather condition](https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2). |
 | `weather_code`           | ID of the [weather condition](https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2).                           |
 | `wind_bearing`           | Wind direction, degrees (meteorological).                                                                                         |
-| `wind_speed`             | Wind speed, metre/sec.                                                                                                            |
-
-### Forecast Weather Conditions
-
-| Condition                            | Description                                                                                                                                                    |
-| :----------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `forecast_cloud_coverage`            | Cloudiness, %.                                                                                                                                                 |
-| `forecast_condition`                 | [Weather condition](https://developers.home-assistant.io/docs/core/entity/weather/#recommended-values-for-state-and-condition) for the forecast's time period. |
-| `forecast_precipitation`             | Combined Rain and Snow volume for the forecast's time period, mm.                                                                                              |
-| `forecast_precipitation_probability` | Probability of precipitation for the forecast's time period.                                                                                                   |
-| `forecast_pressure`                  | Atmospheric pressure at sea level for the forecast's time period, hPa.                                                                                         |
-| `forecast_temperature`               | Maximum temperature for the day.                                                                                                                               |
-| `forecast_temperature_low`           | Minimum temperature for the day.                                                                                                                               |
-| `forecast_time`                      | Time of the forecasted data.                                                                                                                                   |
-| `forecast_wind_bearing`              | Wind direction for the forecast's time period, degrees (meteorological).                                                                                       |
-| `forecast_wind_speed`                | Wind speed for the forecast's time period, metre/sec.                                                                                                          |
+| `wind_speed`             | Wind speed, meter/sec.                                                                                                            |
 
 Details about the API are available in the [OpenWeatherMap documentation](https://openweathermap.org/api).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Remove obsolete forecast sensors as they were fully replaced by `weather.get_forecasts` service.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#119922
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected text, capitalization, and formatting in the OpenWeatherMap integration.
  - Updated wind speed units from "metre/sec" to "meter/sec".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->