### PR TITLE
Update Yale Access Bluetooth setup steps for Android

### DIFF
--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -94,13 +94,13 @@ The iOS app will only save the offline key to your device's filesystem if Auto-U
 
 The Android app will only save the offline key to your device's filesystem if Auto-Unlock has been enabled and used at least once. Auto-Unlock can be disabled once the key has been loaded.
 
-Root access is required to copy the `ModelDatabase.db` from `/data/data/com.august.bennu/databases`. Once copied, you can use [DB Broser for SQLite](https://sqlitebrowser.org/) to open the `ModelDatabase.db`, navigate to the table `LockData` and find the column `offlineKeys`.There, you will find a JSON that includes the `key` and `slot` properties.
+Root access is required to copy the `ModelDatabase.db` from `/data/data/com.august.bennu/databases`. Once copied, you can use [DB Browser for SQLite](https://sqlitebrowser.org/) to open the `ModelDatabase.db`, navigate to the table `LockData` and find the column `offlineKeys`.There, you will find a JSON that includes the `key` and `slot` properties.
 
 ### Android - Yale Home
 
 The Android app will only save the offline key to your device's filesystem if Auto-Unlock has been enabled and used at least once. Auto-Unlock can be disabled once the key has been loaded.
 
-Root access is required to copy the `ModelDatabase.sql` from `/data/data/com.assaabloy.yale/databases`. Once copied, you can use [DB Broser for SQLite](https://sqlitebrowser.org/) to open the `ModelDatabase.sql`, navigate to the table `LockData` and find the column `offlineKeys`.There, you will find a JSON that includes the `key` and `slot` properties.
+Root access is required to copy the `ModelDatabase.sql` from `/data/data/com.assaabloy.yale/databases`. Once copied, you can use [DB Browser for SQLite](https://sqlitebrowser.org/) to open the `ModelDatabase.sql`, navigate to the table `LockData` and find the column `offlineKeys`.There, you will find a JSON that includes the `key` and `slot` properties.
 
 ## Troubleshooting
 

--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -94,13 +94,13 @@ The iOS app will only save the offline key to your device's filesystem if Auto-U
 
 The Android app will only save the offline key to your device's filesystem if Auto-Unlock has been enabled and used at least once. Auto-Unlock can be disabled once the key has been loaded.
 
-Root access is required to copy the `ModelDatabase.db` from `/data/data/com.august.bennu/databases`. Once copied, you can use [DB Browser for SQLite](https://sqlitebrowser.org/) to open the `ModelDatabase.db`, navigate to the table `LockData` and find the column `offlineKeys`.There, you will find a JSON that includes the `key` and `slot` properties.
+Root access is required to copy the `ModelDatabase.db` from `/data/data/com.august.bennu/databases`. Once copied, you can use [DB Browser for SQLite](https://sqlitebrowser.org/) to open the `ModelDatabase.db`, navigate to the table `LockData` and find the column `offlineKeys`. There, you will find a JSON that includes the `key` and `slot` properties.
 
 ### Android - Yale Home
 
 The Android app will only save the offline key to your device's filesystem if Auto-Unlock has been enabled and used at least once. Auto-Unlock can be disabled once the key has been loaded.
 
-Root access is required to copy the `ModelDatabase.sql` from `/data/data/com.assaabloy.yale/databases`. Once copied, you can use [DB Browser for SQLite](https://sqlitebrowser.org/) to open the `ModelDatabase.sql`, navigate to the table `LockData` and find the column `offlineKeys`.There, you will find a JSON that includes the `key` and `slot` properties.
+Root access is required to copy the `ModelDatabase.sql` from `/data/data/com.assaabloy.yale/databases`. Once copied, you can use [DB Browser for SQLite](https://sqlitebrowser.org/) to open the `ModelDatabase.sql`, navigate to the table `LockData` and find the column `offlineKeys`. There, you will find a JSON that includes the `key` and `slot` properties.
 
 ## Troubleshooting
 

--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -94,7 +94,7 @@ The iOS app will only save the offline key to your device's filesystem if Auto-U
 
 The Android app will only save the offline key to your device's filesystem if Auto-Unlock has been enabled and used at least once. Auto-Unlock can be disabled once the key has been loaded.
 
-Root access is required to read the `key` and `slot` stored in `/data/data/com.august.luna/shared_prefs/PeripheralInfoCache.xml`
+Root access is required to copy the `ModelDatabase.db` from `/data/data/com.august.bennu/databases`. Once copied, you can use [DB Broser for SQLite](https://sqlitebrowser.org/) to open the `ModelDatabase.db`, navigate to the table `LockData` and find the column `offlineKeys`.There, you will find a JSON that includes the `key` and `slot` properties.
 
 ### Android - Yale Home
 


### PR DESCRIPTION
## Proposed change

Update the Android documentation for the Yale Access Bluetooth integration. Specifically, changing the Android instructions for the Yale Access app to match the current state of the app.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

In the documentation for the Yale Access Bluetooth integration the steps to fetch credentials on the Android Yale Access app were no longer up to date. The Yale Access app now requires steps that more closely match the documentation for the Yale Home app but with a different path and file extension for the database.

While the file specified by the original documentation (`PeripheralInfoCache`) is still present on the file system, it no longer contains the key and slot properties.

The updated instructions match the existing instructions for Android: Yale Home with the following changes:
 - Path to database file: `/data/data/com.august.bennu/databases`
 - Database filename: `ModelDatabase.db`

### Caveats

This update reflects my experience setting up the integration under the following context. Yale/August/Assa Abloy is particularly inconsistent between countries and sub brands so this may only apply to my locale.

 - Observed on a Pixel 1 running Android 10
 - App downloaded and setup in Canada. [App Link](https://play.google.com/store/apps/details?id=com.august.bennu)
 - Lock is a Yale 450 Assure 2 Touch BLE (YRD450-F-BLE-BSP)

### Tag Alongs
 - Minor spacing and formatting and spelling fixes for existing docs
    - Broser -> Browser
    - Add space after `.`

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to access `key` and `slot` properties: Users now need to copy the `ModelDatabase.db` file and use a SQLite browser to find the required data instead of reading from an XML file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->