### PR TITLE
Remove 'video tutorial' self promotion

### DIFF
--- a/source/_integrations/feedreader.markdown
+++ b/source/_integrations/feedreader.markdown
@@ -93,11 +93,6 @@ automation:
 
 Any field under the `<entry>` tag in the feed can be used for example `trigger.event.data.content` will get the body of the feed entry.
 
-### Video tutorial
-This video tutorial explains how to set up the feedreader and show the latest news feed item on your dashboard in Home Assistant.
-
-<lite-youtube videoid="Va4JOKbesi0" videotitle="How to view RSS feeds on your Dashboard in Home Assistant" posterquality="maxresdefault"></lite-youtube>
-
 For more advanced use cases, a custom integration registering to the `feedreader` event type could be used instead:
 
 ```python


### PR DESCRIPTION
Home Assistant documentation has been allowing these video tutorials of the same author on multiple integrations.

Let met stress his PR is not personal.

I feel HA documentation should not contain Self promotion, other than to HA authorized content.


<img width="825" alt="Scherm­afbeelding 2024-06-26 om 14 42 36" src="https://github.com/home-assistant/home-assistant.io/assets/33354141/cec96175-a030-440d-9d0f-9bdda72ba325">

The HA user should Not be confronted with requests to support business other than HA business imho.

Besides above fundamental aspects, these videos will also be outdated soon.

As a matter of fact, this particular video will be outdated by the release of this months release 2024.7.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Removed the video tutorial section from the feedreader setup guide to focus on advanced integration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->