### PR TITLE
Ring/event stability

### DIFF
--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -147,7 +147,7 @@ Prior to version 2023.12.0 the Home Assistant ring integration would register a 
 If you have been using the ring integration prior to this you may have many `Authorized Client Devices` in the `Control Centre` on [ring.com](https://account.ring.com/account/control-center/authorized-devices).
 This can cause issues receiving ring alerts.
 You should delete all authorised devices from [ring.com](https://account.ring.com/account/control-center/authorized-devices) `Control Centre` which are from Home Assistant
-(i.e. do not delete thsoe named `iPhone` or `Android`; Home Assistant authorized devices are named `ring-doorbell:HomeAssistant/something` or `Python`).
+(i.e. do not delete those named `iPhone` or `Android`; Home Assistant authorized devices are named `ring-doorbell:HomeAssistant/something` or `Python`).
 If you have too many `Authorised Client Devices` to delete one by one, it might be easier to `Remove all devices` and then re-authorize your required devices.
 
 ## Sensor

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -143,12 +143,12 @@ The event entity captures events like doorbell rings, motion alerts, and interco
 ### Realtime event stability
 
 If you are experiencing issues with receiving ring alerts the reason could be that you have too many authenticated devices on your ring account.
-Prior to version 2023.12.0 the Home Assistant ring integration would register a new entry in `Authorized Client Devices` in the `Control Centre` at [ring.com](https://account.ring.com/account/control-center/authorized-devices) every time it restarted.
+Prior to version 2023.12.0, the Home Assistant ring integration would register a new entry in `Authorized Client Devices` in the `Control Centre` at [ring.com](https://account.ring.com/account/control-center/authorized-devices) every time it restarted.
 If you have been using the ring integration prior to this you may have many `Authorized Client Devices` in the `Control Centre` on [ring.com](https://account.ring.com/account/control-center/authorized-devices).
 This can cause issues receiving ring alerts.
 You should delete all authorised devices from [ring.com](https://account.ring.com/account/control-center/authorized-devices) `Control Centre` which are from Home Assistant
 (i.e. do not delete those named `iPhone` or `Android`; Home Assistant authorized devices are named `ring-doorbell:HomeAssistant/something` or `Python`).
-If you have too many `Authorised Client Devices` to delete one by one, it might be easier to `Remove all devices` and then re-authorize your required devices.
+If you have too many `Authorised Client Devices` to delete them individually, it might be easier to `Remove all devices` and then re-authorize your required devices.
 
 ## Sensor
 

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -140,16 +140,15 @@ hass.services.call("downloader", "download_file", data)
 
 The event entity captures events like doorbell rings, motion alerts, and intercom unlocking.
 
-### Event issues and stability
+### Realtime event stability
 
 If you are experiencing issues with receiving ring alerts the reason could be that you have too many authenticated devices on your ring account.
-Prior to version 2023.12.0 HA would register a new entry in `Authorised Client Devices` in the `Control Centre` at ring.com every time it restarted.
-If you have been using ring prior to this you may have many `Authorised Client Devices` in the `Control Centre` on ring.com.
+Prior to version 2023.12.0 the Home Assistant ring integration would register a new entry in `Authorized Client Devices` in the `Control Centre` at [ring.com](https://account.ring.com/account/control-center/authorized-devices) every time it restarted.
+If you have been using the ring integration prior to this you may have many `Authorized Client Devices` in the `Control Centre` on [ring.com](https://account.ring.com/account/control-center/authorized-devices).
 This can cause issues receiving ring alerts.
-You should delete all authorised devices from ring.com control centre which are from HomeAassistant
-(i.e. do not delete thsoe named `iPhone` or `Android`, homeassistant devices are named `ring-doorbell:HomeAssistant/something` or `Python program`).
-If you have too many `Authorised Client Devices` to delete each one it might be easier to `Remove all devices` and then re-authorize your required devices.
-
+You should delete all authorised devices from [ring.com](https://account.ring.com/account/control-center/authorized-devices) `Control Centre` which are from Home Assistant
+(i.e. do not delete thsoe named `iPhone` or `Android`; Home Assistant authorized devices are named `ring-doorbell:HomeAssistant/something` or `Python`).
+If you have too many `Authorised Client Devices` to delete one by one, it might be easier to `Remove all devices` and then re-authorize your required devices.
 
 ## Sensor
 

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -142,9 +142,9 @@ The event entity captures events like doorbell rings, motion alerts, and interco
 
 ### Realtime event stability
 
-If you are experiencing issues with receiving ring alerts the reason could be that you have too many authenticated devices on your ring account.
+If you are experiencing issues with receiving ring alerts, the reason could be that you have too many authenticated devices on your ring account.
 Prior to version 2023.12.0, the Home Assistant ring integration would register a new entry in `Authorized Client Devices` in the `Control Centre` at [ring.com](https://account.ring.com/account/control-center/authorized-devices) every time it restarted.
-If you have been using the ring integration prior to this you may have many `Authorized Client Devices` in the `Control Centre` on [ring.com](https://account.ring.com/account/control-center/authorized-devices).
+If you have been using the ring integration before this, you may have many `Authorized Client Devices` in the `Control Centre` on [ring.com](https://account.ring.com/account/control-center/authorized-devices).
 This can cause issues receiving ring alerts.
 You should delete all authorised devices from [ring.com](https://account.ring.com/account/control-center/authorized-devices) `Control Centre` which are from Home Assistant
 (i.e. do not delete those named `iPhone` or `Android`; Home Assistant authorized devices are named `ring-doorbell:HomeAssistant/something` or `Python`).

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -140,6 +140,17 @@ hass.services.call("downloader", "download_file", data)
 
 The event entity captures events like doorbell rings, motion alerts, and intercom unlocking.
 
+### Event issues and stability
+
+If you are experiencing issues with receiving ring alerts the reason could be that you have too many authenticated devices on your ring account.
+Prior to version 2023.12.0 HA would register a new entry in `Authorised Client Devices` in the `Control Centre` at ring.com every time it restarted.
+If you have been using ring prior to this you may have many `Authorised Client Devices` in the `Control Centre` on ring.com.
+This can cause issues receiving ring alerts.
+You should delete all authorised devices from home assistant which are from HomeAassistant
+(i.e. do not delete thsoe named `iPhone` or `Android`, homeassistant devices are naamed `ring-doorbell:HomeAssistant/something` or `Python program`).
+If you have too many `Authorised Client Devices` it might be easier to `Remove all devices` and re-add your primary devices.
+
+
 ## Sensor
 
 Once you have enabled the [Ring integration](/integrations/ring), you can start using the sensor platform. Currently, it supports doorbell, external chimes and stickup cameras.

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -146,9 +146,9 @@ If you are experiencing issues with receiving ring alerts the reason could be th
 Prior to version 2023.12.0 HA would register a new entry in `Authorised Client Devices` in the `Control Centre` at ring.com every time it restarted.
 If you have been using ring prior to this you may have many `Authorised Client Devices` in the `Control Centre` on ring.com.
 This can cause issues receiving ring alerts.
-You should delete all authorised devices from home assistant which are from HomeAassistant
-(i.e. do not delete thsoe named `iPhone` or `Android`, homeassistant devices are naamed `ring-doorbell:HomeAssistant/something` or `Python program`).
-If you have too many `Authorised Client Devices` it might be easier to `Remove all devices` and re-add your primary devices.
+You should delete all authorised devices from ring.com control centre which are from HomeAassistant
+(i.e. do not delete thsoe named `iPhone` or `Android`, homeassistant devices are named `ring-doorbell:HomeAssistant/something` or `Python program`).
+If you have too many `Authorised Client Devices` to delete each one it might be easier to `Remove all devices` and then re-authorize your required devices.
 
 
 ## Sensor


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update ring integration docs to include note about deleting authorized devices for event stability.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/125506
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a "Realtime event stability" section in the documentation for the Home Assistant Ring integration, providing guidance on managing authorized devices to improve alert stability.
  
- **Documentation**
	- Updated user documentation to clarify issues related to excess authenticated devices and steps for effective device management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->