### PR TITLE
Mention alternative (deco) provisioning for tplink

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -40,7 +40,7 @@ ha_integration_type: integration
 
 The `tplink` integration allows you to control your [TP-Link Kasa Smart Home Devices](https://www.tp-link.com/kasa-smart/) and [TP-Link Tapo Devices](https://www.tapo.com/) such as plugs, power strips, wall switches and bulbs.
 
-You need to provision your newly purchased device to connect to your network before it can be added via the integration. This can be done either by using [kasa command-line tool](https://python-kasa.readthedocs.io/en/latest/cli.html#provisioning) or by adding it to the official Kasa or Tapo app before trying to add them to Home Assistant. Some apps for TP-Link's other products, such as the Deco app, also allow you to add Kasa and Tapo devices within them, these devices use the same TP-Link Cloud Account for authorisation and so work with this integration also.
+You need to provision your newly purchased device to connect to your network before it can be added via the integration. This can be done either by using [kasa command-line tool](https://python-kasa.readthedocs.io/en/latest/cli.html#provisioning) or by adding it to the official Kasa or Tapo app before trying to add them to Home Assistant. Some apps for TP-Link's other products, such as the Deco app, also allow you to add Kasa and Tapo devices within them, these devices use the same TP-Link Cloud Account for authorization and so work with this integration also.
 
 If your device is a newer Kasa or Tapo device it will require your TP-Link cloud username and password to authenticate for local access.
 If you have an older device that does not currently require authentication, you may consider disabling automatic firmware updates to keep it that way.

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -40,7 +40,7 @@ ha_integration_type: integration
 
 The `tplink` integration allows you to control your [TP-Link Kasa Smart Home Devices](https://www.tp-link.com/kasa-smart/) and [TP-Link Tapo Devices](https://www.tapo.com/) such as plugs, power strips, wall switches and bulbs.
 
-You need to provision your newly purchased device to connect to your network before it can be added via the integration. This can be done either by using [kasa command-line tool](https://python-kasa.readthedocs.io/en/latest/cli.html#provisioning) or by adding it to the official Kasa or Tapo app before trying to add them to Home Assistant.
+You need to provision your newly purchased device to connect to your network before it can be added via the integration. This can be done either by using [kasa command-line tool](https://python-kasa.readthedocs.io/en/latest/cli.html#provisioning) or by adding it to the official Kasa or Tapo app before trying to add them to Home Assistant. Some apps for TP-Link's other products, such as the Deco app, also allow you to add Kasa and Tapo devices within them, these devices use the same TP-Link Cloud Account for authorisation and so work with this integration also.
 
 If your device is a newer Kasa or Tapo device it will require your TP-Link cloud username and password to authenticate for local access.
 If you have an older device that does not currently require authentication, you may consider disabling automatic firmware updates to keep it that way.

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -40,7 +40,7 @@ ha_integration_type: integration
 
 The `tplink` integration allows you to control your [TP-Link Kasa Smart Home Devices](https://www.tp-link.com/kasa-smart/) and [TP-Link Tapo Devices](https://www.tapo.com/) such as plugs, power strips, wall switches and bulbs.
 
-You need to provision your newly purchased device to connect to your network before it can be added via the integration. This can be done either by using [kasa command-line tool](https://python-kasa.readthedocs.io/en/latest/cli.html#provisioning) or by adding it to the official Kasa or Tapo app before trying to add them to Home Assistant. Some apps for TP-Link's other products, such as the Deco app, also allow you to add Kasa and Tapo devices within them, these devices use the same TP-Link Cloud Account for authorization and so work with this integration also.
+You need to provision your newly purchased device to connect to your network before it can be added via the integration. This can be done either by using [kasa command-line tool](https://python-kasa.readthedocs.io/en/latest/cli.html#provisioning) or by adding it to the official Kasa or Tapo app before trying to add them to Home Assistant. Some apps for TP-Link's other products, such as the Deco app, also allow you to add Kasa and Tapo devices. Since these devices use the same TP-Link Cloud Account for authorization, they work with this integration as well.
 
 If your device is a newer Kasa or Tapo device it will require your TP-Link cloud username and password to authenticate for local access.
 If you have an older device that does not currently require authentication, you may consider disabling automatic firmware updates to keep it that way.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Clarified that Tapo and Kasa devices that have been set up by other TP-Link apps (such as Deco), work correctly with this integration.

This came from my setting up of some new Tapo devices inside of the Deco app (which I use to manage my Deco wifi routers).  I previously had some devices set up using the Tapo app and a different TP-Link Cloud account (woo, relationship breakdowns in a digital world are complicated!) and had been putting off the migration as I wasn't sure if they'd work if I'd set them up in the Deco app instead of the Tapo one.  Now I've given it a go and see that it works I figured I'd let others who might be unsure know by clarifying in the docs that only mention to two apps used for the specific product lines in question :)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].
  _I'm not entirely certain if "TP-Link Could Account" or "Deco app" are the preferred terms in the TP-Link's own marketing language, so these are best guess terms._

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the `tplink` integration documentation to clarify the use of the Deco, Kasa, and Tapo apps for device provisioning.
	- Revised information on "Total consumption" reporting for Kasa and Tapo devices, including guidance on handling unavailable entities.
	- Modified the "Update" section to inform users about the removal of the entity due to stability issues and future replacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->