### PR TITLE
Adds documentation & example on Pushover `ttl` parameter

### DIFF
--- a/source/_integrations/pushover.markdown
+++ b/source/_integrations/pushover.markdown
@@ -97,3 +97,20 @@ alexa:
 ```
 
 {% endraw %}
+
+It is also possible to set a TTL per message using the `ttl` parameter as specified per the Pushover [API documentation](https://pushover.net/api#ttl). This parameter sets the number of seconds a message will have to live before being automatically deleted from the receiver devices. This can be useful for unimportant messages that have limited usefulness after a short amount of time. 
+
+An example of a message using `ttl`, where the message will be deleted from devices after 30 seconds:
+
+{% raw %}
+
+```yaml
+- service: notify.entity_id
+  data:
+    message: "This is the message"
+    title: "Title of the message"
+    data:
+	  ttl: 30
+```
+
+{% endraw %}


### PR DESCRIPTION
## Proposed change
Adds documentation & example on Pushover `ttl` parameter as per https://github.com/home-assistant/core/pull/121706

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/121706
- This PR fixes or closes issue: fixes [#115868](https://github.com/home-assistant/core/issues/115868)

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to set a Time to Live (TTL) per message in Pushover integrations, enabling automatic deletion of messages from receiver devices after a specified duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->