### PR TITLE
Threshold: Add matrix of state change behavior

### DIFF
--- a/source/_integrations/threshold.markdown
+++ b/source/_integrations/threshold.markdown
@@ -76,6 +76,24 @@ name:
   default: Threshold
 {% endconfiguration %}
 
+## Matrix of state change behavior
+
+### Sensor value rising
+
+| set           | turns on when           | turns off when          |
+| ------------- | ----------------------- | ----------------------- |
+| only upper    | sensor > (upper + hyst) | never                   |
+| only lower    | never                   | sensor > (lower + hyst) |
+| upper & lower | sensor > (lower + hyst) | sensor > (upper + hyst) |
+
+### Sensor value falling
+
+| set           | turns on when           | turns off when          |
+| ------------- | ----------------------- | ----------------------- |
+| only upper    | never                   | sensor < (upper - hyst) |
+| only lower    | sensor < (lower - hyst) | never                   |
+| upper & lower | sensor < (upper - hyst) | sensor < (lower - hyst) |
+
 ## Examples
 
 ### Is the temperature rising or falling

--- a/source/_integrations/threshold.markdown
+++ b/source/_integrations/threshold.markdown
@@ -80,7 +80,7 @@ name:
 
 ### Sensor value rising
 
-| set           | turns on when           | turns off when          |
+| Set           | Turns on when           | Turns off when          |
 | ------------- | ----------------------- | ----------------------- |
 | only upper    | sensor > (upper + hyst) | never                   |
 | only lower    | never                   | sensor > (lower + hyst) |
@@ -88,7 +88,7 @@ name:
 
 ### Sensor value falling
 
-| set           | turns on when           | turns off when          |
+| Set           | Turns on when           | Turns off when          |
 | ------------- | ----------------------- | ----------------------- |
 | only upper    | never                   | sensor < (upper - hyst) |
 | only lower    | sensor < (lower - hyst) | never                   |


### PR DESCRIPTION
Since it was not clear to me from reading the threshold documentation for what upper/lower limits with/without hysteresis exactly a state change would occur, here is the actual behavioral matrix (excluding negative hysteresis, not sure what that should be or if it is really even supported), which I tested with HA 2024.7.2.

Matrix tested with value of hysteresis >= 0

See https://community.home-assistant.io/t/threshold-integration-matrix-of-state-change-behavior/756257

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a "Matrix of state change behavior" section in the documentation, detailing sensor state changes based on readings.
	- Added tables for "Sensor value rising" and "Sensor value falling," clarifying conditions for sensor activation and deactivation.

- **Documentation**
	- Enhanced clarity and usability of the documentation regarding sensor operational logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->