### PR TITLE
Update mealie integration docs with API Token location

### DIFF
--- a/source/_integrations/mealie.markdown
+++ b/source/_integrations/mealie.markdown
@@ -17,17 +17,16 @@ ha_integration_type: integration
 
 The Mealie integration will fetch data from your [Mealie instance](https://mealie.io/).
 
-## Getting an API token
+## Prerequisites
 
 You create your API token on your Mealie installation:
 
-1. Sign in to Mealie
-2. Go to your user (profile)
-3. Go to Manage Your API Tokens (`/user/profile/api-tokens`)
-4. Enter a meaningful token name, such as 'Home Assistant'
-5. Click _Generate_
-6. Copy the token that now appears
-7. Paste the token into Home Assistant
+1. Sign in to Mealie.
+2. Go to your user (profile).
+3. Go to **Manage Your API Tokens** under (`/user/profile/api-tokens`).
+4. Enter a meaningful token name, such as 'Home Assistant'.
+5. Select **Generate**.
+6. Copy the token that now appears so that you can later paste it into Home Assistant.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/mealie.markdown
+++ b/source/_integrations/mealie.markdown
@@ -14,7 +14,20 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
+
 The Mealie integration will fetch data from your [Mealie instance](https://mealie.io/).
+
+## Getting an API token
+
+You create your API token on your Mealie installation:
+
+1. Sign in to Mealie
+2. Go to your user (profile)
+3. Go to Manage Your API Tokens (`/user/profile/api-tokens`)
+4. Enter a meaningful token name, such as 'Home Assistant'
+6. Click _Generate_
+7. Copy the token that now appears
+8. Paste the token into Home Assistant
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/mealie.markdown
+++ b/source/_integrations/mealie.markdown
@@ -25,9 +25,9 @@ You create your API token on your Mealie installation:
 2. Go to your user (profile)
 3. Go to Manage Your API Tokens (`/user/profile/api-tokens`)
 4. Enter a meaningful token name, such as 'Home Assistant'
-6. Click _Generate_
-7. Copy the token that now appears
-8. Paste the token into Home Assistant
+5. Click _Generate_
+6. Copy the token that now appears
+7. Paste the token into Home Assistant
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change
Adding how to get a Mealie API token as it's not entirely obvious.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added detailed instructions for obtaining an API token from Mealie, including steps for generating and using the token in Home Assistant.
  - Updated the list of meal plan types to include Breakfast, Lunch, Dinner, and Side.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->