### PR TITLE
Update scripts.markdown

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -886,6 +886,10 @@ response data must contains a mapping of key/value pairs.
   response_variable: "my_response_variable"
 ```
 
+{% warning %} 
+The response_variable will not be returned when the script mode is set to queued. 
+{% endwarning %}
+
 There is also an `error` option, to indicate we are stopping because of
 an unexpected error. It stops the sequence as well, but marks the {% term automation %}
 or script as failed to run.


### PR DESCRIPTION
Update information about response_variable to make it clear that they will not be returned from a script when the script mode has been set to 'queued'

## Proposed change
Make the documentation more clear in that the response variable assigned in scripts in the stop action will never be honoured nor returned if the scrip mode has been set to queued.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/104218

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a warning message clarifying that the `response_variable` will not be returned when the script mode is set to queued, enhancing user understanding of its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->