### PR TITLE
Update blueprint schema documentation

### DIFF
--- a/source/_docs/blueprint/schema.markdown
+++ b/source/_docs/blueprint/schema.markdown
@@ -72,9 +72,9 @@ homeassistant:
   keys:
     min_version:
       description: >
-        Minimum required version of Home Assistant to use the blueprint in the format of 
-        _major_._minor_._patch_ (all parts are required). For example, `2022.4.0`. It is
-        important to set this if the blueprint uses any features introduced in recent 
+        Minimum required version of Home Assistant to use the blueprint in the format of
+        *major*.*minor*.*patch* (all parts are required). For example, `2022.4.0`. It is
+        important to set this if the blueprint uses any features introduced in recent
         releases to head off issues.
       type: string
       required: false

--- a/source/_docs/blueprint/schema.markdown
+++ b/source/_docs/blueprint/schema.markdown
@@ -155,7 +155,7 @@ allows an optional description, and optionally allows for collapsing those input
 A section is differentiated from an input by the presence of an additional `input` key within that section. 
 
 {% caution %}
-Input sections are a new feature in version 2024.6.0. Set the `min_version` for the blueprint to at least this version if using input sections. Otherwise, the blueprint will generate errors on older versions. 
+Input sections are a new feature in version 2024.6.0. Set the `min_version` for the blueprint to at least this version if using input sections. Otherwise, the blueprint will generate errors on older versions.
 {% endcaution %}
 
 The full configuration for a section is below:

--- a/source/_docs/blueprint/schema.markdown
+++ b/source/_docs/blueprint/schema.markdown
@@ -72,9 +72,10 @@ homeassistant:
   keys:
     min_version:
       description: >
-        Minimum required version of Home Assistant to use the blueprint. For example,
-        `2022.4.0`. It is important to set this if the blueprint uses any features
-        introduced in recent releases to head off issues.
+        Minimum required version of Home Assistant to use the blueprint in the format of 
+        _major_._minor_._patch_ (all parts are required). For example, `2022.4.0`. It is
+        important to set this if the blueprint uses any features introduced in recent 
+        releases to head off issues.
       type: string
       required: false
 input:
@@ -154,7 +155,7 @@ allows an optional description, and optionally allows for collapsing those input
 A section is differentiated from an input by the presence of an additional `input` key within that section. 
 
 {% caution %}
-Input sections are a new feature in version 2024.6. Set the `min_version` for the blueprint to at least this version if using input sections. Otherwise, the blueprint will generate errors on older versions. 
+Input sections are a new feature in version 2024.6.0. Set the `min_version` for the blueprint to at least this version if using input sections. Otherwise, the blueprint will generate errors on older versions. 
 {% endcaution %}
 
 The full configuration for a section is below:


### PR DESCRIPTION
## Proposed change
Documentation update to correct blueprint documentation around min_schema. Make explicit mention of required format.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
n/a

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Improved clarity on the minimum required version format for blueprints, specifying it as _major_._minor_._patch_.
	- Updated caution notes to include the complete version number (2024.6.0) for better user awareness and to prevent configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->