### PR TITLE
Add information how to get exact street names for filtering to waze_travel_time

### DIFF
--- a/source/_integrations/waze_travel_time.markdown
+++ b/source/_integrations/waze_travel_time.markdown
@@ -22,7 +22,7 @@ Notes:
 
 - If a unit system is not specified, the {% term integration %} will use the unit system configured on your Home Assistant instance.
 - **Origin** and **Destination** can be the address or the GPS coordinates of the location. For coordinates, use the following format: `52.5200, 13.4050`. Make sure the coordinates are separated by a comma. They must not include letters. You can also enter an entity id which provides this information in its state, an entity id with latitude and longitude attributes, or zone friendly name (case sensitive).
-- The `incl_filter`/`excl_filter` allow you to force the {% term integration %} to use a particular route or avoid a particular route in its time travel calculation. These inputs must be an exact match to the street name including casing, spaces, and special characters.
+- The `incl_filter`/`excl_filter` allow you to force the {% term integration %} to use a particular route or avoid a particular route in its time travel calculation. These inputs must be an exact match to the street name including casing, spaces, and special characters. Use the service [`waze_travel_time.get_travel_times`](#action-waze_travel_timeget_travel_times) to get the exact street names for each route.
 - When using the `Avoid Toll Roads?`, `Avoid Subscription Roads?` and `Avoid Ferries?` options, be aware that Waze will sometimes still route you over toll roads or ferries if a valid vignette/subscription is assumed. Default behavior is that Waze will route you over roads having subscription options. It is therefor best is to set both `Avoid Toll Roads?` and `Avoid Subscription Roads?` or `Avoid Ferries?` if needed and experiment to ensure the desired outcome.
 
 ## Action `waze_travel_time.get_travel_times`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Reported issues such as [this comment](https://github.com/home-assistant/core/issues/119465#issuecomment-2503320894) show that users think that the value they see for `Route` in the attributes on the sensor are the ones they need to use for filters.
![image](https://github.com/user-attachments/assets/d45f4656-ec43-4c0d-990a-8293e8953df5)


To fix this we should:

1. Explain how to get the street names for filtering (this PR)
2. Remove the confusing route attribute (as was also done in here_travel_time)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified usage of `incl_filter` and `excl_filter` parameters for the Waze Travel Time integration.
	- Specified the use of `waze_travel_time.get_travel_times` service for obtaining exact street names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->