### PR TITLE
Fix clipping text on frontpage

### DIFF
--- a/sass/homeassistant/_overrides.scss
+++ b/sass/homeassistant/_overrides.scss
@@ -620,7 +620,6 @@ article.page,
 article.listing {
   font-size: 1.125em;
   line-height: 1.6;
-  overflow: hidden;
 
   img,
   table {


### PR DESCRIPTION
The text of the features section on the front page is clipped and is now fixed.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Improved layout by removing `overflow: hidden;` from `article.page` and `article.listing`, allowing better handling of overflow content.

- **Bug Fixes**
	- Adjusted scroll position check to ensure the header color change occurs more accurately when scrolling (`<= 1` instead of `<= 10`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->