### PR TITLE
VySync: Add support for Levoit EverestAir air purifiers

### DIFF
--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -62,6 +62,7 @@ This {% term integration %} supports devices controllable by the VeSync App.  Th
 - Core 300S: Smart True HEPA Air Purifier
 - Core 400S: Smart True HEPA Air Purifier
 - Core 600S: Smart True HEPA Air Purifier
+- EverestAir: Smart Air Purifier
 - Vital 100S Smart True HEPA Air Purifier (LAP-V102S-WUS) 
 - Vital 200S Smart True HEPA Air Purifier (LAP-V201S-WUS)
 - LEVOIT Smart Wifi Air Purifier (LV-PUR131S)
@@ -97,11 +98,11 @@ itself. Note that prior versions of the {% term integration %} exposed these as 
 ## Fan & air quality sensors
 All VeSync air purifiers expose the remaining filter lifetime, and some also expose air quality measurements.
 
-| Sensor                                  | Description                                                        | Example |
-| --------------------------------------- | ------------------------------------------------------------------ | ------- |
-| `filter_life`           | Remaining percentage of the filter. (LV-PUR131S, Core200S/300s/400s/600s)         | 142       |
+| Sensor                  | Description                                                                            | Example   |
+| ----------------------- | -------------------------------------------------------------------------------------- | --------- |
+| `filter_life`           | Remaining percentage of the filter. (LV-PUR131S, Core200S/300s/400s/600s/EverestAir)   | 142       |
 | `air_quality`           | The current air quality reading. (LV-PUR131S, Core300s/400s/600s)                      | excellent |
-| `pm2_5`                 | The current air quality reading. (Core300s/400s/600s)                                  | 8         |
+| `pm2_5`                 | The current air quality reading. (Core300s/400s/600s/EverestAir)                       | 8         |
 
 ## Fan exposed attributes
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding the Levoit EverestAir air purifier to the supported devices.

Resolves a closed/stale issue: https://github.com/home-assistant/core/issues/99553


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/123428
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #99553

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a "Minimum requirements" section for the Pinecil V2 in the IronOS documentation.
	- Introduced support for the new "EverestAir" air purifier model in the VeSync integration.
	- Added a blog post outlining the transition of the "Works with Home Assistant" program to the Open Home Foundation.

- **Documentation Improvements**
	- Enhanced clarity regarding password requirements for the Reolink integration.
	- Updated OTA update documentation for Matter devices, emphasizing optional updates.
	- Refined WLED integration documentation for improved usability and navigability.
	- Clarified the description of the "Raw tip voltage" control in the IronOS documentation.
	- Adjusted integration card description in Home Assistant documentation for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->