### PR TITLE
Add play media documentation to Cambridge Audio

### DIFF
--- a/source/_integrations/cambridge_audio.markdown
+++ b/source/_integrations/cambridge_audio.markdown
@@ -55,6 +55,41 @@ Host:
 The integration provides a few entities to configure the device settings. The following entities are supported:
 - Display brightness
 
+## Playing media
+
+Cambridge Audio supports playing a variety of formats using the `media_player.play_media` action. 
+
+### Examples:
+
+Cambridge Audio can recall any stored presets saved on the device. An example action using a preset:
+```yaml
+action: media_player.play_media
+target:
+  entity_id: media_player.cambridge_audio
+data:
+  media_content_type: "preset"
+  media_content_id: "1"
+```
+
+An example action using an Airable radio id:
+```yaml
+action: media_player.play_media
+target:
+  entity_id: media_player.cambridge_audio
+data:
+  media_content_type: "airable"
+  media_content_id: "12345678"
+```
+
+An example action using an internet radio url:
+```yaml
+action: media_player.play_media
+target:
+  entity_id: media_player.cambridge_audio
+data:
+  media_content_type: "internet_radio"
+  media_content_id: "https://example.com/internet-radio/station_abcd.mp3"
+```
 ## Troubleshooting
 
 ### The buttons to skip, shuffle, and repeat the track are missing

--- a/source/_integrations/cambridge_audio.markdown
+++ b/source/_integrations/cambridge_audio.markdown
@@ -71,7 +71,8 @@ data:
   media_content_id: "1"
 ```
 
-An example action using an Airable radio id:
+An example action using an Airable radio ID:
+
 ```yaml
 action: media_player.play_media
 target:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds examples for using the play media feature for Cambridge Audio media players. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/129002
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a section on "Playing media" to the Cambridge Audio integration documentation, including examples for using presets, Airable radio IDs, and internet radio URLs.
  
- **Documentation**
	- Clarified the "Available configuration entities" section to specify the inclusion of "Display brightness" for device settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->