### PR TITLE
Remove extraneous backtick

### DIFF
--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -23,7 +23,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The `**VeSync** {% term integration %} enables you to control smart switches and outlets connected to the VeSync App.
+The **VeSync** {% term integration %} enables you to control smart switches and outlets connected to the VeSync App.
 
 The devices must be added to the VeSync App before this {% term integration %} can discover them.
 


### PR DESCRIPTION
## Proposed change
There is an extraneous backtick visible on this documentation page.


## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A, as this is a simple spot fix that seems to have been overlooked.


## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - **I made a change to the existing documentation and used the `current` branch.**
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated formatting in the VeSync integration documentation for improved clarity.
	- Retained all existing information regarding supported platforms and devices, ensuring users have comprehensive details on smart switches, outlets, and sensors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->