### PR TITLE
Add reference to new notification and event on DB corruption

### DIFF
--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -259,6 +259,8 @@ When using SQLite, if the system encounters unrecoverable disk corruption, it wi
 
 In this event, it may be possible to recover the old database by following the [SQLite recovery guide](https://www.sqlite.org/recovery.html).
 
+The system will create a persistent notification and will fire the event `recorder_database_corrupt` if corruption is detected.
+
 ## Custom database engines
 
 {% warning %}

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -259,7 +259,7 @@ When using SQLite, if the system encounters unrecoverable disk corruption, it wi
 
 In this event, it may be possible to recover the old database by following the [SQLite recovery guide](https://www.sqlite.org/recovery.html).
 
-The system will create a persistent notification and will fire the event `recorder_database_corrupt` if corruption is detected.
+To ensure users are promptly informed of such incidents, the system will create a [persistent notification](/integrations/persistent_notification/) and will fire the event `recorder_database_corrupt` if corruption is detected. You can use this event in your [automations](/docs/automation/trigger/#event-trigger) to perform custom actions when corruption is detected.
 
 ## Custom database engines
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Added that a persistent notification and event will be fire upon SQLite DB corruption being detected.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#131367](https://github.com/home-assistant/core/pull/131367)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new section in the recorder integration documentation for handling database corruption.
	- Added a persistent notification and a new event, `recorder_database_corrupt`, to improve error handling for SQLite users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->