### PR TITLE
Update `service-button` to `action-button`

### DIFF
--- a/source/_dashboards/picture-elements.markdown
+++ b/source/_dashboards/picture-elements.markdown
@@ -2,7 +2,7 @@
 type: card
 title: "Picture elements card"
 sidebar_label: Picture elements
-description: "The picture elements card is one of the most versatile types of cards. The cards allow you to position icons or text and even services! On an image based on coordinates."
+description: "The picture elements card is one of the most versatile types of cards. The cards allow you to position icons or text and even buttons! On an image based on coordinates."
 related:
   - docs: /dashboards/actions/
     title: Card actions
@@ -19,7 +19,7 @@ The picture elements card is one of the most versatile types of cards.
   A functional floorplan powered by picture elements.
 </p>
 
-The cards allow you to position icons or text and even services on an image based on coordinates. Imagine floor plan, imagine [picture-glance](/dashboards/picture-glance/) with no restrictions!
+The cards allow you to position icons or text and even buttons on an image based on coordinates. Imagine floor plan, imagine [picture-glance](/dashboards/picture-glance/) with no restrictions!
 
 {% include dashboard/edit_dashboard.md %}
 
@@ -221,24 +221,28 @@ style:
 
 ### Perform action button
 
-This entity creates a button (with arbitrary text) that can be used to perform a service.
+This entity creates a button (with arbitrary text) that can be used to perform an action.
 
 {% configuration %}
 type:
   required: true
-  description: "`service-button`"
+  description: "`action-button`"
   type: string
 title:
   required: true
   description: Button label.
   type: string
-service:
+action:
   required: true
   description: "`light.turn_on`"
   type: string
-service_data:
+target:
   required: false
-  description: The data to use.
+  description: The target to use for the action.
+  type: map
+data:
+  required: false
+  description: The data to use for the action.
   type: map
 style:
   required: true
@@ -454,8 +458,8 @@ If the option `hold_action` is specified, that action will be performed when the
 tap_action:
   action: toggle
 hold_action:
-  action: call-service
-  service: light.turn_on
+  action: perform-action
+  perform_action: light.turn_on
   data:
     entity_id: light.bed_light
     brightness_pct: 100
@@ -495,13 +499,13 @@ elements:
     style:
       top: 33%
       left: 15%
-  - type: service-button
+  - type: action-button
     title: Turn lights off
     style:
       top: 95%
       left: 60%
-    service: homeassistant.turn_off
-    service_data:
+    action: homeassistant.turn_off
+    target:
       entity_id: group.all_lights
   - type: icon
     icon: mdi:home
@@ -548,9 +552,9 @@ elements:
   - type: image
     entity: media_player.living_room
     tap_action:
-      action: call-service
-      service: media_player.media_play_pause
-      data:
+      action: perform-action
+      perform_action: media_player.media_play_pause
+      target:
         entity_id: media_player.living_room
     image: /local/television.jpg
     filter: brightness(5%)


### PR DESCRIPTION
## Proposed change

The `service-button` element was renamed to `action-button`


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced clarity in the "Picture elements card" documentation by updating terminology from "services" to "buttons."
  - Introduced a new `data` field under the `action` section for improved functionality.

- **Documentation**
  - Updated configuration schema to reflect new naming conventions (e.g., `service` renamed to `action`).
  - Revised action types and button element types for better alignment with user expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->