### PR TITLE
Fix referenced UniFi Protect library

### DIFF
--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -308,5 +308,5 @@ If you get errors while authenticating or fetching data for `NvrError... 404 - R
 Similarly, a `502 Bad Gateway` also means that your UniFi Protect application may not be running.
 
 ```log
-pyunifiprotect.NvrError: Fetching Camera List failed: 404 - Reason: Not Found
+uiprotect.NvrError: Fetching Camera List failed: 404 - Reason: Not Found
 ```


### PR DESCRIPTION
## Proposed change

The `pyunifiprotect` library is no longer used. Home Assistant now uses the `uiprotect` library.
This fixes a reference to the library in an example log output.

### Additional information

There's more outdated information on the Protect docs page that should be adjusted in the future, including in this section.
Quality scale and code-owners also seem to be outdated compared to core. Although those may be pulled in with the next major release.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error message for failing to fetch the camera list in UniFi Protect to reflect new library usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->