### PR TITLE
Remove state label badge

### DIFF
--- a/source/dashboards/badges.markdown
+++ b/source/dashboards/badges.markdown
@@ -70,45 +70,6 @@ double_tap_action:
   type: map
 {% endconfiguration %}
 
-## State label badge
-
-The state label badge allows you to display a state badge. This badge supports [actions](/dashboards/actions/).
-
-```yaml
-type: state-label
-entity: light.living_room
-```
-
-{% configuration state_badge %}
-type:
-  required: true
-  description: "`state-label`"
-  type: string
-entity:
-  required: true
-  description: Entity ID.
-  type: string
-name:
-  required: false
-  description: Overwrites friendly name.
-  type: string
-  default: Name of entity
-icon:
-  required: false
-  description: Overwrites icon or entity picture. You can use any icon from [Material Design Icons](https://pictogrammers.com/library/mdi/). Prefix the icon name with `mdi:`, ie `mdi:home`.
-  type: string
-  default: Entity domain icon
-image:
-  required: false
-  description: The URL of an image.
-  type: string
-show_name:
-  required: false
-  description: Show name.
-  type: boolean
-  default: "true"
-{% endconfiguration %}
-
 ## Entity Filter Badge
 
 This badge allows you to define a list of entities that you want to track only when in a certain state. Very useful for showing lights that you forgot to turn off or show a list of people only when they're at home.


### PR DESCRIPTION
## Proposed change

This badge is replaced by the new entity badge.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Removed the section concerning the "State label badge" from the documentation, affecting guidance on its implementation and configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->