### PR TITLE
signal_messenger: Mention how to receive from Signal running json-rpc

### DIFF
--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -174,3 +174,20 @@ actions:
     data:
       message: "Message received!"
 ```
+
+**NOTE** If the parameter `mode` is set to `json-rpc`, then you can use [signal-api-receiver](https://github.com/kalbasit/signal-api-receiver) to receive from Signal as follows:
+
+```yaml
+- resource: "http://127.0.0.1:8105/receive/pop"
+  sensor:
+    - name: "Signal message received"
+      value_template: >
+        {{ value_json['envelope']['dataMessage']['message'] }}
+      json_attributes_path: envelope
+      json_attributes:
+        - source
+        - sourceNumber
+        - sourceUuid
+        - sourceDevice
+        - timestamp
+```


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The [Signal REST API](https://github.com/bbernhard/signal-cli-rest-api) offers a `json-rpc` mode that significantly improves performance, but it prevents Home Assistant from receiving messages when used with the built-in Signal Messenger integration.

To address this, I've created [signal-api-receiver](https://github.com/kalbasit/signal-api-receiver), a lightweight wrapper that allows Home Assistant to receive Signal messages even when the API is in `json-rpc` mode. This enables users to benefit from the performance gains of `json-rpc` without losing receive functionality.

This pull request adds a mention of `signal-api-receiver` to the Signal Messenger integration documentation to help users who want to use the `json-rpc` mode.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

cc @bbernhard 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation for the Signal Messenger integration to include a new section on configuring message reception using `json-rpc` mode.
	- Added YAML configuration examples to enhance the setup for receiving messages.
	- Clarified methods for triggering actions based on incoming messages.

- **Documentation**
	- Expanded instructions on using the Signal Messenger REST API within Home Assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->