### PR TITLE
home connect: Add instructions for getting the client ID and secret

### DIFF
--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -44,7 +44,7 @@ Note that it depends on the appliance and on API permissions which of the featur
 - Redirect URI: `https://my.home-assistant.io/redirect/oauth`
 - Go to `https://my.home-assistant.io/` and make sure that your Home Assistant URL is set there. For example: `http://homeassistant:8123/` or `http://homeassistant.local:8123`
 
-4. On success, you will be redirected to the Applications page. Click on "Details" for your app. Make note of the client ID and secret - you will need it for the next step. Log out of the Home Connect developer portal.
+4. On success, you will be redirected to the **Applications** page. Select **Details** for your app. Make note of the client ID and secret - you will need it for the next step. Log out of the Home Connect developer portal.
 5. In Home Assistant, find the Home Connect integration and launch it. You will be prompted to create an [Application Credential](https://www.home-assistant.io/integrations/application_credentials). You will need to provide a name (it's arbitrary) in addition to the Client ID and Secret from the previous step. Then, follow the steps in the UI to complete setup.
 
 *Important*:

--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -44,7 +44,7 @@ Note that it depends on the appliance and on API permissions which of the featur
 - Redirect URI: `https://my.home-assistant.io/redirect/oauth`
 - Go to `https://my.home-assistant.io/` and make sure that your Home Assistant URL is set there. For example: `http://homeassistant:8123/` or `http://homeassistant.local:8123`
 
-4. On success, you will be redirect to the Applicatinos page. Click on "Details" for your app. Make note of the client ID and secret - you will need it for the next step. Log out of the Home Connect developer portal.
+4. On success, you will be redirected to the Applications page. Click on "Details" for your app. Make note of the client ID and secret - you will need it for the next step. Log out of the Home Connect developer portal.
 5. In Home Assistant, find the Home Connect integration and launch it. You will be prompted to create an [Application Credential](https://www.home-assistant.io/integrations/application_credentials). You will need to provide a name (it's arbitrary) in addition to the Client ID and Secret from the previous step. Then, follow the steps in the UI to complete setup.
 
 *Important*:

--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -45,7 +45,7 @@ Note that it depends on the appliance and on API permissions which of the featur
 - Go to `https://my.home-assistant.io/` and make sure that your Home Assistant URL is set there. For example: `http://homeassistant:8123/` or `http://homeassistant.local:8123`
 
 4. On success, you will be redirect to the Applicatinos page. Click on "Details" for your app. Make note of the client ID and secret - you will need it for the next step. Log out of the Home Connect developer portal.
-5. In Home Assistant, find the Home Connect integration. You will need to provide a name for the application credential (it's arbitrary) in addition to the Client ID and Secret from the previous step.
+5. In Home Assistant, find the Home Connect integration and launch it. You will be prompted to create an [Application Credential](https://www.home-assistant.io/integrations/application_credentials). You will need to provide a name (it's arbitrary) in addition to the Client ID and Secret from the previous step. Then, follow the steps in the UI to complete setup.
 
 *Important*:
  - **Power on** all your appliances during the integration configuration process; otherwise appliance programs list will be empty.

--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -44,6 +44,9 @@ Note that it depends on the appliance and on API permissions which of the featur
 - Redirect URI: `https://my.home-assistant.io/redirect/oauth`
 - Go to `https://my.home-assistant.io/` and make sure that your Home Assistant URL is set there. For example: `http://homeassistant:8123/` or `http://homeassistant.local:8123`
 
+4. On success, you will be redirect to the Applicatinos page. Click on "Details" for your app. Make note of the client ID and secret - you will need it for the next step. Log out of the Home Connect developer portal.
+5. In Home Assistant, find the Home Connect integration. You will need to provide a name for the application credential (it's arbitrary) in addition to the Client ID and Secret from the previous step.
+
 *Important*:
  - **Power on** all your appliances during the integration configuration process; otherwise appliance programs list will be empty.
  - To update the appliance programs list, you can reload the Home Connect integration when an appliance is turned on. If the re-initialization process is not triggered by reload, restart the Home Assistant when an appliance is turned on. 


### PR DESCRIPTION
## Proposed change
Add instructions for getting the client ID and secret

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Enhanced the Home Connect integration documentation with additional steps for users to follow after redirecting to the Applications page, improving clarity on obtaining necessary credentials for setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->