### PR TITLE
scripts: rename 'service' to 'action'

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -33,9 +33,9 @@ script:
 
 {{ page.content | markdownify | toc_only }}
 
-## Call a service
+## Perform an action
 
-The most important one is the action to call a {% term service %}. This can be done in various ways. For all the different possibilities, have a look at the [service calls page].
+Performing an action can be done in various ways. For all the different possibilities, have a look at the [actions page].
 
 ```yaml
 - alias: "Bedroom lights on"
@@ -48,7 +48,7 @@ The most important one is the action to call a {% term service %}. This can be d
 
 ### Activate a scene
 
-Scripts may also use a shortcut syntax for activating {% term scenes %} instead of calling the `scene.turn_on` service.
+Scripts may also use a shortcut syntax for activating {% term scenes %} instead of calling the `scene.turn_on` action.
 
 ```yaml
 - scene: scene.morning_living_room
@@ -280,11 +280,11 @@ Without `continue_on_timeout: false` the script will always continue since the d
 
 After each time a wait completes, either because the condition was met, the event happened, or the timeout expired, the variable `wait` will be created/updated to indicate the result.
 
-Variable | Description
--|-
-`wait.completed` | Exists only after `wait_template`. `true` if the condition was met, `false` otherwise
-`wait.trigger` | Exists only after `wait_for_trigger`. Contains information about which trigger fired. (See [Available-Trigger-Data](/docs/automation/templating/#available-trigger-data).) Will be `none` if no trigger happened before timeout expired
-`wait.remaining` | Timeout remaining, or `none` if a timeout was not specified
+| Variable         | Description                                                                                                                                                                                                                             |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wait.completed` | Exists only after `wait_template`. `true` if the condition was met, `false` otherwise                                                                                                                                                   |
+| `wait.trigger`   | Exists only after `wait_for_trigger`. Contains information about which trigger fired. (See [Available-Trigger-Data](/docs/automation/templating/#available-trigger-data).) Will be `none` if no trigger happened before timeout expired |
+| `wait.remaining` | Timeout remaining, or `none` if a timeout was not specified                                                                                                                                                                             |
 
 This can be used to take different actions based on whether or not the condition was met, or to use more than one wait sequentially while implementing a single timeout overall.
 
@@ -570,11 +570,11 @@ For example:
 A variable named `repeat` is defined within the repeat {% term action %} (i.e., it is available inside `sequence`, `while` & `until`.)
 It contains the following fields:
 
-field | description
--|-
-`first` | True during the first iteration of the repeat sequence
-`index` | The iteration number of the loop: 1, 2, 3, ...
-`last` | True during the last iteration of the repeat sequence, which is only valid for counted loops
+| field   | description                                                                                  |
+| ------- | -------------------------------------------------------------------------------------------- |
+| `first` | True during the first iteration of the repeat sequence                                       |
+| `index` | The iteration number of the loop: 1, 2, 3, ...                                               |
+| `last`  | True during the last iteration of the repeat sequence, which is only valid for counted loops |
 
 ## If-then
 
@@ -902,8 +902,8 @@ By default, a sequence of {% term actions %} will be halted when one of the {% t
 that sequence encounters an error. The {% term automation %} or script will be halted,
 an error is logged, and the {% term automation %} or script run is marked as errored.
 
-Sometimes these errors are expected, for example, because you know the service
-you call can be problematic at times, and it doesn't matter if it fails.
+Sometimes these errors are expected, for example, because you know the action
+you perform can be problematic at times, and it doesn't matter if it fails.
 You can set `continue_on_error` for those cases on such an {% term action %}.
 
 The `continue_on_error` is available on all {% term actions %} and is set to
@@ -1007,7 +1007,7 @@ will not be used by anything.
 [Script integration]: /integrations/script/
 [automations]: /docs/automation/action/
 [Alexa/Amazon Echo]: /integrations/alexa/
-[service calls page]: /docs/scripts/service-calls/
+[actions page]: /docs/scripts/service-calls/
 [conditions page]: /docs/scripts/conditions/
 [shorthand-template]: /docs/scripts/conditions/#template-condition-shorthand-notation
 [script variables]: /integrations/script/#configuration-variables


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

scripts: rename 'service' to 'action'

- to reflect the renaming of 'service' to 'action' in current software
- https://github.com/home-assistant/frontend/pull/21362/files#diff-e67939fd25c650222db710f18764d10ae69454b0e8ad680f5e10177c2db93cea



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/21362/files#diff-e67939fd25c650222db710f18764d10ae69454b0e8ad680f5e10177c2db93cea
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
