### PR TITLE
Amcrest: Add `channel` configuration

### DIFF
--- a/source/_integrations/amcrest.markdown
+++ b/source/_integrations/amcrest.markdown
@@ -71,6 +71,13 @@ port:
   required: false
   type: integer
   default: 80
+channel:
+  description: >
+    The camera's stream channel to use. For NVRs, this correlates to the camera number in the UI, and may be required to
+    get a connection to a stream or sensor.
+  required: false
+  type: integer
+  default: 0
 resolution:
   description: >
     This parameter allows you to specify the camera resolution.


### PR DESCRIPTION
I'm submitting support for `channel` selection on Amcrest devices. This will enable NVR support, as we need to be able to select a `channel` to get an individual camera's stream and sensors.

Ref: https://github.com/home-assistant/core/pull/123951