### PR TITLE
Update mikrotik.markdown - group policy fix

### DIFF
--- a/source/_integrations/mikrotik.markdown
+++ b/source/_integrations/mikrotik.markdown
@@ -62,10 +62,10 @@ If everything is working fine you can disable the pure `api` service in RouterOS
 
 ## The user privileges in RouterOS
 
-To use this device tracker, you only need limited privileges. To enhance the security of your MikroTik device, create a "read only" user who can connect to API and perform ping test only:
+To use this device tracker, you only need limited privileges. To enhance the security of your MikroTik device, create a "read only" group with solely API and ping test permissions and add a user to that group:
 
 ```bash
-/user group add name=homeassistant policy=read,api,test,!local,!telnet,!ssh,!ftp,!reboot,!write,!policy,!winbox,!password,!web,!sniff,!sensitive,!romon,!dude,!tikapp
-/user add group=homeassistant name=homeassistant
-/user set password="YOUR_PASSWORD" homeassistant
+/user
+group add name=homeassistant policy=read,api,test
+add group=homeassistant name=homeassistant
 ```


### PR DESCRIPTION
My apologies for first creating an issue and afterwards finding out I could send a pull request. If I'm not following the right path, please correct me!

Resolves #35975

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

#35975

 The example given at "The user privileges in RouterOS" for setting the group's policy has and error.
There is no need to state, and is not possible anyway, what not to give access to (this would be bad design anyway. Policies should always be opt-in).
I do not know if this was required to do in older RouterOS versions, I'm running 7.16.1 currently.

So instead of:
/user group add name=homeassistant policy=read,api,test,!local,!telnet,!ssh,!ftp,!reboot,!write,!policy,!winbox,!password,!web,!sniff,!sensitive,!romon,!dude,!tikapp
The example should state:
/user group add name=homeassistant policy=read,api,test

Also, RouterOS (at least the version I am running) asks for a password when creating a new user.
Stating /user every command is also unnessecary.

The entire example can be shortened to:
/user
group add name=homeassistant policy=read,api,test
add group=homeassistant name=homeassistant

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #35975

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [?] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions for user privileges in RouterOS for the `mikrotik` integration.
	- Clarified the process for creating a "read only" group instead of a user.
	- Improved command syntax for adding users and groups for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->