### PR TITLE
Add design.home-assistant.io to footer

### DIFF
--- a/source/_includes/site/footer.html
+++ b/source/_includes/site/footer.html
@@ -25,13 +25,10 @@
           <h4>Join us and contribute!</h4>
           <ul>
             <li><a class="external-link" href="https://github.com/home-assistant/">GitHub repo {% icon "tabler:external-link" %}</a></li>
-            <li>
-              <a class="external-link" href="https://developers.home-assistant.io">Developers Portal {% icon "tabler:external-link" %}</a>
-            </li>
+            <li><a class="external-link" href="https://developers.home-assistant.io">Developers Portal {% icon "tabler:external-link" %}</a></li>
+            <li><a class="external-link" href="https://design.home-assistant.io">Design Portal {% icon "tabler:external-link" %}</a></li>
             <li><a class="external-link" href="https://data.home-assistant.io">Data Science Portal {% icon "tabler:external-link" %}</a></li>
-            <li>
-              <a class="external-link" href="https://community.home-assistant.io">Community Forum {% icon "tabler:external-link" %}</a>
-            </li>
+            <li><a class="external-link" href="https://community.home-assistant.io">Community Forum {% icon "tabler:external-link" %}</a></li>
             <li><a href="/help/reporting_issues/">Reporting issues</a></li>
             <li><a href="https://home-assistant-store.creator-spring.com/">Community Merch Store</a></li>
           </ul>


### PR DESCRIPTION
## Proposed change
This was previously missing from the footer.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
