### PR TITLE
home connect: Update links for registering an app and logging out

### DIFF
--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -37,7 +37,7 @@ Note that it depends on the appliance and on API permissions which of the featur
 
 1. Visit [https://developer.home-connect.com](https://developer.home-connect.com) and sign up for a developer account.
 2. Enter the email of your login for the original Home Connect App from Bosch/Siemens under "Default Home Connect User Account for Testing" in the sign up process.
-3. Navigate to the [Applications](https://developer.home-connect.com/applications) page and click on [Register Application](https://developer.home-connect.com/application/add):
+3. Go to the [Applications](https://developer.home-connect.com/applications) page and select [Register Application](https://developer.home-connect.com/application/add):
 
 - Application ID: Home Assistant (or whatever name makes sense to you)
 - OAuth Flow: Authorization Code Grant Flow
@@ -47,7 +47,7 @@ Note that it depends on the appliance and on API permissions which of the featur
 *Important*:
  - **Power on** all your appliances during the integration configuration process; otherwise appliance programs list will be empty.
  - To update the appliance programs list, you can reload the Home Connect integration when an appliance is turned on. If the re-initialization process is not triggered by reload, restart the Home Assistant when an appliance is turned on. 
- - After performing the steps above [log out](https://developer.home-connect.com/user/logout) of your Home Connect Developer account. If you don't do this, the configuration steps below will fail during OAuth authentication with the message `“error”: “unauthorized_client”`.
+ - After performing the steps above, [log out](https://developer.home-connect.com/user/logout) of your Home Connect Developer account. If you don't do this, the configuration steps below will fail during OAuth authentication with the message `“error”: “unauthorized_client”`.
  - The provided Home Connect User Account email address **must** be all lowercase otherwise it will result in authentication failures.
  - All changes in the developer portal take 15 minutes before the change is implemented.
 

--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -37,7 +37,7 @@ Note that it depends on the appliance and on API permissions which of the featur
 
 1. Visit [https://developer.home-connect.com](https://developer.home-connect.com) and sign up for a developer account.
 2. Enter the email of your login for the original Home Connect App from Bosch/Siemens under "Default Home Connect User Account for Testing" in the sign up process.
-3. Navigate to the the [Applications](https://developer.home-connect.com/applications) page and click on [Register Application](https://developer.home-connect.com/application/add):
+3. Navigate to the [Applications](https://developer.home-connect.com/applications) page and click on [Register Application](https://developer.home-connect.com/application/add):
 
 - Application ID: Home Assistant (or whatever name makes sense to you)
 - OAuth Flow: Authorization Code Grant Flow

--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -47,7 +47,7 @@ Note that it depends on the appliance and on API permissions which of the featur
 *Important*:
  - **Power on** all your appliances during the integration configuration process; otherwise appliance programs list will be empty.
  - To update the appliance programs list, you can reload the Home Connect integration when an appliance is turned on. If the re-initialization process is not triggered by reload, restart the Home Assistant when an appliance is turned on. 
- - After performing the steps above [**log out**]([url](https://developer.home-connect.com/user/logout)) of your Home Connect Developer account. If you don't do this, the configuration steps below will fail during OAuth authentication with the message `“error”: “unauthorized_client”`.
+ - After performing the steps above [log out](https://developer.home-connect.com/user/logout) of your Home Connect Developer account. If you don't do this, the configuration steps below will fail during OAuth authentication with the message `“error”: “unauthorized_client”`.
  - The provided Home Connect User Account email address **must** be all lowercase otherwise it will result in authentication failures.
  - All changes in the developer portal take 15 minutes before the change is implemented.
 

--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -37,7 +37,7 @@ Note that it depends on the appliance and on API permissions which of the featur
 
 1. Visit [https://developer.home-connect.com](https://developer.home-connect.com) and sign up for a developer account.
 2. Enter the email of your login for the original Home Connect App from Bosch/Siemens under "Default Home Connect User Account for Testing" in the sign up process.
-3. Under [Applications](https://developer.home-connect.com/applications), register a new App:
+3. Navigate to the the [Applications](https://developer.home-connect.com/applications) page and click on [Register Application](https://developer.home-connect.com/application/add):
 
 - Application ID: Home Assistant (or whatever name makes sense to you)
 - OAuth Flow: Authorization Code Grant Flow
@@ -47,7 +47,7 @@ Note that it depends on the appliance and on API permissions which of the featur
 *Important*:
  - **Power on** all your appliances during the integration configuration process; otherwise appliance programs list will be empty.
  - To update the appliance programs list, you can reload the Home Connect integration when an appliance is turned on. If the re-initialization process is not triggered by reload, restart the Home Assistant when an appliance is turned on. 
- - After performing the steps above **log out** of your Home Connect Developer account. If you don't do this, the configuration steps below will fail during OAuth authentication with the message `“error”: “unauthorized_client”`.
+ - After performing the steps above [**log out**]([url](https://developer.home-connect.com/user/logout)) of your Home Connect Developer account. If you don't do this, the configuration steps below will fail during OAuth authentication with the message `“error”: “unauthorized_client”`.
  - The provided Home Connect User Account email address **must** be all lowercase otherwise it will result in authentication failures.
  - All changes in the developer portal take 15 minutes before the change is implemented.
 


### PR DESCRIPTION
## Proposed change
Adding some links to the Home Connect docs page

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Enhanced clarity and detail in the instructions for integrating with the Home Connect API.
	- Updated steps for registering a new application, including navigation guidance and direct hyperlinks for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->