### PR TITLE
Use entity more info action

### DIFF
--- a/source/dashboards/actions.markdown
+++ b/source/dashboards/actions.markdown
@@ -173,7 +173,7 @@ hold_action:
       description: "If supported, listen for voice commands when opening the assist dialog and the `action` is defined as `assist`"
       type: boolean
       default: none
-    entity_id:
+    entity:
       required: false
       description: "Overrides the default entity to show when the `action` is defined as `more-info`"
       type: string
@@ -245,7 +245,7 @@ double_tap_action:
       description: "If supported, listen for voice commands when opening the assist dialog and the `action` is defined as `assist`"
       type: boolean
       default: none
-    entity_id:
+    entity:
       required: false
       description: "Overrides the default entity to show when the `action` is defined as `more-info`"
       type: string

--- a/source/dashboards/actions.markdown
+++ b/source/dashboards/actions.markdown
@@ -101,7 +101,7 @@ tap_action:
       description: "If supported, listen for voice commands when opening the assist dialog and the `action` is defined as `assist`"
       type: boolean
       default: none
-    entity_id:
+    entity:
       required: false
       description: "Overrides the default entity to show when the `action` is defined as `more-info`"
       type: string


### PR DESCRIPTION
## Proposed change

Use entity instead of entity_id for more info action to be consistent with card configurations.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/22603
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Renamed the `entity_id` key to `entity` in the configuration for `tap_action`, `hold_action`, and `double_tap_action` to streamline naming conventions.

- **Documentation**
	- Enhanced documentation for action configurations with clearer descriptions of required and optional keys.
	- Updated sections on `tap_action`, `hold_action`, and `double_tap_action` to clarify structure and requirements, including confirmation dialogs and exemptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->