### PR TITLE
Fix: update seventeentrack example card

### DIFF
--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -62,7 +62,7 @@ type: markdown
 title: Packages in transit
 content: >
   {% for package in
-  states.sensor.seventeentrack_packages_in_transit.attributes.packages %}
+  states.sensor['17track_in_transit'].attributes.packages %}
 
   >- **{{ package.friendly_name }} ({{ package.tracking_number }}):** {{
   package.info_text }}


### PR DESCRIPTION
This is to match integration changes as of Home Assistant version 2024.8. Sensor names are now defaulting to "17track_*" and since they starts with numbers, a diffferent syntax is required.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package tracking integration to utilize a different state sensor for improved clarity in tracking packages in transit.
- **Bug Fixes**
	- Adjusted the data source for package attributes to ensure reliable access to in-transit package information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->