### PR TITLE
Redirect virtual integration yale_home to point to yale

### DIFF
--- a/source/_integrations/yale_home.markdown
+++ b/source/_integrations/yale_home.markdown
@@ -1,6 +1,6 @@
 ---
 title: Yale Home
-description: Connect and control your Yale Home devices using the August integration
+description: Connect and control your Yale Home devices using the Yale integration
 ha_category:
   - Binary sensor
   - Button
@@ -12,8 +12,8 @@ ha_category:
 ha_release: 0.64
 ha_domain: yale_home
 ha_integration_type: virtual
-ha_supporting_domain: august
-ha_supporting_integration: August
+ha_supporting_domain: yale
+ha_supporting_integration: Yale
 ha_codeowners:
   - '@bdraco'
 ha_config_flow: true


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Users should no longer use the august integration for the Yale Home brand as support for this brand is being removed and will be handled in the yale integration instead

Additional details: https://github.com/home-assistant/home-assistant.io/pull/33890

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/124817
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the documentation for the Yale Home integration to reflect the new branding, enhancing clarity for users regarding device connectivity.
- **Documentation**
	- Revised descriptions and supporting domain names to align with the Yale brand, improving consistency and user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->