### PR TITLE
Link to min_version docs where it is referenced

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -1108,7 +1108,7 @@ blueprint:
 ## Merging lists of triggers
 
 {% caution %}
-This feature requires Home Assistant version 2024.10 or later. If using this in a blueprint, set the `min_version` for the blueprint to at least this version. See the [blueprint schema docuementation](/docs/blueprint/schema/#min_version) for more details.
+This feature requires Home Assistant version 2024.10 or later. If using this in a blueprint, set the `min_version` for the blueprint to at least this version. See the [blueprint schema documentation](/docs/blueprint/schema/#min_version) for more details.
 {% endcaution %}
 
 In some advanced cases (like for blueprints with trigger selectors), it may be necessary to insert a second list of triggers into the main trigger list. This can be done by adding a dictionary in the main trigger list with the sole key `triggers`, and the value for that key contains a second list of triggers. These will then be flattened into a single list of triggers. For example:

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -1108,7 +1108,7 @@ blueprint:
 ## Merging lists of triggers
 
 {% caution %}
-This feature requires Home Assistant version 2024.10 or later. If using this in a blueprint, set the `min_version` for the blueprint to at least this version.
+This feature requires Home Assistant version 2024.10 or later. If using this in a blueprint, set the `min_version` for the blueprint to at least this version. See the [blueprint schema docuementation](/docs/blueprint/schema/#min_version) for more details.
 {% endcaution %}
 
 In some advanced cases (like for blueprints with trigger selectors), it may be necessary to insert a second list of triggers into the main trigger list. This can be done by adding a dictionary in the main trigger list with the sole key `triggers`, and the value for that key contains a second list of triggers. These will then be flattened into a single list of triggers. For example:

--- a/source/_docs/blueprint/schema.markdown
+++ b/source/_docs/blueprint/schema.markdown
@@ -157,7 +157,7 @@ by their name; not by section and name.
 A section is differentiated from an input by the presence of an additional `input` key within that section. 
 
 {% caution %}
-Input sections are a new feature in version 2024.6.0. Set the `min_version` for the blueprint to at least this version if using input sections. Otherwise, the blueprint will generate errors on older versions.
+Input sections are a new feature in version 2024.6.0. Set the `min_version` for the blueprint to at least this version if using input sections. Otherwise, the blueprint will generate errors on older versions. See [this section](/docs/blueprint/schema/#min_version) for more details.
 {% endcaution %}
 
 The full configuration for a section is below:


### PR DESCRIPTION
## Proposed change
As a new blueprint author, I may not know how to use `min_version` that is recommended in the documentation.
Providing a direct link to the relevant schema documentation provides immediate clarity on what it is, how it works, etc...


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
None that I'm aware of. I found no references to this in the Issues.
I'm open to other wording ideas, please edit as you see fit.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  **- I made a change to the existing documentation and used the `current` branch.**
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and detail in the "Automation Trigger" document regarding various trigger types and their configuration.
	- Added YAML examples for different trigger types to aid user understanding.
	- Updated cautionary notes about version requirements for features in both the "Automation Trigger" and "Blueprint Schema" documents.
	- Improved formatting and added links for better usability and reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->