### PR TITLE
Flux: Specify default values for start_time and stop_time

### DIFF
--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -50,12 +50,14 @@ name:
   default: Flux
   type: string
 start_time:
-  description: The start time, defaults to sunrise.
+  description: The start time.
   required: false
+  default: sunrise
   type: time
 stop_time:
-  description: The stop time, defaults to dusk.
+  description: The stop time.
   required: false
+  default: dusk
   type: time
 start_colortemp:
   description: The color temperature at the start.

--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -50,11 +50,11 @@ name:
   default: Flux
   type: string
 start_time:
-  description: The start time.
+  description: The start time, defaults to sunrise.
   required: false
   type: time
 stop_time:
-  description: The stop time.
+  description: The stop time, defaults to dusk.
   required: false
   type: time
 start_colortemp:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

These are optional, and the documentation is very much not clear about what it's supposed to happen if left out. So I found [this](https://github.com/home-assistant/home-assistant.io/issues/33370), then confirmed by looking at the source code.
Here's the PR to spare some time to the next guy with the same question, hopefully 🙂 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33370

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced default values for `start_time` (now `sunrise`) and `stop_time` (now `dusk`) in the configuration schema.
	
- **Impact**
	- Enhances usability by reducing errors related to omitted values, creating a more user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->