### PR TITLE
Fix incorrect description of home assistant cloud

### DIFF
--- a/source/_integrations/cloud.markdown
+++ b/source/_integrations/cloud.markdown
@@ -16,7 +16,7 @@ ha_platforms:
 ha_integration_type: system
 ---
 
-The Home Assistant Cloud allows you to quickly integrate your local Home Assistant with various cloud services like Amazon Alexa and Google Assistant. [Learn more.](/cloud)
+Home Assistant Cloud is a subscription service provided by our partner Nabu Casa, Inc. [Learn more.](/cloud)
 
 ## Configuration
 


### PR DESCRIPTION

## Proposed change
Home Assistant Cloud has *nothing* to do with Google or Alexa.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Home Assistant Cloud integration documentation to clarify that it is a subscription service offered by Nabu Casa, Inc.
	- Revised the description to enhance understanding while retaining existing configuration examples and instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->