### PR TITLE
ubus.markdown: fix JSON syntax

### DIFF
--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -49,7 +49,7 @@ Then, create an ACL file at `/usr/share/rpcd/acl.d/hass.json` for the user `hass
       "ubus": {
         "hostapd.*": ["get_clients"],
         "uci": ["get"]
-      },
+      }
     },
     "write": {}
   }


### PR DESCRIPTION
## Proposed change
This still does not fix ubus integration for me, but the config broke some things on my OpenWRT for me, so let's not break it for other users if they leave the config there. :pray: 



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Minor formatting adjustment made to the JSON structure for improved syntax clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->