### PR TITLE
Docs for unit_of_measurement for template number

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -214,6 +214,11 @@ number:
       description: Template for the number's current value.
       required: true
       type: template
+    unit_of_measurement:
+      description: Defines the units of measurement of the number, if any.
+      required: false
+      type: string
+      default: None
     set_value:
       description: Defines actions to run when the number value changes. The variable `value` will contain the number entered.
       required: true
@@ -805,6 +810,33 @@ template:
         state: "{{ now().isoformat() }}"
         attributes:
           forecast: "{{ hourly['weather.home'].forecast }}"
+```
+
+{% endraw %}
+
+### Number entity changing the unit of measurement of another number
+
+This example demonstrates the usage of a template number with a unit of measurement set to change a unit-less value of another number entity.
+
+{% raw %}
+
+```yaml
+template:
+  - number:
+      - name: "Cutting Height"
+        unit_of_measurement: "cm"
+        unique_id: automower_cutting_height
+        state: "{{ states('number.automower_cutting_height_raw')|int(0) * 0.5 + 1.5 }}"
+        set_value:
+          - service: number.set_value
+            target:
+              entity_id: number.automower_cutting_height_raw
+            data:
+              value: "{{ (value - 1.5) * 2 }}"
+        step: 0.5
+        min: 2
+        max: 6
+        icon: mdi:ruler
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation for https://github.com/home-assistant/core/pull/122862 that adds the unit_of_measurement to template numbers


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/122862
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `unit_of_measurement` property for the number entity template, allowing users to specify measurement units.
	- Provided an example to demonstrate the use of the new property in template configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->