### PR TITLE
Z-Wave: move term equivalents table to getting started

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -63,7 +63,7 @@ Throughout this documentation, Home Assistant terminology is used. For some of t
 | exclusion            | remove                                                          |
 | barrier operator     | cover                                                           |
 | window covering      | cover                                                           |
-| multilevel switch    | represented by different entity types: light, fan etc.        |
+| multilevel switch    | represented by different entity types: light, fan etc.          |
 
 ### Prerequisites
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -63,7 +63,7 @@ Throughout this documentation, Home Assistant terminology is used. For some of t
 | exclusion            | remove                                                          |
 | barrier operator     | cover                                                           |
 | window covering      | cover                                                           |
-| multilevel switch    | represented by different entity types: cover, fan, dimmer, etc. |
+| multilevel switch    | represented by different entity types: light, fan etc. |
 
 ### Prerequisites
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -51,6 +51,22 @@ The Z-Wave integration allows you to control a Z-Wave network via the [Z-Wave JS
 
 ## Getting started
 
+This sections shows you how to set up a Z-Wave JS server how to add your first Z-Wave device to Home Assistant. It also introduces you to some of the basic terminology.
+
+### Z-Wave terminology
+
+Throughout this documentation, Home Assistant terminology is used. For some of the concepts, the terminology does not correspond to the terminology used in Z-Wave documentation. The table below provides equivalents for some of those terms.
+
+| Z-Wave functionality | Home Assistant                                                  |
+| -------------------- | --------------------------------------------------------------- |
+| inclusion            | add                                                             |
+| exclusion            | remove                                                          |
+| barrier operator     | cover                                                           |
+| window covering      | cover                                                           |
+| multilevel switch    | represented by different entity types: cover, fan, dimmer, etc. |
+
+### Prerequisites
+
 To run a Z-Wave network, you need the following elements:
 
 - A [supported Z-Wave controller](/docs/z-wave/controllers/#supported-z-wave-usb-sticks--hardware-modules). First-time user? For recommendations on what to buy, go [here](#which-z-wave-controller-should-i-buy).
@@ -934,16 +950,3 @@ Set the log level for `zwave_js_server` to `debug`. This can either be done in y
 ##### Disable Z-Wave JS logging manually, or via an automation
 
 Set the log level for `zwave_js_server` to a level higher than `debug`. This can either be done in your `configuration.yaml` in the `logger` section, or using the `logger.set_level` action. The Z-Wave JS logs will no longer be included in the Home Assistant logs, and if the log level of Z-Wave JS was changed by the integration, it will automatically change back to its original level.
-
-## Z-Wave terminology
-
-For some of the concepts, you may come across different terminology in Z-Wave than in Home Assistant.
-The table below provides equivalents for some of those terms.
-
-| Z-Wave functionality | Home Assistant                                                  |
-| -------------------- | --------------------------------------------------------------- |
-| inclusion            | add                                                             |
-| exclusion            | remove                                                          |
-| barrier operator     | cover                                                           |
-| window covering      | cover                                                           |
-| multilevel switch    | represented by different entity types: cover, fan, dimmer, etc. |

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -63,7 +63,7 @@ Throughout this documentation, Home Assistant terminology is used. For some of t
 | exclusion            | remove                                                          |
 | barrier operator     | cover                                                           |
 | window covering      | cover                                                           |
-| multilevel switch    | represented by different entity types: light, fan etc. |
+| multilevel switch    | represented by different entity types: light, fan etc.        |
 
 ### Prerequisites
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new section on Z-Wave terminology to clarify differences for Home Assistant users.
	- Included a table of equivalents for Z-Wave functionalities.
	- Provided an overview of prerequisites for setting up a Z-Wave network, highlighting the need for a supported Z-Wave controller.
	- Consolidated information by removing the previous terminology section for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->