### PR TITLE
Update sensor.markdown

### DIFF
--- a/source/_integrations/sensor.markdown
+++ b/source/_integrations/sensor.markdown
@@ -61,9 +61,9 @@ The following device classes are supported for sensors:
 - **nitrous_oxide**: Concentration of Nitrous Oxide in µg/m³
 - **ozone**: Concentration of Ozone in µg/m³
 - **ph**: Potential hydrogen (pH) value of a water solution
-- **pm1**: Concentration of particulate matter less than 1 micrometer in µg/m³
-- **pm25**: Concentration of particulate matter less than 2.5 micrometers in µg/m³
-- **pm10**: Concentration of particulate matter less than 10 micrometers in µg/m³
+- **pm1**: Concentration of particulate matter less than 1 microgram in µg/m³
+- **pm25**: Concentration of particulate matter less than 2.5 microgram in µg/m³
+- **pm10**: Concentration of particulate matter less than 10 microgram in µg/m³
 - **power_factor**: Power factor (unitless), unit may be `None` or %
 - **power**: Power in W or kW
 - **precipitation**: Accumulated precipitation in cm, in or mm


### PR DESCRIPTION
Corrected description

## Proposed change
mg/l are microgram not micrometer



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated descriptions of particulate matter sensor classes to clarify the unit of measurement, changing "µg/m³" to "microgram" for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->