### PR TITLE
Fix the category list font cutoff in Safari

### DIFF
--- a/sass/homeassistant/_overrides.scss
+++ b/sass/homeassistant/_overrides.scss
@@ -690,6 +690,7 @@ article.listing {
     overflow-wrap: break-word;
 
     &.btn {
+      font-size: 1.1em;
       text-decoration: none;
       transition: box-shadow .33;
 


### PR DESCRIPTION
## Proposed change
The category list in integrations was experiencing some vertical cutoff of the list items in Safari. This fixes it.

Before:
![Before](https://github.com/home-assistant/home-assistant.io/assets/16113535/34458817-9203-4957-abd9-74e3a42f92fa)

After:
![CleanShot 2024-07-01 at 11 58 20](https://github.com/home-assistant/home-assistant.io/assets/16113535/7b5a1574-d4de-4795-8c1d-f186c517b41a)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

This is just a styling tweak, to improve readability.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved button readability by increasing font size within listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->