### PR TITLE
Specify that monitored_conditions is not really optional

### DIFF
--- a/source/_integrations/ebusd.markdown
+++ b/source/_integrations/ebusd.markdown
@@ -18,9 +18,7 @@ Integration between the [ebusd](https://github.com/john30/ebusd/) daemon (used f
 
 ## Configuration
 
-Enable the sensor by adding the following to your {% term "`configuration.yaml`" %} file.
-The integration will only monitor conditions explicitly specified as `monitored_conditions`.
-Their availability depends on your heater, ebusd configuration and specific setup.
+Enable the sensor by adding the following to your {% term "`configuration.yaml`" %} file. The integration will only monitor conditions explicitly specified as `monitored_conditions`. Their availability depends on your heater, ebusd configuration and specific setup.
 {% include integrations/restart_ha_after_config_inclusion.md %}
 
 ```yaml

--- a/source/_integrations/ebusd.markdown
+++ b/source/_integrations/ebusd.markdown
@@ -19,13 +19,17 @@ Integration between the [ebusd](https://github.com/john30/ebusd/) daemon (used f
 ## Configuration
 
 Enable the sensor by adding the following to your {% term "`configuration.yaml`" %} file.
+The integration will only monitor conditions explicitly specified as `monitored_conditions`.
+Their availability depends on your heater, ebusd configuration and specific setup.
 {% include integrations/restart_ha_after_config_inclusion.md %}
 
 ```yaml
 # Example configuration.yaml entry
 ebusd:
-  host: 127.0.0.1
+  host: localhost
   circuit: "700"
+  monitored_conditions:
+    - FlowTemp
 ```
 
 {% configuration %}
@@ -50,7 +54,7 @@ name:
 monitored_conditions:
   description: List of conditions to monitor. Note that not all monitored_conditions listed here can be supported by your circuit. This integration maps limited set of keys to circuit specific ebusd values.
   type: list
-  required: false
+  required: true
   keys:
     ActualFlowTemperatureDesired:
       description: Heating circuit flow temperature desired.


### PR DESCRIPTION
Specify that monitored_conditions is not really optional for a functional integration.

## Proposed change
This marks monitored_conditions as non-optional and explains why. Otherwise a user might have an integration without any errors, that does not show up in the UI nor provides and entites.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes 124739

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - `monitored_conditions` is now a required field in the configuration, enhancing user control over monitored parameters.

- **Improvements**
  - Default host value changed from `127.0.0.1` to `localhost` for better readability and user-friendliness.

- **Documentation**
  - Updated documentation to reflect the new configuration requirements and clarify the use of `monitored_conditions`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->