### PR TITLE
Document missing `hue` and `sat` variables in MQTT Template Schema Light

### DIFF
--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -934,7 +934,7 @@ command_off_template:
   required: true
   type: template
 command_on_template:
-  description: "The [template](/docs/configuration/templating/#using-templates-with-the-mqtt-integration) for *on* state changes. Available variables: `state`, `brightness`, `color_temp`, `red`, `green`, `blue`, `flash`, `transition` and `effect`. Values `red`, `green`, `blue`, `brightness` are provided as integers from range 0-255. Value of `color_temp` is provided as integer representing mired units."
+  description: "The [template](/docs/configuration/templating/#using-templates-with-the-mqtt-integration) for *on* state changes. Available variables: `state`, `brightness`, `color_temp`, `red`, `green`, `blue`, `hue`, `sat`, `flash`, `transition` and `effect`. Values `red`, `green`, `blue`, `brightness` are provided as integers from range 0-255. Value of `hue` is provided as float from range 0-360. Value of `sat` is provided as float from range 0-100. Value of `color_temp` is provided as integer representing mired units."
   required: true
   type: template
 command_topic:


### PR DESCRIPTION
## Proposed change
Add some variables that are provided to the `command_on_template` that weren't listed.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

They're shown in one of the examples, but not explicitly listed as available.

https://github.com/home-assistant/core/blob/444560543ccf793ae423e31b63875bef79923d59/homeassistant/components/mqtt/light/schema_template.py#L324 shows them being sent.
I'm not 100% certain on the ranges (or if they're integers or floats), but what I documented sees to be implied at https://github.com/home-assistant/core/blob/6e38cf878e82a15d7084242c7c8d2cc252accc5b/homeassistant/util/color.py#L375.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Expanded the description of the command_on_template entity to include new variables hue and sat, along with their value ranges (0-360 for hue and 0-100 for saturation). This enhances clarity and completeness for users utilizing the MQTT integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->