### PR TITLE
Document new config param for modbus integration

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -688,6 +688,12 @@ climates:
         value 1 is written."
       required: false
       type: integer
+    hvac_onoff_register_write_type:
+      description: "Register (write) type of On/Off state. Valid options: `write_register`, `write_registers` and `write_coil`.
+        When set, this value will override the default value for controlling the On/Off state.
+        When not set, the default value will be either `write_register` or  `write_registers` (depending on the global boolean `write_registers` setting).
+      required: false
+      type: string
     swing_mode_register:
       description: "Configuration of the register for swing mode"
       required: false

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -691,7 +691,7 @@ climates:
     hvac_onoff_register_write_type:
       description: "Register (write) type of On/Off state. Valid options: `write_register`, `write_registers` and `write_coil`.
         When set, this value will override the default value for controlling the On/Off state.
-        When not set, the default value will be either `write_register` or  `write_registers` (depending on the global boolean `write_registers` setting).
+        When not set, the default value will be either `write_register` or  `write_registers` (depending on the global boolean `write_registers` setting)."
       required: false
       type: string
     swing_mode_register:


### PR DESCRIPTION
…/github.com/home-assistant/core/pull/121680

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

see https://github.com/home-assistant/core/pull/121680

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration field `hvac_onoff_register_write_type` for custom control of HVAC On/Off states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->