### PR TITLE
Cover: add state

### DIFF
--- a/source/_integrations/cover.markdown
+++ b/source/_integrations/cover.markdown
@@ -20,6 +20,17 @@ Home Assistant can give you an interface to control covers such as rollershutter
 
 {% include integrations/building_block_integration.md %}
 
+## The state of a cover
+
+A can have the following states:
+
+- **Opening**: The cover is in the process of opening to reach a set position.
+- **Open**: The cover has reached the open position.
+- **Closing**: The cover is in the process of closing to reach a set position.
+- **Closed**: The cover has reached the closed position.
+
+How the state of a cover is represented in the frontend depends on the device class.
+
 ## Device class
 
 {% include integrations/device_class_intro.md %}
@@ -54,8 +65,8 @@ The following device classes are supported for covers.
 Available actions: `cover.open_cover`, `cover.close_cover`, `cover.stop_cover`, `cover.toggle`, `cover.open_cover_tilt`, `cover.close_cover_tilt`, `cover.stop_cover_tilt`, `cover.toggle_tilt`
 
 | Data attribute | Optional | Description                                                                                          |
-| ---------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all. |
+| -------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `entity_id`    | yes      | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all. |
 
 #### Automation example
 
@@ -75,9 +86,9 @@ automation:
 Set cover position of one or multiple covers.
 
 | Data attribute | Optional | Description                                                                                          |
-| ---------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all. |
-| `position`             | no       | Integer between 0 and 100.                                                                           |
+| -------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `entity_id`    | yes      | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all. |
+| `position`     | no       | Integer between 0 and 100.                                                                           |
 
 #### Automation example
 
@@ -98,10 +109,10 @@ automation:
 
 Set cover tilt position of one or multiple covers.
 
-| Data attribute | Optional | Description                                                                                          |
-| ---------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all. |
-| `tilt_position`        | no       | Integer between 0 and 100.                                                                           |
+| Data attribute  | Optional | Description                                                                                          |
+| --------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `entity_id`     | yes      | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all. |
+| `tilt_position` | no       | Integer between 0 and 100.                                                                           |
 
 #### Automation example
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new section in the documentation detailing the operational states of covers: Opening, Open, Closing, and Closed.
  
- **Documentation**
	- Enhanced the formatting of table headers for improved consistency and readability across data attributes such as entity_id, position, and tilt_position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->