### PR TITLE
Update: remove redundant information

### DIFF
--- a/source/_integrations/update.markdown
+++ b/source/_integrations/update.markdown
@@ -20,17 +20,6 @@ device or service. This can be any update, including update of a firmware
 for a device like a light bulb or router, or software updates for things like
 add-ons or containers.
 
-The state of the update {% term entity %} indicates if there is an update pending or not,
-and if there is an update available, more information on that update can be
-provided by an integration to the {% term entity %}. For example, the version that is
-available, a summary of the release notes, and even links that provide more
-information on the available update.
-
-Lastly, there are two actions available for the update {% term entity %}. If possible and
-made available by the integration providing the update {% term entity %}, triggering
-the actual update from Home Assistant. The other action exposed allows for
-skipping the offered update.
-
 {% include integrations/building_block_integration.md %}
 
 For a list of {% term integrations %} offering update entities, on the integrations page, select the ["Update" category](/integrations/#update).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update: remove redundant information
- the information is provided below in separate sections on state and actions

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Revised the description of the update entity for conciseness, focusing on the general concept of updates rather than detailed functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->