### PR TITLE
Update ZHA documentation for OTA providers

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -255,23 +255,9 @@ custom_quirks_path:
 
 ### Advanced OTA configuration
 
-The default configuration for OTA firmware updates is chosen by ZHA developers, so normal users should not need to change any configuration. Most of the config options listed in the zigpy section are just meant for development or advanced users.
+OTA for a few manufacturers is enabled by default, currently Ledvance, Sonoff, Inovelli, and ThirdReality. Other manufacturers are supported but disabled by default because their updates may change or remove device functionality, may require you to reconfigure devices, or are contributed by the community and may be minimally tested.
 
-Further advanced configuration options are only provided in the [zigpy project's developers documentation](https://github.com/zigpy/zigpy).
-
-However, if you want to disable OTA updates for a specific manufacturer, you can add the following lines to your `configuration.yaml` and restart Home Assistant.
-
-```yaml
-zha:
-  zigpy_config:
-    ota:
-      ikea_provider: false                       # Disable OTA update downloads for Trådfri devices
-      inovelli_provider: false                   # Disable OTA update downloads for INOVELLI devices
-      ledvance_provider: false                   # Disable OTA update downloads for LEDVANCE/OSRAM devices
-      salus_provider: false                      # Disable OTA update downloads for SALUS/Computime devices
-      sonoff_provider: false                     # Disable OTA update downloads for Sonoff (ITead) devices
-      thirdreality_provider: false               # Disable OTA update downloads for 3REALITY devices
-```
+Refer to the [zigpy documentation for OTA configuration](https://github.com/zigpy/zigpy/wiki/OTA-Configuration) for more information on additional OTA providers.
 
 ### Defining Zigbee channel to use
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The OTA provider configuration format has changed in zigpy and there are deprecation warnings in logs for users that currently use them.

I've removed example OTA YAML from ZHA's documentation and have created a separate page in zigpy's documentation that outlines it in depth.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Default OTA firmware updates are now enabled for specific manufacturers: Ledvance, Sonoff, Inovelli, and ThirdReality.
  
- **Documentation**
	- Removed detailed YAML configuration examples for disabling OTA updates, directing users to external zigpy documentation for guidance instead.
  
- **Clarity Improvements**
	- Enhanced clarity on the default OTA settings and the associated risks for unsupported manufacturers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->