### PR TITLE
Remove mention of the old library from Onkyo

### DIFF
--- a/source/_integrations/onkyo.markdown
+++ b/source/_integrations/onkyo.markdown
@@ -52,7 +52,7 @@ max_volume:
   default: 100
   type: integer
 receiver_max_volume:
-  description: The maximum volume of the receiver. For older Onkyo receivers this was 80, newer Onkyo receivers use 200.
+  description: The number of steps it takes for the receiver to go from the lowest to the highest possible volume. Possible values are: 50, 80, 100, 200. For older Onkyo receivers this typically is 80, newer Onkyo receivers use 200.
   required: false
   default: 80
   type: integer
@@ -90,22 +90,6 @@ List of source names:
 - `multi-ch`
 - `xm`
 - `sirius`
-
-If your source is not listed above, and you want to figure out how to format that source name so you can map its entry, you can use the `onkyo-eiscp` Python module to discover the exact naming needed. First, change your receiver's source to the one that you need to define, and then run:
-
-```bash
-onkyo --host 192.168.0.100 source=query
-```
-
-If this returns multiple, comma-separated values, use the first one. For example, if `dvd,bd,dvd` is returned, use `dvd`.
-
-To find your receivers max volume use the onkyo-eiscp Python module set the receiver to its maximum volume
-(don't do this whilst playing something!) and run:
-
-```bash
-onkyo --host 192.168.0.100 volume=query
-unknown-model: master-volume = 191
-```
 
 ### Service `onkyo_select_hdmi_output`
 

--- a/source/_integrations/onkyo.markdown
+++ b/source/_integrations/onkyo.markdown
@@ -52,7 +52,7 @@ max_volume:
   default: 100
   type: integer
 receiver_max_volume:
-  description: The number of steps it takes for the receiver to go from the lowest to the highest possible volume. Possible values are 50, 80, 100, 200. For older Onkyo receivers this typically is 80, newer Onkyo receivers use 200.
+  description: The number of steps it takes for the receiver to go from the lowest to the highest possible volume. Possible values are 50, 80, 100, 200. For older Onkyo receivers, this typically is 80; newer Onkyo receivers use 200.
   required: false
   default: 80
   type: integer

--- a/source/_integrations/onkyo.markdown
+++ b/source/_integrations/onkyo.markdown
@@ -52,7 +52,7 @@ max_volume:
   default: 100
   type: integer
 receiver_max_volume:
-  description: The number of steps it takes for the receiver to go from the lowest to the highest possible volume. Possible values are: 50, 80, 100, 200. For older Onkyo receivers this typically is 80, newer Onkyo receivers use 200.
+  description: The number of steps it takes for the receiver to go from the lowest to the highest possible volume. Possible values are 50, 80, 100, 200. For older Onkyo receivers this typically is 80, newer Onkyo receivers use 200.
   required: false
   default: 80
   type: integer


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove mention of the old library from Onkyo.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Revised the description of the `receiver_max_volume` parameter for better clarity on its functionality and possible values (50, 80, 100, 200).
	- Removed outdated information regarding source name discovery and maximum volume checks to streamline documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->