### PR TITLE
Add docs for the new action archive_package

### DIFF
--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -92,3 +92,21 @@ The `seventeentrack.get_packages` action allows you to query the 17track API for
     config_entry_id: 2b4be47a1fa7c3764f14cf756dc98991
     package_state: ["Delivered", "In transit"]
 ```
+
+### Action `seventeentrack.archive_package`
+
+The `seventeentrack.archive_package` action allows you to archive a package using the 17track API.
+
+
+| Data attribute            | Optional | Description                                 |
+|---------------------------|----------|---------------------------------------------|
+| `config_entry_id`         | No       | The ID of the 17Track service config entry. |
+| `package_tracking_number` | No       | The package tracking number.                |
+
+```yaml
+# Example automation action to archive a package with a tracking number
+- action: seventeentrack.archive_package
+  data:
+    config_entry_id: 2b4be47a1fa7c3764f14cf756dc98991
+    package_tracking_number: RU0103445624A
+```

--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -79,7 +79,6 @@ content: >
 
 The `seventeentrack.get_packages` action allows you to query the 17track API for the latest package data.
 
-
 | Data attribute | Optional | Description                                 |
 |------------------------|----------|---------------------------------------------|
 | `config_entry_id`      | No       | The ID of the 17Track service config entry. |
@@ -96,7 +95,6 @@ The `seventeentrack.get_packages` action allows you to query the 17track API for
 ### Action `seventeentrack.archive_package`
 
 The `seventeentrack.archive_package` action allows you to archive a package using the 17track API.
-
 
 | Data attribute            | Optional | Description                                 |
 |---------------------------|----------|---------------------------------------------|


### PR DESCRIPTION
## Proposed change
Add documentation for the new action `archive_package` to the `17track` integration.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/123493
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new action to archive packages within the 17track API integration, enhancing package management capabilities.
- **Documentation**
	- Updated documentation with a detailed description of the new archival action, including required data attributes and an example YAML snippet for user reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->