### PR TITLE
S3 box as voice assistant: add troubleshoot instructions for Linux

### DIFF
--- a/source/voice_control/s3_box_voice_assistant.markdown
+++ b/source/voice_control/s3_box_voice_assistant.markdown
@@ -57,13 +57,17 @@ Before you can use this device with Home Assistant, you need to install a bit of
 
     2. To connect the ESP32-S3-BOX-3 to your computer, follow these steps:
        - In the pop-up window, view the available ports.
-       - Plug the USB-C cable into the box directly, not into the docking station (not into the blue part) and connect it to your computer.
-       - **Troubleshooting**: If your ESP32-S3-BOX-3 does not appear in the list of devices presented by your browser, you need to manually invoke "flash mode":
-         - Hold the "boot" button (left side upper button) as you tap the "reset" button (left side lower button).
-         - After a few seconds, the ESP32-S3-BOX-3 should appear in the list of USB devices presented by your browser.
-         - Follow the steps until step 3. After selecting the **Next** button, on the S3-Box-3, tap the "Reset" button again.
-         - Then, select the blue **Connect button** again, select the USB device and follow the prompts to configure the Wi-Fi.
-         - In the pop-up window, there should now appear a new entry. Select this USB serial port and select **Connect**.
+       - Plug the USB-C cable into the box directly, not into the docking station (not into the blue part) and connect it to your computer. In the pop-up window, there should now appear a new entry.
+         - **Troubleshooting**: If your ESP32-S3-BOX-3 does not appear in the list of devices presented by your browser, you need to manually invoke "flash mode":
+           1. Hold the "boot" button (left side upper button) as you tap the "reset" button (left side lower button).
+           2. After a few seconds, the ESP32-S3-BOX-3 should appear in the list of USB devices presented by your browser.
+           3. Follow the steps until step 3. After selecting the **Next** button, on the S3-Box-3, tap the "Reset" button again.
+           4. Then, select the blue **Connect button** again, and the new serial port should appear in the list.
+       - Select this new USB serial port and select **Connect**.
+         - **Troubleshooting**: If you're using Linux and an error shows right after you try to connect to the serial port, make sure your user belongs to the `dialout` group for proper serial permissions:
+           1. Run `sudo usermod -aG dialout $USER` from the command line.
+           2. Log out and log back in, so the new group is applied globally.
+           3. Reopen the browser and try the **Connect** button again.
     3. Select **Install Voice Assistant**, then **Install**.
          - Once the installation is complete, select **Next**.
          - Add the ESP32-S3-BOX-3 to your Wi-Fi:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

I'm trying to improve the setup instructions for Linux users, as I had quite some trouble trying to figure out how to do it as simple as the tutorial seems to be.

The correct steps were found by accident, and reported on the original project at https://github.com/esphome/esp-web-tools/issues/520.

However, considering this is not just "a problem" some users might have, but actually something everyone not used to ESP will need to comply as a setup step, I tried adding it directly to the setup steps.
Not sure if this is necessary for Mac users as well, though, given it could be a Unix-wide issue?

I also moved around some bits which were confusing for me, making following step-by-step easier (for example, the "now press Connect" step was only inside the Troubleshooting section).

Lastly, I would suggest reorganizing the structure a bit, as it looks like the flashing steps are the same for all ESP32-S3 boxes? But this is a bit more complex for me, as I don't understand completely the doc structure. :sweat_smile:

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and organization of the "ESP32-S3-BOX voice assistant" document.
	- Refined prerequisites section with specific Home Assistant version and new variant inclusion.
	- Improved installation instructions and troubleshooting steps for better user flow.
	- Expanded wake word settings with detailed instructions and examples for voice command control.
	- Structured updates section for systematic firmware updates based on Home Assistant version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->