### PR TITLE
Adds note about unit and device class for database size sensor

### DIFF
--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -248,11 +248,11 @@ SELECT pg_database_size('dsmrreader')/1024/1024 as db_size;
 Use `db_size` as column for value.
 Replace `dsmrreader` with the correct name of your database.
 
-{% note %}
+{% tip %}
 The unit of measurement returned by the above query is `MiB`, please configure this correctly.
 
 Set the device class to `Data size` so you can use UI unit conversion.
-{% endnote %}
+{% endtip %}
 
 #### MariaDB/MySQL
 
@@ -263,11 +263,11 @@ SELECT table_schema "database", Round(Sum(data_length + index_length) / POWER(10
 ```
 Use `value` as column for value.
 
-{% note %}
+{% tip %}
 The unit of measurement returned by the above query is `MiB`, please configure this correctly.
 
 Set the device class to `Data size` so you can use UI unit conversion.
-{% endnote %}
+{% endtip %}
 
 #### SQLite
 
@@ -278,11 +278,11 @@ SELECT ROUND(page_count * page_size / 1024 / 1024, 1) as size FROM pragma_page_c
 ```
 Use `size` as column for value.
 
-{% note %}
+{% tip %}
 The unit of measurement returned by the above query is `MiB`, please configure this correctly.
 
 Set the device class to `Data size` so you can use UI unit conversion.
-{% endnote %}
+{% endtip %}
 
 #### MS SQL
 
@@ -301,8 +301,8 @@ SELECT TOP 1 SUM(m.size) * 8 / 1024 as size FROM sys.master_files m INNER JOIN s
 ```
 Use `size` as column for value.
 
-{% note %}
+{% tip %}
 The unit of measurement returned by the above query is `MiB`, please configure this correctly.
 
 Set the device class to `Data size` so you can use UI unit conversion.
-{% endnote %}
+{% endtip %}

--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -248,6 +248,13 @@ SELECT pg_database_size('dsmrreader')/1024/1024 as db_size;
 Use `db_size` as column for value.
 Replace `dsmrreader` with the correct name of your database.
 
+{% note %}
+The unit of measurement returned by the above query is `MiB`, please configure this correctly.
+
+
+Set the state class to `Data size` so you can use UI unit conversion.
+{% endnote %}
+
 #### MariaDB/MySQL
 
 Change `table_schema="homeassistant"` to the name that you use as the database name, to ensure that your sensor will work properly.
@@ -257,6 +264,13 @@ SELECT table_schema "database", Round(Sum(data_length + index_length) / POWER(10
 ```
 Use `value` as column for value.
 
+{% note %}
+The unit of measurement returned by the above query is `MiB`, please configure this correctly.
+
+
+Set the state class to `Data size` so you can use UI unit conversion.
+{% endnote %}
+
 #### SQLite
 
 If you are using the `recorder` integration then you don't need to specify the location of the database. For all other cases, add `sqlite:////path/to/database.db` as Database URL.
@@ -265,6 +279,13 @@ If you are using the `recorder` integration then you don't need to specify the l
 SELECT ROUND(page_count * page_size / 1024 / 1024, 1) as size FROM pragma_page_count(), pragma_page_size();
 ```
 Use `size` as column for value.
+
+{% note %}
+The unit of measurement returned by the above query is `MiB`, please configure this correctly.
+
+
+Set the state class to `Data size` so you can use UI unit conversion.
+{% endnote %}
 
 #### MS SQL
 
@@ -282,3 +303,10 @@ Connecting with MSSQL requires "pyodbc" to be installed on your system, which ca
 SELECT TOP 1 SUM(m.size) * 8 / 1024 as size FROM sys.master_files m INNER JOIN sys.databases d ON d.database_id=m.database_id WHERE d.name='DB_NAME';
 ```
 Use `size` as column for value.
+
+{% note %}
+The unit of measurement returned by the above query is `MiB`, please configure this correctly.
+
+
+Set the state class to `Data size` so you can use UI unit conversion.
+{% endnote %}

--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -251,8 +251,7 @@ Replace `dsmrreader` with the correct name of your database.
 {% note %}
 The unit of measurement returned by the above query is `MiB`, please configure this correctly.
 
-
-Set the state class to `Data size` so you can use UI unit conversion.
+Set the device class to `Data size` so you can use UI unit conversion.
 {% endnote %}
 
 #### MariaDB/MySQL
@@ -267,8 +266,7 @@ Use `value` as column for value.
 {% note %}
 The unit of measurement returned by the above query is `MiB`, please configure this correctly.
 
-
-Set the state class to `Data size` so you can use UI unit conversion.
+Set the device class to `Data size` so you can use UI unit conversion.
 {% endnote %}
 
 #### SQLite
@@ -283,8 +281,7 @@ Use `size` as column for value.
 {% note %}
 The unit of measurement returned by the above query is `MiB`, please configure this correctly.
 
-
-Set the state class to `Data size` so you can use UI unit conversion.
+Set the device class to `Data size` so you can use UI unit conversion.
 {% endnote %}
 
 #### MS SQL
@@ -307,6 +304,5 @@ Use `size` as column for value.
 {% note %}
 The unit of measurement returned by the above query is `MiB`, please configure this correctly.
 
-
-Set the state class to `Data size` so you can use UI unit conversion.
+Set the device class to `Data size` so you can use UI unit conversion.
 {% endnote %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds note about unit and device class for database size sensor.

Link to the SQL page on deploy: https://deploy-preview-33642--home-assistant-docs.netlify.app/integrations/sql/

I chose to place the note at the end of each statement to add each database engine's data size sensor. So, if the user gets there via a link ([this example](https://deploy-preview-33642--home-assistant-docs.netlify.app/integrations/sql/#ms-sql)) they will still see the observation.

But if this is overkill, we can move it to the beginning of the statement, before going into each database engine.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #32666

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added notes on configuring the correct unit of measurement (`MiB`) and setting the state class to `Data size` for UI unit conversion across different database systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->