### PR TITLE
Remove deprecated information from Swiss public transport

### DIFF
--- a/source/_integrations/swiss_public_transport.markdown
+++ b/source/_integrations/swiss_public_transport.markdown
@@ -23,22 +23,6 @@ The [Stationboard](https://transport.opendata.ch/examples/stationboard.html) web
 
 {% include integrations/config_flow.md %}
 
-{% configuration %}
-from:
-  description: The ID of the station of the start station.
-  required: true
-  type: string
-to:
-  description: The ID of the station of the end station.
-  required: true
-  type: string
-name:
-  description: The name of the sensor.
-  required: false
-  type: string
-  default: Next Departure
-{% endconfiguration %}
-
 The public timetables are coming from [Swiss public transport](https://transport.opendata.ch/).
 
 ### Defining a custom polling interval


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This has already been removed from the core repo.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/119813
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [c] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Swiss public transport integration to focus on the "end station" ID for enhanced functionality.
  
- **Documentation**
	- Revised configuration documentation to clarify the changes and simplify user setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->