### PR TITLE
clarify prometheus supported domains

### DIFF
--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -122,6 +122,9 @@ prometheus:
 
 {% include common-tasks/filters.md %}
 
+> [!TIP]
+> Metrics are exported only for certain domains. To find out which ones are supported you can search for `def _handle_` in the [source](https://github.com/home-assistant/core/blob/dev/homeassistant/components/prometheus/__init__.py).
+
 ## Full Example
 
 Advanced configuration example:

--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -209,4 +209,4 @@ For example:
 
 Metrics are exported only for the following domains:
 
-`automation`, `binary_sensor`, `climate`, `cover`, `counter`, `device_tracker`, `fan`, `humidifier`, `input_boolean`, `input_number`, `light`, `lock`, `number`, `person`, `sensor`, `update`, `switch`, `zwave`
+`automation`, `binary_sensor`, `climate`, `cover`, `counter`, `device_tracker`, `fan`, `humidifier`, `input_boolean`, `input_number`, `light`, `lock`, `number`, `person`, `sensor`, `update`, `switch`

--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -122,8 +122,9 @@ prometheus:
 
 {% include common-tasks/filters.md %}
 
-> [!TIP]
-> Metrics are exported only for certain domains. To find out which ones are supported you can search for `def _handle_` in the [source](https://github.com/home-assistant/core/blob/dev/homeassistant/components/prometheus/__init__.py).
+<div class='note'>
+Metrics are exported only for certain domains. For details, see the `def _handle_` functions in the [Prometheus integration source code](https://github.com/home-assistant/core/blob/dev/homeassistant/components/prometheus/__init__.py).
+</div>
 
 ## Full Example
 

--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -122,9 +122,7 @@ prometheus:
 
 {% include common-tasks/filters.md %}
 
-<div class='note'>
-Metrics are exported only for certain domains. For details, see the `def _handle_` functions in the [Prometheus integration source code](https://github.com/home-assistant/core/blob/dev/homeassistant/components/prometheus/__init__.py).
-</div>
+> Note: Metrics are exported only for certain domains. For details, see the `def _handle_` functions in the [Prometheus integration source code](https://github.com/home-assistant/core/blob/dev/homeassistant/components/prometheus/__init__.py).
 
 ## Full Example
 

--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -226,4 +226,6 @@ Metrics are exported only for the following domains:
 - sensor
 - update
 - switch
+<!-- textlint-disable -->
 - zwave
+<!-- textlint-enable -->

--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -209,23 +209,4 @@ For example:
 
 Metrics are exported only for the following domains:
 
-- automation
-- binary_sensor
-- climate
-- cover
-- counter
-- device_tracker
-- fan
-- humidifier
-- input_boolean
-- input_number
-- light
-- lock
-- number
-- person
-- sensor
-- update
-- switch
-<!-- textlint-disable -->
-- zwave
-<!-- textlint-enable -->
+`automation`, `binary_sensor`, `climate`, `cover`, `counter`, `device_tracker`, `fan`, `humidifier`, `input_boolean`, `input_number`, `light`, `lock`, `number`, `person`, `sensor`, `update`, `switch`, `zwave`

--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -122,8 +122,6 @@ prometheus:
 
 {% include common-tasks/filters.md %}
 
-> Note: Metrics are exported only for certain domains. For details, see the `def _handle_` functions in the [Prometheus integration source code](https://github.com/home-assistant/core/blob/dev/homeassistant/components/prometheus/__init__.py).
-
 ## Full Example
 
 Advanced configuration example:
@@ -206,3 +204,26 @@ For example:
 - record: "known_temperature_c"
   expr: "temperature_c unless entity_available == 0"
 ```
+
+## Supported metrics
+
+Metrics are exported only for the following domains:
+
+- automation
+- binary_sensor
+- climate
+- cover
+- counter
+- device_tracker
+- fan
+- humidifier
+- input_boolean
+- input_number
+- light
+- lock
+- number
+- person
+- sensor
+- update
+- switch
+- zwave


### PR DESCRIPTION
## Proposed change
Clarify that Prometheus metrics only include certain domains, regardless of filter configuration.

## Type of change
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information
- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/119803

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a note in the Prometheus section indicating that metrics are exported only for specific domains.
  - Included a list of supported metrics for specific domains in the Prometheus integration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->