### PR TITLE
Docs - Added clarity to location of download folder for Home Assistan…

### DIFF
--- a/source/_integrations/downloader.markdown
+++ b/source/_integrations/downloader.markdown
@@ -63,4 +63,4 @@ Along with the event the following payload parameters are available:
 
 #### Location of Folder
 
-For Home Assistant OS, the Downloader extension is based off the intial folder `/root/homeassistant/`. To that effect, if you have a folder called `/root/homeassistant/my_download_folder`, you would enter simply `my_download_folder` under the prompt for "Select a location to get to store downloads. The setup will check if the directory exists."
+For Home Assistant OS, the Downloader extension is based off the initial folder `/root/homeassistant/`. To that effect, if you have a folder called `/root/homeassistant/my_download_folder`, you would enter simply `my_download_folder` under the prompt for "Select a location to get to store downloads. The setup will check if the directory exists."

--- a/source/_integrations/downloader.markdown
+++ b/source/_integrations/downloader.markdown
@@ -16,7 +16,7 @@ The **Downloader** {% term integration %} provides an action to download files. 
 
 {% include integrations/config_flow.md %}
 
-If the path is not absolute, it’s assumed to be relative to the Home Assistant configuration directory (for example, `/config/downloads`). When prompted to enter a folder name, only enter the folder name, not the path. So if you have a folder called `/config/my_download_folder`, when prompted to **Select a location to get to store downloads**, enter `my_download_folder`. Home Assistant checks if the directory exists.
+If the path is not absolute, it’s assumed to be relative to the Home Assistant configuration directory (for example, `/config/downloads`). So if you have a folder called `/config/my_download_folder`, when prompted to **Select a location to get to store downloads**, enter `my_download_folder`. Home Assistant checks if the directory exists.
 
 ### Use the action
 

--- a/source/_integrations/downloader.markdown
+++ b/source/_integrations/downloader.markdown
@@ -16,7 +16,7 @@ The **Downloader** {% term integration %} provides an action to download files. 
 
 {% include integrations/config_flow.md %}
 
-If the path is not absolute, it’s assumed to be relative to the Home Assistant configuration directory (for example, `.homeassistant/downloads`). For Home Assistant OS, the Downloader extension is based off the initial folder `/root/homeassistant/`. To that effect, if you have a folder called `/root/homeassistant/my_download_folder`, you would enter simply `my_download_folder` under the prompt for "Select a location to get to store downloads. The setup will check if the directory exists."
+If the path is not absolute, it’s assumed to be relative to the Home Assistant configuration directory (for example, `.homeassistant/downloads`). When prompted to enter a folder name, only enter the folder name, not the path. So if you have a folder called `.homeassistant/my_download_folder`, when prompted to **Select a location to get to store downloads**, enter `my_download_folder`. Home Assistant checks if the directory exists.
 
 ### Use the action
 

--- a/source/_integrations/downloader.markdown
+++ b/source/_integrations/downloader.markdown
@@ -12,7 +12,7 @@ ha_integration_type: integration
 ha_config_flow: true
 ---
 
-The **Downloader** {% term integration %} provides an action to download files. It will raise an error and not continue to set itself up when the download directory does not exist. The directory needs to be writable for the user who is running Home Assistant.
+The **Downloader** {% term integration %} provides an action to download files. It will raise an error and not continue to set itself up when the download directory does not exist. The directory needs to be writable for the user who is running Home Assistant. See Location of Folder, below.
 
 {% include integrations/config_flow.md %}
 
@@ -60,3 +60,7 @@ Along with the event the following payload parameters are available:
       message: "{{trigger.event.data.filename}} download failed"
       title: "Download Failed"
  ```
+
+#### Location of Folder
+
+For Home Assistant OS, the Downloader extension is based off the intial folder `/root/homeassistant/`. To that effect, if you have a folder called `/root/homeassistant/my_download_folder`, you would enter simply `my_download_folder` under the prompt for "Select a location to get to store downloads. The setup will check if the directory exists."

--- a/source/_integrations/downloader.markdown
+++ b/source/_integrations/downloader.markdown
@@ -12,11 +12,11 @@ ha_integration_type: integration
 ha_config_flow: true
 ---
 
-The **Downloader** {% term integration %} provides an action to download files. It will raise an error and not continue to set itself up when the download directory does not exist. The directory needs to be writable for the user who is running Home Assistant. See Location of Folder, below.
+The **Downloader** {% term integration %} provides an action to download files. It will raise an error and not continue to set itself up when the download directory does not exist. The directory needs to be writable for the user who is running Home Assistant.
 
 {% include integrations/config_flow.md %}
 
-If the path is not absolute, it’s assumed to be relative to the Home Assistant configuration directory (for example, .homeassistant/downloads).
+If the path is not absolute, it’s assumed to be relative to the Home Assistant configuration directory (for example, `.homeassistant/downloads`). For Home Assistant OS, the Downloader extension is based off the initial folder `/root/homeassistant/`. To that effect, if you have a folder called `/root/homeassistant/my_download_folder`, you would enter simply `my_download_folder` under the prompt for "Select a location to get to store downloads. The setup will check if the directory exists."
 
 ### Use the action
 
@@ -60,7 +60,3 @@ Along with the event the following payload parameters are available:
       message: "{{trigger.event.data.filename}} download failed"
       title: "Download Failed"
  ```
-
-#### Location of Folder
-
-For Home Assistant OS, the Downloader extension is based off the initial folder `/root/homeassistant/`. To that effect, if you have a folder called `/root/homeassistant/my_download_folder`, you would enter simply `my_download_folder` under the prompt for "Select a location to get to store downloads. The setup will check if the directory exists."

--- a/source/_integrations/downloader.markdown
+++ b/source/_integrations/downloader.markdown
@@ -16,7 +16,7 @@ The **Downloader** {% term integration %} provides an action to download files. 
 
 {% include integrations/config_flow.md %}
 
-If the path is not absolute, it’s assumed to be relative to the Home Assistant configuration directory (for example, `.homeassistant/downloads`). When prompted to enter a folder name, only enter the folder name, not the path. So if you have a folder called `.homeassistant/my_download_folder`, when prompted to **Select a location to get to store downloads**, enter `my_download_folder`. Home Assistant checks if the directory exists.
+If the path is not absolute, it’s assumed to be relative to the Home Assistant configuration directory (for example, `/config/downloads`). When prompted to enter a folder name, only enter the folder name, not the path. So if you have a folder called `/config/my_download_folder`, when prompted to **Select a location to get to store downloads**, enter `my_download_folder`. Home Assistant checks if the directory exists.
 
 ### Use the action
 


### PR DESCRIPTION
## Proposed change
In the previous documentation, it's not clear where that folder should exist or live. This is a pure docs update that adds clarity to usage of Downloader Add-on for folder locations, by including root path for Home Assistant OS installs



## Type of change
Adds clarity to usage of Downloader Add-on for folder locations, by including root path for Home Assistant OS installs

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation for the Downloader integration to clarify file path handling and provide a more accurate example for users.
	- Introduced new instructions regarding user input for folder names to enhance understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->