### PR TITLE
ZHA common error codes in ZHA logs and fixes

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -725,10 +725,22 @@ services:
     network_mode: host
 ```
 
-### EZSP error and other log messages
+### Common error codes in ZHA logs and other log messages
 
-#### NCP entered failed state
+#### EZSP error - NCP entered failed state
 
-When you see `NCP entered failed state. Requesting APP controller restart` in logs during normal operation, it indicates a drop in communication between ZHA and the serial interface of the Silabs EmberZNet Zigbee Coordinator.
+When you see `NCP entered failed state. Requesting APP controller restart` in ZHA logs during normal operation, that indicates was or is a drop in communication between ZHA and the serial interface of the Silabs EmberZNet Zigbee Coordinator (EZSP).
 
-The EZSP (EmberZNet Serial Protocol) interface used by Silicon Labs EmberZNet Zigbee Coordinator adapters requires a stable connection to the serial port; therefore, it is not recommended to use a connection over Wi-Fi, WAN, VPN, etc.
+The root cause is lost serial connection and correlated symptoms for reset connections include freezes and device non-responsiveness. The solution is to make sure to always have a stable end-to-end serial connection to the Zigbee Coordinator adapter.
+
+The reason is EZSP (EmberZNet Serial Protocol) interface used by Silicon Labs Zigbee Coordinator adapter via bellows requires a stable connection to the serial port, (it is therefore not recommended to use a connection over Wi-Fi, WAN, VPN, etc.).
+
+#### MAC CHANNEL ACCESS FAILURE
+
+The radio error code `MAC_CHANNEL_ACCESS_FAILURE` is common in ZHA logs and means the radio refuses to transmit. This happens when the wireless spectrum is too occupied and that mostly occurs when there is too much EMI/RMI interference, like from EMF sources or when a WiFi network uses the same radio frequency range as the Zigbee channel your Zigbee network in ZHA uses.
+
+If see this often then resolve it by following the suggested actions and tips in the above section about Zigbee interference avoidance and network range/coverage optimization, as well as consider changing either to a different Zigbee channel in ZHA or better yet, try changing your WiFi access point(s) to non-overlapping WiFi channels.
+
+##### NWK TABLE FULL
+
+`NWK_TABLE_FULL` has the same root cause and solutions as the above `MAC_CHANNEL_ACCESS_FAILURE` error.

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -729,7 +729,7 @@ services:
 
 #### EZSP error - NCP entered failed state
 
-When you see `NCP entered failed state. Requesting APP controller restart` in ZHA logs during normal operation, that indicates was or is a drop in communication between ZHA and the serial interface of the Silabs EmberZNet Zigbee Coordinator (EZSP).
+When you see `NCP entered failed state. Requesting APP controller restart` in ZHA logs during normal operation,  there was drop in communication between ZHA and the coordinator.
 
 The root cause is lost serial connection and correlated symptoms for reset connections include freezes and device non-responsiveness. The solution is to make sure to always have a stable end-to-end serial connection to the Zigbee Coordinator adapter.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add two root cause and fixes to two more common error codes in ZHA logs under troubleshooting.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced error message descriptions in ZHA logs for better troubleshooting.
  - Added detailed explanations for common ZHA error codes:
    - Clarified the cause and solutions for `EZSP error - NCP entered failed state`.
    - Emphasized the importance of a stable connection for Zigbee Coordinator adapters.
    - Provided insights into `MAC_CHANNEL_ACCESS_FAILURE` and `NWK_TABLE_FULL` errors, including potential causes and resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->