### PR TITLE
Update URLs pointing to wrong domain

### DIFF
--- a/source/_posts/2024-08-21-hacs-the-best-way-to-share-community-made-projects.markdown
+++ b/source/_posts/2024-08-21-hacs-the-best-way-to-share-community-made-projects.markdown
@@ -36,13 +36,13 @@ This is one of the biggest updates yet for HACS, but if you're not sure what HAC
 
 <img src='/images/blog/2024-08-hacs2/frontend.png' style='border: 0;box-shadow: none;' alt="HACS frontend looks like data tables">
 
-HACS 2.0 [main dashboard](https://www.hacs.dev/docs/use/repositories/dashboard/) has taken cues from Home Assistant, and now closely matches the native look and functionality of the data tables you find on the entities or automation pages. This includes the options to filter, group, sort, and search.
+HACS 2.0 [main dashboard](https://www.hacs.xyz/docs/use/repositories/dashboard/) has taken cues from Home Assistant, and now closely matches the native look and functionality of the data tables you find on the entities or automation pages. This includes the options to filter, group, sort, and search.
 
 ### Faster downloads <!-- omit from toc -->
 
 <img src='/images/blog/2024-08-hacs2/downloads.png' style='border: 0;box-shadow: none;' alt="HDownload window going very fast">
 
-Previously, HACS 100% relied on GitHub to retrieve information, from file locations to the number of stars, so we needed to limit the API (as there are a lot of HACS users). To speed things up, we've created a [remote dataset](https://www.hacs.dev/docs/faq/data_sources/) stored in Cloudflare R2 buckets, which are updated at regular intervals.  Files are still downloaded from GitHub and their API is still contacted, but it will see drastically fewer calls, and the speed improvement is massive. Behind the scenes, this was a big piece of work, which has ongoing costs, and shows the kind of support the Open Home Foundation can provide to a community-driven project like HACS.
+Previously, HACS 100% relied on GitHub to retrieve information, from file locations to the number of stars, so we needed to limit the API (as there are a lot of HACS users). To speed things up, we've created a [remote dataset](https://www.hacs.xyz/docs/faq/data_sources/) stored in Cloudflare R2 buckets, which are updated at regular intervals.  Files are still downloaded from GitHub and their API is still contacted, but it will see drastically fewer calls, and the speed improvement is massive. Behind the scenes, this was a big piece of work, which has ongoing costs, and shows the kind of support the Open Home Foundation can provide to a community-driven project like HACS.
 
 ### Update and repair <!-- omit from toc -->
 
@@ -52,10 +52,10 @@ No more visiting the HACS page every day to check for updates. They'll now appea
 
 ### Other improvements <!-- omit from toc -->
 
-We have also renamed things to help them make more sense, including changing "category" to "type", and "Lovelace" to "dashboard" (Lovelace needs to make room for [Grace](https://www.home-assistant.io/blog/2024/03/04/dashboard-chapter-1/#what-is-project-grace)). We're also including Template management, which utilizes the new [template type](https://www.hacs.dev/docs/publish/template/) to enhance your Jinja templates.
+We have also renamed things to help them make more sense, including changing "category" to "type", and "Lovelace" to "dashboard" (Lovelace needs to make room for [Grace](https://www.home-assistant.io/blog/2024/03/04/dashboard-chapter-1/#what-is-project-grace)). We're also including Template management, which utilizes the new [template type](https://www.hacs.xyz/docs/publish/template/) to enhance your Jinja templates.
 
 {% note %}
-**Breaking changes** - There have been some breaking changes, such as removing the yaml configuration, no longer including the NetDaemon type, and moving [beta selection to a switch entity](https://www.hacs.dev/docs/use/entities/update/). Many of the changes are more likely to affect those sharing their code via HACS, check the [release notes for the full list](https://github.com/hacs/integration/releases/tag/2.0.0).
+**Breaking changes** - There have been some breaking changes, such as removing the yaml configuration, no longer including the NetDaemon type, and moving [beta selection to a switch entity](https://www.hacs.xyz/docs/use/entities/switch/). Many of the changes are more likely to affect those sharing their code via HACS, check the [release notes for the full list](https://github.com/hacs/integration/releases/tag/2.0.0).
 {% endnote %}
 
 ## What is HACS?
@@ -94,7 +94,7 @@ Just before we released this big update, it passed 5,000 stars on GitHub! It's t
 
 HACS should work on any up-to-date version of Home Assistant, it even runs on core installations. It also requires a GitHub account. If you already have HACS 1.X installed, perform a backup, go into HACS and then click the update button for HACS (note: if you update, there is no downgrading).
 
-If you're a Home Assistant OS user here is the installation method (If you're not using our OS, [visit this page](https://www.hacs.dev/docs/use/download/download/#to-download-hacs-core)),
+If you're a Home Assistant OS user here is the installation method (If you're not using our OS, [visit this page](https://www.hacs.xyz/docs/use/download/download/#to-download-hacs-core)),
 
 1. Make a [backup of your system](https://my.home-assistant.io/redirect/backup/) and download it to another device for safekeeping.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The doc links used the wrong domain, and one pointed to the wrong entity types.
Both things have been corrected here.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation links to reflect the new HACS website domain (`hacs.xyz`).
  
- **Bug Fixes**
	- Minor textual adjustments for improved clarity and user comprehension.

- **Breaking Changes**
	- Removed YAML configuration and transitioned beta selection to a switch entity, impacting code sharing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->