### PR TITLE
Docker compose: remove version

### DIFF
--- a/source/_includes/installation/container.md
+++ b/source/_includes/installation/container.md
@@ -96,7 +96,6 @@ In order to use Zigbee or other integrations that require access to devices, you
   content: |
 
     ```yaml
-    version: '3'
     services:
       homeassistant:
         ...
@@ -125,7 +124,6 @@ As jemalloc can cause issues on certain hardware, it can be disabled by passing 
   content: |
 
     ```yaml
-    version: '3'
     services:
       homeassistant:
       ...

--- a/source/_includes/installation/container/compose.md
+++ b/source/_includes/installation/container/compose.md
@@ -1,5 +1,4 @@
 ```yaml
-  version: '3'
   services:
     homeassistant:
       container_name: homeassistant


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Docker compose: remove version
- obsolete according to docker compose specifications: https://docs.docker.com/compose/compose-file/04-version-and-name/
- implements feedback from #33259

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Home Assistant setup guide to remove outdated `version: '3'` declarations from YAML configuration examples for Zigbee integrations and jemalloc configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->