### PR TITLE
restore play on roku docs

### DIFF
--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -93,6 +93,13 @@ data:
 
 When the Home Assistant Roku integration is enabled and a Roku device has been configured, in the Home Assistant UI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will attempt to launch the channel on your Roku device.
 
+{% include integrations/option_flow.md %}
+
+{% configuration_basic %}
+Play Media Application ID:
+  description: The application ID to use when launching media playback. This application must support the PlayOnRoku API.
+{% endconfiguration_basic %}
+
 ## Source Automation
 
 The `media_player.select_source` action may be used to launch specific applications/streaming channels on your Roku device.

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -153,6 +153,7 @@ actions:
 ```
 
 ## Play on Roku
+
 The `media_player.play_media` service may be used to send media URLs (primarily videos) for direct playback on your device.
 
 This feature previously made use of the built-in PlayOnRoku application that was available prior to Roku OS 11.5. Since Home Assistant v2024.10.3, you can set a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
@@ -166,6 +167,7 @@ This feature previously made use of the built-in PlayOnRoku application that was
 | `extra.name` | yes | A name for the media. | Big Buck Bunny
 | `extra.thumbnail` | yes | A thumbnail URL for the media. | 
 | `extra.artist_name` | yes | The name of the media artist. | Blender
+
 ### Example
 ```yaml
 action:
@@ -179,8 +181,11 @@ action:
         format: mp4
         name: Big Buck Bunny
 ```
+
 ## Camera Stream Integration
-The `camera.play_stream` service may be used to send camera streams (HLS) directly to your device. This feature requires the `stream` integration and makes use of the built-in PlayOnRoku application.
+
+The `camera.play_stream` service may be used to send camera streams (HLS) directly to your device. This feature requires the `stream` integration and makes use of the PlayOnRoku API.
+
 ### Example
 ```yaml
 action:

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -161,9 +161,9 @@ actions:
 
 ## Play on Roku
 
-The `media_player.play_media` service may be used to send media URLs (primarily videos) for direct playback on your device.
+The `media_player.play_media` action may be used to send media URLs (primarily videos) for direct playback on your device.
 
-This feature previously made use of the built-in PlayOnRoku application that was available before Roku OS 11.5. Since Home Assistant v2024.10.3, you can set a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
+This feature previously made use of the built-in PlayOnRoku application that was available before Roku OS 11.5. You can also configure a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
 
 The following third-party applications have been tested with this integration:
 
@@ -172,7 +172,7 @@ The following third-party applications have been tested with this integration:
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | ------- |
 | `entity_id` | no | Target a specific media player. | 
-| `media_content_id` | no | A media URL. | http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
+| `media_content_id` | no | A media URL. | `http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4`
 | `media_content_type` | no | A media type. | `url`
 | `extra.format` | no | A media format. It should be one of `mp4` (supports mov and m4v), `mp3`, `hls`, `ism` (smooth streaming), `dash` (MPEG-DASH), `mkv`, `mka`, `mks` | `mp4`
 | `extra.name` | yes | A name for the media. | Big Buck Bunny
@@ -181,26 +181,26 @@ The following third-party applications have been tested with this integration:
 
 ### Example
 ```yaml
-action:
-  - service: media_player.play_media
+actions:
+  - action: media_player.play_media
     target:
       entity_id: media_player.roku
     data:
-      media_content_id: http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
+      media_content_id: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
       media_content_type: url
       extra:
-        format: mp4
-        name: Big Buck Bunny
+        format: "mp4"
+        name: "Big Buck Bunny"
 ```
 
 ## Camera Stream Integration
 
-The `camera.play_stream` service may be used to send camera streams (HLS) directly to your device. This feature requires the `stream` integration and makes use of the PlayOnRoku API.
+The `camera.play_stream` action may be used to send camera streams (HLS) directly to your device. This feature requires the [`stream` integration](/integrations/stream) and makes use of the PlayOnRoku API.
 
 ### Example
 ```yaml
-action:
-  service: camera.play_stream
+actions:
+  - action: camera.play_stream
     target:
       entity_id: camera.camera
     data:

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -165,7 +165,7 @@ The `media_player.play_media` service may be used to send media URLs (primarily 
 
 This feature previously made use of the built-in PlayOnRoku application that was available before Roku OS 11.5. Since Home Assistant v2024.10.3, you can set a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
 
-The following Applications have been tested with this integration:
+The following third-party applications have been tested with this integration:
 
 - [Media Assistant](https://channelstore.roku.com/details/625f8ef7740dff93df7d85fc510303b4/media-assistant) (ID: 782875)
 

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -153,7 +153,10 @@ actions:
 ```
 
 ## Play on Roku
-The `media_player.play_media` service may be used to send media URLs (primarily videos) for direct playback on your device. This feature makes use of the built-in PlayOnRoku application.
+The `media_player.play_media` service may be used to send media URLs (primarily videos) for direct playback on your device.
+
+This feature previously made use of the built-in PlayOnRoku application that was available prior to Roku OS 11.5. Since Home Assistant v2024.10.3, you can set a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
+
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | ------- |
 | `entity_id` | no | Target a specific media player. | 

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -163,7 +163,7 @@ actions:
 
 The `media_player.play_media` service may be used to send media URLs (primarily videos) for direct playback on your device.
 
-This feature previously made use of the built-in PlayOnRoku application that was available prior to Roku OS 11.5. Since Home Assistant v2024.10.3, you can set a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
+This feature previously made use of the built-in PlayOnRoku application that was available before Roku OS 11.5. Since Home Assistant v2024.10.3, you can set a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
 
 The following Applications have been tested with this integration:
 
@@ -174,7 +174,7 @@ The following Applications have been tested with this integration:
 | `entity_id` | no | Target a specific media player. | 
 | `media_content_id` | no | A media URL. | http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
 | `media_content_type` | no | A media type. | `url`
-| `extra.format` | no | A media format. Should be one of `mp4` (supports mov and m4v), `mp3`, `hls`, `ism` (smooth streaming), `dash` (MPEG-DASH), `mkv`, `mka`, `mks` | `mp4`
+| `extra.format` | no | A media format. It should be one of `mp4` (supports mov and m4v), `mp3`, `hls`, `ism` (smooth streaming), `dash` (MPEG-DASH), `mkv`, `mka`, `mks` | `mp4`
 | `extra.name` | yes | A name for the media. | Big Buck Bunny
 | `extra.thumbnail` | yes | A thumbnail URL for the media. | 
 | `extra.artist_name` | yes | The name of the media artist. | Blender

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -152,6 +152,42 @@ actions:
       media_content_type: channel
 ```
 
+## Play on Roku
+The `media_player.play_media` service may be used to send media URLs (primarily videos) for direct playback on your device. This feature makes use of the built-in PlayOnRoku application.
+| Service data attribute | Optional | Description | Example |
+| ---------------------- | -------- | ----------- | ------- |
+| `entity_id` | no | Target a specific media player. | 
+| `media_content_id` | no | A media URL. | http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
+| `media_content_type` | no | A media type. | `url`
+| `extra.format` | no | A media format. Should be one of `mp4` (supports mov and m4v), `mp3`, `hls`, `ism` (smooth streaming), `dash` (MPEG-DASH), `mkv`, `mka`, `mks` | `mp4`
+| `extra.name` | yes | A name for the media. | Big Buck Bunny
+| `extra.thumbnail` | yes | A thumbnail URL for the media. | 
+| `extra.artist_name` | yes | The name of the media artist. | Blender
+### Example
+```yaml
+action:
+  - service: media_player.play_media
+    target:
+      entity_id: media_player.roku
+    data:
+      media_content_id: http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
+      media_content_type: url
+      extra:
+        format: mp4
+        name: Big Buck Bunny
+```
+## Camera Stream Integration
+The `camera.play_stream` service may be used to send camera streams (HLS) directly to your device. This feature requires the `stream` integration and makes use of the built-in PlayOnRoku application.
+### Example
+```yaml
+action:
+  service: camera.play_stream
+    target:
+      entity_id: camera.camera
+    data:
+      media_player: media_player.roku
+```
+
 ## Content Deeplinking
 
 The `media_player.play_media` action may be used to deep-link to content within an application.

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -167,7 +167,7 @@ This feature previously made use of the built-in PlayOnRoku application that was
 
 The following Applications have been tested with this integration:
 
-*  [Media Assistant](https://channelstore.roku.com/details/625f8ef7740dff93df7d85fc510303b4/media-assistant) (ID: 782875)
+- [Media Assistant](https://channelstore.roku.com/details/625f8ef7740dff93df7d85fc510303b4/media-assistant) (ID: 782875)
 
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | ------- |

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -158,6 +158,10 @@ The `media_player.play_media` service may be used to send media URLs (primarily 
 
 This feature previously made use of the built-in PlayOnRoku application that was available prior to Roku OS 11.5. Since Home Assistant v2024.10.3, you can set a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
 
+The following Applications have been tested with this integration:
+
+*  [Media Assistant](https://channelstore.roku.com/details/625f8ef7740dff93df7d85fc510303b4/media-assistant) (ID: 782875)
+
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | ------- |
 | `entity_id` | no | Target a specific media player. | 

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -163,7 +163,7 @@ actions:
 
 The `media_player.play_media` action may be used to send media URLs (primarily videos) for direct playback on your device.
 
-This feature previously made use of the built-in PlayOnRoku application that was available before Roku OS 11.5. You can also configure a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
+This feature makes use of the PlayOnRoku API. If you are using an older Roku OS (pre-11.5), the defaults of this integration should just work. Alternatively, you can configure a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
 
 The following third-party applications have been tested with this integration:
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This section was previously removed as the functionality was broken on new Roku OS versions. It turns out Roku has fully killed this feature even via mobile app. However, it is possible to create channels that recreate said functionality. Until now, no channels had been published to make it reasonably feasible to use this feature.

The developer of [Media Assistant](https://channelstore.roku.com/details/625f8ef7740dff93df7d85fc510303b4/media-assistant) has reached out alerting us that he implemented the Play on Roku API for his channel. It is available in all regions making it the best viable option.

Users can also sideload channels/apps and use the "dev" app id if they want a non-store option or something custom.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/128133
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options for the "Play Media Application ID" for enhanced media playback.
	- Expanded capabilities for the `media_player.play_media` action, allowing direct media URL sending.
	- Added `camera.play_stream` service for streaming camera feeds to Roku devices.
	- Implemented deep-linking to content within applications via `media_player.play_media`.
	- New `roku.search` action to open the search screen on Roku devices. 

- **Documentation**
	- Enhanced documentation with detailed instructions and examples for new features and actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->