### PR TITLE
use html5 details element instead of javascript

### DIFF
--- a/plugins/details.rb
+++ b/plugins/details.rb
@@ -40,29 +40,17 @@ module Jekyll
       end
 
       <<~MARKUP
-        <script>
-        function showDetails(el) {
-          const content = el.parentElement.querySelector(".details-block-content");
-          const up = el.querySelector("svg#up");
-          const down = el.querySelector("svg#down");
-          const shouldExpand = down.style.display === "block";
-          up.style.display = shouldExpand ? "block" : "none";
-          down.style.display = !shouldExpand ? "block" : "none";
-          content.hidden = !shouldExpand;
-          el.ariaExpanded = shouldExpand;
-        }
-        </script>
         <div class="details-block">
-          <div class='details-block-item'>
-            <button class='details-block-title' onclick='showDetails(this)' aria-controls="content_#{idx}" aria-expanded="false">
+          <details class='details-block-item'>
+            <summary class='details-block-title'>
               <span>#{icon}#{title}</span>
               <div class='details-block-arrow'>
-              <svg id="down" style="display: block;" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>
-              <svg id="up" style="display: none;" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" /></svg>
+              <svg class="down" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>
+              <svg class="up" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" /></svg>
               </div>
-            </button>
-            <div class='details-block-content' id="content_#{idx}" hidden>#{contents}</div>
-          </div>
+            </summary>
+            <div class='details-block-content' id="content_#{idx}">#{contents}</div>
+          </details>
         </div>
       MARKUP
     end

--- a/sass/homeassistant/plugins/_details.scss
+++ b/sass/homeassistant/plugins/_details.scss
@@ -3,6 +3,26 @@ div.details-block {
   display: block;
   margin: 0 0 1.5em 0;
 
+  summary {
+    .up {
+      display: none;
+    }
+
+    .down {
+      display: block;
+    }
+  }
+
+  &[open] summary {
+    .up {
+      display: block;
+    }
+
+    .down {
+      display: none;
+    }
+  }
+
   .details-block-item {
     background-color: #f8f8f8;
     padding: 4px 24px;

--- a/sass/homeassistant/plugins/_details.scss
+++ b/sass/homeassistant/plugins/_details.scss
@@ -3,32 +3,22 @@ div.details-block {
   display: block;
   margin: 0 0 1.5em 0;
 
-  summary {
-    .up {
-      display: none;
-    }
-
-    .down {
-      display: block;
-    }
-  }
-
-  &[open] summary {
-    .up {
-      display: block;
-    }
-
-    .down {
-      display: none;
-    }
-  }
-
   .details-block-item {
     background-color: #f8f8f8;
     padding: 4px 24px;
     margin: 8px 0;
     border: 1px solid rgba(0, 0, 0, .12);
     border-radius: 16px;
+
+    &[open] .details-block-title {
+      .up {
+        display: block;
+      }
+
+      .down {
+        display: none;
+      }
+    }
 
     .details-block-title {
       font-weight: bold;
@@ -43,6 +33,14 @@ div.details-block {
       border: 0px;
       width: 100%;
       padding: 0;
+
+      .up {
+        display: none;
+      }
+
+      .down {
+        display: block;
+      }
     }
     .details-block-content {
       margin: 4px 0 12px 0;


### PR DESCRIPTION
## Proposed change

Changed from using JavaScript for the details block to using the native `details` and `summary` element from HTML.

This (very slightly) reduces the reliance on JavaScript for content - specifically I found when the JS didn't full load (because of my flaky connection), I couldn't open these detail blocks and then content was fully hidden (can be replicated by disabling JavaScript and trying to read the details on [this and other pages](https://www.home-assistant.io/integrations/google_assistant_sdk/#enable-personal-results-for-advanced-users)).

Also means the accessibility features come for "free" with a native details element.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

None of the above. Changes (reduces) markup used.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: fixes n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [/] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Implemented a semantic HTML structure for expandable content using `<details>` and `<summary>` elements, enhancing usability and accessibility.
	- Added new styles for dynamic visibility of summary content based on expansion state, improving user interface feedback.

- **Bug Fixes**
	- Removed reliance on JavaScript for basic expand/collapse functionality, simplifying interactions and improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->