### PR TITLE
Group and explain modbus climate entity settings

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -541,7 +541,7 @@ climates:
   type: map
   keys:
     temperature_unit:
-      description: "Temperature unit, C or F."
+      description: "Temperature unit: C or F."
       required: false
       default: C
       type: list

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -571,7 +571,6 @@ climates:
       required: false
       type: integer
       default: 5
-
     # Current Temperature
     count:
       description: "Number of registers to read to fetch the current temperature.
@@ -625,7 +624,6 @@ climates:
       required: false
       type: float
       default: 0
-
     # Target temperature
     target_temp_register:
       description: "Register address for target temperature (Setpoint). Using a list, it is possible to define one register for each of the available HVAC Modes. The list has to have a fixed size of 7 registers corresponding to the 7 available HVAC Modes, as follows: Register **1: HVAC AUTO mode**; Register **2: HVAC Cool mode**; Register **3: HVAC Dry mode**; Register **4: HVAC Fan only mode**; Register **5: HVAC Heat mode**; Register **6: HVAC Heat Cool mode**; Register **7: HVAC OFF mode**. It is possible to set duplicated values for the modes where the devices has not a related register."
@@ -660,7 +658,6 @@ climates:
           description: "Swap word ABCD -> CDAB, **not valid with data types: `int16`, `uint16`**"
         word_byte:
           description: "Swap word ABCD -> DCBA, **not valid with data types: `int16`, `uint16`**"
-
     # HVAC mode
     hvac_mode_register:
       description: "Configuration of register for HVAC mode"
@@ -711,7 +708,6 @@ climates:
               description: "Value corresponding to HVAC Heat/Cool mode."
               required: false
               type: [integer, list]
-    
     # Fan mode
     fan_mode_register:
       description: "Configuration of register for Fan mode"
@@ -768,7 +764,6 @@ climates:
               description: "Value corresponding to Fan Diffuse mode."
               required: false
               type: integer
-
     # Swing mode  
     swing_mode_register:
       description: "Configuration of the register for swing mode"
@@ -804,7 +799,6 @@ climates:
               description: "Value corresponding to Swing mode both."
               required: false
               type: integer
-
     # On/Off state
     hvac_onoff_register:
       description: "Address of On/Off state.

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -530,7 +530,7 @@ The master configuration like device_class are automatically copied to the slave
 
 ## Configuring climate entities
 
-The Modbus climate platform allows you to monitor a thermostat or heaters as well as set a target temperature, HVAC mode and fan state.
+The Modbus climate platform allows you to monitor a thermostat or heaters as well as set a target temperature, HVAC mode, swing mode and fan state.
 
 Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
@@ -540,13 +540,46 @@ climates:
   required: false
   type: map
   keys:
+    # General
+    temperature_unit:
+      description: "Temperature unit, C or F."
+      required: false
+      default: C
+      type: list
+      keys:
+        C:
+          description: "Celsius"
+        F:
+          description: "Fahrenheit"
+    precision:
+      description: "Number of valid decimals for temperature."
+      required: false
+      type: integer
+      default: 0
+    temp_step:
+      description: "Step size target temperature."
+      required: false
+      type: float
+      default: 0.5
+    max_temp:
+      description: "Maximum setpoint for target temperature."
+      required: false
+      type: integer
+      default: 35
+    min_temp:
+      description: "Minimum setpoint for target temperature."
+      required: false
+      type: integer
+      default: 5
+
+    # Current Temperature
     count:
-      description: "Number of registers to read.
+      description: "Number of registers to read to fetch the current temperature.
       **only valid for `data_type: custom` and `data_type: string`**, for other data types count is automatically calculated."
       required: false
       type: integer
     data_type:
-      description: "Response representation."
+      description: "Response representation when reading the current temperature register(s)."
       required: false
       default: int16
       type: list
@@ -577,6 +610,58 @@ climates:
           description: "32 bit unsigned integer (2 registers holds 1 value)."
         uint64:
           description: "64 bit unsigned integer (4 registers holds 1 value)."
+    input_type:
+      description: Modbus register type for current temperature.
+      required: false
+      default: holding
+      type: list
+      keys:
+        holding:
+          description: "Holding register."
+        input:
+          description: "Input register."
+    offset:
+      description: "Final offset for current temperature (output = scale * value + offset)."
+      required: false
+      type: float
+      default: 0
+
+    # Target temperature
+    target_temp_register:
+      description: "Register address for target temperature (Setpoint). Using a list, it is possible to define one register for each of the available HVAC Modes. The list has to have a fixed size of 7 registers corresponding to the 7 available HVAC Modes, as follows: Register **1: HVAC AUTO mode**; Register **2: HVAC Cool mode**; Register **3: HVAC Dry mode**; Register **4: HVAC Fan only mode**; Register **5: HVAC Heat mode**; Register **6: HVAC Heat Cool mode**; Register **7: HVAC OFF mode**. It is possible to set duplicated values for the modes where the devices has not a related register."
+      required: true
+      type: [integer, list]
+    target_temp_write_registers:
+      description: "If `true` use `write_registers` for target temperature (`target_temp_register`), else use `write_register`."
+      required: false
+      type: boolean
+      default: false
+    scale:
+      description: "Scale factor (output = scale * value + offset) for setting target temperature."
+      required: false
+      type: float
+      default: 1
+    structure:
+      description: "If `data_type: custom` is specified a double-quoted Python struct is expected,
+      to format the string to unpack the value. See Python documentation for details.
+      Example: `>i`."
+      required: false
+      type: string
+      default: ">f"
+    swap:
+      description: "Swap the order of bytes/words, **not valid with `custom` and `datatype: string`** when setting target temperature"
+      required: false
+      default: none
+      type: list
+      keys:
+        byte:
+          description: "Swap bytes AB -> BA."
+        word:
+          description: "Swap word ABCD -> CDAB, **not valid with data types: `int16`, `uint16`**"
+        word_byte:
+          description: "Swap word ABCD -> DCBA, **not valid with data types: `int16`, `uint16`**"
+
+    # HVAC mode
     hvac_mode_register:
       description: "Configuration of register for HVAC mode"
       required: false
@@ -587,7 +672,7 @@ climates:
           required: true
           type: integer
         write_registers:
-          description: "Request type, use `write_registers` if true  else `write_register`.
+          description: "Request type for setting HVAC mode, use `write_registers` if true else `write_register`.
             If more than one value is specified for a specific mode, only the first one is used for writing to the register."
           required: false
           type: boolean
@@ -598,7 +683,8 @@ climates:
           type: map
           keys:
             state_off:
-              description: "Value corresponding to HVAC Off mode."
+              description: "Value corresponding to HVAC Off mode.
+                If the On/Off state handled on a different address and/or register the `state_off` state should be omitted from your configuration"
               required: false
               type: [integer, list]
             state_heat:
@@ -625,6 +711,8 @@ climates:
               description: "Value corresponding to HVAC Heat/Cool mode."
               required: false
               type: [integer, list]
+    
+    # Fan mode
     fan_mode_register:
       description: "Configuration of register for Fan mode"
       required: false
@@ -680,14 +768,8 @@ climates:
               description: "Value corresponding to Fan Diffuse mode."
               required: false
               type: integer
-    hvac_onoff_register:
-      description: "Address of On/Off state.
-        When zero is read from this register, the HVAC state is set to Off, otherwise the `hvac_mode_register`
-        dictates the state of the HVAC. If no such register is defined, it defaults to Auto.
-        When the HVAC mode is set to Off, the value 0 is written to the register, otherwise the
-        value 1 is written."
-      required: false
-      type: integer
+
+    # Swing mode  
     swing_mode_register:
       description: "Configuration of the register for swing mode"
       required: false
@@ -722,86 +804,20 @@ climates:
               description: "Value corresponding to Swing mode both."
               required: false
               type: integer
-    input_type:
-      description: Modbus register type for current temperature.
-      required: false
-      default: holding
-      type: list
-      keys:
-        holding:
-          description: "Holding register."
-        input:
-          description: "Input register."
-    max_temp:
-      description: "Maximum setpoint temperature."
+
+    # On/Off state
+    hvac_onoff_register:
+      description: "Address of On/Off state.
+        Only use this setting if your On/Off state is not handled as a HVAC mode.
+        When zero is read from this register, the HVAC state is set to Off, otherwise the `hvac_mode_register`
+        dictates the state of the HVAC. If no such register is defined, it defaults to Auto.
+        When the HVAC mode is set to Off, the value 0 is written to the register, otherwise the
+        value 1 is written."
       required: false
       type: integer
-      default: 35
-    min_temp:
-      description: "Minimum setpoint temperature."
-      required: false
-      type: integer
-      default: 5
-    offset:
-      description: "Final offset (output = scale * value + offset)."
-      required: false
-      type: float
-      default: 0
-    precision:
-      description: "Number of valid decimals."
-      required: false
-      type: integer
-      default: 0
-    scale:
-      description: "Scale factor (output = scale * value + offset)."
-      required: false
-      type: float
-      default: 1
-    structure:
-      description: "If `data_type: custom` is specified a double-quoted Python struct is expected,
-      to format the string to unpack the value. See Python documentation for details.
-      Example: `>i`."
-      required: false
-      type: string
-      default: ">f"
-    swap:
-      description: "Swap the order of bytes/words, **not valid with `custom` and `datatype: string`**"
-      required: false
-      default: none
-      type: list
-      keys:
-        byte:
-          description: "Swap bytes AB -> BA."
-        word:
-          description: "Swap word ABCD -> CDAB, **not valid with data types: `int16`, `uint16`**"
-        word_byte:
-          description: "Swap word ABCD -> DCBA, **not valid with data types: `int16`, `uint16`**"
-    target_temp_register:
-      description: "Register address for target temperature (Setpoint). Using a list, it is possible to define one register for each of the available HVAC Modes. The list has to have a fixed size of 7 registers corresponding to the 7 available HVAC Modes, as follows: Register **1: HVAC AUTO mode**; Register **2: HVAC Cool mode**; Register **3: HVAC Dry mode**; Register **4: HVAC Fan only mode**; Register **5: HVAC Heat mode**; Register **6: HVAC Heat Cool mode**; Register **7: HVAC OFF mode**. It is possible to set duplicated values for the modes where the devices has not a related register." 
-      required: true
-      type: [integer, list]
-    target_temp_write_registers:
-      description: "If `true` use `write_registers` for target temperature."
-      required: false
-      type: boolean
-      default: false
-    temp_step:
-      description: "Step size target temperature."
-      required: false
-      type: float
-      default: 0.5
-    temperature_unit:
-      description: "Temperature unit reported by current_temp_register. C or F."
-      required: false
-      default: C
-      type: list
-      keys:
-        C:
-          description: "Celsius"
-        F:
-          description: "Fahrenheit"
     write_registers:
-      description: "Request type, use `write_registers` if true  else `write_register`."
+      description: "If `true` use `write_registers` to control the On/Off state (`hvac_onoff_register`), else use `write_register`."
+      Note that is not yet possible to control the On/Off state via a coil."
       required: false
       type: boolean
       default: false

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -530,7 +530,7 @@ The master configuration like device_class are automatically copied to the slave
 
 ## Configuring climate entities
 
-The Modbus climate platform allows you to monitor a thermostat or heaters as well as set a target temperature, HVAC mode, swing mode and fan state.
+The Modbus climate platform allows you to monitor a thermostat or heaters as well as set a target temperature, HVAC mode, swing mode, and fan state.
 
 Please refer to [Parameter usage](#parameters-usage-matrix) for conflicting parameters.
 
@@ -623,7 +623,7 @@ climates:
       type: float
       default: 0
     target_temp_register:
-      description: "Register address for target temperature (Setpoint). Using a list, it is possible to define one register for each of the available HVAC Modes. The list has to have a fixed size of 7 registers corresponding to the 7 available HVAC Modes, as follows: Register **1: HVAC AUTO mode**; Register **2: HVAC Cool mode**; Register **3: HVAC Dry mode**; Register **4: HVAC Fan only mode**; Register **5: HVAC Heat mode**; Register **6: HVAC Heat Cool mode**; Register **7: HVAC OFF mode**. It is possible to set duplicated values for the modes where the devices has not a related register."
+      description: "Register address for target temperature (Setpoint). Using a list, it is possible to define one register for each of the available HVAC Modes. The list has to have a fixed size of 7 registers corresponding to the 7 available HVAC Modes, as follows: Register **1: HVAC AUTO mode**; Register **2: HVAC Cool mode**; Register **3: HVAC Dry mode**; Register **4: HVAC Fan only mode**; Register **5: HVAC Heat mode**; Register **6: HVAC Heat Cool mode**; Register **7: HVAC OFF mode**. It is possible to set duplicated values for the modes where the devices don't have a related register."
       required: true
       type: [integer, list]
     target_temp_write_registers:
@@ -804,7 +804,7 @@ climates:
       type: integer
     write_registers:
       description: "If `true` use `write_registers` to control the On/Off state (`hvac_onoff_register`), else use `write_register`.
-      Note that is not yet possible to control the On/Off state via a coil."
+      Note that it is not yet possible to control the On/Off state via a coil."
       required: false
       type: boolean
       default: false

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -540,7 +540,6 @@ climates:
   required: false
   type: map
   keys:
-    # General
     temperature_unit:
       description: "Temperature unit, C or F."
       required: false
@@ -571,7 +570,6 @@ climates:
       required: false
       type: integer
       default: 5
-    # Current Temperature
     count:
       description: "Number of registers to read to fetch the current temperature.
       **only valid for `data_type: custom` and `data_type: string`**, for other data types count is automatically calculated."
@@ -624,7 +622,6 @@ climates:
       required: false
       type: float
       default: 0
-    # Target temperature
     target_temp_register:
       description: "Register address for target temperature (Setpoint). Using a list, it is possible to define one register for each of the available HVAC Modes. The list has to have a fixed size of 7 registers corresponding to the 7 available HVAC Modes, as follows: Register **1: HVAC AUTO mode**; Register **2: HVAC Cool mode**; Register **3: HVAC Dry mode**; Register **4: HVAC Fan only mode**; Register **5: HVAC Heat mode**; Register **6: HVAC Heat Cool mode**; Register **7: HVAC OFF mode**. It is possible to set duplicated values for the modes where the devices has not a related register."
       required: true
@@ -658,7 +655,6 @@ climates:
           description: "Swap word ABCD -> CDAB, **not valid with data types: `int16`, `uint16`**"
         word_byte:
           description: "Swap word ABCD -> DCBA, **not valid with data types: `int16`, `uint16`**"
-    # HVAC mode
     hvac_mode_register:
       description: "Configuration of register for HVAC mode"
       required: false
@@ -708,7 +704,6 @@ climates:
               description: "Value corresponding to HVAC Heat/Cool mode."
               required: false
               type: [integer, list]
-    # Fan mode
     fan_mode_register:
       description: "Configuration of register for Fan mode"
       required: false
@@ -764,7 +759,6 @@ climates:
               description: "Value corresponding to Fan Diffuse mode."
               required: false
               type: integer
-    # Swing mode  
     swing_mode_register:
       description: "Configuration of the register for swing mode"
       required: false
@@ -799,7 +793,6 @@ climates:
               description: "Value corresponding to Swing mode both."
               required: false
               type: integer
-    # On/Off state
     hvac_onoff_register:
       description: "Address of On/Off state.
         Only use this setting if your On/Off state is not handled as a HVAC mode.

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -803,7 +803,7 @@ climates:
       required: false
       type: integer
     write_registers:
-      description: "If `true` use `write_registers` to control the On/Off state (`hvac_onoff_register`), else use `write_register`."
+      description: "If `true` use `write_registers` to control the On/Off state (`hvac_onoff_register`), else use `write_register`.
       Note that is not yet possible to control the On/Off state via a coil."
       required: false
       type: boolean


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
With this commit I'm trying to group the different "parts" when configuring a modbus climate entity, being:

- General settings like C or F and the temperature steps
- Read current temperature
- Set target temperature
- Set/Read HVAC mode
- Set/Read fan mode
- Set/Read swing mode
- Set/read on off state

I think this is needed as in the current state, personally, I found the naming of the config settings to be quite confusing. 
Only by reading the actual Python code it became clear how I could fully configure my AC units.
By grouping the settings and explicitly name which "part" some setting applies to I think more people will be able to configure their AC units.

This contribution was sparked by the fact I'm trying to add a feature to the modbus climate entity without introducing backwards compatible changes. By improving the docs I'm hoping to pave the way for getting that PR merged

https://github.com/home-assistant/home-assistant.io/pull/33741
https://github.com/home-assistant/core/pull/121680

I'd like this PR to be judged on at least these things:

1) Would grouping/shuffling the current entities indeed make it more readable?
2) Did I correctly reverse-engineer the current settings?
3) Not sure If I'm allowed to use yaml comments in order to separate the "groups" of settings (an/or if there is a better way to do this)

N.B. somewhere down the road I think it would make sense to propose some modbus climatev2 entity in which more flexibility and declarative naming for different settings could be introduced.

PR's like https://github.com/home-assistant/core/pull/118013 also show that more flexibility might be needed in order to control different units. Until then though, let's just improve what we have without having to break backwards compatibility

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Expanded configuration options for managing climate entities, including new parameters such as temperature unit, precision, temperature step, maximum temperature, minimum temperature, input type, offset, target temperature registers, scale, structure, and swap.
	- Enhanced clarity on controlling HVAC state with updates to the HVAC On/Off register, fan mode register, and swing mode register.
- **Documentation**
	- Improved descriptions and usability of existing parameters related to climate control systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->