### PR TITLE
Add last restart sensor to devolo_home_network

### DIFF
--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -77,6 +77,9 @@ Currently the following device types within Home Assistant are supported.
 - PLC PHY rates
   - Updates every 5 minutes
   - PHY rates to/from the device attached to the router are enabled by default. PHY rates between all other devices are disabled by default.
+- Last restart of the device
+  - Updates every 15 seconds
+  - Is disabled by default because its of lower interest to most users
 
 ### Switch
 

--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -79,7 +79,7 @@ Currently the following device types within Home Assistant are supported.
   - PHY rates to/from the device attached to the router are enabled by default. PHY rates between all other devices are disabled by default.
 - Last restart of the device
   - Updates every 15 seconds
-  - Is disabled by default because its of lower interest to most users
+  - Is disabled by default because it's of lower interest to most users
 
 ### Switch
 

--- a/source/_integrations/devolo_home_network.markdown
+++ b/source/_integrations/devolo_home_network.markdown
@@ -79,7 +79,7 @@ Currently the following device types within Home Assistant are supported.
   - PHY rates to/from the device attached to the router are enabled by default. PHY rates between all other devices are disabled by default.
 - Last restart of the device
   - Updates every 15 seconds
-  - Is disabled by default because it's of lower interest to most users
+  - Is disabled by default because it's of lower interest to most users.
 
 ### Switch
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add a last restart sensor to devolo_home_network.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/122190
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added documentation detailing the "Last restart of the device" for supported device types, providing users with enhanced monitoring capabilities.
	- Updated information on the frequency of updates (every 15 seconds) and noted that the feature is disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->