### PR TITLE
 Update HomeKit Bridge documentation to include 2024 US AQI PM2.5 cutoffs

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -675,3 +675,15 @@ With either strategy, the accessory will behave as if it's the first time the ac
 The HomeKit integration remembers a public key for each paired device. Occasionally the public key for a device pairing will be missing because of pairing failures. Suppose one or more devices show the accessory as unavailable. In that case, it may be necessary to unpair and re-pair the device to ensure the integration has the public key for each paired client. The `homekit.unpair` service will forcefully remove all pairings and allow re-pairing with the accessory. When setting up HomeKit from the UI, this avoids the sometimes time-consuming process of deleting and create a new instance.
 
 The accessory will behave as if it's the first time the accessory has been set up, so you will need to restore the name, group, room, scene, and/or automation settings.
+
+#### Air Quality Sensor Entities
+
+HomeKit provides five different values to represent air quality: Excellent, Good, Fair, Inferior, and Poor. For PM2.5 sensor entities in Home Assistant, the raw density value (µg/m3) is used to determine the corresponding value based on the [2024 US AQI](https://www.epa.gov/system/files/documents/2024-02/pm-naaqs-air-quality-index-fact-sheet.pdf) standard. The mapping is as follows:
+
+| HomeKit   | US AQI                                   | PM2.5 µg/m3   |
+|-----------|------------------------------------------|---------------|
+| Excellent | Good (0-50)                              | 0.0 to 9.0    |
+| Good      | Moderate (51-100)                        | 9.1 to 35.4   |
+| Fair      | Unhealthy for Sensitive Groups (101-150) | 35.5 to 55.4  |
+| Inferior  | Unhealthy (151-200)                      | 55.5 to 125.4 |
+| Poor      | Very Unhealthy (201+)                    | 125.5+        |

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -680,7 +680,7 @@ The accessory will behave as if it's the first time the accessory has been set u
 
 HomeKit provides five values to represent air quality: Excellent, Good, Fair, Inferior, and Poor. For PM2.5 sensor entities in Home Assistant, the raw density value (µg/m3) is used to determine the corresponding value based on the [2024 US AQI](https://www.epa.gov/system/files/documents/2024-02/pm-naaqs-air-quality-index-fact-sheet.pdf) standard. The mapping is as follows:
 
-| HomeKit   | US AQI                                   | PM2.5 µg/m3   |
+| HomeKit   | US AQI                                   | PM2.5 µg/m³   |
 |-----------|------------------------------------------|---------------|
 | Excellent | Good (0-50)                              | 0.0 to 9.0    |
 | Good      | Moderate (51-100)                        | 9.1 to 35.4   |

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -678,7 +678,7 @@ The accessory will behave as if it's the first time the accessory has been set u
 
 #### Air Quality Sensor Entities
 
-HomeKit provides five different values to represent air quality: Excellent, Good, Fair, Inferior, and Poor. For PM2.5 sensor entities in Home Assistant, the raw density value (µg/m3) is used to determine the corresponding value based on the [2024 US AQI](https://www.epa.gov/system/files/documents/2024-02/pm-naaqs-air-quality-index-fact-sheet.pdf) standard. The mapping is as follows:
+HomeKit provides five values to represent air quality: Excellent, Good, Fair, Inferior, and Poor. For PM2.5 sensor entities in Home Assistant, the raw density value (µg/m3) is used to determine the corresponding value based on the [2024 US AQI](https://www.epa.gov/system/files/documents/2024-02/pm-naaqs-air-quality-index-fact-sheet.pdf) standard. The mapping is as follows:
 
 | HomeKit   | US AQI                                   | PM2.5 µg/m3   |
 |-----------|------------------------------------------|---------------|


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document air quality standard used to map PM2.5 air quality sensor entities to HomeKit air quality values.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/109900
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detailed guidance on managing air quality sensor entities within the HomeKit integration for Home Assistant.
  - Introduced a mapping table that correlates PM2.5 sensor values to US AQI air quality levels.
  - Enhanced user understanding and interaction with air quality data within the HomeKit setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->