### PR TITLE
Add icons for quality scale and classify IoT on the integration page

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -51,8 +51,8 @@
   
   {%- if page.ha_quality_scale %}
   <div class='section'>  
-    {% if page.ha_quality_scale == "silver" %}🥈 This is a great integration.<br />{%- endif -%}
-    {% if page.ha_quality_scale == "gold" %}🥇 This is a solid integration.<br />{%- endif -%}
+    {% if page.ha_quality_scale == "silver" %}🥈 This is a great integration!<br />{%- endif -%}
+    {% if page.ha_quality_scale == "gold" %}🥇 This is a solid integration!<br />{%- endif -%}
     {% if page.ha_quality_scale == "platinum" %}🏆 Best of the best!<br />{%- endif -%}
     {% if page.ha_quality_scale == "internal" %}🏠 Under core!<br />{%- endif -%}
     It scores {{page.ha_quality_scale}} on our <a href='/docs/quality_scale/'>quality scale</a>

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -44,7 +44,16 @@
       {% endif %}
 
       {%- if page.ha_iot_class %}
-        <br />Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}.</a>
+      <div class='section'>
+        <iconify-icon icon='mdi:
+          {% if page.ha_iot_class == "Assumed State" %}circle-half-full{%- endif -%}
+          {% if page.ha_iot_class == "Cloud Polling" %}cloud-upload{%- endif -%}
+          {% if page.ha_iot_class == "Cloud Push" %}cloud-download{%- endif -%}
+          {% if page.ha_iot_class == "Local Polling" %}download-network-outline{%- endif -%}
+          {% if page.ha_iot_class == "Local Push" %}upload-network-outline{%- endif -%}
+        '></iconify-icon>
+        Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}.</a>
+      </div>
       {%- endif -%}
     {% endif %}
   </div>

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -47,12 +47,12 @@
 
     {%- if page.ha_iot_class %}
     <div class='section'>
-      {% if page.ha_iot_class == "Assumed State" %}<iconify-icon icon='mdi:circle-half-full'></iconify-icon> {%- endif -%}
-      {% if page.ha_iot_class == "Cloud Polling" %}<iconify-icon icon='mdi:cloud-upload'></iconify-icon> {%- endif -%}
-      {% if page.ha_iot_class == "Cloud Push" %}<iconify-icon icon='mdi:cloud-download'></iconify-icon> {%- endif -%}
-      {% if page.ha_iot_class == "Local Polling" %}<iconify-icon icon='mdi:download-network-outline'></iconify-icon> {%- endif -%}
-      {% if page.ha_iot_class == "Local Push" %}<iconify-icon icon='mdi:upload-network-outline'></iconify-icon> {%- endif -%}
-      Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}.</a>
+      {% if page.ha_iot_class == "Assumed State" %}<iconify-icon icon='mdi:circle-half-full'></iconify-icon>{%- endif -%}
+      {% if page.ha_iot_class == "Cloud Polling" %}<iconify-icon icon='mdi:cloud-upload'></iconify-icon>{%- endif -%}
+      {% if page.ha_iot_class == "Cloud Push" %}<iconify-icon icon='mdi:cloud-download'></iconify-icon>{%- endif -%}
+      {% if page.ha_iot_class == "Local Polling" %}<iconify-icon icon='mdi:download-network-outline'></iconify-icon>{%- endif -%}
+      {% if page.ha_iot_class == "Local Push" %}<iconify-icon icon='mdi:upload-network-outline'></iconify-icon>{%- endif -%}
+      &nbsp;Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}.</a>
     </div>
     {%- endif -%}
   

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -54,7 +54,7 @@
       {% if page.ha_iot_class == "Local Push" %}<iconify-icon icon='mdi:upload-network-outline'></iconify-icon>{%- endif -%}
       Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}.</a>
     </div>
-  {%- endif -%}
+    {%- endif -%}
   
   {%- if page.ha_quality_scale %}
   <div class='section'>  

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -44,8 +44,9 @@
       {% endif %}
 
       {%- if page.ha_iot_class %}
-        <br />Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}</a>
+        <br />Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}.</a>
       {%- endif -%}
+    {% endif %}
   </div>
   
   {%- if page.ha_quality_scale %}

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -42,21 +42,19 @@
           {{ percentage | remove: ".0" }}%</a> of the active installations.
         {% endif %}
       {% endif %}
-
-      {%- if page.ha_iot_class %}
-      <div class='section'>
-        <iconify-icon icon='mdi:
-          {% if page.ha_iot_class == "Assumed State" %}circle-half-full{%- endif -%}
-          {% if page.ha_iot_class == "Cloud Polling" %}cloud-upload{%- endif -%}
-          {% if page.ha_iot_class == "Cloud Push" %}cloud-download{%- endif -%}
-          {% if page.ha_iot_class == "Local Polling" %}download-network-outline{%- endif -%}
-          {% if page.ha_iot_class == "Local Push" %}upload-network-outline{%- endif -%}
-        '></iconify-icon>
-        Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}.</a>
-      </div>
-      {%- endif -%}
     {% endif %}
   </div>
+
+    {%- if page.ha_iot_class %}
+    <div class='section'>
+      {% if page.ha_iot_class == "Assumed State" %}<iconify-icon icon='mdi:circle-half-full'></iconify-icon>{%- endif -%}
+      {% if page.ha_iot_class == "Cloud Polling" %}<iconify-icon icon='mdi:cloud-upload'></iconify-icon>{%- endif -%}
+      {% if page.ha_iot_class == "Cloud Push" %}<iconify-icon icon='mdi:cloud-download'></iconify-icon>{%- endif -%}
+      {% if page.ha_iot_class == "Local Polling" %}<iconify-icon icon='mdi:download-network-outline'></iconify-icon>{%- endif -%}
+      {% if page.ha_iot_class == "Local Push" %}<iconify-icon icon='mdi:upload-network-outline'></iconify-icon>{%- endif -%}
+      Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}.</a>
+    </div>
+  {%- endif -%}
   
   {%- if page.ha_quality_scale %}
   <div class='section'>  

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -44,20 +44,20 @@
       {% endif %}
 
       {%- if page.ha_iot_class %}
-        Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}</a>
+        <br />Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}</a>
       {%- endif -%}
-
-      {%- if page.ha_quality_scale %}
-        {% if page.ha_iot_class %}
-          and it
-        {% else %}
-          It
-        {% endif %}
-        scores {{page.ha_quality_scale}} on our <a href='/docs/quality_scale/'>quality scale</a>
-      {%- endif -%}{%- if page.ha_quality_scale or page.ha_iot_class %}.{%- endif -%}
-    {% endif %}
   </div>
-
+  
+  {%- if page.ha_quality_scale %}
+  <div class='section'>  
+    {% if page.ha_quality_scale == "silver" %}🥈 This is a great integration.<br />{%- endif -%}
+    {% if page.ha_quality_scale == "gold" %}🥇 This is a solid integration.<br />{%- endif -%}
+    {% if page.ha_quality_scale == "platinum" %}🏆 Best of the best!<br />{%- endif -%}
+    {% if page.ha_quality_scale == "internal" %}🏠 Under core!<br />{%- endif -%}
+    It scores {{page.ha_quality_scale}} on our <a href='/docs/quality_scale/'>quality scale</a>
+  </div>
+  {%- endif -%}
+  
   {% if page.works_with %}
     {%- for type in page.works_with -%}
       <div class="section">

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -47,11 +47,11 @@
 
     {%- if page.ha_iot_class %}
     <div class='section'>
-      {% if page.ha_iot_class == "Assumed State" %}<iconify-icon icon='mdi:circle-half-full'></iconify-icon>{%- endif -%}
-      {% if page.ha_iot_class == "Cloud Polling" %}<iconify-icon icon='mdi:cloud-upload'></iconify-icon>{%- endif -%}
-      {% if page.ha_iot_class == "Cloud Push" %}<iconify-icon icon='mdi:cloud-download'></iconify-icon>{%- endif -%}
-      {% if page.ha_iot_class == "Local Polling" %}<iconify-icon icon='mdi:download-network-outline'></iconify-icon>{%- endif -%}
-      {% if page.ha_iot_class == "Local Push" %}<iconify-icon icon='mdi:upload-network-outline'></iconify-icon>{%- endif -%}
+      {% if page.ha_iot_class == "Assumed State" %}<iconify-icon icon='mdi:circle-half-full'></iconify-icon> {%- endif -%}
+      {% if page.ha_iot_class == "Cloud Polling" %}<iconify-icon icon='mdi:cloud-upload'></iconify-icon> {%- endif -%}
+      {% if page.ha_iot_class == "Cloud Push" %}<iconify-icon icon='mdi:cloud-download'></iconify-icon> {%- endif -%}
+      {% if page.ha_iot_class == "Local Polling" %}<iconify-icon icon='mdi:download-network-outline'></iconify-icon> {%- endif -%}
+      {% if page.ha_iot_class == "Local Push" %}<iconify-icon icon='mdi:upload-network-outline'></iconify-icon> {%- endif -%}
       Its IoT class is <a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'>{{ page.ha_iot_class }}.</a>
     </div>
     {%- endif -%}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add icons for quality scale and classify IoT on the integration page

The icons used and the comments are based on the [quality scale documentation](https://www.home-assistant.io/docs/quality_scale/) (but I had to improvise for Silver and Internal, feel free to change) and [classify IoT](https://www.home-assistant.io/blog/2016/02/12/classifying-the-internet-of-things/#classifiers).

Screenshots:
* Quality scale:
   | Scale | Screenshot |
   |---|---|
   | [No score](https://deploy-preview-33648--home-assistant-docs.netlify.app/integrations/icloud/) | ![image](https://github.com/home-assistant/home-assistant.io/assets/31328123/783ebef7-2852-46c8-b805-18bd0155a584) |
   | [Internal](https://deploy-preview-33648--home-assistant-docs.netlify.app/integrations/utility_meter/) | ![image](https://github.com/home-assistant/home-assistant.io/assets/31328123/a2db964b-9f02-4e38-acb6-b19ee9ca36c4) |
   | [Silver](https://deploy-preview-33648--home-assistant-docs.netlify.app/integrations/directv) | ![image](https://github.com/home-assistant/home-assistant.io/assets/31328123/865570e1-c02f-4eda-bb72-56cedd50eaa6) |
   | [Gold](https://deploy-preview-33648--home-assistant-docs.netlify.app/integrations/fastdotcom) | ![image](https://github.com/home-assistant/home-assistant.io/assets/31328123/725410ba-b56c-43d3-adff-44636f67c36f) |
   | [Platinum](https://deploy-preview-33648--home-assistant-docs.netlify.app/integrations/mqtt) | ![image](https://github.com/home-assistant/home-assistant.io/assets/31328123/c3a51d4d-59c9-40b8-bff5-418b5641f5c4)) |

* Classify IoT:
   | Classify | Screenshot |
   |---|---|
   | [Assumed State](https://deploy-preview-33648--home-assistant-docs.netlify.app/integrations/lightwave) | ![image](https://github.com/home-assistant/home-assistant.io/assets/31328123/612ac015-984b-4a1c-85b1-ffffe6542197) |
   | [Cloud Polling](https://deploy-preview-33648--home-assistant-docs.netlify.app/integrations/icloud) | ![image](https://github.com/home-assistant/home-assistant.io/assets/31328123/783ebef7-2852-46c8-b805-18bd0155a584) |
   | [Cloud Push](https://deploy-preview-33648--home-assistant-docs.netlify.app/integrations/abode) | ![image](https://github.com/home-assistant/home-assistant.io/assets/31328123/d97d652b-cea4-43d4-92db-092a090a0a4c) |
   | [Local Polling](https://deploy-preview-33648--home-assistant-docs.netlify.app/integrations/directv) | ![image](https://github.com/home-assistant/home-assistant.io/assets/31328123/865570e1-c02f-4eda-bb72-56cedd50eaa6) |
   | [Local Push](https://deploy-preview-33648--home-assistant-docs.netlify.app/integrations/mqtt) | ![image](https://github.com/home-assistant/home-assistant.io/assets/31328123/14214ebf-ae63-4eea-a5e8-7bbd8e8e549a) |

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dynamic sections that display messages and emojis based on the quality scale and IoT class values to enhance the presentation of integration quality assessment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->