### PR TITLE
Fix AprilAire case

### DIFF
--- a/source/_integrations/aprilaire.markdown
+++ b/source/_integrations/aprilaire.markdown
@@ -1,6 +1,6 @@
 ---
-title: Aprilaire
-description: Instructions on how to integrate Aprilaire devices into Home Assistant.
+title: AprilAire
+description: Instructions on how to integrate AprilAire devices into Home Assistant.
 ha_category:
   - Climate
 ha_iot_class: Local Push
@@ -14,11 +14,11 @@ ha_platforms:
 ha_integration_type: device
 ---
 
-The Aprilaire integration allows you to control an Aprilaire thermostat.
+The AprilAire integration allows you to control an AprilAire thermostat.
 
 ## Supported Models
 
-This integration supports Aprilaire [8800-series Home Automation Wi-Fi Thermostats](https://www.aprilaire.com/whole-house-products/thermostats/home-automation) and [6000-series Wi-Fi Zone Control devices](https://www.aprilaire.com/whole-house-products/zone-control) which support setting the thermostat to automation mode. It is known that there are some models which are marketed as home automation capable that do not support automation mode, and are therefore not supported.
+This integration supports AprilAire [8800-series Home Automation Wi-Fi Thermostats](https://www.aprilaire.com/whole-house-products/thermostats/home-automation) and [6000-series Wi-Fi Zone Control devices](https://www.aprilaire.com/whole-house-products/zone-control) which support setting the thermostat to automation mode. It is known that there are some models which are marketed as home automation capable that do not support automation mode, and are therefore not supported.
 
 ## Prerequisites
 
@@ -28,4 +28,4 @@ In order to connect to the thermostat, you will need to enable automation mode. 
 
 ## Caution regarding device limitations
 
-Due to limitations of the thermostats, only one automation connection to a device is permitted at one time (the Aprilaire app is not included in this limitation as it uses a separate protocol). Attempting to connect multiple times to the same thermostat simultaneously can cause various issues, including the thermostat becoming unresponsive and shutting down. If this does occur, power cycling the thermostat should restore functionality.
+Due to limitations of the thermostats, only one automation connection to a device is permitted at one time (the AprilAire app is not included in this limitation as it uses a separate protocol). Attempting to connect multiple times to the same thermostat simultaneously can cause various issues, including the thermostat becoming unresponsive and shutting down. If this does occur, power cycling the thermostat should restore functionality.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Fixes the case in the title of the AprilAire integration (the second A is supposed to be capitalized to match the manufacturer branding).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated references from "Aprilaire" to "AprilAire" for consistency.
  - Improved clarity and consistency in the descriptions of supported models and device limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->