### PR TITLE
Z-Wave Supervision CC: add note about working or fail status

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1026,9 +1026,7 @@ The following table lists the Command Classes together with the implemented vers
 | Z-Wave Plus Info              | 2       | None            |
 
 {% note %}
-The documentation must list all cases where a "Working" of "Fail" status is returned for a valid and supported command of the Supervision Command Class:
-
-Home Assistant and Z-Wave JS will never return a "Working" of "Fail" status for a valid and supported command of the Supervision Command Class.
+Home Assistant and Z-Wave JS will never return a "Working" or "Fail" status for a valid and supported command of the Supervision Command Class.
 {% endnote %}
 
 ## Z-Wave terminology

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1027,7 +1027,8 @@ The following table lists the Command Classes together with the implemented vers
 
 {% note %}
 The documentation must list all cases where a "Working" of "Fail" status is returned for a valid and supported command of the Supervision Command Class:
-- Home Assistant and Z-Wave JS will never return a "Working" of "Fail" status for a valid and supported command of the Supervision Command Class.
+
+Home Assistant and Z-Wave JS will never return a "Working" of "Fail" status for a valid and supported command of the Supervision Command Class.
 {% endnote %}
 
 ## Z-Wave terminology

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1025,6 +1025,11 @@ The following table lists the Command Classes together with the implemented vers
 | Version                       | 3       | Highest granted |
 | Z-Wave Plus Info              | 2       | None            |
 
+{% note %}
+The documentation must list all cases where a "Working" of "Fail" status is returned for a valid and supported command of the Supervision Command Class:
+- Home Assistant and Z-Wave JS will never return a "Working" of "Fail" status for a valid and supported command of the Supervision Command Class.
+{% endnote %}
+
 ## Z-Wave terminology
 
 This section explains some Z-Wave terms and concepts you might find in Z-Wave product documentation.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

- To satisfy mandatory documentation requirement for Z-Wave certification

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added clarification on the behavior of Home Assistant and Z-Wave JS regarding the Supervision Command Class, ensuring users understand that "Working" will never be returned as "Fail" for valid commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->