### PR TITLE
Events: add heading to improve visibility of section

### DIFF
--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -12,7 +12,11 @@ The core of Home Assistant is the event bus. The event bus allows any integratio
 
 ## Events and state changes
 
-All {% term entities %} produce state change events. Every time a {% term state %} changes, a state change event is produced. State change events are just one type of event on the event bus, but there are other kinds of events, such as the [built-in events](#built-in-events-core) that are used to coordinate between various integrations. State change events are not to be confused with the [event entity](/integrations/event/). This is a specific type of entity, that itself produces event state changes, just like all other entities.
+All {% term entities %} produce state change events. Every time a {% term state %} changes, a state change event is produced. State change events are just one type of event on the event bus, but there are other kinds of events, such as the [built-in events](#built-in-events-core) that are used to coordinate between various integrations.
+
+### State change events versus event entity
+
+State change events are not to be confused with the [event entity](/integrations/event/). The event entity is a specific type of entity that itself produces event state changes, just like all other entities.
 
 Any state change will be announced on the event bus as a `state_changed` event, containing the previous and the new state of an entity.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified the distinction between state change events and event entities in the Home Assistant event bus.
	- Introduced a new section to enhance understanding of these concepts for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->