### PR TITLE
Z-Wave: Reword firmware warnings, add Z-Station as recommended

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -22,7 +22,7 @@ The firmwares of 700 and 800 series Z-Wave controllers have several bugs which i
   - SDK versions 7.17.2 to 7.19.x are okay
   - avoid SDK versions before 7.17.2
   - avoid SDK versions 7.20 to 7.21.3
- 
+
 Note that the SDK version does not have to match the firmware version. If you are unsure which SDK versions a firmware is based on, contact the manufacturer.
 
 Users should upgrade the firmware on all 700 and 800 series controllers to a recommended version.
@@ -158,11 +158,11 @@ If you've installed the Z-Wave.Me Z-Way software. In order to use Z-Wave JS inst
 
 This procedure has been tested with the following modules:
 
-  - Aeotec Z-Pi 7 Raspberry Pi HAT/Shield
-  - Z-Wave.Me RaZberry 7
-  - Z-Wave.Me RaZberry 7 Pro
+- Aeotec Z-Pi 7 Raspberry Pi HAT/Shield
+- Z-Wave.Me RaZberry 7
+- Z-Wave.Me RaZberry 7 Pro
 
-1. Make sure the module is properly seated on the Home Assistant Yellow. 
+1. Make sure the module is properly seated on the Home Assistant Yellow.
    ![Aeotec Z-Pi 7 on Home Assistant Yellow](/images/docs/z-wave/zpi-7-yellow.jpg).
 2. Carefully [close the case](https://yellow.home-assistant.io/guides/add-ssd-existing-installation/#reassembling-top-part) and power up Home Assistant Yellow.
 3. Follow the procedure on [setting up a Z-Wave JS server](/integrations/zwave_js/#setting-up-a-z-wave-js-server).

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -10,12 +10,13 @@ You need to have a compatible Z-Wave stick or module installed. The following de
 {% warning %}
 
 The firmwares of 700 and 800 series Z-Wave controllers have several bugs which impact the stability of the mesh and can cause the controller to become unresponsive. Because there is no known firmware version that is completely fixed, it is recommended to choose a firmware based on the following criteria:
+
 - 700 series:
   - prefer SDK versions 7.17.2 to 7.18.x
   - SDK versions 7.19.x are okay
   - avoid SDK versions before 7.17.2
   - avoid SDK versions 7.20 to 7.21.3
- 
+
 - 800 series
   - prefer SDK versions 7.22.x
   - SDK versions 7.17.2 to 7.19.x are okay

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -23,7 +23,9 @@ The firmwares of 700 and 800 series Z-Wave controllers have several bugs which i
   - avoid SDK versions before 7.17.2
   - avoid SDK versions 7.20 to 7.21.3
 
-Note that the SDK version does not have to match the firmware version. If you are unsure which SDK versions a firmware is based on, contact the manufacturer.
+{% note %}
+The SDK version does not have to match the firmware version. If you are unsure which SDK versions a firmware is based on, contact the manufacturer of your device.
+{% endnote %}
 
 Users should upgrade the firmware on all 700 and 800 series controllers to a recommended version.
 

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -9,9 +9,22 @@ You need to have a compatible Z-Wave stick or module installed. The following de
 
 {% warning %}
 
-Until recently, 700 series Z-Wave Controllers had a bug that could cause the mesh to be flooded on some networks and the controller to become unresponsive. At present, all 700 series controllers share the same firmware and are subject to this bug. It appears that this bug is largely, if not completely, resolved as of firmware version 7.17.2.
+The firmwares of 700 and 800 series Z-Wave controllers have several bugs which impact the stability of the mesh and can cause the controller to become unresponsive. Because there is no known firmware version that is completely fixed, it is recommended to choose a firmware based on the following criteria:
+- 700 series:
+  - prefer SDK versions 7.17.2 to 7.18.x
+  - SDK versions 7.19.x are okay
+  - avoid SDK versions before 7.17.2
+  - avoid SDK versions 7.20 to 7.21.3
+ 
+- 800 series
+  - prefer SDK versions 7.22.x
+  - SDK versions 7.17.2 to 7.19.x are okay
+  - avoid SDK versions before 7.17.2
+  - avoid SDK versions 7.20 to 7.21.3
 
-Users should upgrade the firmware on all 700 series controllers to version 7.17.2 or greater. Firmware can be upgraded using the below directions:
+Users should upgrade the firmware on all 700 and 800 series controllers to a recommended version.
+
+Firmware can be upgraded using the below directions:
 
 - [Upgrade instructions using Linux](https://github.com/kpine/zwave-js-server-docker/wiki/700-series-Controller-Firmware-Updates-(Linux))
 - [Upgrade instructions using Windows (Aeotec)](https://aeotec.freshdesk.com/support/solutions/articles/6000252296-update-z-stick-7-with-windows)
@@ -21,8 +34,9 @@ Users should upgrade the firmware on all 700 series controllers to version 7.17.
 {% endwarning %}
 
 - 800 series controllers (with some caveats, see notes)
-  - Zooz 800 Series Z-Wave Long Range S2 Stick (ZST39 LR)
+  - Z-Wave.Me Z-Station
   - HomeSeer SmartStick G8
+  - Zooz 800 Series Z-Wave Long Range S2 Stick (ZST39 LR)
 
 - 700 series controllers
   - Aeotec Z-Stick 7 USB stick (ZWA010) (the EU version is not recommended due to RF performance issues)

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -27,7 +27,9 @@ The firmwares of 700 and 800 series Z-Wave controllers have several bugs which i
 The SDK version does not have to match the firmware version. If you are unsure which SDK versions a firmware is based on, contact the manufacturer of your device.
 {% endnote %}
 
-Users should upgrade the firmware on all 700 and 800 series controllers to a recommended version.
+{% important %}
+You should upgrade the firmware on all 700 and 800 series controllers to a recommended version.
+{% endimportant %}
 
 Firmware can be upgraded using the below directions:
 

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -21,6 +21,8 @@ The firmwares of 700 and 800 series Z-Wave controllers have several bugs which i
   - SDK versions 7.17.2 to 7.19.x are okay
   - avoid SDK versions before 7.17.2
   - avoid SDK versions 7.20 to 7.21.3
+ 
+Note that the SDK version does not have to match the firmware version. If you are unsure which SDK versions a firmware is based on, contact the manufacturer.
 
 Users should upgrade the firmware on all 700 and 800 series controllers to a recommended version.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Revised documentation for Z-Wave controllers to clarify firmware recommendations.
	- Provided specific guidance on preferred firmware versions for both 700 and 800 series controllers.
	- Emphasized the importance of upgrading firmware for enhanced stability and preventing unresponsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->