### PR TITLE
Remove Yale (Assa Abloy) devices from the august integration docs

### DIFF
--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -29,6 +29,8 @@ ha_integration_type: integration
 
 The `august` integration allows you to integrate your [August](https://august.com/) and some Yale Access devices in Home Assistant.
 
+For devices that use the [Yale Home](https://yalehome.com/global) app, the [Yale](/integrations/yale) integration should be used instead.
+
 {% include integrations/config_flow.md %}
 
 ## Known working devices
@@ -43,10 +45,6 @@ The `august` integration allows you to integrate your [August](https://august.co
 | August View | no |
 | Yale Assure Lock | yes |
 | Yale Assure Lock 2 | yes |
-| Yale Conexis L1 | yes |
-| Yale Conexis L2 | yes |
-| Yale Doorman L3 | yes |
-| Yale Linus | yes |
 | Yale Smart Safe | yes |
 
 Other devices not listed above have not been tested and may not function as expected.

--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -122,9 +122,7 @@ If you have an August Keypad, once you have enabled the August integration, you 
 
 ## Integration with Yale Access Bluetooth
 
-Following Assa Abloy, Yale's parent company, purchasing August in 2017, most newer devices use the Yale Access branding. 
-
-The [Yale Access Bluetooth](/integrations/yalexs_ble) integration provides local control over Bluetooth of many Yale Access locks and some August locks that use the same system. 
+The [Yale Access Bluetooth](/integrations/yalexs_ble) integration provides local control over Bluetooth of many Yale Access locks and some August locks that use the same system.
 
 For locks that support the Yale Access system, the August integration can keep your offline access keys up to date to ensure you can operate your lock over Bluetooth. The following requirements must be met for the offline key updates to work:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The new yale integration should be used for these devices instead


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/124677
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a note directing users with Yale Home app devices to refer to the Yale integration for better guidance.
	- Updated the list of known working devices by removing several Yale devices, indicating potential changes in compatibility.
	- Streamlined documentation to enhance clarity on device compatibility and integration usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->