### PR TITLE
Add bronze to IQS section and sync naming with ha frontend

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -58,11 +58,11 @@
   
   {%- if page.ha_quality_scale %}
   <div class='section'>  
-    {% if page.ha_quality_scale == "silver" %}🥈 This is a great integration!<br />{%- endif -%}
-    {% if page.ha_quality_scale == "gold" %}🥇 This is a solid integration!<br />{%- endif -%}
-    {% if page.ha_quality_scale == "platinum" %}🏆 Best of the best!<br />{%- endif -%}
-    {% if page.ha_quality_scale == "internal" %}🏠 Under core!<br />{%- endif -%}
-    It scores {{page.ha_quality_scale}} on our <a href='/docs/quality_scale/'>quality scale</a>
+    {% if page.ha_quality_scale == "bronze" %}<a href='/docs/quality_scale/#-bronze'>🥉 Bronze quality</a><br />{%- endif -%}
+    {% if page.ha_quality_scale == "silver" %}<a href='/docs/quality_scale/#-silver'>🥈 Silver quality</a><br />{%- endif -%}
+    {% if page.ha_quality_scale == "gold" %}<a href='/docs/quality_scale/#-gold'>🥇 Gold quality</a><br />{%- endif -%}
+    {% if page.ha_quality_scale == "platinum" %}<a href='/docs/quality_scale/#-platinum'>🏆 Platinum quality</a><br />{%- endif -%}
+    {% if page.ha_quality_scale == "internal" %}<a href='/docs/quality_scale/#-internal'>🏠 Internal quality</a><br />{%- endif -%}
   </div>
   {%- endif -%}
   

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -64,7 +64,7 @@
     {% if page.ha_quality_scale == "platinum" %}<a href='/docs/quality_scale/#-platinum'>🏆 Platinum quality</a><br />{%- endif -%}
     {% if page.ha_quality_scale == "internal" %}<a href='/docs/quality_scale/#-internal'>🏠 Internal integration</a><br />{%- endif -%}
     {% if page.ha_quality_scale == "legacy" %}<a href='/docs/quality_scale/#-legacy'>💾 Legacy integration</a><br />{%- endif -%}
-    {% if page.ha_quality_scale == "custom" %}<a href='/docs/quality_scale/#-custom'>🏠 Custom integration</a><br />{%- endif -%}
+    {% if page.ha_quality_scale == "custom" %}<a href='/docs/quality_scale/#-custom'>📦 Custom integration</a><br />{%- endif -%}
   </div>
   {%- endif -%}
   

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -62,7 +62,9 @@
     {% if page.ha_quality_scale == "silver" %}<a href='/docs/quality_scale/#-silver'>🥈 Silver quality</a><br />{%- endif -%}
     {% if page.ha_quality_scale == "gold" %}<a href='/docs/quality_scale/#-gold'>🥇 Gold quality</a><br />{%- endif -%}
     {% if page.ha_quality_scale == "platinum" %}<a href='/docs/quality_scale/#-platinum'>🏆 Platinum quality</a><br />{%- endif -%}
-    {% if page.ha_quality_scale == "internal" %}<a href='/docs/quality_scale/#-internal'>🏠 Internal quality</a><br />{%- endif -%}
+    {% if page.ha_quality_scale == "internal" %}<a href='/docs/quality_scale/#-internal'>🏠 Internal integration</a><br />{%- endif -%}
+    {% if page.ha_quality_scale == "legacy" %}<a href='/docs/quality_scale/#-legacy'>💾 Legacy integration</a><br />{%- endif -%}
+    {% if page.ha_quality_scale == "custom" %}<a href='/docs/quality_scale/#-custom'>🏠 Custom integration</a><br />{%- endif -%}
   </div>
   {%- endif -%}
   


### PR DESCRIPTION
## Proposed change
- Integration: integration quality scale section:
  - add bronze option
  - Sync naming with frontend

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/frontend#23036

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the component navigation in the Home Assistant documentation by linking quality scale levels to their respective sections for improved clarity.
- **Bug Fixes**
	- Retained the logic for displaying active installations percentage, ensuring consistent functionality.
- **Documentation**
	- Updated the HTML template for better presentation of quality scale information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->