### PR TITLE
Update sonarr.markdown

### DIFF
--- a/source/_integrations/sonarr.markdown
+++ b/source/_integrations/sonarr.markdown
@@ -23,7 +23,7 @@ The Sonarr integration pulls data from a given [Sonarr](https://sonarr.tv/) inst
 URL:
   description: The IP, FQDN, or URL of your Sonarr instance including the port number if you are not using port 8989 and your custom URL base if applicable.
 API Key:
-  description: To retrieve your API key, open your Sonarr web interface and navigate to Settings then General tab. Your Sonarr API Key will be listed on this page under the Security section.
+  description: To retrieve your API key, open your Sonarr web interface and navigate to Settings, then the General tab. Your Sonarr API Key will be listed on this page under the Security section.
 {% endconfiguration_basic %}
 
 ## Sensors

--- a/source/_integrations/sonarr.markdown
+++ b/source/_integrations/sonarr.markdown
@@ -19,7 +19,12 @@ The Sonarr integration pulls data from a given [Sonarr](https://sonarr.tv/) inst
 
 {% include integrations/config_flow.md %}
 
-To retrieve your API key, open your Sonarr web interface and navigate to Settings then General tab. Your Sonarr API Key will be listed on this page under the Security section.
+{% configuration_basic %}
+URL:
+  description: The IP, FQDN, or URL of your Sonarr instance including the port number if you are not using port 8989 and your custom URL base if applicable.
+API Key:
+  description: To retrieve your API key, open your Sonarr web interface and navigate to Settings then General tab. Your Sonarr API Key will be listed on this page under the Security section.
+{% endconfiguration_basic %}
 
 ## Sensors
 


### PR DESCRIPTION
## Proposed change
Add a description for the configuration URL value to include reference to the fact that port number is required for any Sonarr instance running on anything other than port 8989.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: Closes #31949 Closes #22806 Closes #32694

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and structure of the Sonarr integration configuration instructions.
	- Reformatted API key retrieval instructions into a structured configuration block, including detailed descriptions for the URL and API Key requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->