### PR TITLE
Rename Ruckus Unleashed to Ruckus, update docs

### DIFF
--- a/source/_integrations/ruckus_unleashed.markdown
+++ b/source/_integrations/ruckus_unleashed.markdown
@@ -29,13 +29,12 @@ There is currently support for the following device types within Home Assistant:
 - **Presence detection** - The platform will look at devices connected to the access point and will
 create a `device_tracker` for each discovered device.
 
-## Configuration
+## Prerequisites
 
-To add a Ruckus Unleashed device to your installation, go to **Settings** -> **Devices & services**,
-click the `+` button, then select **Ruckus** from the list of integrations.
+- **IP address / hostname**, **Username** and **Password** which you use to connect
+    to your Ruckus controller's web dashboard.
 
-Enter be the **IP address / hostname**, **Username** and **Password** which you use to connect
-to your Ruckus controller's web dashboard.
+{% include integrations/config_flow.md %}
 
 ### Ruckus Unleashed
 

--- a/source/_integrations/ruckus_unleashed.markdown
+++ b/source/_integrations/ruckus_unleashed.markdown
@@ -20,7 +20,7 @@ This platform allows you to connect to [Ruckus](https://www.ruckusnetworks.com/)
 
 [Ruckus Unleashed](https://www.ruckusnetworks.com/products/network-control-and-management/controller-less/),
 [Ruckus ZoneDirector](https://support.ruckuswireless.com/products/73),
-[Ruckus SmartZone](https://www.ruckusnetworks.com/products/network-control-and-management/network-controllers/)
+[Ruckus SmartZone](https://www.ruckusnetworks.com/products/network-control-and-management/network-controllers/),
 and [Ruckus One](https://www.ruckusnetworks.com/products/network-control-and-management/cloud-managed/)
 access points are supported. Access points running Standalone/Solo firmware are not supported.
 
@@ -46,16 +46,16 @@ If you've configured an Unleashed Management Interface then use this instead.
 
 You'll need to use your Ruckus One dashboard to create an Application Token. Go to the bottom of the
 **Administration** > **Settings** screen and click the **Add Token** link. Choose any
-**Application Name**, e.g. `Home Assistant`. The **Token Scope** can be `Read Only`.
+**Application Name**, for example `Home Assistant`. The **Token Scope** can be **Read Only**.
 
 When Home Assistant prompts for Ruckus connection details, use the full URL of a Ruckus One
-dashboard page as the Host (e.g. `https://asia.ruckus.cloud/5dd1000334cc2a01fcf28a740a6c95cf/t/dashboard`),
+dashboard page as the Host (such as `https://asia.ruckus.cloud/5dd1000334cc2a01fcf28a740a6c95cf/t/dashboard`),
 your Token **Client ID** as the Username & your Token **Shared Secret** as the Password.
 
 ## Limitations
 
 This integration is not currently suitable for large multi-venue SmartZone or Ruckus One networks: there
-is no way to filter devices by e.g. Venue or Zone.
+is no way to filter devices by Venue or Zone.
 
 If you've configured your access points with an extended Client Inactivity Timeout then this is how long
 you'll need to wait for devices to be detected as `not_home`.
@@ -64,4 +64,4 @@ you'll need to wait for devices to be detected as `not_home`.
 
 For this platform to work, the Ruckus controller or Unleashed AP will need to be accessible over HTTPS.
 If you are having trouble with Home Assistant not connecting, make sure the user you have specified
-can log in to the web dashboard and view AP, WLAN and Client information.
+can log in to the web dashboard and view AP, WLAN, and Client information.

--- a/source/_integrations/ruckus_unleashed.markdown
+++ b/source/_integrations/ruckus_unleashed.markdown
@@ -1,5 +1,5 @@
 ---
-title: Ruckus Networks
+title: Ruckus
 description: Instructions on how to integrate your Ruckus Networks device into Home Assistant.
 ha_category:
   - Presence detection

--- a/source/_integrations/ruckus_unleashed.markdown
+++ b/source/_integrations/ruckus_unleashed.markdown
@@ -34,7 +34,6 @@ create a `device_tracker` for each discovered device.
 - **IP address / hostname**, **Username** and **Password** which you use to connect
     to your Ruckus controller's web dashboard.
 
-{% include integrations/config_flow.md %}
 
 ### Ruckus Unleashed
 
@@ -50,6 +49,8 @@ You'll need to use your Ruckus One dashboard to create an Application Token. Go 
 When Home Assistant prompts for Ruckus connection details, use the full URL of a Ruckus One
 dashboard page as the Host (such as `https://asia.ruckus.cloud/5dd1000334cc2a01fcf28a740a6c95cf/t/dashboard`),
 your Token **Client ID** as the Username & your Token **Shared Secret** as the Password.
+
+{% include integrations/config_flow.md %}
 
 ## Limitations
 

--- a/source/_integrations/ruckus_unleashed.markdown
+++ b/source/_integrations/ruckus_unleashed.markdown
@@ -1,6 +1,6 @@
 ---
-title: Ruckus Unleashed
-description: Instructions on how to integrate your Ruckus Unleashed device into Home Assistant.
+title: Ruckus Networks
+description: Instructions on how to integrate your Ruckus Networks device into Home Assistant.
 ha_category:
   - Presence detection
 ha_release: 0.117
@@ -16,38 +16,52 @@ ha_platforms:
 ha_integration_type: hub
 ---
 
-This platform allows you to connect to a [Ruckus Unleashed](https://support.ruckuswireless.com/product_families/19-ruckus-unleashed) access point.
+This platform allows you to connect to [Ruckus](https://www.ruckusnetworks.com/) access points.
+
+[Ruckus Unleashed](https://www.ruckusnetworks.com/products/network-control-and-management/controller-less/),
+[Ruckus ZoneDirector](https://support.ruckuswireless.com/products/73),
+[Ruckus SmartZone](https://www.ruckusnetworks.com/products/network-control-and-management/network-controllers/)
+and [Ruckus One](https://www.ruckusnetworks.com/products/network-control-and-management/cloud-managed/)
+access points are supported. Access points running Standalone/Solo firmware are not supported.
 
 There is currently support for the following device types within Home Assistant:
 
-- **Presence detection** - The platform will look at devices connected to the access point and will create a `device_tracker` for each discovered device.
+- **Presence detection** - The platform will look at devices connected to the access point and will
+create a `device_tracker` for each discovered device.
 
 ## Configuration
 
-To add a Ruckus Unleashed device to your installation, go to **Settings** -> **Devices & services**, click the `+` button, then select **Ruckus** from the list of integrations.
+To add a Ruckus Unleashed device to your installation, go to **Settings** -> **Devices & services**,
+click the `+` button, then select **Ruckus** from the list of integrations.
 
-It is required to configure the IP address of your **master access point**. See the section Access Points on the management web interface. And perhaps consider to set a preferred master (Admin & Services>System>System Info>Preferred master).
+Enter be the **IP address / hostname**, **Username** and **Password** which you use to connect
+to your Ruckus controller's web dashboard.
 
-You will have to create a user on the device which is a **Monitoring Admin**. Login to the Ruckus Unleashed admin UI and follow these steps:
+### Ruckus Unleashed
 
- - [Create a new role](https://docs.ruckuswireless.com/unleashed/200.1.9.12/t-ConfigUserRoles.html).
-   - Check **Allow Unleashed Administration**.
-   - Select the **Monitoring Admin (Monitoring and viewing operation status only)** radio button. 
- - [Create a new user](https://docs.ruckuswireless.com/unleashed/200.1.9.12/t-AddingNewUsersInternal.html) with the new role.
+You may enter the **IP address / hostname** of any access point as the Host.
+If you've configured an Unleashed Management Interface then use this instead.
+
+### Ruckus One
+
+You'll need to use your Ruckus One dashboard to create an Application Token. Go to the bottom of the
+**Administration** > **Settings** screen and click the **Add Token** link. Choose any
+**Application Name**, e.g. `Home Assistant`. The **Token Scope** can be `Read Only`.
+
+When Home Assistant prompts for Ruckus connection details, use the full URL of a Ruckus One
+dashboard page as the Host (e.g. `https://asia.ruckus.cloud/5dd1000334cc2a01fcf28a740a6c95cf/t/dashboard`),
+your Token **Client ID** as the Username & your Token **Shared Secret** as the Password.
+
+## Limitations
+
+This integration is not currently suitable for large multi-venue SmartZone or Ruckus One networks: there
+is no way to filter devices by e.g. Venue or Zone.
+
+If you've configured your access points with an extended Client Inactivity Timeout then this is how long
+you'll need to wait for devices to be detected as `not_home`.
 
 ## Troubleshooting
 
-For this platform to work, the Ruckus Unleashed device will need to be accessible over SSH. If you are having trouble with Home Assistant not connecting, make sure the user you created above can log in to SSH and can run privileged commands.
-
-Terminal:
-
-```bash
-ssh <ruckus_ip>
-
-Please login: <username>
-Password: <password>
-Welcome to Ruckus Unleashed Network Command Line Interface
-ruckus> enable
-ruckus# exit
-Exit ruckus CLI.
-```
+For this platform to work, the Ruckus controller or Unleashed AP will need to be accessible over HTTPS.
+If you are having trouble with Home Assistant not connecting, make sure the user you have specified
+can log in to the web dashboard and view AP, WLAN and Client information.

--- a/source/_integrations/ruckus_unleashed.markdown
+++ b/source/_integrations/ruckus_unleashed.markdown
@@ -40,12 +40,12 @@ to your Ruckus controller's web dashboard.
 ### Ruckus Unleashed
 
 You may enter the **IP address / hostname** of any access point as the Host.
-If you've configured an Unleashed Management Interface then use this instead.
+If you've configured an Unleashed Management Interface, then use this instead.
 
 ### Ruckus One
 
 You'll need to use your Ruckus One dashboard to create an Application Token. Go to the bottom of the
-**Administration** > **Settings** screen and click the **Add Token** link. Choose any
+**Administration** > **Settings** screen and select the **Add Token** link. Choose any
 **Application Name**, for example `Home Assistant`. The **Token Scope** can be **Read Only**.
 
 When Home Assistant prompts for Ruckus connection details, use the full URL of a Ruckus One
@@ -57,7 +57,7 @@ your Token **Client ID** as the Username & your Token **Shared Secret** as the P
 This integration is not currently suitable for large multi-venue SmartZone or Ruckus One networks: there
 is no way to filter devices by Venue or Zone.
 
-If you've configured your access points with an extended Client Inactivity Timeout then this is how long
+If you've configured your access points with an extended Client Inactivity Timeout, then this is how long
 you'll need to wait for devices to be detected as `not_home`.
 
 ## Troubleshooting


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Changed integration name from "Ruckus Unleashed" to "Ruckus": this integration now supports all Ruckus controller platforms.

Also update instructions to cover extra platforms and different connection requirements (the integration now connects over HTTPS instead of SSH).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/125392
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced clarity in the documentation for Ruckus Networks integration with Home Assistant.
	- Added support details for multiple Ruckus access point types.

- **Documentation**
	- Updated title and description for better specificity.
	- Improved readability and formatting of the integration guide.
	- Revised configuration instructions for Ruckus One connection.
	- Expanded troubleshooting section with new accessibility details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->