### PR TITLE
Generalize the warning about using an unstable connection

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -729,6 +729,6 @@ services:
 
 #### NCP entered failed state
 
-When see `NCP entered failed state. Requesting APP controller restart` in logs during normal operation it indicates there was a drop in communication between ZHA and the serial interface of the Silabs EmberZNet Zigbee Coordinator.
+When you see `NCP entered failed state. Requesting APP controller restart` in logs during normal operation, it indicates a drop in communication between ZHA and the serial interface of the Silabs EmberZNet Zigbee Coordinator.
 
 EZSP (EmberZNet Serial Protocol) interface used by Silicon Labs EmberZNet Zigbee Coordinator adapters requires a stable connection to the serial port, therefor it is not recommended to use a connection over WiFi, WAN, or VPN, etc..

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -138,7 +138,7 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
 
 Be aware that using a Zigbee Coordinator via a Serial-Proxy-Server (also known as Serial-to-IP bridge or Ser2Net remote adapter) over a Wi-Fi, WAN, or VPN connection is not recommended.
 
-Serial protocols used by Zigbee Coordinator do not have enough robustness, resilience, or fault-tolerance to handle packet loss and latency delays that can occur over unstable connections.
+Serial protocols used by the Zigbee Coordinator do not have enough robustness, resilience, or fault tolerance to handle packet loss and latency delays that can occur over unstable connections.
 
 Zigbee Coordinator requires a stable local connection to its serial port interface with no drops in communication between it and the Zigbee gateway application running on the host computer.
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -731,4 +731,4 @@ services:
 
 When you see `NCP entered failed state. Requesting APP controller restart` in logs during normal operation, it indicates a drop in communication between ZHA and the serial interface of the Silabs EmberZNet Zigbee Coordinator.
 
-EZSP (EmberZNet Serial Protocol) interface used by Silicon Labs EmberZNet Zigbee Coordinator adapters requires a stable connection to the serial port, therefor it is not recommended to use a connection over WiFi, WAN, or VPN, etc..
+The EZSP (EmberZNet Serial Protocol) interface used by Silicon Labs EmberZNet Zigbee Coordinator adapters requires a stable connection to the serial port; therefore, it is not recommended to use a connection over Wi-Fi, WAN, VPN, etc.

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -136,7 +136,7 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
 
 <div class="note warning">
 
-Be aware that it is not recommended to use a Zigbee Coordinator via a Serial-Proxy-Server (also known as Serial-to-IP bridge or Ser2Net remote adapter) over a WiFi, WAN, or VPN connection.
+Be aware that using a Zigbee Coordinator via a Serial-Proxy-Server (also known as Serial-to-IP bridge or Ser2Net remote adapter) over a Wi-Fi, WAN, or VPN connection is not recommended.
 
 Serial protocols used by Zigbee Coordinator do not have enough robustness, resilience, or fault-tolerance to handle packet loss and latency delays that can occur over unstable connections.
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -132,7 +132,7 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
   - [ZiGate-Ethernet (Ethernet gateway board for PiZiGate)](https://zigate.fr/produit/zigate-ethernet/)
   - [ZiGate + WiFi Pack](https://zigate.fr/produit/zigatev2-pack-wifi/)
 
-#### Warning about using Zigbee Coordinator over WiFi/WAN/VPN
+#### Warning about using Zigbee Coordinator over Wi-Fi/WAN/VPN
 
 <div class="note warning">
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -132,12 +132,15 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
   - [ZiGate-Ethernet (Ethernet gateway board for PiZiGate)](https://zigate.fr/produit/zigate-ethernet/)
   - [ZiGate + WiFi Pack](https://zigate.fr/produit/zigatev2-pack-wifi/)
 
-#### Warning about Wi-Fi-based Zigbee-to-Serial bridges/gateways
+#### Warning about using Zigbee Coordinator over WiFi/WAN/VPN
 
 <div class="note warning">
 
-The **EZSP** protocol requires a stable connection to the serial port. With _ITEAD Sonoff ZBBridge_ connecting over the WiFi network
-it is expected to see `NCP entered failed state. Requesting APP controller restart` in the logs. This is a normal part of the operation and indicates there was a drop in communication between ZHA and Sonoff bridge.
+Be aware that it is not recommended to use a Zigbee Coordinator via a Serial-Proxy-Server (also known as Serial-to-IP bridge or Ser2Net remote adapter) over a WiFi, WAN, or VPN connection.
+
+Serial protocols used by Zigbee Coordinator do not have enough robustness, resilience, or fault-tolerance to handle packet loss and latency delays that can occur over unstable connections.
+
+Zigbee Coordinator requires a stable local connection to its serial port interface with no drops in communication between it and the Zigbee gateway application running on the host computer.
 
 </div>
 
@@ -721,3 +724,11 @@ services:
     restart: always
     network_mode: host
 ```
+
+### EZSP error and other log messages
+
+#### NCP entered failed state
+
+When see `NCP entered failed state. Requesting APP controller restart` in logs during normal operation it indicates there was a drop in communication between ZHA and the serial interface of the Silabs EmberZNet Zigbee Coordinator.
+
+EZSP (EmberZNet Serial Protocol) interface used by Silicon Labs EmberZNet Zigbee Coordinator adapters requires a stable connection to the serial port, therefor it is not recommended to use a connection over WiFi, WAN, or VPN, etc..

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -140,7 +140,7 @@ Be aware that using a Zigbee Coordinator via a Serial-Proxy-Server (also known a
 
 Serial protocols used by the Zigbee Coordinator do not have enough robustness, resilience, or fault tolerance to handle packet loss and latency delays that can occur over unstable connections.
 
-Zigbee Coordinator requires a stable local connection to its serial port interface with no drops in communication between it and the Zigbee gateway application running on the host computer.
+A Zigbee Coordinator requires a stable local connection to its serial port interface with no drops in communication between it and the Zigbee gateway application running on the host computer.
 
 </div>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Generalize warning about why users should be aware before use an unstable connection to a Zigbee Coordinator serial interface. Also moved the specific EZSP error message can see when get dropped connection to the bottom of the troubleshooting section.

The reason for generalizing this generally warning not recommend to not use a WiFi, WAN and VPN connection between the ZHA integration and a network-attached Zigbee Coordinator with Serial-Proxy-Server is that some such remote adapters now include a built-in VPN and because of that some people in the community have begun suggesting that it is a good idea that normal users should connect ZHA (or Zigbee2MQTT) running one site directly to a Zigbee Coordinator located on a second site via VPN over WAN instead of setting up another instance of Home Assistant + ZHA (or Zigbee2MQTT) to run locally on that second site.

FYI, Z2M generalized their warning -> https://www.zigbee2mqtt.io/advanced/remote-adapter/connect_to_a_remote_adapter.html

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a warning about using Zigbee Coordinator over unreliable connections like WiFi, WAN, or VPN, recommending a stable local connection for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->