### PR TITLE
Add option to trigger when a template trigger renders any result.

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -136,6 +136,7 @@ These are the properties available for a [Template trigger](/docs/automation/tri
 | `trigger.from_state` | Previous [state object] of entity that caused change.
 | `trigger.to_state` | New [state object] of entity that caused template to change.
 | `trigger.for` | Timedelta object how long state has been to state, if any.
+| `trigger.value` | Rendered value from the `value_template` template.
 
 ### Time
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -678,6 +678,22 @@ Use of the `for` option will not survive Home Assistant restart or the reload of
 If for your use case this is undesired, you could consider using the automation to set an [`input_datetime`](/integrations/input_datetime) to the desired time and then use that [`input_datetime`](/integrations/input_datetime) as an automation trigger to perform the desired actions at the set time.
 {% endimportant %}
 
+### Render on any template update
+
+Template triggers can optionally trigger on each template change.  To achieve this result, set the `render` option to `true`.
+
+{% raw %}
+
+```yaml
+automation:
+  trigger:
+    - platform: template
+      value_template: "{{ label_entities('living_room') | select('is_state', 'on') | list }}"
+      render: true
+```
+
+{% endraw %}
+
 ## Time trigger
 
 The time trigger is configured to fire once a day at a specific time, or at a specific time on a specific date. There are three allowed formats:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->


Currently, template triggers only trigger when the template previously renders `false` and then renders `true`.  This limits template triggers and forces users to create template entities.

Adding the ability to optionally trigger off any template change opens up functionality for automations and template entities.

e.g. A user would now be able to create a trigger based template sensor where there's shared templates across states and attributes.

```
template:
- trigger:
  - platform: template
    value_template: "{{ states.binary_sensor | map('entity_id') | select('is_state_attr', 'device_class', 'battery') | select('is_state', 'on') | list }}"
    trigger_on_new_value: True
  sensor:
  - name: Binary Sensors On Entities
    state: "{{ trigger.value | count }}"
    attributes:
      entity_id: "{{ trigger.value }}"
```

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/121451
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `trigger.value` property for Template triggers, providing the rendered value from the `value_template`.
	- Introduced the `render` option for template triggers, enabling activation on each template change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->