### PR TITLE
Add merge_response templating

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1286,6 +1286,7 @@ Template: {% raw %}{{ merge_response(response_variable, sort_by='start') }}{% en
   },
 ]
 ```
+
 ### Example using `selected_key`
 
 ```json

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1153,19 +1153,10 @@ See: [Python regular expression operations](https://docs.python.org/3/library/re
 Using action responses we can collect information from various entities at the same time.
 Using the `merge_response` template we can merge several responses into one list.
 
-| Variable       | Description                                           |
-| -------------- | ----------------------------------                    |
-| `value`        | The incoming value (action response).                 |
-| `sort_by`      | Sort the combined response dictionaries by this key.  |
-| `selected_key` | Return dictionary from second level key.              |
+| Variable       | Description                                     |
+| -------------- | ----------------------------------              |
+| `value`        | The incoming value (must be a action response). |
 
-{% note %}
-
-`selected_key` is used for selecting a second level key from within the dictionary.
-
-It can only be used when the response contains dictionaries on second level, not lists like, for example, with `weather.get_forecasts` and `calendar.get_events`
-
-{% endnote %}
 
 ### Example
 
@@ -1245,115 +1236,6 @@ It can only be used when the response contains dictionaries on second level, not
     "value_key": "events"
   }
 ]
-```
-
-### Example using `sort_by`
-
-Useful for sorting dictionaries by a certain key
-
-```json
-{
-    "calendar.sports": {
-        "events": [
-            {
-                "start": "2024-02-27T17:00:00-06:00",
-                "end": "2024-02-27T18:00:00-06:00",
-                "summary": "Basketball vs. Rockets",
-                "description": "",
-            }
-        ]
-    },
-    "calendar.local_furry_events": {"events": []},
-    "calendar.yap_house_schedules": {
-        "events": [
-            {
-                "start": "2024-02-26T08:00:00-06:00",
-                "end": "2024-02-26T09:00:00-06:00",
-                "summary": "Dr. Appt",
-                "description": "",
-            }
-        ]
-    },
-}
-```
-**Template:**
-```yaml
-{% raw %}
-{{ merge_response(response_variable, sort_by='start') }}
-{% endraw %}
-```
-```json
-[
-  {
-    "description": "",
-    "end": "2024-02-26T09:00:00-06:00",
-    "entity_id": "calendar.yap_house_schedules",
-    "start": "2024-02-26T08:00:00-06:00",
-    "summary": "Dr. Appt",
-    "value_key": "events"
-  },
-  {
-    "description": "",
-    "end": "2024-02-27T18:00:00-06:00",
-    "entity_id": "calendar.sports",
-    "start": "2024-02-27T17:00:00-06:00",
-    "summary": "Basketball vs. Rockets",
-    "value_key": "events"
-  },
-]
-```
-
-### Example using `selected_key`
-
-Useful with complex responses where you might only be interested to get a certain key from the second level.
-
-```json
-{
-    "vacuum.deebot_n8_plus_1": {
-      "header": {
-        "ver": "0.0.1",
-      },
-      "payloadType": "j",
-      "resp": {
-        "body": {
-          "msg": "ok",
-        },
-      },
-    },
-    "vacuum.deebot_n8_plus_2": {
-      "header": {
-        "ver": "0.0.1",
-      },
-      "payloadType": "j",
-      "resp": {
-        "body": {
-          "msg": "not_ok",
-        },
-      },
-    },
-  }
-```
-**Template:**
-```yaml
-{% raw %}
-{{ merge_response(response_variable, selected_key='resp') }}
-{% endraw %}
-```
-```json
-[
-    {
-      "body": {
-        "msg": "ok",
-      },
-      "entity_id": "vacuum.deebot_n8_plus_1",
-    },
-    {
-      "body": {
-        "msg": "not_ok",
-      },
-      "entity_id": "vacuum.deebot_n8_plus_2",
-    },
-  ]
 ```
 
 ## Processing incoming data

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1157,6 +1157,11 @@ Using the `merge_response` template we can merge several responses into one list
 | -------------- | ----------------------------------              |
 | `value`        | The incoming value (must be a action response). |
 
+`entity_id` key is appended to each dictionary within the template output list as a reference of origin. If the input dictionary already contains an `entity_id` key the template will fail.
+`value_key` key is appended to each dictionary within the template output list as a reference of origin if the original service call was providing a list of dictionaries, as example `calendar.get_events` or `weather.get_forecasts`.
+
+Examples of these two keys can can be seen in [example merge calendar action response](#example-merge-calendar-action-response) template output.
+
 
 ### Example
 
@@ -1169,37 +1174,49 @@ Using the `merge_response` template we can merge several responses into one list
 {% endraw %}
 ```
 
+### Example how to sort
+
+Sorting the dictionaries within the list based on a specific key can be done directly by using the jinja's `sort` filter.
+
+```yaml
+{% raw %}
+
+{{ merge_response(calendar_response) | sort(attribute='start') | ... }}
+
+{% endraw %}
+```
+
 ### Example merge calendar action response
 
 ```json
 {
-    "calendar.sports": {
-        "events": [
-            {
-                "start": "2024-02-27T17:00:00-06:00",
-                "end": "2024-02-27T18:00:00-06:00",
-                "summary": "Basketball vs. Rockets",
-                "description": "",
-            }
-        ]
-    },
-    "calendar.local_furry_events": {"events": []},
-    "calendar.yap_house_schedules": {
-        "events": [
-            {
-                "start": "2024-02-26T08:00:00-06:00",
-                "end": "2024-02-26T09:00:00-06:00",
-                "summary": "Dr. Appt",
-                "description": "",
-            },
-            {
-                "start": "2024-02-28T20:00:00-06:00",
-                "end": "2024-02-28T21:00:00-06:00",
-                "summary": "Bake a cake",
-                "description": "something good",
-            }
-        ]
-    },
+  "calendar.sports": {
+    "events": [
+      {
+        "start": "2024-02-27T17:00:00-06:00",
+        "end": "2024-02-27T18:00:00-06:00",
+        "summary": "Basketball vs. Rockets",
+        "description": "",
+      }
+    ]
+  },
+  "calendar.local_furry_events": {"events": []},
+  "calendar.yap_house_schedules": {
+    "events": [
+      {
+        "start": "2024-02-26T08:00:00-06:00",
+        "end": "2024-02-26T09:00:00-06:00",
+        "summary": "Dr. Appt",
+        "description": "",
+      },
+      {
+        "start": "2024-02-28T20:00:00-06:00",
+        "end": "2024-02-28T21:00:00-06:00",
+        "summary": "Bake a cake",
+        "description": "something good",
+      }
+    ]
+  },
 }
 ```
 **Template:**
@@ -1235,6 +1252,70 @@ Using the `merge_response` template we can merge several responses into one list
     "summary": "Bake a cake",
     "value_key": "events"
   }
+]
+```
+
+### Example non-list action responses
+
+```json
+{
+  "vacuum.deebot_n8_plus_1": {
+    "header": {
+      "ver": "0.0.1",
+    },
+    "payloadType": "j",
+    "resp": {
+      "body": {
+        "msg": "ok",
+      },
+    },
+  },
+  "vacuum.deebot_n8_plus_2": {
+    "header": {
+      "ver": "0.0.1",
+    },
+    "payloadType": "j",
+    "resp": {
+      "body": {
+        "msg": "ok",
+      },
+    },
+  },
+}
+```
+**Template:**
+```yaml
+{% raw %}
+{{ merge_response(response_variable) }}
+{% endraw %}
+```
+
+```json
+[
+  {
+    "entity_id": "vacuum.deebot_n8_plus_1",
+    "header": {
+      "ver": "0.0.1",
+    },
+    "payloadType": "j",
+    "resp": {
+      "body": {
+        "msg": "ok",
+      },
+    },
+  },
+  {
+    "entity_id": "vacuum.deebot_n8_plus_2",
+    "header": {
+      "ver": "0.0.1",
+    },
+    "payloadType": "j",
+    "resp": {
+      "body": {
+        "msg": "ok",
+      },
+    },
+  },
 ]
 ```
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1155,9 +1155,10 @@ Using the `merge_response` template we can merge several responses into one list
 
 | Variable       | Description                                     |
 | -------------- | ----------------------------------              |
-| `value`        | The incoming value (must be a action response). |
+| `value`        | The incoming value (must be an action response). |
 
 `entity_id` key is appended to each dictionary within the template output list as a reference of origin. If the input dictionary already contains an `entity_id` key the template will fail.
+
 `value_key` key is appended to each dictionary within the template output list as a reference of origin if the original service call was providing a list of dictionaries, as example `calendar.get_events` or `weather.get_forecasts`.
 
 Examples of these two keys can can be seen in [example merge calendar action response](#example-merge-calendar-action-response) template output.
@@ -1219,7 +1220,7 @@ Sorting the dictionaries within the list based on a specific key can be done dir
   },
 }
 ```
-**Template:**
+
 ```yaml
 {% raw %}
 {{ merge_response(response_variable) }}
@@ -1283,7 +1284,7 @@ Sorting the dictionaries within the list based on a specific key can be done dir
   },
 }
 ```
-**Template:**
+
 ```yaml
 {% raw %}
 {{ merge_response(response_variable) }}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1153,25 +1153,184 @@ See: [Python regular expression operations](https://docs.python.org/3/library/re
 Using action responses we can collect information from various entities at the same time.
 Using the `merge_response` template we can merge several responses into one list.
 
-| Variable     | Description                                            |
-| ------------ | ----------------------------------                     |
-| `value`      | The incoming value (action response).                  |
-| `sort_by`    | Sort a response dictionary by this key.                |
-| `single_key` | Return a list with information from a single key only. |
+| Variable       | Description                                            |
+| -------------- | ----------------------------------                     |
+| `value`        | The incoming value (action response).                  |
+| `sort_by`      | Sort a response dictionary by this key.                |
+| `selected_key` | Return a list with information from a single key only. |
 
-{% note %}
-
-`sort_by` and `single_key` have only use if the action call is returning dictionaries, for example `weather` and `calendar` action responses.
-
-{% endnote %}
-
-Example:
+### Example
 {% raw %}
 
 {% set combined_forecast = merge_response(response) %}
 {{ combined_forecast[0].precipitation | float(0) | round(1) }}
 
 {% endraw %}
+
+### Example merge calendar action response
+
+```json
+{
+    "calendar.sports": {
+        "events": [
+            {
+                "start": "2024-02-27T17:00:00-06:00",
+                "end": "2024-02-27T18:00:00-06:00",
+                "summary": "Basketball vs. Rockets",
+                "description": "",
+            }
+        ]
+    },
+    "calendar.local_furry_events": {"events": []},
+    "calendar.yap_house_schedules": {
+        "events": [
+            {
+                "start": "2024-02-26T08:00:00-06:00",
+                "end": "2024-02-26T09:00:00-06:00",
+                "summary": "Dr. Appt",
+                "description": "",
+            },
+            {
+                "start": "2024-02-28T20:00:00-06:00",
+                "end": "2024-02-28T21:00:00-06:00",
+                "summary": "Bake a cake",
+                "description": "something good",
+            }
+        ]
+    },
+}
+```
+Template: {% raw %}{{ merge_response(response_variable) }}{% endraw %}
+```json
+[
+  {
+    "description": "",
+    "end": "2024-02-27T18:00:00-06:00",
+    "entity_id": "calendar.sports",
+    "start": "2024-02-27T17:00:00-06:00",
+    "summary": "Basketball vs. Rockets",
+    "value_key": "events"
+  },
+  {
+    "description": "",
+    "end": "2024-02-26T09:00:00-06:00",
+    "entity_id": "calendar.yap_house_schedules",
+    "start": "2024-02-26T08:00:00-06:00",
+    "summary": "Dr. Appt",
+    "value_key": "events"
+  },
+  {
+    "description": "something good",
+    "end": "2024-02-28T21:00:00-06:00",
+    "entity_id": "calendar.yap_house_schedules",
+    "start": "2024-02-28T20:00:00-06:00",
+    "summary": "Bake a cake",
+    "value_key": "events"
+  }
+]
+```
+
+{% note %}
+
+`sort_by` is used for sorting by a selected key within a dictionary.
+`selected_key` is used for selecting a particular key to return from the second level in a dictionary.
+See below examples on how they can be used
+
+{% endnote %}
+
+### Example using `sort_by`
+
+```json
+{
+    "calendar.sports": {
+        "events": [
+            {
+                "start": "2024-02-27T17:00:00-06:00",
+                "end": "2024-02-27T18:00:00-06:00",
+                "summary": "Basketball vs. Rockets",
+                "description": "",
+            }
+        ]
+    },
+    "calendar.local_furry_events": {"events": []},
+    "calendar.yap_house_schedules": {
+        "events": [
+            {
+                "start": "2024-02-26T08:00:00-06:00",
+                "end": "2024-02-26T09:00:00-06:00",
+                "summary": "Dr. Appt",
+                "description": "",
+            }
+        ]
+    },
+}
+```
+Template: {% raw %}{{ merge_response(response_variable, sort_by='start') }}{% endraw %}
+```json
+[
+  {
+    "description": "",
+    "end": "2024-02-26T09:00:00-06:00",
+    "entity_id": "calendar.yap_house_schedules",
+    "start": "2024-02-26T08:00:00-06:00",
+    "summary": "Dr. Appt",
+    "value_key": "events"
+  },
+  {
+    "description": "",
+    "end": "2024-02-27T18:00:00-06:00",
+    "entity_id": "calendar.sports",
+    "start": "2024-02-27T17:00:00-06:00",
+    "summary": "Basketball vs. Rockets",
+    "value_key": "events"
+  },
+]
+```
+### Example using `selected_key`
+
+```json
+{
+    'vacuum.deebot_n8_plus_1': {
+      'header': {
+        'ver': '0.0.1',
+      },
+      'payloadType': 'j',
+      'resp': {
+        'body': {
+          'msg': 'ok',
+        },
+      },
+    },
+    'vacuum.deebot_n8_plus_2': {
+      'header': {
+        'ver': '0.0.1',
+      },
+      'payloadType': 'j',
+      'resp': {
+        'body': {
+          'msg': 'not_ok',
+        },
+      },
+    },
+  }
+```
+Template: {% raw %}{{ merge_response(response_variable, selected_key='resp') }}{% endraw %}
+```json
+[
+    {
+      'body': {
+        'msg': 'ok',
+      },
+      'entity_id': 'vacuum.deebot_n8_plus_1',
+    },
+    {
+      'body': {
+        'msg': 'not_ok',
+      },
+      'entity_id': 'vacuum.deebot_n8_plus_2',
+    },
+  ]
+```
 
 ## Processing incoming data
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1153,11 +1153,19 @@ See: [Python regular expression operations](https://docs.python.org/3/library/re
 Using action responses we can collect information from various entities at the same time.
 Using the `merge_response` template we can merge several responses into one list.
 
-| Variable       | Description                                            |
-| -------------- | ----------------------------------                     |
-| `value`        | The incoming value (action response).                  |
-| `sort_by`      | Sort a response dictionary by this key.                |
-| `selected_key` | Return a list with information from a single key only. |
+| Variable       | Description                                           |
+| -------------- | ----------------------------------                    |
+| `value`        | The incoming value (action response).                 |
+| `sort_by`      | Sort the combined response dictionaries by this key.  |
+| `selected_key` | Return dictionary from second level key.              |
+
+{% note %}
+
+`selected_key` is used for selecting a second level key from within the dictionary.
+
+It can only be used when the response contains dictionaries on second level, not lists like, for example, with `weather.get_forecasts` and `calendar.get_events`
+
+{% endnote %}
 
 ### Example
 
@@ -1165,7 +1173,6 @@ Using the `merge_response` template we can merge several responses into one list
 {% raw %}
 
 {% set combined_forecast = merge_response(response) %}
-
 {{ combined_forecast[0].precipitation | float(0) | round(1) }}
 
 {% endraw %}
@@ -1204,7 +1211,13 @@ Using the `merge_response` template we can merge several responses into one list
     },
 }
 ```
-**Template:** {% raw %}{{ merge_response(response_variable) }}{% endraw %}
+**Template:**
+```yaml
+{% raw %}
+{{ merge_response(response_variable) }}
+{% endraw %}
+```
+
 ```json
 [
   {
@@ -1234,17 +1247,9 @@ Using the `merge_response` template we can merge several responses into one list
 ]
 ```
 
-{% note %}
-
-`sort_by` is used for sorting by a selected key within a dictionary.
-
-`selected_key` is used for selecting a particular key to return from the second level in a dictionary.
-
-See below examples on how they can be used
-
-{% endnote %}
-
 ### Example using `sort_by`
+
+Useful for sorting dictionaries by a certain key
 
 ```json
 {
@@ -1271,7 +1276,12 @@ See below examples on how they can be used
     },
 }
 ```
-**Template:** {% raw %}{{ merge_response(response_variable, sort_by='start') }}{% endraw %}
+**Template:**
+```yaml
+{% raw %}
+{{ merge_response(response_variable, sort_by='start') }}
+{% endraw %}
+```
 ```json
 [
   {
@@ -1294,6 +1304,8 @@ See below examples on how they can be used
 ```
 
 ### Example using `selected_key`
+
+Useful with complex responses where you might only be interested to get a certain key from the second level.
 
 ```json
 {
@@ -1321,7 +1333,12 @@ See below examples on how they can be used
     },
   }
 ```
-**Template:** {% raw %}{{ merge_response(response_variable, selected_key='resp') }}{% endraw %}
+**Template:**
+```yaml
+{% raw %}
+{{ merge_response(response_variable, selected_key='resp') }}
+{% endraw %}
+```
 ```json
 [
     {

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1157,11 +1157,11 @@ Using the `merge_response` template we can merge several responses into one list
 | -------------- | ----------------------------------              |
 | `value`        | The incoming value (must be an action response). |
 
-`entity_id` key is appended to each dictionary within the template output list as a reference of origin. If the input dictionary already contains an `entity_id` key the template will fail.
+The `entity_id` key is appended to each dictionary within the template output list as a reference of origin. If the input dictionary already contains an `entity_id` key, the template will fail.
 
-`value_key` key is appended to each dictionary within the template output list as a reference of origin if the original service call was providing a list of dictionaries, as example `calendar.get_events` or `weather.get_forecasts`.
+The `value_key` key is appended to each dictionary within the template output list as a reference of origin if the original service call was providing a list of dictionaries, for example, `calendar.get_events` or `weather.get_forecasts`.
 
-Examples of these two keys can can be seen in [example merge calendar action response](#example-merge-calendar-action-response) template output.
+Examples of these two keys can be seen in [example merge calendar action response](#example-merge-calendar-action-response) template output.
 
 
 ### Example
@@ -1177,7 +1177,7 @@ Examples of these two keys can can be seen in [example merge calendar action res
 
 ### Example how to sort
 
-Sorting the dictionaries within the list based on a specific key can be done directly by using the jinja's `sort` filter.
+Sorting the dictionaries within the list based on a specific key can be done directly by using Jinja's `sort` filter.
 
 ```yaml
 {% raw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1160,12 +1160,16 @@ Using the `merge_response` template we can merge several responses into one list
 | `selected_key` | Return a list with information from a single key only. |
 
 ### Example
+
+```yaml
 {% raw %}
 
 {% set combined_forecast = merge_response(response) %}
+
 {{ combined_forecast[0].precipitation | float(0) | round(1) }}
 
 {% endraw %}
+```
 
 ### Example merge calendar action response
 
@@ -1200,7 +1204,7 @@ Using the `merge_response` template we can merge several responses into one list
     },
 }
 ```
-Template: {% raw %}{{ merge_response(response_variable) }}{% endraw %}
+**Template:** {% raw %}{{ merge_response(response_variable) }}{% endraw %}
 ```json
 [
   {
@@ -1233,7 +1237,9 @@ Template: {% raw %}{{ merge_response(response_variable) }}{% endraw %}
 {% note %}
 
 `sort_by` is used for sorting by a selected key within a dictionary.
+
 `selected_key` is used for selecting a particular key to return from the second level in a dictionary.
+
 See below examples on how they can be used
 
 {% endnote %}
@@ -1265,7 +1271,7 @@ See below examples on how they can be used
     },
 }
 ```
-Template: {% raw %}{{ merge_response(response_variable, sort_by='start') }}{% endraw %}
+**Template:** {% raw %}{{ merge_response(response_variable, sort_by='start') }}{% endraw %}
 ```json
 [
   {
@@ -1291,44 +1297,44 @@ Template: {% raw %}{{ merge_response(response_variable, sort_by='start') }}{% en
 
 ```json
 {
-    'vacuum.deebot_n8_plus_1': {
-      'header': {
-        'ver': '0.0.1',
+    "vacuum.deebot_n8_plus_1": {
+      "header": {
+        "ver": "0.0.1",
       },
-      'payloadType': 'j',
-      'resp': {
-        'body': {
-          'msg': 'ok',
+      "payloadType": "j",
+      "resp": {
+        "body": {
+          "msg": "ok",
         },
       },
     },
-    'vacuum.deebot_n8_plus_2': {
-      'header': {
-        'ver': '0.0.1',
+    "vacuum.deebot_n8_plus_2": {
+      "header": {
+        "ver": "0.0.1",
       },
-      'payloadType': 'j',
-      'resp': {
-        'body': {
-          'msg': 'not_ok',
+      "payloadType": "j",
+      "resp": {
+        "body": {
+          "msg": "not_ok",
         },
       },
     },
   }
 ```
-Template: {% raw %}{{ merge_response(response_variable, selected_key='resp') }}{% endraw %}
+**Template:** {% raw %}{{ merge_response(response_variable, selected_key='resp') }}{% endraw %}
 ```json
 [
     {
-      'body': {
-        'msg': 'ok',
+      "body": {
+        "msg": "ok",
       },
-      'entity_id': 'vacuum.deebot_n8_plus_1',
+      "entity_id": "vacuum.deebot_n8_plus_1",
     },
     {
-      'body': {
-        'msg': 'not_ok',
+      "body": {
+        "msg": "not_ok",
       },
-      'entity_id': 'vacuum.deebot_n8_plus_2',
+      "entity_id": "vacuum.deebot_n8_plus_2",
     },
   ]
 ```

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1161,7 +1161,7 @@ Using the `merge_response` template we can merge several responses into one list
 
 {% note %}
 
-`sort_by` and `single_key` has only use if the action call is returning dictionaries
+`sort_by` and `single_key` have only use if the action call is returning dictionaries, for example `weather` and `calendar` action responses.
 
 {% endnote %}
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1148,6 +1148,31 @@ See: [Python regular expression operations](https://docs.python.org/3/library/re
 - Filter `value | regex_findall(find='', ignorecase=False)` will find all regex matches of the find expression in `value` and return the array of matches.
 - Filter `value | regex_findall_index(find='', index=0, ignorecase=False)` will do the same as `regex_findall` and return the match at index.
 
+## Merge action responses
+
+Using action responses we can collect information from various entities at the same time.
+Using the `merge_response` template we can merge several responses into one list.
+
+| Variable     | Description                                            |
+| ------------ | ----------------------------------                     |
+| `value`      | The incoming value (action response).                  |
+| `sort_by`    | Sort a response dictionary by this key.                |
+| `single_key` | Return a list with information from a single key only. |
+
+{% note %}
+
+`sort_by` and `single_key` has only use if the action call is returning dictionaries
+
+{% endnote %}
+
+Example:
+{% raw %}
+
+{% set combined_forecast = merge_response(response) %}
+{{ combined_forecast[0].precipitation | float(0) | round(1) }}
+
+{% endraw %}
+
 ## Processing incoming data
 
 The other part of templating is processing incoming data. It allows you to modify incoming data and extract only the data you care about. This will only work for platforms and integrations that mention support for this in their documentation.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds `merge_response` to HA templating


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/114204
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Enhanced the templating documentation with a new section on `merge_response` functionality, detailing parameters `value`, `sort_by`, and `selected_key`, along with practical examples to guide users in merging action responses effectively.
	- Added comprehensive examples in both YAML and JSON formats to illustrate the merging of multiple calendar event responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->