### PR TITLE
Update docs of Markdown card to reflect show_empty functionality

### DIFF
--- a/source/_dashboards/markdown.markdown
+++ b/source/_dashboards/markdown.markdown
@@ -55,7 +55,7 @@ theme:
   type: string
 show_empty:
   required: false
-  description: By default, an empty card will still be shown (resulting in a small empty box). Setting this to `false`, hides that empty card instead.
+  description: By default, an empty card will still be shown (resulting in a small empty box). Setting this to `false` hides that empty card instead.
   default: true
   type: boolean
 {% endconfiguration %}

--- a/source/_dashboards/markdown.markdown
+++ b/source/_dashboards/markdown.markdown
@@ -53,6 +53,11 @@ theme:
   required: false
   description: Override the used theme for this card with any loaded theme. For more information about themes, see the [frontend documentation](/integrations/frontend/).
   type: string
+show_empty:
+  required: false
+  description: By default, an empty card will still be shown (resulting in a small empty box). Setting this to `true`, hides that empty card instead.
+  default: true
+  type: string
 {% endconfiguration %}
 
 ### Example

--- a/source/_dashboards/markdown.markdown
+++ b/source/_dashboards/markdown.markdown
@@ -55,9 +55,9 @@ theme:
   type: string
 show_empty:
   required: false
-  description: By default, an empty card will still be shown (resulting in a small empty box). Setting this to `true`, hides that empty card instead.
+  description: By default, an empty card will still be shown (resulting in a small empty box). Setting this to `false`, hides that empty card instead.
   default: true
-  type: string
+  type: boolean
 {% endconfiguration %}
 
 ### Example


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This documents the implementation of `show_empty: true/ false` functionality for the markdown card. The functionality is similar to the _entity filter_ card.

This resolves a requested feature here (https://www.reddit.com/r/homeassistant/comments/y2nwz0/hide_markdown_card_if_empty/) for which there are no appropriate solutions.

It is possible using templates to create conditions which far exceed the capability of the conditional card or the "visibility" settings of cards so this functionality is required. For example, you currently cannot toggle visibility based on an attribute of a card currently.

The workaround suggested in that reddit thread (using a template sensor and outputting to state) isn't appropriate because the text output from a markdown card can exceed the maximum of 255 characters. 

There is no existing translation in the entity filter card for "show_empty" so the visual editor couldn't be implmented in this case.

By default, the existing behaviour is kept i.e. an empty card is shown which results in a small empty box.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/21379
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: fixes N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configuration option `show_empty` to control the visibility of empty cards in dashboards. By default, empty cards are displayed (`true`), but this can be set to `false` to hide them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->