### PR TITLE
Cleanup mqtt publish action template option documentation

### DIFF
--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -1110,11 +1110,7 @@ The MQTT integration will register the `mqtt.publish` action, which allows publi
 | `qos`                  | yes      | Quality of Service to use. (default: 0)                      |
 | `retain`               | yes      | If message should have the retain flag set. (default: false) |
 
-
-{% important %}
-You must include either `topic` or `topic_template`, but not both. If providing a payload, you need to include either `payload` or `payload_template`, but not both.
-{% endimportant %}
-
+### Publish action data examples
 
 ```yaml
 topic: homeassistant/light/1/command
@@ -1125,7 +1121,7 @@ payload: on
 
 ```yaml
 topic: homeassistant/light/1/state
-payload_template: "{{ states('device_tracker.paulus') }}"
+payload: "{{ states('device_tracker.paulus') }}"
 ```
 
 {% endraw %}
@@ -1133,27 +1129,24 @@ payload_template: "{{ states('device_tracker.paulus') }}"
 {% raw %}
 
 ```yaml
-topic_template: "homeassistant/light/{{ states('sensor.light_active') }}/state"
+topic: "homeassistant/light/{{ states('sensor.light_active') }}/state"
 payload_template: "{{ states('device_tracker.paulus') }}"
 ```
 
 {% endraw %}
 
-`payload` must be a string.
+Be aware that `payload` must be a string.
 If you want to send JSON using the YAML editor then you need to format/escape
 it properly. Like:
+
+{% raw %}
 
 ```yaml
 topic: homeassistant/light/1/state
 payload: "{\"Status\":\"off\", \"Data\":\"something\"}"`
 ```
 
-When using Home Assistant's YAML editor for formatting JSON
-you should take special care if `payload` contains template content.
-Home Assistant will force you in to the YAML editor and will treat your
-definition as a template. Make sure you escape the template blocks as like
-in the example below. Home Assistant will convert the result to a string
-and will pass it to the MQTT publish action.
+{% endraw %}
 
 The example below shows how to publish a temperature sensor 'Bathroom Temperature'.
 The `device_class` is set, so it is not needed to set the "name" option. The entity

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -1130,7 +1130,7 @@ payload: "{{ states('device_tracker.paulus') }}"
 
 ```yaml
 topic: "homeassistant/light/{{ states('sensor.light_active') }}/state"
-payload_template: "{{ states('device_tracker.paulus') }}"
+payload: "{{ states('device_tracker.paulus') }}"
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Cleanup mqtt publish action template option documentation.

This is a follow up on https://github.com/home-assistant/home-assistant.io/pull/33854

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #34245

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated MQTT integration documentation to provide illustrative YAML examples for the `topic` and `payload` parameters.
	- Clarified that `payload` must be a string and included guidance on JSON formatting in YAML.
	- Simplified instructions regarding the use of Home Assistant's YAML editor to reduce confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->