### PR TITLE
polling, homeassistant: rename 'service' to 'action'

### DIFF
--- a/source/_includes/common-tasks/define_custom_polling.md
+++ b/source/_includes/common-tasks/define_custom_polling.md
@@ -12,6 +12,6 @@ To add the automation:
    - Go to {% my automations title="**Settings** > **Automations & scenes**" %} and create a new automation.
    - Define any trigger and condition you like.
    - Select **Add action**, then, select **Other actions**.
-   - Select **Perform action**, and from the list, select the [`homeassistant.update_entity` action](/integrations/homeassistant/#service-homeassistantupdate_entity).
+   - Select **Perform action**, and from the list, select the [`homeassistant.update_entity` action](/integrations/homeassistant/#action-homeassistantupdate_entity).
    ![Update entity](/images/screenshots/custom_polling_02.png)
 4. Save your new automation to poll for data.

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -18,7 +18,7 @@ related:
   - docs: /docs/configuration/customizing-devices/
 ---
 
-The **Home Assistant Core** {% term integration %} provides generic implementations like the generic `homeassistant.turn_on` service.
+The **Home Assistant Core** {% term integration %} provides generic implementations like the generic `homeassistant.turn_on` action.
 
 ## Editing the General Settings in YAML
 
@@ -251,60 +251,60 @@ homeassistant:
       icon: mdi:other
 ```
 
-## Services
+## Actions
 
-The `homeassistant` integration provides services for controlling Home Assistant itself, as well as generic controls for any entity.
+The `homeassistant` integration provides actions for controlling Home Assistant itself, as well as generic controls for any entity.
 
-### Service `homeassistant.check_config`
+### Action `homeassistant.check_config`
 
 Reads the configuration files and checks them for correctness, but **does not** load them into Home Assistant. Creates a persistent notification and log entry if errors are found.
 
-### Service `homeassistant.reload_all`
+### Action `homeassistant.reload_all`
 
 Reload all YAML configuration that can be reloaded without restarting Home Assistant.
 
-It calls the `reload` service on all domains that have it available. Additionally,
+It calls the `reload` action on all domains that have it available. Additionally,
 it reloads the core configuration (equivalent to calling
 `homeassistant.reload_core_config`), themes (`frontend.reload_themes`), and custom Jinja (`homeassistant.reload_custom_templates`).
 
 Prior to reloading, a basic configuration check is performed. If that fails, the reload
 will not be performed and will raise an error.
 
-### Service `homeassistant.reload_custom_templates`
+### Action `homeassistant.reload_custom_templates`
 
 Reload all Jinja templates in the `config/custom_templates` directory. Changes to these templates
 will take effect the next time an importing template is rendered.
 
-### Service `homeassistant.reload_config_entry`
+### Action `homeassistant.reload_config_entry`
 
 Reloads an integration config entry.
 
-| Service data attribute | Description                                                |
+| Data attribute | Description                                                |
 | ---------------------- | ---------------------------------------------------------- |
 | `entity_id`            | List of entity ids used to reference a config entry.       |
 | `area_id`              | List of area ids used to reference a config entry.         |
 | `device_id`            | List of device ids used to reference a config entry.       |
 | `entry_id`             | A single config entry id used to reference a config entry. |
 
-### Service `homeassistant.reload_core_config`
+### Action `homeassistant.reload_core_config`
 
 Reloads the core configuration under `homeassistant:` and all linked files. Once loaded the new configuration is applied. New `customize:` information will be applied the next time the state of the entity gets updated.
 
-### Service `homeassistant.restart`
+### Action `homeassistant.restart`
 
 Restarts the Home Assistant instance (also reloading the configuration on start).
 
 This will also do a configuration check before doing a restart. If the configuration check fails then Home Assistant will not be restarted, instead a persistent notification with the ID `persistent_notification.homeassistant_check_config` will be created. The logs will show details on what failed the configuration check.
 
-### Service `homeassistant.stop`
+### Action `homeassistant.stop`
 
 Stops the Home Assistant instance. Home Assistant must be restarted from the Host device to run again.
 
-### Service `homeassistant.set_location`
+### Action `homeassistant.set_location`
 
 Update the location of the Home Assistant default zone (usually "Home").
 
-| Service data attribute | Optional | Description                 |
+| Data attribute | Optional | Description                 |
 | ---------------------- | -------- | --------------------------- |
 | `latitude`             | no       | Latitude of your location.  |
 | `longitude`            | no       | Longitude of your location. |
@@ -321,14 +321,14 @@ action:
     elevation: 120
 ```
 
-### Service `homeassistant.toggle`
+### Action `homeassistant.toggle`
 
-Generic service to toggle devices on/off. Same usage as the
-`light.toggle`, `switch.toggle`, etc. services. The difference with this
-service compared the others, is that is can be used to mix different domains,
-for example, a light and a switch can be toggled in a single service call.
+Generic action to toggle devices on/off. Same usage as the
+`light.toggle`, `switch.toggle`, etc. actions. The difference with this
+action compared the others, is that is can be used to mix different domains,
+for example, a light and a switch can be toggled in a single action.
 
-| Service data attribute | Optional | Description                                   |
+| Data attribute | Optional | Description                                   |
 | ---------------------- | -------- | --------------------------------------------- |
 | `entity_id`            | yes      | The entity_id of the device to toggle on/off. |
 
@@ -343,14 +343,14 @@ action:
       - switch.tv
 ```
 
-### Service `homeassistant.turn_on`
+### Action `homeassistant.turn_on`
 
-Generic service to toggle devices on. Same usage as the
-`light.turn_on`, `switch.turn_on`, etc. services. The difference with this
-service compared the others, is that is can be used to mix different domains,
-for example, a light and a switch can be turned on in a single service call.
+Generic action to toggle devices on. Same usage as the
+`light.turn_on`, `switch.turn_on`, etc. actions. The difference with this
+action compared the others, is that is can be used to mix different domains,
+for example, a light and a switch can be turned on in a single action.
 
-| Service data attribute | Optional | Description                             |
+| Data attribute | Optional | Description                             |
 | ---------------------- | -------- | --------------------------------------- |
 | `entity_id`            | yes      | The entity_id of the device to turn on. |
 
@@ -365,14 +365,14 @@ action:
       - switch.tv
 ```
 
-### Service `homeassistant.turn_off` 
+### Action `homeassistant.turn_off` 
 
-Generic service to toggle devices off. Same usage as the
-`light.turn_off`, `switch.turn_off`, etc. services. The difference with this
-service compared the others, is that is can be used to mix different domains,
-for example, a light and a switch can be turned off in a single service call.
+Generic action to toggle devices off. Same usage as the
+`light.turn_off`, `switch.turn_off`, etc. actions. The difference with this
+action compared the others, is that is can be used to mix different domains,
+for example, a light and a switch can be turned off in a single action.
 
-| Service data attribute | Optional | Description                              |
+| Data attribute | Optional | Description                              |
 | ---------------------- | -------- | ---------------------------------------- |
 | `entity_id`            | yes      | The entity_id of the device to turn off. |
 
@@ -387,11 +387,11 @@ action:
       - switch.tv
 ```
 
-### Service `homeassistant.update_entity`
+### Action `homeassistant.update_entity`
 
 Force one or more entities to update its data rather than wait for the next scheduled update.
 
-| Service data attribute | Optional | Description                                             |
+| Data attribute | Optional | Description                                             |
 | ---------------------- | -------- | ------------------------------------------------------- |
 | `entity_id`            | no       | One or multiple entity_ids to update. It can be a list. |
 
@@ -406,7 +406,7 @@ action:
     - switch.coffe_pot
 ```
 
-### Service `homeassistant.save_persistent_states`
+### Action `homeassistant.save_persistent_states`
 
 Save the persistent states (for entities derived from RestoreEntity) immediately.
 Maintain the normal periodic saving interval.


### PR DESCRIPTION
- to reflect the renaming of 'service' to 'action' in current software
- https://github.com/home-assistant/frontend/pull/21362/files#diff-e67939fd25c650222db710f18764d10ae69454b0e8ad680f5e10177c2db93cea

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
polling, homeassistant: rename 'service' to 'action'

- to reflect the renaming of 'service' to 'action' in current software
- https://github.com/home-assistant/frontend/pull/21362/files#diff-e67939fd25c650222db710f18764d10ae69454b0e8ad680f5e10177c2db93cea

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/frontend/pull/21362/files#diff-e67939fd25c650222db710f18764d10ae69454b0e8ad680f5e10177c2db93cea
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
