### PR TITLE
Terminology tooltip in tables: fix display issue

### DIFF
--- a/plugins/terminology_tooltip.rb
+++ b/plugins/terminology_tooltip.rb
@@ -1,51 +1,51 @@
 module Jekyll
   module HomeAssistant
     class TerminologyTooltip < Liquid::Tag
-
       def initialize(tag_name, args, tokens)
         super
-        if args.strip =~ SYNTAX
-          @term = Regexp.last_match(1)
-          @text = Regexp.last_match(2)
-        else
-          raise SyntaxError, <<~MSG
-            Syntax error in tag 'term' while parsing the following options:
+        raise SyntaxError, <<~MSG unless args.strip =~ SYNTAX
+          Syntax error in tag 'term' while parsing the following options:
 
-            #{args}
+          #{args}
 
-            Valid syntax:
-              {% term <term> [<text>] %}
-          MSG
-        end
+          Valid syntax:
+            {% term <term> [<text>] %}
+        MSG
+
+        @term = Regexp.last_match(1)
+        @text = Regexp.last_match(2)
       end
 
       def render(context)
-        @term.gsub!(/\"/, "")
-        entries = context.registers[:site].data["glossary"].select do |entry|
-          entry.key?("term") and (@term.casecmp(entry["term"]).zero? or (entry.key?("aliases") and entry["aliases"].any?{ |s| s.casecmp(@term)==0 }))
+        @term.gsub!(/"/, '')
+        entries = context.registers[:site].data['glossary'].select do |entry|
+          entry.key?('term') and (@term.casecmp(entry['term']).zero? or (entry.key?('aliases') and entry['aliases'].any? do |s|
+                                                                           s.casecmp(@term) == 0
+                                                                         end))
         end
 
         raise ArgumentError, "Term #{@term} was not found in the glossary" if entries.length == 0
         raise ArgumentError, "Term #{@term} is in the glossary multiple times" if entries.length > 1
-        raise ArgumentError, "Term #{@term} is missing a definition" unless entries[0].key?("definition")
+        raise ArgumentError, "Term #{@term} is missing a definition" unless entries[0].key?('definition')
+
         glossary = entries[0]
 
-        definition = glossary["excerpt"] || glossary["definition"]
-        
-        if glossary.key?("link")
-          rendered_link = Liquid::Template.parse(glossary["link"]).render(context).strip
-          link = "<small><a class='terminology-link' href='#{rendered_link}'>[Learn more]</a></small>"
+        definition = glossary['excerpt'] || glossary['definition']
+
+        if glossary.key?('link')
+          rendered_link = Liquid::Template.parse(glossary['link']).render(context).strip
+          link = "<a class='terminology-link' href='#{rendered_link}'> [Learn more]</a>"
+          definition = "#{definition.strip}#{link}".strip
         end
 
-        tooltip = "<span class='terminology-tooltip'>#{definition}#{link || ""}</span>"
+        tooltip = "<span class='terminology-tooltip'>#{definition.strip}</span>"
 
         "<span class='terminology'>#{@text || @term}#{tooltip}</span>"
       end
 
       private
 
-      SYNTAX = %r!^(\w+?|".+?")(?:\s+(\w+|".+"))?$!.freeze
-
+      SYNTAX = /^(\w+?|".+?")(?:\s+(\w+|".+"))?$/
     end
   end
 end


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- fix display issue in tables where 'learn more' link jumps on a new table line
![image](https://github.com/user-attachments/assets/3c36a753-22eb-465e-ae5e-7aac2e6ae978)

- reported in #https://github.com/home-assistant/home-assistant.io/pull/34040#discussion_r1698393720

Solution:
![image](https://github.com/user-attachments/assets/4d365863-56d4-49ea-85f6-36160c1a0ac1)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Streamlined error handling to improve user feedback when arguments do not match expected syntax.
  
- **Improvements**
	- Enhanced tooltip rendering for consistent output and clarity.
	- Adjusted string handling to remove unnecessary whitespace and ensure proper link inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->