### PR TITLE
Add documentation for notify group

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -45,6 +45,11 @@ Home Assistant can group multiple binary sensors, covers, events, fans, lights, 
 
 {% include integrations/config_flow.md %}
 
+{% note %}
+Notification entities can only be grouped via the UI. 
+The older notification services can only be grouped via YAML configuration.
+{% endnote %}
+
 ## Group behavior
 
 ### Binary sensor, light, and switch groups
@@ -103,6 +108,11 @@ In short, when any group member entity is `unlocked`, the group will also be `un
 - Otherwise, the group state is `unlocking` if at least one group member is `unlocking`.
 - Otherwise, the group state is `unlocked` if at least one group member is `unlocked`.
 - Otherwise, the group state is `locked`.
+
+### Notify entity groups
+
+- The group state is `unavailable` if all group members are `unavailable`.
+- Otherwise, the group state is the last notification is sent to the group.
 
 ### Media player groups
 

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -112,7 +112,7 @@ In short, when any group member entity is `unlocked`, the group will also be `un
 ### Notify entity groups
 
 - The group state is `unavailable` if all group members are `unavailable`.
-- Otherwise, the group state is the last notification is sent to the group.
+- Otherwise, the group state is the last notification sent to the group.
 
 ### Media player groups
 

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -46,7 +46,7 @@ Home Assistant can group multiple binary sensors, covers, events, fans, lights, 
 {% include integrations/config_flow.md %}
 
 {% note %}
-Notification entities can only be grouped via the UI. 
+Notification entities can only be grouped via the UI.
 The older notification services can only be grouped via YAML configuration.
 {% endnote %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for notify group


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/122123
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated documentation on grouping behavior of notification entities for clarity.
	- Added a note emphasizing that notification entities can only be grouped through the user interface, not via YAML configuration.
	- Introduced a new section detailing rules for group state management based on member availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->