### PR TITLE
Auto reauth mqtt entry when the broker add-on is re-installed

### DIFF
--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -123,7 +123,7 @@ The easiest option is to install the official Mosquitto Broker add-on. You can c
 You can set up additional logins for your MQTT devices and services using the [Mosquitto add-on configuration](https://my.home-assistant.io/create-link/?redirect=supervisor_addon&addon=core_mosquitto).
 
 {% important %}
-When MQTT is set up with the official Mosquitto MQTT broker add-on, the brokers credentials are generated and kept secret. If the official Mosquitto MQTT broker needs to be re-installed, make sure you save a copy of the add-on user options, like the additional logins. After re-install of the add-on, the MQTT integration will automatically update the new password for the re-installed broker, and will reconnect automatically.
+When MQTT is set up with the official Mosquitto MQTT broker add-on, the broker's credentials are generated and kept secret. If the official Mosquitto MQTT broker needs to be re-installed, make sure you save a copy of the add-on user options, like the additional logins. After re-installing the add-on, the MQTT integration will automatically update the new password for the re-installed broker. It will then reconnect automatically.
 {% endimportant %}
 
  Alternatively, you can use a different MQTT broker that you configure yourself, ensuring it is compatible with Home Assistant.

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -122,9 +122,9 @@ Your first step to get MQTT and Home Assistant working is to choose a broker.
 The easiest option is to install the official Mosquitto Broker add-on. You can choose to set up and configure this add-on automatically when you set up the MQTT integration. Home Assistant will automatically generate and assign a safe username and password, and no further attention is required. This also works if you have already set up this add-on yourself in advance.
 You can set up additional logins for your MQTT devices and services using the [Mosquitto add-on configuration](https://my.home-assistant.io/create-link/?redirect=supervisor_addon&addon=core_mosquitto).
 
-{% warning %}
+{% important %}
 When MQTT is set up with the official Mosquitto MQTT broker add-on, the brokers credentials are generated and kept secret. If the official Mosquitto MQTT broker needs to be re-installed, make sure you save a copy of the add-on user options, like the additional logins. After re-install of the add-on, the MQTT integration will automatically update the new password for the re-installed broker, and will reconnect automatically.
-{% endwarning %}
+{% endimportant %}
 
  Alternatively, you can use a different MQTT broker that you configure yourself, ensuring it is compatible with Home Assistant.
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -122,6 +122,10 @@ Your first step to get MQTT and Home Assistant working is to choose a broker.
 The easiest option is to install the official Mosquitto Broker add-on. You can choose to set up and configure this add-on automatically when you set up the MQTT integration. Home Assistant will automatically generate and assign a safe username and password, and no further attention is required. This also works if you have already set up this add-on yourself in advance.
 You can set up additional logins for your MQTT devices and services using the [Mosquitto add-on configuration](https://my.home-assistant.io/create-link/?redirect=supervisor_addon&addon=core_mosquitto).
 
+{% warning %}
+When MQTT is set up with the official Mosquitto MQTT broker add-on, the brokers credentials are generated and kept secret. If the official Mosquitto MQTT broker needs to be re-installed, make sure you save the user options, like the additional logins. After re-install the MQTT integration will automatically update the new password for the re-installed broker and will reconnect automatically.
+{% endwarning %}
+
  Alternatively, you can use a different MQTT broker that you configure yourself, ensuring it is compatible with Home Assistant.
 
 ## Setting up a broker

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -123,7 +123,7 @@ The easiest option is to install the official Mosquitto Broker add-on. You can c
 You can set up additional logins for your MQTT devices and services using the [Mosquitto add-on configuration](https://my.home-assistant.io/create-link/?redirect=supervisor_addon&addon=core_mosquitto).
 
 {% warning %}
-When MQTT is set up with the official Mosquitto MQTT broker add-on, the brokers credentials are generated and kept secret. If the official Mosquitto MQTT broker needs to be re-installed, make sure you save the user options, like the additional logins. After re-install the MQTT integration will automatically update the new password for the re-installed broker and will reconnect automatically.
+When MQTT is set up with the official Mosquitto MQTT broker add-on, the brokers credentials are generated and kept secret. If the official Mosquitto MQTT broker needs to be re-installed, make sure you save a copy of the add-on user options, like the additional logins. After re-install of the add-on, the MQTT integration will automatically update the new password for the re-installed broker, and will reconnect automatically.
 {% endwarning %}
 
  Alternatively, you can use a different MQTT broker that you configure yourself, ensuring it is compatible with Home Assistant.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Auto reauth mqtt entry when the broker add-on is re-installed

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/124514
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Introduced a new warning section to the MQTT integration documentation, emphasizing the importance of saving user options and clarifying that the MQTT integration will automatically update passwords and reconnect after broker re-installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->