### PR TITLE
Fix front page bug

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -316,11 +316,24 @@ feedback: false
             src="/images/press/LinuxMagazine.png"
         /></div></a>
 
-          <a
-            href="https://www.heise.de/select/ct/2017/26/1513910625909214"
-            target="_blank"
-            rel="noopener"
-            ><img alt="Ct logo" src="/images/press/ct.png"
+        <a
+          href="https://www.heise.de/select/ct/2017/26/1513910625909214"
+          target="_blank"
+          rel="noopener"
+          ><div class="material-card"><img alt="Ct logo" src="/images/press/ct.png"
+        /></div></a>
+      </div>
+    </section>
+
+
+    <!-- Sponsor section -->
+
+    <section class="sponsor">
+      <div class="sponsored-by grid__item one-whole">
+        <h2>The Home Assistant project is sponsored by</h2>
+        <div class="material-card text">
+          <a href="https://www.nabucasa.com"
+            ><img alt="Nabu Casa logo" src="/images/sponsors/nabu_casa.svg"
           /></a>
         </div>
       </div>


### PR DESCRIPTION
## Proposed change
The footer of the front page is at the wrong place due to a bad code commit. The original code has been restored.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a sponsor section on the main page, complete with a "Sponsored by" header and a Nabu Casa logo link within a material card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->