### PR TITLE
Revert "Remove `topic_template` option for mqtt publish service"

### DIFF
--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -1106,6 +1106,7 @@ The MQTT integration will register the service `mqtt.publish` which allows publi
 | Service data attribute | Optional | Description                                                  |
 | ---------------------- | -------- | ------------------------------------------------------------ |
 | `topic`                | no       | Topic to publish payload to.                                 |
+| `topic_template`       | no       | Template to render as topic to publish payload to.           |
 | `payload`              | yes      | Payload to publish.                                          |
 | `payload_template`     | yes      | Template to render as payload value.                         |
 | `qos`                  | yes      | Quality of Service to use. (default: 0)                      |
@@ -1113,7 +1114,7 @@ The MQTT integration will register the service `mqtt.publish` which allows publi
 
 
 {% important %}
-If providing a payload, you need to include either `payload` or `payload_template`, but not both.
+You must include either `topic` or `topic_template`, but not both. If providing a payload, you need to include either `payload` or `payload_template`, but not both.
 {% endimportant %}
 
 


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#33656

Parent PR https://github.com/home-assistant/core/pull/121695 is to be reverted



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `topic_template` attribute in the MQTT integration service configuration for dynamic topic rendering.
- **Documentation**
  - Updated documentation to reflect the new `topic_template` attribute and revised the note on `topic` and `topic_template` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->