### PR TITLE
Update rflink.markdown anchors and `ha_category`

### DIFF
--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -3,6 +3,11 @@ title: RFLink
 description: Instructions on how to integrate RFLink gateway into Home Assistant.
 ha_category:
   - Hub
+  - Cover
+  - Binary sensor
+  - Light
+  - Sensor
+  - Switch
 ha_iot_class: Assumed State
 ha_release: 0.38
 ha_domain: rflink
@@ -137,7 +142,7 @@ sensor:
     automatic_add: true
 ```
 
-[RFLink Switches](/integrations/switch.rflink/) and [RFLink Binary Sensors](/integrations/binary_sensor.rflink/) cannot be added automatically.
+[RFLink Switches](#switch) and [RFLink Binary Sensors](#binary-sensor) cannot be added automatically.
 
 The RFLink integration does not know the difference between a binary sensor, a switch and a light. Therefore, all switchable devices are automatically added as light by default. However, once the ID of a switch is known, it can be used to configure it as a switch or a binary sensor type in Home Assistant, for example, to add it to a different group or configure a nice name.
 
@@ -279,7 +284,7 @@ Initially, the state of a binary sensor is unknown. When a sensor update is rece
 
 ### Device support
 
-See [device support](/integrations/rflink/#device-support)
+See [device support](#device-support)
 
 ### Additional configuration examples
 
@@ -492,7 +497,7 @@ cover:
 
 ### Device support
 
-See [device support](/integrations/rflink/#device-support).
+See [device support](#device-support).
 
 ## Additional configuration examples
 
@@ -581,7 +586,7 @@ devices:
           default: RFLink ID
           type: string
         type:
-          description: "Override automatically detected type of the light device, can be: switchable, dimmable, hybrid or toggle. See [Light Types](/integrations/light.rflink/#light-types) below."
+          description: "Override automatically detected type of the light device, can be: switchable, dimmable, hybrid or toggle. See [Light Types](#light-types) below."
           required: false
           default: switchable
           type: string
@@ -650,11 +655,11 @@ Lights are added automatically when the RFLink gateway intercepts a wireless com
 
 - Disable automatically adding of unconfigured new sensors (set `automatic_add` to `false`).
 - Hide unwanted devices using [customizations](/getting-started/customizing-devices/)
-- [Ignore devices on a platform level](/integrations/rflink/#ignoring-devices)
+- [Ignore devices on a platform level](#ignoring-devices)
 
 ### Device support
 
-See [device support](/integrations/rflink/#device-support)
+See [device support](#device-support)
 
 ### Additional configuration examples
 
@@ -723,7 +728,7 @@ devices:
           default: RFLink ID
           type: string
         sensor_type:
-          description: Override automatically detected type of sensor. For list of [values](/integrations/sensor.rflink/#sensors-types) see below.
+          description: Override automatically detected type of sensor. For list of [values](#sensors-types) see below.
           required: true
           type: string
         unit_of_measurement:
@@ -779,11 +784,11 @@ Sensor type values:
 Sensors are added automatically when the RFLink gateway intercepts a wireless command in the ether. To prevent cluttering the frontend use any of these methods:
 
 - Disable automatically adding of unconfigured new sensors (set `automatic_add` to `false`).
-- [Ignore devices on a platform level](/integrations/rflink/#ignoring-devices)
+- [Ignore devices on a platform level](#ignoring-devices)
 
 ### Device support
 
-See [device support](/integrations/rflink/#device-support)
+See [device support](#device-support)
 
 ### Additional configuration examples
 
@@ -926,7 +931,7 @@ Any on/off command from any alias ID updates the current state of the switch. Ho
 
 ### Device support
 
-See [device support](/integrations/rflink/#device-support)
+See [device support](#device-support)
 
 #### Additional configuration examples
 

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -264,7 +264,7 @@ devices:
           required: false
           type: list
         device_class:
-          description: Sets the [class of the device](../binary_sensor/#device-class), changing the device state and icon that is displayed on the frontend.
+          description: Sets the [class of the device](/integrations/binary_sensor/#device-class), changing the device state and icon that is displayed on the frontend.
           required: false
           type: string
         off_delay:

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -31,7 +31,7 @@ This {% term integration %} is tested with the following hardware/software:
 
 - Nodo RFLink Gateway V1.4/RFLink R46
 
-### Device support {#device-support}
+### Device support
 The 433 MHz spectrum is used by many manufacturers. Mostly using their own protocol/standard, they use this spectrum to communicate with devices such as light switches, blinds, weather stations, alarms, and various other sensors.
 
 The RFLink Gateway supports a number of RF frequencies, using a wide range of low-cost hardware. [Their website](https://www.rflink.nl) provides details for various RF transmitters, receivers, and transceiver modules for 433MHz, 868MHz, and 2.4 GHz.
@@ -42,7 +42,7 @@ Versions later than R44 add support for IKEA Ansluta, Philips Living Colors Gen1
 
 A complete list of devices supported by RFLink can be found [here](https://www.rflink.nl/devlist.php).
 
-Even though a lot of devices are supported by RFLink, not all have been tested/implemented. If you have a device supported by RFLink but not by this integration please consider testing and adding support yourself.
+Even though many devices are supported by RFLink, not all have been tested/implemented. If you have a device supported by RFLink but not by this integration please consider testing and adding support yourself.
 
 ## Configuration
 
@@ -149,7 +149,7 @@ sensor:
 
 The RFLink integration does not know the difference between a binary sensor, a switch and a light. Therefore, all switchable devices are automatically added as light by default. However, once the ID of a switch is known, it can be used to configure it as a switch or a binary sensor type in Home Assistant, for example, to add it to a different group or configure a nice name.
 
-### Ignoring devices {#ignoring-devices}
+### Ignoring devices
 
 The RFLink platform can be configured to completely ignore a device on a platform level. This is useful when you have neighbors which also use 433 MHz technology.
 
@@ -224,7 +224,7 @@ This will give you output looking like this:
 17-03-07 20:12:05 DEBUG (MainThread) [homeassistant.components.rflink] event of type unknown: {'version': '1.1', 'firmware': 'RFLink Gateway', 'revision': '45', 'hardware': 'Nodo RadioFrequencyLink', 'id': 'rflink'}
 ```
 
-## Binary sensor {#binary-sensor}
+## Binary sensor
 
 The RFLink integration does not know the difference between a `binary_sensor`, a `switch`, and a `light`. Therefore, all switchable devices are automatically added as `light` by default.
 
@@ -263,7 +263,7 @@ devices:
           required: false
           type: list
         device_class:
-          description: Sets the [class of the device](/integrations/binary_sensor/), changing the device state and icon that is displayed on the frontend.
+          description: Sets the [class of the device](/integrations/binary_sensor/#device-class), changing the device state and icon that is displayed on the frontend.
           required: false
           type: string
         off_delay:
@@ -304,7 +304,7 @@ binary_sensor:
          off_delay: 5
 ```
 
-## Cover {#cover}
+## Cover
 
 After configuring the RFLink hub, covers will be automatically discovered and added. Except the Somfy RTS devices.
 
@@ -527,7 +527,7 @@ cover:
         fire_event: true
 ```
 
-## Lights {#light}
+## Light
 
 After configuring the RFLink hub, lights will be automatically discovered and added.
 
@@ -637,7 +637,7 @@ light:
 
 Any on/off command from any alias ID updates the current state of the light. However when sending a command through the frontend only the primary ID is used.
 
-### Light types {#light-types}
+### Light types
 
 Light devices can come in different forms. Some only switch on and off, other support dimming. Dimmable devices might not always respond nicely to repeated `on` command as they turn into a pulsating state until `on` is pressed again (for example KlikAanKlikUit). The RFLink integration support three types of lights to make things work in every situation:
 
@@ -687,7 +687,7 @@ light:
         name: Bedroom Lamp
 ```
 
-## Sensors {#sensor}
+## Sensor
 
 After configuring the RFLink hub, sensors will be automatically discovered and added.
 
@@ -740,7 +740,7 @@ devices:
           type: [list, string]
 {% endconfiguration %}
 
-### Sensor types {#sensor-types}
+### Sensor types
 
 Sensor type values:
 
@@ -817,7 +817,7 @@ sensor:
           - xiron_4001_bat
 ```
 
-## Switch {#switch}
+## Switch
 
 The RFLink integration does not know the difference between a `switch`, a `binary_sensor`, and a `light`. Therefore, all switchable devices are automatically added as `light` by default.
 

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -264,7 +264,7 @@ devices:
           required: false
           type: list
         device_class:
-          description: Sets the [class of the device](/integrations/binary_sensor/#device-class), changing the device state and icon that is displayed on the frontend.
+          description: Sets the [class of the device](../binary_sensor/#device-class), changing the device state and icon that is displayed on the frontend.
           required: false
           type: string
         off_delay:

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -42,7 +42,7 @@ Versions later than R44 add support for IKEA Ansluta, Philips Living Colors Gen1
 
 A complete list of devices supported by RFLink can be found [here](https://www.rflink.nl/devlist.php).
 
-Even though many devices are supported by RFLink, not all have been tested/implemented. If you have a device supported by RFLink but not by this integration please consider testing and adding support yourself.
+Even though many devices are supported by RFLink, not all have been tested/implemented. If you have a device supported by RFLink but not by this integration, please consider testing and adding support yourself.
 
 ## Configuration
 
@@ -281,7 +281,7 @@ devices:
 
 Initially, the state of a binary sensor is unknown. When a sensor update is received, the state is known and will be shown in the frontend.
 
-### Device support for binary sensors {#binary-sensor-device-support}
+### Device support for binary sensors
 
 See [device support](#device-support)
 
@@ -494,7 +494,7 @@ cover:
         name: "Room blinds"
 ```
 
-### Device support for covers {#cover-device-support}
+### Device support for covers
 
 See [device support](#device-support).
 
@@ -656,7 +656,7 @@ Lights are added automatically when the RFLink gateway intercepts a wireless com
 - Hide unwanted devices using [customizations](/getting-started/customizing-devices/)
 - [Ignore devices on a platform level](#ignoring-devices)
 
-### Device support for lights {#light-device-support}
+### Device support for lights
 
 See [device support](#device-support)
 
@@ -785,7 +785,7 @@ Sensors are added automatically when the RFLink gateway intercepts a wireless co
 - Disable automatically adding of unconfigured new sensors (set `automatic_add` to `false`).
 - [Ignore devices on a platform level](#ignoring-devices)
 
-### Device support for sensors {#sensor-device-support}
+### Device support for sensors
 
 See [device support](#device-support)
 
@@ -928,7 +928,7 @@ switch:
 
 Any on/off command from any alias ID updates the current state of the switch. However, when sending a command through the frontend only the primary ID is used.
 
-### Device support for switches {#switch-device-support}
+### Device support for switches
 
 See [device support](#device-support)
 

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -32,6 +32,7 @@ This {% term integration %} is tested with the following hardware/software:
 - Nodo RFLink Gateway V1.4/RFLink R46
 
 ### Device support
+
 The 433 MHz spectrum is used by many manufacturers. Mostly using their own protocol/standard, they use this spectrum to communicate with devices such as light switches, blinds, weather stations, alarms, and various other sensors.
 
 The RFLink Gateway supports a number of RF frequencies, using a wide range of low-cost hardware. [Their website](https://www.rflink.nl) provides details for various RF transmitters, receivers, and transceiver modules for 433MHz, 868MHz, and 2.4 GHz.

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -27,6 +27,11 @@ related:
 
 The `rflink` {% term integration %} supports devices that use [RFLink gateway firmware](https://www.rflink.nl/download.php), for example, the [Nodo RFLink Gateway](https://www.nodo-shop.nl/21-rflink-). RFLink Gateway is an Arduino Mega firmware that allows two-way communication with a multitude of RF wireless devices using cheap hardware (Arduino + transceiver).
 
+This {% term integration %} is tested with the following hardware/software:
+
+- Nodo RFLink Gateway V1.4/RFLink R46
+
+### Device support {#device-support}
 The 433 MHz spectrum is used by many manufacturers. Mostly using their own protocol/standard, they use this spectrum to communicate with devices such as light switches, blinds, weather stations, alarms, and various other sensors.
 
 The RFLink Gateway supports a number of RF frequencies, using a wide range of low-cost hardware. [Their website](https://www.rflink.nl) provides details for various RF transmitters, receivers, and transceiver modules for 433MHz, 868MHz, and 2.4 GHz.
@@ -37,9 +42,7 @@ Versions later than R44 add support for IKEA Ansluta, Philips Living Colors Gen1
 
 A complete list of devices supported by RFLink can be found [here](https://www.rflink.nl/devlist.php).
 
-This {% term integration %} is tested with the following hardware/software:
-
-- Nodo RFLink Gateway V1.4/RFLink R46
+Even though a lot of devices are supported by RFLink, not all have been tested/implemented. If you have a device supported by RFLink but not by this integration please consider testing and adding support yourself.
 
 ## Configuration
 
@@ -184,10 +187,6 @@ cover:
 
 This configuration uses `0a0a0a` to control the inverted shutter (send UP to close and Down to open) and listen commands sent by `0f1f2f` remote control.
 
-### Device support
-
-Even though a lot of devices are supported by RFLink, not all have been tested/implemented. If you have a device supported by RFLink but not by this integration please consider testing and adding support yourself.
-
 ### Device Incorrectly Identified
 
 If you find a device is recognized differently, with different protocols or the ON OFF is swapped or detected as two ON commands, it can  be overcome with the RFLink 'RF Signal Learning' mechanism from RFLink Rev 46 (11 March 2017). [Link to further detail.](https://www.rflink.nl/faq.php#RFFind)
@@ -282,7 +281,7 @@ devices:
 
 Initially, the state of a binary sensor is unknown. When a sensor update is received, the state is known and will be shown in the frontend.
 
-### Device support
+### Device support for binary sensors {#binary-sensor-device-support}
 
 See [device support](#device-support)
 
@@ -495,7 +494,7 @@ cover:
         name: "Room blinds"
 ```
 
-### Device support
+### Device support for covers {#cover-device-support}
 
 See [device support](#device-support).
 
@@ -657,7 +656,7 @@ Lights are added automatically when the RFLink gateway intercepts a wireless com
 - Hide unwanted devices using [customizations](/getting-started/customizing-devices/)
 - [Ignore devices on a platform level](#ignoring-devices)
 
-### Device support
+### Device support for lights {#light-device-support}
 
 See [device support](#device-support)
 
@@ -786,7 +785,7 @@ Sensors are added automatically when the RFLink gateway intercepts a wireless co
 - Disable automatically adding of unconfigured new sensors (set `automatic_add` to `false`).
 - [Ignore devices on a platform level](#ignoring-devices)
 
-### Device support
+### Device support for sensors {#sensor-device-support}
 
 See [device support](#device-support)
 
@@ -929,7 +928,7 @@ switch:
 
 Any on/off command from any alias ID updates the current state of the switch. However, when sending a command through the frontend only the primary ID is used.
 
-### Device support
+### Device support for switches {#switch-device-support}
 
 See [device support](#device-support)
 

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -149,7 +149,7 @@ sensor:
 
 The RFLink integration does not know the difference between a binary sensor, a switch and a light. Therefore, all switchable devices are automatically added as light by default. However, once the ID of a switch is known, it can be used to configure it as a switch or a binary sensor type in Home Assistant, for example, to add it to a different group or configure a nice name.
 
-### Ignoring devices
+### Ignoring devices {#ignoring-devices}
 
 The RFLink platform can be configured to completely ignore a device on a platform level. This is useful when you have neighbors which also use 433 MHz technology.
 
@@ -224,7 +224,7 @@ This will give you output looking like this:
 17-03-07 20:12:05 DEBUG (MainThread) [homeassistant.components.rflink] event of type unknown: {'version': '1.1', 'firmware': 'RFLink Gateway', 'revision': '45', 'hardware': 'Nodo RadioFrequencyLink', 'id': 'rflink'}
 ```
 
-## Binary sensor
+## Binary sensor {#binary-sensor}
 
 The RFLink integration does not know the difference between a `binary_sensor`, a `switch`, and a `light`. Therefore, all switchable devices are automatically added as `light` by default.
 
@@ -304,7 +304,7 @@ binary_sensor:
          off_delay: 5
 ```
 
-## Cover
+## Cover {#cover}
 
 After configuring the RFLink hub, covers will be automatically discovered and added. Except the Somfy RTS devices.
 
@@ -527,7 +527,7 @@ cover:
         fire_event: true
 ```
 
-## Lights
+## Lights {#light}
 
 After configuring the RFLink hub, lights will be automatically discovered and added.
 
@@ -637,7 +637,7 @@ light:
 
 Any on/off command from any alias ID updates the current state of the light. However when sending a command through the frontend only the primary ID is used.
 
-### Light types
+### Light types {#light-types}
 
 Light devices can come in different forms. Some only switch on and off, other support dimming. Dimmable devices might not always respond nicely to repeated `on` command as they turn into a pulsating state until `on` is pressed again (for example KlikAanKlikUit). The RFLink integration support three types of lights to make things work in every situation:
 
@@ -687,7 +687,7 @@ light:
         name: Bedroom Lamp
 ```
 
-## Sensors
+## Sensors {#sensor}
 
 After configuring the RFLink hub, sensors will be automatically discovered and added.
 
@@ -727,7 +727,7 @@ devices:
           default: RFLink ID
           type: string
         sensor_type:
-          description: Override automatically detected type of sensor. For list of [values](#sensors-types) see below.
+          description: Override automatically detected type of sensor. For list of [values](#sensor-types) see below.
           required: true
           type: string
         unit_of_measurement:
@@ -817,7 +817,7 @@ sensor:
           - xiron_4001_bat
 ```
 
-## Switch
+## Switch {#switch}
 
 The RFLink integration does not know the difference between a `switch`, a `binary_sensor`, and a `light`. Therefore, all switchable devices are automatically added as `light` by default.
 

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -741,7 +741,7 @@ devices:
           type: [list, string]
 {% endconfiguration %}
 
-### Sensor types
+### Sensor types {#sensor-types}
 
 Sensor type values:
 


### PR DESCRIPTION
Small markdown fix to add RFLink to categories and fix the links anchors

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Just noticied that the RFLink integration was not listed in the HA categories for generic devices (switch, light, cover,...).
I have updated the `ha_category` and fixed the page anchors.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded device support in RFLink integration documentation to include Cover, Binary sensor, Light, Sensor, and Switch.
- **Documentation**
	- Improved clarity and consistency in configuration options and examples.
	- Enhanced maintainability with relative links.
	- Clarified behavior regarding automatic addition of devices, specifying default treatment of switchable devices as lights.
	- Added a section detailing device support tested with specific hardware (Nodo RFLink Gateway V1.4/RFLink R46).
	- Structural changes for better navigation and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->