### PR TITLE
Docs for 'Allow override entity_id in more-info action'

### DIFF
--- a/source/dashboards/actions.markdown
+++ b/source/dashboards/actions.markdown
@@ -101,6 +101,11 @@ tap_action:
       description: "If supported, listen for voice commands when opening the assist dialog and the `action` is defined as `assist`"
       type: boolean
       default: none
+    entity_id:
+      required: false
+      description: "Overrides the default entity to show when when the `action` is defined as `more-info`"
+      type: string
+      default: none
 {% endconfiguration %}
 
 ## Hold action
@@ -168,6 +173,11 @@ hold_action:
       description: "If supported, listen for voice commands when opening the assist dialog and the `action` is defined as `assist`"
       type: boolean
       default: none
+    entity_id:
+      required: false
+      description: "Overrides the default entity to show when when the `action` is defined as `more-info`"
+      type: string
+      default: none      
 {% endconfiguration %}
 
 ## Double tap action
@@ -235,6 +245,11 @@ double_tap_action:
       description: "If supported, listen for voice commands when opening the assist dialog and the `action` is defined as `assist`"
       type: boolean
       default: none
+    entity_id:
+      required: false
+      description: "Overrides the default entity to show when when the `action` is defined as `more-info`"
+      type: string
+      default: none      
 {% endconfiguration %}
 
 ## Options for confirmation

--- a/source/dashboards/actions.markdown
+++ b/source/dashboards/actions.markdown
@@ -103,7 +103,7 @@ tap_action:
       default: none
     entity_id:
       required: false
-      description: "Overrides the default entity to show when when the `action` is defined as `more-info`"
+      description: "Overrides the default entity to show when the `action` is defined as `more-info`"
       type: string
       default: none
 {% endconfiguration %}
@@ -175,9 +175,9 @@ hold_action:
       default: none
     entity_id:
       required: false
-      description: "Overrides the default entity to show when when the `action` is defined as `more-info`"
+      description: "Overrides the default entity to show when the `action` is defined as `more-info`"
       type: string
-      default: none      
+      default: none
 {% endconfiguration %}
 
 ## Double tap action
@@ -247,9 +247,9 @@ double_tap_action:
       default: none
     entity_id:
       required: false
-      description: "Overrides the default entity to show when when the `action` is defined as `more-info`"
+      description: "Overrides the default entity to show when the `action` is defined as `more-info`"
       type: string
-      default: none      
+      default: none
 {% endconfiguration %}
 
 ## Options for confirmation


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document new option for more-info action.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/22147
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `entity_id` parameter for `tap_action`, `hold_action`, and `double_tap_action`, allowing users to customize the entity displayed during actions.
  
- **Documentation**
	- Updated documentation to reflect the new `entity_id` parameter, including its description and default value in YAML configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->