### PR TITLE
Update selectors.markdown

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -283,6 +283,10 @@ The output of this selector is the name of the selected network storage. It may
 also be the value `/backup`, if the user chooses to use the local data disk option
 instead of one of the configured network storage locations.
 
+```yaml
+backup_location:
+```
+
 ## Boolean selector
 
 The boolean selector shows a toggle that allows the user to turn on or off


### PR DESCRIPTION
## Proposed change
Update the current online version of [Blueprint selectors](https://www.home-assistant.io/docs/blueprint/selectors/#backup-location-selector) to include missing information on how to properly use the YAML configuration for the "Backup location selector."

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new YAML declaration for `backup_location`, clarifying options for local data disk choices versus network storage configurations in the documentation.
  
- **Bug Fixes**
	- Corrected a formatting issue by adding a newline at the end of the documentation file to enhance readability and adherence to coding standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->