### PR TITLE
Elelabs adapters is supported but no longer recommended

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -97,8 +97,6 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
   - [Home Assistant Connect ZBT-1](/connectzbt1/) (EFR32MG21-based USB dongle)
   - [Home Assistant Yellow](/yellow/) with integrated EFR32MG21 radio
   - [ITead SONOFF Zigbee 3.0 USB Dongle Plus Model "ZBDongle-E" (EFR32MG21 variant)](https://itead.cc/product/zigbee-3-0-usb-dongle/)
-  - [Elelabs Zigbee USB Adapter](https://elelabs.com/products/elelabs-usb-adapter.html)/POPP ZB-Stick (Note! Not a must but recommend [upgrade the EmberZNet NCP application firmware](https://github.com/Elelabs/elelabs-zigbee-ezsp-utility))
-  - [Elelabs Zigbee Raspberry Pi Shield](https://elelabs.com/products/elelabs-zigbee-shield.html) (Note! Not a must but recommend [upgrade the EmberZNet NCP application firmware](https://github.com/Elelabs/elelabs-zigbee-ezsp-utility))
   - [SMLIGHT SLZB-07](https://smlight.tech/product/slzb-07/) (EFR32MG21-based USB dongle)
 - Texas Instruments based radios (via the [zigpy-znp](https://github.com/zigpy/zigpy-znp) library for zigpy)
   - [CC2652P/CC2652R/CC2652RB USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/guide/adapters/)
@@ -112,6 +110,8 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
 ### Other supported but not recommended Zigbee radio adapters or modules
 
 - Silicon Labs EmberZNet based radios using legacy hardware using the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy)
+  - [Elelabs Zigbee USB Adapter](https://elelabs.com/products/elelabs-usb-adapter.html)/POPP ZB-Stick (Note! Not a must but recommend [upgrade the EmberZNet NCP application firmware](https://github.com/Elelabs/elelabs-zigbee-ezsp-utility))
+  - [Elelabs Zigbee Raspberry Pi Shield](https://elelabs.com/products/elelabs-zigbee-shield.html) (Note! Not a must but recommend [upgrade the EmberZNet NCP application firmware](https://github.com/Elelabs/elelabs-zigbee-ezsp-utility))
   - [ITead Sonoff ZBBridge](https://itead.cc/product/sonoff-zbbridge/) (Note! [WiFi-based bridges are not recommended for ZHA with EZSP radios](https://github.com/home-assistant/home-assistant.io/issues/17170). Also, this first has to be flashed with [Tasmota firmware and Silabs EmberZNet NCP EZSP UART Host firmware to use as Serial-to-IP adapter](https://www.digiblur.com/2020/07/how-to-use-sonoff-zigbee-bridge-with.html))
   - [Nortek GoControl QuickStick Combo Model HUSBZB-1 (Z-Wave & Zigbee Ember 3581 USB Adapter)](https://www.nortekcontrol.com/products/2gig/husbzb-1-gocontrol-quickstick-combo/) (Note! Not a must but recommend [upgrade the EmberZNet NCP application firmware](https://github.com/walthowd/husbzb-firmware))
   - [Bitron Video/Smabit BV AV2010/10 USB-Stick](https://manuals.smabit.eu/len/av2010_10.html) with Silicon Labs Ember 3587


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Move the two EFR32MG13-based radio adapters from Elelabs to ZHA list of "_supported but not recommended_" Zigbee radios as those are now also classified as "legacy hardware" and should therefore not be recommended for a new adapter purchase.

* Elelabs Zigbee USB Adapter ELU013 (EFR32MG13P Silicon Labs MCU inside)
  * https://elelabs.com/products/elelabs-usb-adapter.html
* Elelabs Zigbee Raspberry Pi Shield ELR023 (EFR32MG13P Silicon Labs MCU inside)
  * https://elelabs.com/products/elelabs-zigbee-shield.html

Elelabs ELU013 and ELR023 were not only retired by Elelabs a while ago but they are also both based on the older EFR32MG1 Series 1 radio SoC from Silabs and EFR32MG1x is not supported in Silicon Labs Gecko SDK 5.0.0.0 so those will never ever get the EmberZNet 8.0.0.0 firmware or later, 

* https://www.tindie.com/stores/elelabs/

Elelabs website has by the way also been down a while, and the company has not updated its website or social media in years,

* https://elelabs.com
  * https://downforeveryoneorjustme.com/elelabs.com

Neither Elelabs ELU013 and ELR023 or rebranded while-label POPP ZB-Stick adapters look to be for sale anymore anywhere either.

* https://popp.eu/portfolio/zb-stick/
  * https://shop.zwave.eu/products/controller/pc-adaptors-usb-dongles/2496/popp-zb-stick-zigbee
  * https://www.domadoo.fr/fr/interface-domotique/5431-popp-dongle-usb-zigbee-zb-stick-chipset-efr32mg13-4251295701554.html

Elelabs themselves have not released any newer firmware images in over two years, though those who already own one can continue to use it using inofficial community firmware builds up to EmberZNet 7.4.x.x (but again will never get EmberZNet 8.x.x.x)

* https://github.com/Elelabs/elelabs-zigbee-ezsp-utility/tree/master/data/EFR32MG13

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the categorization of the Elelabs Zigbee USB Adapter and Elelabs Zigbee Raspberry Pi Shield, moving them to a section for "Other supported but not recommended Zigbee radio adapters or modules." This change reflects a shift in recommendation status for these devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->