### PR TITLE
Add Feasycom FSC-BP106 to ibeacon

### DIFF
--- a/source/_integrations/ibeacon.markdown
+++ b/source/_integrations/ibeacon.markdown
@@ -78,6 +78,7 @@ To get the Estimated distance sensor to work, in most cases, it has to be calibr
 - [Blue SLIM ID](https://elainnovation.com/en/product/blue-slim-id-en/)
 - [Feasycom FSC-BP103B](https://www.feasycom.com/bluetooth-ibeacon-da14531)
 - [Feasycom FSC-BP104D](https://www.feasycom.com/dialog-da14531-bluetooth-low-energy-beacon)
+- [Feasycom FSC-BP106](https://www.feasycom.com/fsc-bp106)
 - [Feasycom FSC-BP108](https://www.feasycom.com/bluetooth-5-1-waterproof-bluetooth-beacon)
 - [MikroTik TG-BT5-IN](https://mikrotik.com/product/tg_bt5_in) (Additional sensors such as angle or impact are not compatible)
 - [NRF51822 iBeacon](https://www.aliexpress.com/item/32826502025.html)


### PR DESCRIPTION
Confirmed that FSC-BP106 works with the integration and added to the list. Thanks!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Feasycom FSC-BP106 iBeacon device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->