### PR TITLE
OWM: mention correct deprecation date for Onecall API 2.5

### DIFF
--- a/source/_integrations/openweathermap.markdown
+++ b/source/_integrations/openweathermap.markdown
@@ -34,7 +34,7 @@ You need an API key, it requires a [subscription](https://openweathermap.org/api
 
 ### OpenWeatherMap API V2.5 Deprecation
 
-OpenWeatherMap API V2.5 will be closed in June 2024. After this date, you will need to use API V3.0.
+OpenWeatherMap API V2.5 will be closed on October 7th 2024. After this date, you will need to use API V3.0.
 
 To continue using the service:
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
According to the latest email from OWM to subscribers the free Onecall API 2.5 will be closed in a few days. We should mention this date instead of June (as it was not deprecated yet).

Reference Email:
<img width="571" alt="image" src="https://github.com/user-attachments/assets/0eb4290a-3dcb-4810-a2fe-24bae0989051">




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the deprecation date for the OpenWeatherMap API V2.5 to October 7th, 2024, in the Important Deprecation Notice section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->