### PR TITLE
Add information about cover tilt to Shelly documentation

### DIFF
--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -132,8 +132,8 @@ The integration uses the following strategy to name its entities:
 Shelly 2PM Gen3 supports `tilt` for `cover` entities. To enable this feature, you need to configure the device:
 
 - change the device profile to `Cover` (**Settings** >> **Device profile**)
-- calibrate the cover (**Home** >> **Cover 0** >> **Calibration** >> **Start**)
-- enable and configure **Slat control** (**Home** >> **Cover 0** >> **Slat control**)
+- calibrate the cover (**Home** >> **Cover** >> **Calibration** >> **Start**)
+- enable and configure **Slat control** (**Home** >> **Cover** >> **Slat control**)
 
 ## Binary input sensors
 

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -131,9 +131,9 @@ The integration uses the following strategy to name its entities:
 
 Shelly 2PM Gen3 supports `tilt` for `cover` entities. To enable this feature, you need to configure the device:
 
-- change the device profile to `Cover` (**Settings** >> **Device profile**)
-- calibrate the cover (**Home** >> **Cover** >> **Calibration** >> **Start**)
-- enable and configure **Slat control** (**Home** >> **Cover** >> **Slat control**)
+- Change the device profile to `Cover` (**Settings** > **Device profile**)
+- Calibrate the cover (**Home** > **Cover** > **Calibration** > **Start**)
+- Enable and configure **Slat control** (**Home** > **Cover** > **Slat control**)
 
 ## Binary input sensors
 

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -127,6 +127,14 @@ The integration uses the following strategy to name its entities:
 - If `Channel Name` is set in the device, the integration will use it to generate the entities' name, e.g. `Kitchen Light`
 - If `Channel Name` is set to the default value, the integration will use the `Device ID` and default channel name to generate the entities' name, e.g. `ShellyPro4PM-9808D1D8B912 switch_0`.
 
+## Cover entities
+
+Shelly 2PM Gen3 supports `tilt` for `cover` entities. To enable this feature, you need to configure the device:
+
+- change the device profile to `Cover` (**Settings** >> **Device profile**)
+- calibrate the cover (**Home** >> **Cover 0** >> **Calibration** >> **Start**)
+- enable and configure **Slat control** (**Home** >> **Cover 0** >> **Slat control**)
+
 ## Binary input sensors
 
 ### Binary input sensors (generation 1)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds information about cover tilt for Shelly 2PM Gen3.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/125717
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced documentation for the `tilt` functionality in `cover` entities for the Shelly 2PM Gen3 integration.
	- Provided clear instructions for enabling and configuring the new capabilities of the device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->