### PR TITLE
Clarify continuous mode is enabled by default in the Roomba integration

### DIFF
--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -36,7 +36,7 @@ This {% term integrations %}  has been tested and confirmed to be working with t
 {% include integrations/config_flow.md %}
 
 {% warning %}
-The Roomba's MQTT server only allows a single connection. Enabling continuous mode will force the App to connect via the cloud to your Roomba. For more information, refer to the [Roomba 980 repository](https://github.com/NickWaterton/Roomba980-Python#firmware-2xx-notes).
+The Roomba's MQTT server only allows a single connection. Continuous mode is enabled by default, which will force the App to connect via the cloud to your Roomba. Continuous mode can be disabled in the configuration options for the integration after it is added. For more information, refer to the [Roomba 980 repository](https://github.com/NickWaterton/Roomba980-Python#firmware-2xx-notes).
 {% endwarning %}
 
 ## Integration entities


### PR DESCRIPTION
## Proposed change

The Roomba integration [defaults to enabling continuous mode](https://github.com/home-assistant/core/blob/f53da62026cc508d86703f45788418dfd8225597/homeassistant/components/roomba/config_flow.py#L39), yet the docs say otherwise. This PR cleans that up!

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated warning message regarding the Roomba's MQTT server connection behavior for clarity.
  
- **Documentation**
	- Enhanced documentation to indicate that continuous mode is enabled by default and users can disable it in configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->