### PR TITLE
Further improve Plugwise documentation

### DIFF
--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -1,6 +1,6 @@
 ---
 title: Plugwise
-description: Plugwise Smile platform integration.
+description: Plugwise Gateway platform integration.
 ha_category:
   - Binary sensor
   - Button
@@ -34,7 +34,7 @@ ha_integration_type: hub
 
 ## Supported devices
 
-This integration supports Plugwise devices connected to a network connected hub called a **Smile**. You can connect to the Smile using your browser, their Plugwise App or this Home Assistant integration. There are 5 types of Smiles:
+This integration supports one or more of the Plugwise Gateways available on your network. You can connect to these gateways  using your browser, the Plugwise App, or this Home Assistant integration. There are 5 types of gateways:
 
 - Full zonecontrol using the [Adam](https://www.plugwise.com/en_US/zonecontrol) using [additional devices](#devices-overview) such as smart valves and smart-plugs.
 - A stand-alone smart thermostat called [Anna](https://www.plugwise.com/en_US/products/anna).
@@ -46,29 +46,29 @@ Plugwise formerly sold power-based products using a USB stick as the controller.
 
 ## Platforms
 
-Depending on your specific Smile and connected devices, the following platforms will be available:
+Depending on your specific gateway and connected devices, the following platforms will be available:
 
 - [Climate](#climate) for Adam and (a stand-alone) Anna.
 - [Binary Sensor](#binary-sensor) for status of your domestic hot water or secondary heater.
-- [Button](#button) to reboot your Smile.
+- [Button](#button) to reboot your Plugwise Gateway.
 - [Number](#number) to change a boiler setpoint or temperature offset.
-- [Sensor](#sensor) a variety of sensors is available for all Smiles.
+- [Sensor](#sensor) a variety of sensors is available for all gateways and connected devices..
 - [Select](#select) to change your thermostat schedule or regulation mode.
 - [Switch](#switch) allowing plugs to be commanded.
 
 ## Pre-requisites
 
-The Plugwise Smile(s) in your network will be automatically discovered and shown on the integrations dashboard. You will need the Smile ID, which serves as its password. You can find this 8-character string printed on the sticker on the bottom of your Smile. Repeat this for each individual Smile.
+The Plugwise Gateway(s) in your network will be automatically discovered and shown on the integrations dashboard. You will need the ID, which serves as its password. You can find this 8-character string printed on the sticker on the bottom of your gateway. Repeat this for each individual gateway..
 
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}
 Host:
-  description: "The hostname or IP address of your Smile. For example: `192.168.1.25`. You can find it in your router or in the Plugwise app using the **Settings** icon (&#9776;) -> **System** -> **Network**. If you are looking for a different device in the Plugwise App, first select **Gateways** on the main screen, choose the Smile of your choice, and then follow the previous instructions. Normally, the Smile(s) are automatically discovered, and you don't have to provide the hostname or IP address."
+  description: "The hostname or IP address of your Gateway. For example: `192.168.1.25`. You can find it in your router or in the Plugwise app using the **Settings** icon (&#9776;) -> **System** -> **Network**. If you are looking for a different device in the Plugwise App, first select **Gateways** on the main screen, choose the Gateway of your choice, and then follow the previous instructions. Normally, the Gateway(s) are automatically discovered, and you don't have to provide the hostname or IP address."
 Username:
-  description: "Username to log in to the Smile. This should be `smile` for most devices, or `stretch` for a Stretch."
+  description: "Username to log in to the Gateway. This should be `smile` for most devices, or `stretch` for a Stretch."
 Password:
-  description: "This is the password (i.e., Smile ID) printed on the sticker on the back of your Smile (e.g., Adam, Smile-T, or P1) and should be 8 characters long."
+  description: "This is the password (i.e., ID) printed on the sticker on the back of your Gateway (e.g., Adam, Smile-T, or P1) and should be 8 characters long."
 {% endconfiguration_basic %}
 
 ### Further configuration
@@ -79,7 +79,7 @@ Auto means the schedule is active, and Heat means it's not active. The active th
 
 ## Data updates
 
-The interval at which the integration fetches data from the Smile depends on the device-type.
+The interval at which the integration fetches data from the gateway depends on the device-type.
 
 |Device-type|Interval|
 --- | ---
@@ -89,9 +89,9 @@ The interval at which the integration fetches data from the Smile depends on the
 
 ## Entities
 
-This integration will show all Plugwise devices (such as hardware devices, multi-thermostat climate-zones, and virtual switchgroups) present in your Plugwise configuration. In addition, you will see a Gateway device representing your central Plugwise gateway (i.e., the Adam, Smile Anna, Smile P1 or Stretch).
+This integration will show all Plugwise devices (such as hardware devices, multi-thermostat climate-zones, and virtual switchgroups) present in your Plugwise configuration. In addition, you will see a device representing your Plugwise Gateway (i.e., the Adam, Smile Anna, Smile P1 or Stretch).
 
-For example, if you have an Adam setup with a Lisa named `Living` and a Tom named `Bathroom`, these will show up as individual devices. The heating/cooling device connected to your Smile will be shown as `OpenTherm` or `OnOff`, depending on how the Smile communicates with the device. If you have Plugs (as in, pluggable switches connecting to an Adam) or Aqara Smart Plugs those will be shown as devices as well.
+For example, if you have an Adam setup with a Lisa named `Living` and a Tom named `Bathroom`, these will show up as individual devices. The heating/cooling device connected to your gateway will be shown as `OpenTherm` or `OnOff`, depending on how the gateway communicates with the device. If you have Plugs (as in, pluggable switches connecting to an Adam) or Aqara Smart Plugs those will be shown as devices as well.
 
 Under each device there will be entities shown such as `binary_sensors`, `sensors`, etc. depending on the capabilities of the device: for instance centralized measurements such as `power` for a P1, `outdoor_temperature` on Anna or Adam will be assigned to your gateway device. Heating/cooling device measurements such as `boiler_temperature` will be assigned to the OpenTherm/OnOff device.
 
@@ -99,7 +99,7 @@ Under each device there will be entities shown such as `binary_sensors`, `sensor
 
 ### Climate
 
-The [climate entity](/integrations/climate) is displayed for each zone that includes a thermostat. This can be any supported thermostat, such as the standalone Anna. For Adam, it represents each user-defined climate zone that contains the necessary devices, such as an Anna, a wired thermostat, or a combination of Jip or Lisa with one or more Tom/Floor devices.
+The [climate entity](/integrations/climate) is displayed for each zone that includes a thermostat. This can be any supported single thermostat such as the Anna or another type of wired-thermostat, Jip or Lisa combined with one or more Tom/Floor devices. Or a combination of for instance a Lisa, two Jips and several Toms in one large zone.
 
 #### Setting the HVAC mode
 
@@ -156,9 +156,9 @@ actions:
 mode: single
 ```
 
-#### Update Smile data
+#### Update gateway data
 
-Forced update of data from your Smile can be triggered by calling the generic `homeassistant.update_entity` action with your Smile entity as the target.
+Forced update of data from your gateway  can be triggered by calling the generic `homeassistant.update_entity` action.
 
 ```yaml
 # Example script to retreive the latest living room temperature measurement
@@ -224,7 +224,7 @@ Depending on your setup, a [binary sensor](/integrations/binary_sensor) will pro
 
 ### Button
 
-For each Smile a [button](/integrations/button) is added to enable a restart (reboot) of the Smile.
+For each gateway a [button](/integrations/button) is added to trigger a restart (reboot) of physical device.
 
 ### Number
 
@@ -300,18 +300,18 @@ Allows commanding [switches](/integrations/switch), e.g. `on`/`off` for Plugs or
 
 #### Accessing the local device
 
-If you need to configure the Smile directly, without using the Plugwise App, you can find the link to your device by:
+If you need to configure the gateway directly, without using the Plugwise App, you can find the link to your device by:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
-2. If you have more than one Plugwise Smile, select the one to configure.
-3. Select the device with 'Smile' in its name.
+2. If you have more than one Plugwise Gateway, select the one to configure.
+3. Select the gateway device, this should be called `Adam` or contain `Smile` in its name.
 4. On the integration entry, choose to open the configuration URL left of the {% icon "mdi:dots-vertical" %} icon.
-5. A new window/tab will open, enter `smile` (or `stretch`) as the username and your Smile ID as the password.
+5. A new window/tab will open, enter `smile` (or `stretch`) as the username and the ID, from the sticker on the back, as the password.
 6. Consult the manual or click the `search` button on the [Plugwise Support](https://plugwise.com/support/) page for interactive help.
 
-#### Modify the Smile update interval
+#### Adjusting the update interval
 
-Please note that the [default intervals](#data-updates) are considered best practice and according to how Plugwise normally updates their data. Updating too frequently may induce considerable load on your Smile resulting in unexpected results.
+Please note that the [default intervals](#data-updates) are considered best practice and according to how Plugwise normally updates their data. Updating too frequently may induce considerable load on your gateway(s) resulting in unexpected results or .
 
 {% include common-tasks/define_custom_polling.md %}
 
@@ -320,19 +320,19 @@ Please note that the [default intervals](#data-updates) are considered best prac
 If you need to create an issue to report a bug or want to inspect diagnostic data, use the below method to retrieve diagnostics:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
-2. If you have more than one Plugwise Smile, select the gateway that is experiencing issues.
-3. Select the device with 'Smile' in its name.
+2. If you have more than one Plugwise Gateway, select the gateway that is experiencing issues.
+3. Select the gateway device, this should be called `Adam` or contain `Smile` in its name.
 4. On the integration entry, select the {% icon "mdi:dots-vertical" %}.
    - Then, select **Download diagnostics** and a JSON file will be downloaded.
 5. You can inspect the downloaded file or, when requested, upload it to your issue report.
 
-#### Rebooting your Smile
+#### Rebooting your gateway
 
-For each Smile there will be a reboot [button](#button) available in your integration.
+For each gateway there will be a reboot [button](#button) available in your integration.
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
 2. If you have more than one Plugwise Smile, select the gateway that is experiencing issues.
-3. Select the device with 'Smile' in its name.
+3. Select the gateway device, this should be called `Adam` or contain `Smile` in its name.
 4. On the integration entry, look for the `Reboot` button to press in the **Configuration** section.
 
 ## Devices overview

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -250,17 +250,18 @@ script:
 
 ### Sensor
 
-A number of [sensors](/integrations/sensor) will be available, included but not limited to the examples shown below. By default, not all sensors will be shown, for example; we disable the Anna's `outdoor_temperature` sensor in favor of the one provided by an auxiliary device if it has one.
+A number of [sensors](/integrations/sensor) will be available, included but not limited to the examples shown below.
 
 Example sensors (not extensive):
 
 |Sensor|Description|
 --- | ---
-|Outdoor temperature | For Anna, this will show the temperature it retrieves from the internet, unless you have an auxiliary device with a temperature sensor |
+|Gas Consumed Interval | The gas consumed since the last interval |
 |Indoor temperature | For Anna, Lisa or Jip this will show the temperature measured at the specific thermostat |
+|Outdoor temperature | The temperature your climate gateway retrieves online |
+|Outdoor air temperature |  If you have an auxiliary device with a temperature sensor |
 |P1 Net Electricity Point | Your netto electricity use at this time, can be negative when producing energy, i.e. though solar panels |
 |P1 Electricity Produced off-peak cumulative | The total produced electricity during off-peak |
-|Gas Consumed Interval | The gas consumed since the last interval |
 
 ### Select
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -40,7 +40,7 @@ This integration supports Plugwise devices connected to a network connected hub 
 - A stand-alone smart thermostat called [Anna](https://www.plugwise.com/en_US/products/anna).
 - For power monitoring there is a device simply called the [P1](https://www.plugwise.com/en_US/products/smile-p1).
 - Although no longer sold, there also is support for Stretch, a gateway to create network connectivity for their older power products.
-- **Not supported yet!** The newest in the family, [Anna P1](https://www.plugwise.com/product/anna-p1/) cleverly uses energy (solar) information to transfer abundant energy in heatpump usage.
+- **Not supported yet!** The newest in the family, [Anna P1](https://www.plugwise.com/product/anna-p1/) cleverly uses energy (solar) information to transfer abundant energy in heatpump usage. [Contact us](#anna-p1) if you have one!
 
 Plugwise formerly sold power-based products using a USB stick as the controller. This integration does not support the `Stick` directly, see [legacy power devices](#legacy-power-devices) for more information.
 
@@ -58,17 +58,17 @@ Depending on your specific Smile and connected devices, the following platforms 
 
 ## Pre-requisites
 
-The Plugwise Smile(s) in your network will be automatically discovered and shown on the integrations dashboard. All you need is the Smile ID as its password, which is an 8-character string printed on the sticker on the bottom of your Smile. Repeat this for each individual Smile.
+The Plugwise Smile(s) in your network will be automatically discovered and shown on the integrations dashboard. You will need the Smile ID, which serves as its password. You can find thi 8-character string printed on the sticker on the bottom of your Smile. Repeat this for each individual Smile.
 
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}
 Host:
-  description: "The hostname or IP address of your Smile. For example: `192.168.1.25`. You can find it in your router or in the Plugwise app using the **Settings** icon (&#9776;) -> **System** -> **Network**. If you are looking for a different device in the Plugwise App, on the main screen first select **Gateways** -> the Smile of your choice, and then follow the previous instruction. Normally, the Smile(s) are automatically discovered, and you don't have to provide the hostname or IP address."
+  description: "The hostname or IP address of your Smile. For example: `192.168.1.25`. You can find it in your router or in the Plugwise app using the **Settings** icon (&#9776;) -> **System** -> **Network**. If you are looking for a different device in the Plugwise App, first select **Gateways** on the main screen, choose the Smile of your choice, and then follow the previous instructions. Normally, the Smile(s) are automatically discovered, and you don't have to provide the hostname or IP address."
 Username:
-  description: "Username to log in to the Smile. This should be just `smile` - or `stretch` for a Stretch."
+  description: "Username to log in to the Smile. This should be `smile` for most devices, or `stretch` for a Stretch."
 Password:
-  description: "This is the password (i.e. Smile ID) printed on the sticker on the back of your Smile (i.e. Adam, Smile-T, or P1) and should be 8 characters long."
+  description: "This is the password (i.e., Smile ID) printed on the sticker on the back of your Smile (e.g., Adam, Smile-T, or P1) and should be 8 characters long."
 {% endconfiguration_basic %}
 
 ### Further configuration
@@ -79,7 +79,7 @@ Auto means the schedule is active, and Heat means it's not active. The active th
 
 ## Data updates
 
-The interval which the integration fetches data from the Smile depends on the device-type.
+The interval at which the integration fetches data from the Smile depends on the device-type.
 
 |Device-type|Interval|
 --- | ---
@@ -89,11 +89,11 @@ The interval which the integration fetches data from the Smile depends on the de
 
 ## Entities
 
-This integration will show all Plugwise devices (like hardware devices, multi-thermostat climate-zones, and virtual switchgroups) present in your Plugwise configuration. In addition, you will see a Gateway device representing your central Plugwise gateway (i.e., the Adam, Smile Anna, Smile P1 or Stretch).
+This integration will show all Plugwise devices (such as hardware devices, multi-thermostat climate-zones, and virtual switchgroups) present in your Plugwise configuration. In addition, you will see a Gateway device representing your central Plugwise gateway (i.e., the Adam, Smile Anna, Smile P1 or Stretch).
 
 For example, if you have an Adam setup with a Lisa named `Living` and a Tom named `Bathroom`, these will show up as individual devices. The heating/cooling device connected to your Smile will be shown as `OpenTherm` or `OnOff`, depending on how the Smile communicates with the device. If you have Plugs (as in, pluggable switches connecting to an Adam) or Aqara Smart Plugs those will be shown as devices as well.
 
-Under each device there will be entities shown like `binary_sensors`, `sensors`, etc. depending on the capabilities of the device: for instance centralized measurements such as `power` for a P1, `outdoor_temperature` on Anna or Adam will be assigned to your gateway device. Heating/cooling device measurements such as `boiler_temperature` will be assigned to the OpenTherm/OnOff device.
+Under each device there will be entities shown such as `binary_sensors`, `sensors`, etc. depending on the capabilities of the device: for instance centralized measurements such as `power` for a P1, `outdoor_temperature` on Anna or Adam will be assigned to your gateway device. Heating/cooling device measurements such as `boiler_temperature` will be assigned to the OpenTherm/OnOff device.
 
 ## Platform information
 
@@ -137,16 +137,23 @@ action: `climate.turn_off`, `climate.turn_on` (Adam only)
 These actions will switch the Adam regulation mode (= HVAC system mode) to off or on, affecting the operation of all connected thermostats.
 `climate.turn_on` will activate the previously selected heating or cooling mode.
 
-Example:
+Automation example:
 
 ```yaml
-# Example script climate.turn_off in the cinema
-script:
-  turn_heating_on:
-    sequence:
-      - action: climate.turn_off
-        target:
-          entity_id: climate.cinema
+# Example automation using climate.turn_off for your cinema room
+alias: Stop climate in cinema after movie
+description: "Automatically turn off climate when the movie ends."
+triggers:
+  - trigger: state
+    entity_id:
+      - media_player.cinema
+    attribute: sound_mode
+    from: Movie
+actions:
+  - action: homeassistant.turn_off
+    target:
+      entity_id: climate.cinema
+mode: single
 ```
 
 #### Update Smile data
@@ -154,7 +161,7 @@ script:
 Forced update of data from your Smile can be triggered by calling the generic `homeassistant.update_entity` action with your Smile entity as the target.
 
 ```yaml
-# Example script change the living room temperature
+# Example script to retreive the latest living room temperature measurement
 script:
   force_adam_update:
     sequence:
@@ -170,7 +177,7 @@ action: `climate.set_temperature`
 Example:
 
 ```yaml
-# Example script change the temperature
+# Example script to change the temperature
 script:
   anna_set_predefined_temperature:
     sequence:
@@ -187,16 +194,28 @@ action: `climate.set_preset_mode`
 
 Available options include: `home`, `vacation` (Anna only), `no_frost`, `asleep` & `away`.
 
-Example:
+Automation example:
 
 ```yaml
-# Example script changing the active (or currently set by schedule) preset
-script:
-  anna_activate_preset_asleep:
-    sequence:
-      - action: climate.set_preset_mode
-        data:
-          preset_mode: asleep
+# Example automation  changing the active (or currently set by schedule) preset
+alias: Set climate to away when nobody is home
+description: "Set climate to away when everyone is gone for considerable time"
+triggers:
+  - trigger: state
+    entity_id:
+      - person.mom
+      - sensor.dad
+    to: not_home
+    for:
+      hours: 0
+      minutes: 15
+      seconds: 0
+actions:
+  - action: climate.set_preset_mode
+    data:
+      preset_mode: away
+    target:
+      entity_id: climate.anna
 ```
 
 ### Binary Sensor
@@ -218,7 +237,7 @@ Examples include the boiler setpoint as shown below and adjusting your temperatu
 action: `number.set_value`
 
 ```yaml
-# Example script change the boiler setpoint
+# Example script to change the boiler setpoint
 script:
   change_max_boiler_tempeture_setpoint:
     sequence:
@@ -253,16 +272,24 @@ Schedules can be created using the Plugwise App or the web-interface.
 
 action: `select.select_option`
 
+Assuming you have something to indicate your current day of night shift based on a calendar you can automatically change the active schedule. The automation example below assumes an (`input_select`)[/integrations/input_select/] helper is present, e.g., containing something like `Day shift`, `Night shift` and `Weekend shift`). Assuming you have created the appropriate schedules using your Plugwise App, your automation for night shifts could look like:
+
 ```yaml
-# Example script change the thermostat schedule in the cinema
-script:
-  lisa_change_schedule:
-    sequence:
-      - action: select.select_option
-        target:
-          entity_id: select.cinema_thermostat_schedule
-        data:
-          option: "Cosy"
+# Example automation change the thermostate schedule based on your shift
+alias: Change schedule according to active shift
+description: "Select the appropriate schedule for todays shift"
+triggers:
+  - trigger: state
+    entity_id:
+      - input_select.shift
+    to: Night shift
+actions:
+  - action: select.select_option
+    data:
+      option: Nightshift
+    target:
+      entity_id: select.anna_thermostat_schedule
+mode: single
 ```
 
 ### Switch
@@ -297,19 +324,14 @@ If you need to create an issue to report a bug or want to inspect diagnostic dat
    - Then, select **Download diagnostics** and a JSON file will be downloaded.
 5. You can inspect the downloaded file or, when requested, upload it to your issue report.
 
-#### Adding a Smile reboot button
+#### Rebooting your Smile
 
-action: `button.press`
+For each Smile there will be a reboot (button)[#button] available in your integration.
 
-```yaml
-# Example script to reboot the gateway
-script:
-  reboot_gateway:
-    sequence:
-      - action: button.press
-        target:
-          entity_id: button.adam_reboot
-```
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
+2. If you have more than one Plugwise Smile, select the gateway that is experiencing issues.
+3. Select the device with 'Smile' in its name.
+4. On the integration entry, look for the `Reboot` button to press in the **Configuration** section 
 
 ## Devices overview
 
@@ -325,7 +347,7 @@ A complete zone control system also known as Adam HA, supporting:
   - Zone thermostats such as Lisa or Anna (see warning below on Anna),
   - A temperature sensor, Jip,
   - Valve controllers called Floor or Tom,
-  - An under-floor heating controller Koen (always comes with a Plug as the active part),
+  - An under-floor heating controller Koen (note: a Koen always comes with a Plug, which is the active part),
   - Smart switches, either Plug or Aqara Smart Plug.
 
 ### Anna
@@ -361,8 +383,20 @@ If you are using your Anna as part of your adam zone control system, it cannot b
 
 ### Anna with Elga
 
-The cooling mode can only be toggled via a physical switch on the device (not through the Plugwise App).
-After changing the cooling mode switch position, you must reload the Plugwise integration for the changes to take effect.
+The cooling mode can only be toggled via a **physical switch** on the device (not through a toggle in the Plugwise App or using Home Assistant).
+
+Please **reload** the Plugwise integration after changing the cooling mode switch to ensure the integration adapts to the change:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
+2. On the "**Hubs**" page, use the {% icon "mdi:dots-vertical" %} icon next to your Anna and choose "**Reload**""
+
+### Vacation preset
+
+The `vacation` preset is only available on an Anna.
+
+### Idling climate actions
+
+You can only stop climate actions on an Adam, see (Turn on / Turn off)[#turn-on--turn-off]. An alternative could be to adjust your (preset mode)[#set-preset-mode] to `no_frost` to stop any heating actions.
 
 ### Legacy power devices
 
@@ -370,9 +404,9 @@ Plugwise formerly sold Power based products comprised of a USB stick and smart p
 
 ## Removing the integration
 
-This integration follows standard integration removal. No extra steps are required within Home Assistant or on your Plugwise devices.
+This integration follows the standard removal procedss. No extra steps are required within Home Assistant, the Plugwise App or any other Plugwise devices.
 
 {% include integrations/remove_device_service.md %}
 
-This will also remove all connected Adam devices (such as Anna, Tom or Lisa) or connected Adam/Stretch plugs.
+This will also remove all connected Adam devices (such as Anna, Tom, or Lisa) and connected Adam/Stretch plugs.
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -34,12 +34,13 @@ ha_integration_type: hub
 
 ## Supported devices
 
-This integration supports Plugwise devices connected to a network connected hub called a **Smile**. You can connect to the Smile using your browser, their Plugwise App or this Home Assistant integration. There are 4 types of Smiles:
+This integration supports Plugwise devices connected to a network connected hub called a **Smile**. You can connect to the Smile using your browser, their Plugwise App or this Home Assistant integration. There are 5 types of Smiles:
 
 - Full zonecontrol using the [Adam](https://www.plugwise.com/en_US/zonecontrol) using [additional devices](#devices-overview) such as smart valves and smart-plugs.
 - A stand-alone smart thermostat called [Anna](https://www.plugwise.com/en_US/products/anna).
 - For power monitoring there is one simply called the [P1](https://www.plugwise.com/en_US/products/smile-p1).
 - Although no longer sold, there also is support for Stretch, a gateway to create network connectivity for their older power products.
+- __Not supported yet__: The newest in the family, [Anna P1](https://www.plugwise.com/product/anna-p1/) cleverly uses energy (solar) information to transfer abundant energy in heatpump usage.
 
 Plugwise formerly sold power based products using a USB stick as the controller. This integration does not support the `Stick` directly, see [legacy power devices](#legacy-power-devices) for more information.
 
@@ -334,6 +335,10 @@ A smart thermostat, supporting:
 
 - OnOff, OpenTherm heating and Elga or Loria/Thermastage with heating and cooling support. (see [known limitations](#known-limitations) below for the Elga).
 - Running firmware v4.x, v3.x or v1.x.
+
+### Anna P1
+
+A smart thermostat, providing abundant solar energy billing. Currently not supported. If you have one, let us know by opening a [feature request](https://github.com/plugwise/python-plugwise/issues/new/choose).
 
 ### P1 (DSMR)
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -30,11 +30,11 @@ ha_platforms:
 ha_integration_type: hub
 ---
 
-[Plugwise](https://www.plugwise.com) provides smart home climate and power monitoring devices. This integation allows you to monitor and control your climate and energy (including gas) consumption and energy production. The energy information can be used for the [energy dashboard](/home-energy-management).
+[Plugwise](https://www.plugwise.com) provides smart home climate and power monitoring devices. This integration allows you to monitor and control your climate and energy (including gas) consumption and energy production. The energy information can be used for the [energy dashboard](/home-energy-management).
 
 ## Supported devices
 
-This integration supports one or more of the Plugwise Gateways available on your network. You can connect to these gateways  using your browser, the Plugwise App, or this Home Assistant integration. There are 5 types of gateways:
+This integration supports one or more of the Plugwise Gateways available on your network. You can connect to these gateways using your browser, the Plugwise App, or this Home Assistant integration. There are 5 types of gateways:
 
 - Full zonecontrol using the [Adam](https://www.plugwise.com/en_US/zonecontrol) using [additional devices](#devices-overview) such as smart valves and smart-plugs.
 - A stand-alone smart thermostat called [Anna](https://www.plugwise.com/en_US/products/anna).
@@ -52,30 +52,30 @@ Depending on your specific gateway and connected devices, the following platform
 - [Binary Sensor](#binary-sensor) for status of your domestic hot water or secondary heater.
 - [Button](#button) to reboot your Plugwise Gateway.
 - [Number](#number) to change a boiler setpoint or temperature offset.
-- [Sensor](#sensor) a variety of sensors is available for all gateways and connected devices..
+- [Sensor](#sensor) a variety of sensors is available for all gateways and connected devices.
 - [Select](#select) to change your thermostat schedule or regulation mode.
 - [Switch](#switch) allowing plugs to be commanded.
 
 ## Pre-requisites
 
-The Plugwise Gateway(s) in your network will be automatically discovered and shown on the integrations dashboard. You will need the ID, which serves as its password. You can find this 8-character string printed on the sticker on the bottom of your gateway. Repeat this for each individual gateway..
+Plugwise gateways on your network are automatically discovered and displayed on the integrations dashboard. Each gateway requires its unique 8-character ID, found on a sticker at the bottom, as its password. Repeat this process for each gateway.
 
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}
 Host:
-  description: "The hostname or IP address of your Gateway. For example: `192.168.1.25`. You can find it in your router or in the Plugwise app using the **Settings** icon (&#9776;) -> **System** -> **Network**. If you are looking for a different device in the Plugwise App, first select **Gateways** on the main screen, choose the Gateway of your choice, and then follow the previous instructions. Normally, the Gateway(s) are automatically discovered, and you don't have to provide the hostname or IP address."
+  description: "The hostname or IP address of your Gateway. For example: `192.168.1.25`. You can find it in your router or in the Plugwise app using the **Settings** icon (&#9776;) -> **System** -> **Network**. In the Plugwise App, to locate a specific device, select **Gateways** on the main screen, choose your desired gateway, and then follow the previous instructions. Normally, the Gateway(s) are automatically discovered, and you don't have to provide the hostname or IP address."
 Username:
   description: "Username to log in to the Gateway. This should be `smile` for most devices, or `stretch` for a Stretch."
 Password:
-  description: "This is the password (i.e., ID) printed on the sticker on the back of your Gateway (e.g., Adam, Smile-T, or P1) and should be 8 characters long."
+  description: "Each gateway requires its unique 8-character ID, found on a sticker at the bottom, as its password."
 {% endconfiguration_basic %}
 
 ### Further configuration
 
-For a thermostat, the active schedule can be deactivated or reactivated via the climate card. Please note, that when no schedule is active, one must first be activated in the Plugwise App. Once that has been done, the Plugwise Integration can manage future operations.
+For a thermostat, the active schedule can be deactivated or reactivated via the climate card. Note: If no schedule is active, activate one first in the Plugwise App. Once that has been done, the Plugwise Integration can manage future operations.
 
-Auto means the schedule is active, and Heat means it's not active. The active thermostat schedule can be changed via the connected thermostat select entity. Please note that only schedules with two or more schedule points will be shown as select options.
+In this context, `Auto` indicates the schedule is active, while `Heat` signifies it is inactive. The active thermostat schedule can be changed via the connected thermostat select entity. Please note that only schedules with two or more schedule points will be shown as select options.
 
 ## Data updates
 
@@ -89,11 +89,11 @@ The interval at which the integration fetches data from the gateway depends on t
 
 ## Entities
 
-This integration will show all Plugwise devices (such as hardware devices, multi-thermostat climate-zones, and virtual switchgroups) present in your Plugwise configuration. In addition, you will see a device representing your Plugwise Gateway (i.e., the Adam, Smile Anna, Smile P1 or Stretch).
+This integration displays all Plugwise devices in your configuration, including hardware devices, multi-thermostat climate zones, and virtual switch groups. Additionally, a device representing your Plugwise gateway (e.g., Adam, Smile-T, or P1) will be visible.
 
 For example, if you have an Adam setup with a Lisa named `Living` and a Tom named `Bathroom`, these will show up as individual devices. The heating/cooling device connected to your gateway will be shown as `OpenTherm` or `OnOff`, depending on how the gateway communicates with the device. If you have Plugs (as in, pluggable switches connecting to an Adam) or Aqara Smart Plugs those will be shown as devices as well.
 
-Under each device there will be entities shown such as `binary_sensors`, `sensors`, etc. depending on the capabilities of the device: for instance centralized measurements such as `power` for a P1, `outdoor_temperature` on Anna or Adam will be assigned to your gateway device. Heating/cooling device measurements such as `boiler_temperature` will be assigned to the OpenTherm/OnOff device.
+Each device will list entities such as `binary sensors`, `sensors`, etc., depending on its capabilities: for instance centralized measurements such as `power` for a P1, `outdoor_temperature` on Anna or Adam will be assigned to your gateway device. Heating/cooling device measurements such as `boiler_temperature` will be assigned to the OpenTherm/OnOff device.
 
 ## Platform information
 
@@ -109,10 +109,10 @@ Available options include `off` (Adam only) `auto`, `cool`, `heat`, and `heat_co
 
 |HVAC mode|Indication|Description|
 --- | --- | ---
-|`off`| Adam regulation is set to off | The connected HVAC-system does not heat or cool, only the domestic hot water heating function, if available, is active. |
+|`auto` | Active schedule | The thermostat will change presets/setpoints accordingly. |
 |`cool` or `heat`| No active schedule | If the system is **manually** set to cooling- or heating-mode, the system will be active if the room temperature is above/below the thermostat setpoint. |
-|`heat/cool`| No active schedule | If the system is in **automatic** cooling- or heating-mode, the active preset or manually set temperature is used to control the HVAC system. |
-|`auto` | Active schedule |  The thermostat will change presets/setpoints accordingly. |
+|`heat_cool`| No active schedule | If the system is in **automatic** cooling- or heating-mode, the active preset or manually set temperature is used to control the HVAC system. |
+|`off`| Adam regulation is set to off | The connected HVAC-system does not heat or cool, only the domestic hot water heating function, if available, is active. |
 
 The last schedule that was active is determined the same way long-tapping the top of Anna works.
 
@@ -158,7 +158,7 @@ mode: single
 
 #### Update gateway data
 
-Forced update of data from your gateway  can be triggered by calling the generic `homeassistant.update_entity` action.
+Forced update of data from your gateway can be triggered by calling the generic `homeassistant.update_entity` action.
 
 ```yaml
 # Example script to retreive the latest living room temperature measurement
@@ -197,7 +197,7 @@ Available options include: `home`, `vacation` (Anna only), `no_frost`, `asleep` 
 Automation example:
 
 ```yaml
-# Example automation  changing the active (or currently set by schedule) preset
+# Example automation changing the active (or currently set by schedule) preset
 alias: Set climate to away when nobody is home
 description: "Set climate to away when everyone is gone for considerable time"
 triggers:
@@ -311,7 +311,7 @@ If you need to configure the gateway directly, without using the Plugwise App, y
 
 #### Adjusting the update interval
 
-Please note that the [default intervals](#data-updates) are considered best practice and according to how Plugwise normally updates their data. Updating too frequently may induce considerable load on your gateway(s) resulting in unexpected results or .
+Please note that the [default intervals](#data-updates) are considered best practice and according to how Plugwise normally updates their data. Updating too frequently may induce considerable load on your gateway(s) resulting in unexpected results or missing data.
 
 {% include common-tasks/define_custom_polling.md %}
 
@@ -402,13 +402,13 @@ You can only stop climate actions on an Adam, see [Turn on / Turn off](#turn-on-
 
 ### Legacy power devices
 
-Plugwise formerly sold Power based products comprised of a USB stick and smart plugs (amongst a few other items). This integration does **not** support the USB-stick. Reuse of the these products, such as Circles and Stealths using a Stretch or an Adam is supported. Work for USB support is in development by the community but not ready to become a formal Home Assistant integration just yet.
+Plugwise formerly sold power-based products comprised of a USB stick and smart plugs (amongst a few other items). This integration does **not** support the USB-stick. Reuse of the these products, such as Circles and Stealths using a Stretch or an Adam is supported. Work for USB support is in development by the community, but not ready to become a formal Home Assistant integration just yet.
 
 ## Removing the integration
 
-This integration follows the standard removal procedss. No extra steps are required within Home Assistant, the Plugwise App or any other Plugwise devices.
+This integration adheres to the standard removal process. No extra steps are required within Home Assistant, the Plugwise App or any other Plugwise devices.
 
 {% include integrations/remove_device_service.md %}
 
-This will also remove all connected Adam devices (such as Anna, Tom, or Lisa) and connected Adam/Stretch plugs.
+This will also remove, from Home Assistant, any connected Adam devices (such as Anna, Tom, or Lisa) and connected Adam/Stretch plugs.
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -58,7 +58,7 @@ Depending on your specific Smile and connected devices, the following platforms 
 
 ## Pre-requisites
 
-The Plugwise Smile(s) in your network will be automatically discovered and shown on the integrations dashboard. You will need the Smile ID, which serves as its password. You can find thi 8-character string printed on the sticker on the bottom of your Smile. Repeat this for each individual Smile.
+The Plugwise Smile(s) in your network will be automatically discovered and shown on the integrations dashboard. You will need the Smile ID, which serves as its password. You can find this 8-character string printed on the sticker on the bottom of your Smile. Repeat this for each individual Smile.
 
 {% include integrations/config_flow.md %}
 
@@ -99,7 +99,7 @@ Under each device there will be entities shown such as `binary_sensors`, `sensor
 
 ### Climate
 
-The [climate entity](/integrations/climate) is shown for each zone containing a thermostat. This can be any supported themostat such as the Anna or another type of wired-thermostat, Jip or Lisa combined with one or more Tom/Floor devices.
+The [climate entity](/integrations/climate) is displayed for each zone that includes a thermostat. This can be any supported thermostat, such as the standalone Anna. For Adam, it represents each user-defined climate zone that contains the necessary devices, such as an Anna, a wired thermostat, or a combination of Jip or Lisa with one or more Tom/Floor devices.
 
 #### Setting the HVAC mode
 
@@ -272,7 +272,7 @@ Schedules can be created using the Plugwise App or the web-interface.
 
 action: `select.select_option`
 
-Assuming you have something to indicate your current day of night shift based on a calendar you can automatically change the active schedule. The automation example below assumes an (`input_select`)[/integrations/input_select/] helper is present, e.g., containing something like `Day shift`, `Night shift` and `Weekend shift`). Assuming you have created the appropriate schedules using your Plugwise App, your automation for night shifts could look like:
+Assuming you have something to indicate your current day of night shift based on a calendar you can automatically change the active schedule. The automation example below assumes an [`input_select`](/integrations/input_select/) helper is present, e.g., containing something like `Day shift`, `Night shift` and `Weekend shift`). Assuming you have created the appropriate schedules using your Plugwise App, your automation for night shifts could look like:
 
 ```yaml
 # Example automation change the thermostate schedule based on your shift
@@ -311,6 +311,8 @@ If you need to configure the Smile directly, without using the Plugwise App, you
 
 #### Modify the Smile update interval
 
+Please note that the [default intervals](#data-updates) are considered best practice and according to how Plugwise normally updates their data. Updating too frequently may induce considerable load on your Smile resulting in unexpected results.
+
 {% include common-tasks/define_custom_polling.md %}
 
 #### Diagnostic data
@@ -326,12 +328,12 @@ If you need to create an issue to report a bug or want to inspect diagnostic dat
 
 #### Rebooting your Smile
 
-For each Smile there will be a reboot (button)[#button] available in your integration.
+For each Smile there will be a reboot [button](#button) available in your integration.
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
 2. If you have more than one Plugwise Smile, select the gateway that is experiencing issues.
 3. Select the device with 'Smile' in its name.
-4. On the integration entry, look for the `Reboot` button to press in the **Configuration** section 
+4. On the integration entry, look for the `Reboot` button to press in the **Configuration** section.
 
 ## Devices overview
 
@@ -388,7 +390,7 @@ The cooling mode can only be toggled via a **physical switch** on the device (no
 Please **reload** the Plugwise integration after changing the cooling mode switch to ensure the integration adapts to the change:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
-2. On the "**Hubs**" page, use the {% icon "mdi:dots-vertical" %} icon next to your Anna and choose "**Reload**""
+2. On the "**Hubs**" page, use the {% icon "mdi:dots-vertical" %} icon next to your Anna and choose "**Reload**"".
 
 ### Vacation preset
 
@@ -396,7 +398,7 @@ The `vacation` preset is only available on an Anna.
 
 ### Idling climate actions
 
-You can only stop climate actions on an Adam, see (Turn on / Turn off)[#turn-on--turn-off]. An alternative could be to adjust your (preset mode)[#set-preset-mode] to `no_frost` to stop any heating actions.
+You can only stop climate actions on an Adam, see [Turn on / Turn off](#turn-on--turn-off). An alternative could be to adjust your [preset mode](#set-preset-mode) to `no_frost` to stop any heating actions.
 
 ### Legacy power devices
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -40,7 +40,7 @@ This integration supports Plugwise devices connected to a network connected hub 
 - A stand-alone smart thermostat called [Anna](https://www.plugwise.com/en_US/products/anna).
 - For power monitoring there is a device simply called the [P1](https://www.plugwise.com/en_US/products/smile-p1).
 - Although no longer sold, there also is support for Stretch, a gateway to create network connectivity for their older power products.
-- __Not supported yet__: The newest in the family, [Anna P1](https://www.plugwise.com/product/anna-p1/) cleverly uses energy (solar) information to transfer abundant energy in heatpump usage.
+- **Not supported yet!** The newest in the family, [Anna P1](https://www.plugwise.com/product/anna-p1/) cleverly uses energy (solar) information to transfer abundant energy in heatpump usage.
 
 Plugwise formerly sold power-based products using a USB stick as the controller. This integration does not support the `Stick` directly, see [legacy power devices](#legacy-power-devices) for more information.
 
@@ -292,7 +292,7 @@ If you need to create an issue to report a bug or want to inspect diagnostic dat
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
 2. If you have more than one Plugwise Smile, select the gateway that is experiencing issues.
-3. Select the device with 'Smile' in it's name.
+3. Select the device with 'Smile' in its name.
 4. On the integration entry, select the {% icon "mdi:dots-vertical" %}.
    - Then, select **Download diagnostics** and a JSON file will be downloaded.
 5. You can inspect the downloaded file or, when requested, upload it to your issue report.
@@ -302,7 +302,7 @@ If you need to create an issue to report a bug or want to inspect diagnostic dat
 action: `button.press`
 
 ```yaml
-# Example script change the thermostat schedule
+# Example script to reboot the gateway
 script:
   reboot_gateway:
     sequence:
@@ -357,7 +357,7 @@ To display your schedule as a valid `select` option for this integration ensure 
 
 ### Anna as a zone thermostat
 
-If you are using your Anna as part of your adam zone control system, it can not be configured as a smart thermostat. The integration will not discover your Anna or allow manual configuration.
+If you are using your Anna as part of your adam zone control system, it cannot be configured as a smart thermostat. The integration will not discover your Anna or allow manual configuration.
 
 ### Anna with Elga
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -30,7 +30,7 @@ ha_platforms:
 ha_integration_type: hub
 ---
 
-[Plugwise](https://www.plugwise.com) provides smart home climate and power monitoring devices. This integration allows you to monitor and control your climate and energy (including gas) consumption and energy production. The energy information can be used for the [energy dashboard](/home-energy-management).
+[Plugwise](https://www.plugwise.com) provides smart home climate and power monitoring devices. This integration allows you to monitor and control your climate, energy consumption (including gas) consumption, and energy production. The energy information can be used for the [energy dashboard](/home-energy-management).
 
 ## Supported devices
 
@@ -71,11 +71,18 @@ Password:
   description: "Each gateway requires its unique 8-character ID, found on a sticker at the bottom, as its password."
 {% endconfiguration_basic %}
 
-### Further configuration
+### Schedule Management
 
-For a thermostat, the active schedule can be deactivated or reactivated via the climate card. Note: If no schedule is active, activate one first in the Plugwise App. Once that has been done, the Plugwise Integration can manage future operations.
+1. **Initial Setup**: First, activate a schedule using the Plugwise App or browser.
+2. **Control via Home Assistant**:
+   - Use the [climate](#climate) card to activate/deactivate schedules.
+   - `Auto` mode indicates the schedule is active.
+   - `Heat` mode signifies the schedule is ininactive.
+3. **Changing Schedules**: Use the thermostat [select](#select) entity.
 
-In this context, `Auto` indicates the schedule is active, while `Heat` signifies it is inactive. The active thermostat schedule can be changed via the connected thermostat select entity. Please note that only schedules with two or more schedule points will be shown as select options.
+{% note %}
+Only schedules with two or more schedule points will appear as options.
+{% endnote %}
 
 ## Data updates
 
@@ -149,10 +156,16 @@ triggers:
       - media_player.cinema
     attribute: sound_mode
     from: Movie
+condition:
+  - condition: state
+    entity_id: climate.cinema
+    state: 'on'
 actions:
   - action: homeassistant.turn_off
     target:
       entity_id: climate.cinema
+  - delay:
+      seconds: 30
 mode: single
 ```
 
@@ -388,10 +401,11 @@ If you are using your Anna as part of your adam zone control system, it cannot b
 
 The cooling mode can only be toggled via a **physical switch** on the device (not through a toggle in the Plugwise App or using Home Assistant).
 
-Please **reload** the Plugwise integration after changing the cooling mode switch to ensure the integration adapts to the change:
+The change in cooling mode should be detected by Home Assistant. If not, please try to **reload** the Plugwsie integration as indicated below and report your findings.
 
-1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
-2. On the "**Hubs**" page, use the {% icon "mdi:dots-vertical" %} icon next to your Anna and choose "**Reload**"".
+1. Create an issue including your [diagnostic data](#diagnostic-data).
+2. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
+3. On the "**Hubs**" page, use the {% icon "mdi:dots-vertical" %} icon next to your Anna and choose "**Reload**"".
 
 ### Vacation preset
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -48,7 +48,7 @@ Plugwise formerly sold power based products using a USB stick as the controller.
 Depending on your specific Smile and connected devices, the following platforms will be available:
 
 - [Climate](#climate) for Adam and (a stand-alone) Anna.
-- [Binary Sensor](#binary_sensor) for status of your domestic hot water or secondary heater.
+- [Binary Sensor](#binary-sensor) for status of your domestic hot water or secondary heater.
 - [Button](#button) to reboot your Smile.
 - [Number](#number) to change a boiler setpoint or temperature offset.
 - [Sensor](#sensor) a variety of sensors is available for all Smiles.

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -30,19 +30,30 @@ ha_platforms:
 ha_integration_type: hub
 ---
 
-This enables [Plugwise](https://www.plugwise.com) integrations with a central Smile gateway to be integrated. This integration talks locally to your **Smile** interface, and you will need its password and IP address.
-The platform supports [Anna](https://www.plugwise.com/en_US/products/anna), [Adam (zonecontrol)](https://www.plugwise.com/en_US/zonecontrol), [P1](https://www.plugwise.com/en_US/products/smile-p1) Smile products and the Stretch products (not in sale). See below list for more details.
+[Plugwise](https://www.plugwise.com) provides smart home climate and power monitoring devices. This integation allows you to monitor and control your climate and energy (including gas) consumption and energy production. The energy information can be used for the [energy dashboard](/home-energy-management).
 
-Platforms available - depending on your Smile and setup include:
+## Supported devices
 
- - `climate` (for the stand-alone Anna, for Adam, a climate entity is shown for each zone containing devices like an Anna or another type of wired-thermostat, Jip or Lisa combined with one or more Tom/Floor devices)
- - `binary_sensor` (for showing the status of e.g. domestic hot water heating or secondary heater)
- - `button` (for the Adam and the non-legacy Anna and P1 gateways)
- - `number` (for changing a boiler setpoint, a temperature offset)
- - `sensor` (for all relevant products including the Smile P1)
- - `select` (for changing a thermostat schedule, a regulation mode (Adam only))
- - `switch` (for Plugs connected to Adam, or Circles and Stealths connected to a Stretch)
+This integration supports Plugwise devices connected to a network connected hub called a **Smile**. You can connect to the Smile using your browser, their Plugwise App or this Home Assistant integration. There are 4 types of Smiles:
 
+- Full zonecontrol using the [Adam](https://www.plugwise.com/en_US/zonecontrol) using [additional devices](#devices-overview) such as smart valves and smart-plugs.
+- A stand-alone smart thermostat called [Anna](https://www.plugwise.com/en_US/products/anna).
+- For power monitoring there is one simply called the [P1](https://www.plugwise.com/en_US/products/smile-p1).
+- Although no longer sold, there also is support for Stretch, a gateway to create network connectivity for their older power products.
+
+Plugwise formerly sold power based products using a USB stick as the controller. This integration does not support the `Stick` directly, see [legacy power devices](#legacy-power-devices) for more information.
+
+## Platforms
+
+Depending on your specific Smile and connected devices, the following platforms will be available:
+
+- [Climate](#climate) for Adam and (a stand-alone) Anna.
+- [Binary Sensor](#binary_sensor) for status of your domestic hot water or secondary heater.
+- [Button](#button) to reboot your Smile.
+- [Number](#number) to change a boiler setpoint or temperature offset.
+- [Sensor](#sensor) a variety of sensors is available for all Smiles.
+- [Select](#select) to change your thermostat schedule or regulation mode.
+- [Switch](#switch) allowing plugs to be commanded.
 
 ## Pre-requisites
 
@@ -65,80 +76,49 @@ For a thermostat, the active schedule can be deactivated or reactivated via the 
 
 Auto means the schedule is active, and Heat means it's not active. The active thermostat schedule can be changed via the connected thermostat select entity. Please note that only schedules with two or more schedule points will be shown as select options.
 
-## Entities
-
-This integration will show all Plugwise devices (like hardware devices, multi-thermostat climate-zones, and virtual switchgroups) present in your Plugwise configuration. In addition, you will see a Gateway device representing your central Plugwise gateway (i.e., the Smile Anna, Smile P1, Adam or Stretch).
-
-For example, if you have an Adam setup with a Lisa named 'Living' and a Tom named 'Bathroom', these will show up as individual devices. The heating/cooling device connected to your Smile will be shown as 'OpenTherm' or 'OnOff', depending on how the Smile communicates with the device. If you have Plugs (as in, pluggable switches connecting to an Adam) those will be shown as devices as well.
-
-Under each device there will be entities shown like binary_sensors, sensors, etc. depending on the capabilities of the device: for instance centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna or Adam will be assigned to your gateway device. Heating/cooling device measurements such as 'boiler_temperature' will be assigned to the OpenTherm/OnOff device.
-
 ## Data updates
 
-The interval which the integration fetches data from the Smile depends on the device:
+The interval which the integration fetches data from the Smile depends on the device-type.
 
-- Power entities, such as the P1, will be refreshed every 10 seconds.
-- Climate entities will be refreshed every 60 seconds.
-- Stretch entities will be refreshed every 60 seconds.
+|Device-type|Interval|
+--- | ---
+| Climate entities |60 seconds|
+| Energy and gas entities |10 seconds|
+| Stretch entities |60 seconds|
 
-## Removing the integration
+## Entities
 
-This integration follows standard integration removal. No extra steps are required within Home Assistant or on your Plugwise devices.
+This integration will show all Plugwise devices (like hardware devices, multi-thermostat climate-zones, and virtual switchgroups) present in your Plugwise configuration. In addition, you will see a Gateway device representing your central Plugwise gateway (i.e., the Adam, Smile Anna, Smile P1 or Stretch).
 
-{% include integrations/remove_device_service.md %}
+For example, if you have an Adam setup with a Lisa named `Living` and a Tom named `Bathroom`, these will show up as individual devices. The heating/cooling device connected to your Smile will be shown as `OpenTherm` or `OnOff`, depending on how the Smile communicates with the device. If you have Plugs (as in, pluggable switches connecting to an Adam) or Aqara Smart Plugs those will be shown as devices as well.
 
-This will also remove all connected Adam devices (such as Anna, Tom or Lisa) or connected Adam/Stretch plugs.
+Under each device there will be entities shown like `binary_sensors`, `sensors`, etc. depending on the capabilities of the device: for instance centralized measurements such as `power` for a P1, `outdoor_temperature` on Anna or Adam will be assigned to your gateway device. Heating/cooling device measurements such as `boiler_temperature` will be assigned to the OpenTherm/OnOff device.
 
-### Actions
+## Platform information
 
-#### Update Smile data
+### Climate
 
-Forced update of data from your Smile can be triggered by calling the generic `homeassistant.update_entity` action with your Smile entity as the target.
+The [climate entity](/integrations/climate) is shown for each zone containing a thermostat. This can be any supported themostat such as the Anna or another type of wired-thermostat, Jip or Lisa combined with one or more Tom/Floor devices.
 
-```yaml
-# Example script change the temperature
-script:
-  force_adam_update:
-    sequence:
-      - action: homeassistant.update_entity
-        target:
-          entity_id: climate.living_room
-```
-
-#### Reboot the Plugwise gateway
-
-action: `button.press`
-
-```yaml
-# Example script change the thermostat schedule
-script:
-  reboot_gateway:
-    sequence:
-      - action: button.press
-        target:
-          entity_id: button.adam_reboot
-```
-
-#### Set HVAC mode
+#### Setting the HVAC mode
 
 action: `climate.set_hvac_mode`
 
 Available options include `off` (Adam only) `auto`, `cool`, `heat`, and `heat_cool` (Anna with Elga only).
 
-The meaning of `off` is that the Adam regulation is set to off. This means that the connected HVAC-system does not heat or cool, only the domestic hot water heating function, when available, is active.
-
-The meaning of `cool` or `heat` is that there is no schedule active. For example, if the system is manually set to cooling- or heating-mode, the system will be active if the room temperature is above/below the thermostat setpoint.
-
-The meaning of `heat/cool` is that there is no schedule active. For example, if the system is in automatic cooling- or heating-mode, the active preset or manually set temperature is used to control the HVAC system.
-
-The meaning of `auto` is that a schedule is active and the thermostat will change presets/setpoints accordingly.
+|HVAC mode|Indication|Description|
+--- | --- | ---
+|`off`| Adam regulation is set to off | The connected HVAC-system does not heat or cool, only the domestic hot water heating function, if available, is active. |
+|`cool` or `heat`| No active schedule | If the system is **manually** set to cooling- or heating-mode, the system will be active if the room temperature is above/below the thermostat setpoint. |
+|`heat/cool`| No active schedule | If the system is in **automatic** cooling- or heating-mode, the active preset or manually set temperature is used to control the HVAC system. |
+|`auto` | Active schedule |  The thermostat will change presets/setpoints accordingly. |
 
 The last schedule that was active is determined the same way long-tapping the top of Anna works.
 
 Example:
 
 ```yaml
-# Example script climate.set_hvac_mode to auto = schedule active
+# Example script climate.set_hvac_mode in the living room to auto = schedule active
 script:
   lisa_reactivate_last_schedule:
     sequence:
@@ -159,45 +139,27 @@ These actions will switch the Adam regulation mode (= HVAC system mode) to off o
 Example:
 
 ```yaml
-# Example script climate.turn_off
+# Example script climate.turn_off in the cinema
 script:
   turn_heating_on:
     sequence:
       - action: climate.turn_off
         target:
-          entity_id: climate.bios
+          entity_id: climate.cinema
 ```
 
-#### Change climate schedule
+#### Update Smile data
 
-action: `select.select_option`
-
-```yaml
-# Example script change the thermostat schedule
-script:
-  lisa_change_schedule:
-    sequence:
-      - action: select.select_option
-        target:
-          entity_id: select.bios_thermostat_schedule
-        data:
-          option: "Regulier"
-```
-
-#### Change boiler setpoint
-
-action: `number.set_value`
+Forced update of data from your Smile can be triggered by calling the generic `homeassistant.update_entity` action with your Smile entity as the target.
 
 ```yaml
-# Example script change the boiler setpoint
+# Example script change the living room temperature
 script:
-  change_max_boiler_tempeture_setpoint:
+  force_adam_update:
     sequence:
-      - action: number.set_value
+      - action: homeassistant.update_entity
         target:
-          entity_id: number.opentherm_max_boiler_temperature_setpoint
-        data:
-          value: 60
+          entity_id: climate.living_room
 ```
 
 #### Set temperature
@@ -236,33 +198,177 @@ script:
           preset_mode: asleep
 ```
 
-### Supported devices
+### Binary Sensor
 
-The current implementation of the Python module (Plugwise-Smile) includes:
+Depending on your setup, a [binary sensor](/integrations/binary_sensor) will provide the status of your domestic hot water heating or secondary heater.
 
-Adam (zone_control) with On/Off, OpenTherm, and Loria/Thermastage heating and cooling support:
+### Button
 
- - v3.x
- - v2.3
+For each Smile a [button](/integrations/button) is added to enable a restart (reboot) of the Smile.
 
- - Devices supported are Anna, Lisa, Jip, Floor, Tom, Plug, Aqara Smart Plug, and Koen (a Koen always comes with a Plug, the active part)
+### Number
 
-Anna (thermostat) with OnOff, OpenTherm heating, and Elga and Loria/Thermastage with heating and cooling support:
+Modifying specific [number](/integrations/button)-based settings allows you to fine-tune your setup.
 
- - v4.x
- - v3.x
- - v1.x
+Examples include the boiler setpoint as shown below and adjusting your temperature offset.
 
-On the Elga, the cooling-mode can only be turned on, or off, via a switch present on the device, not via a toggle in the Plugwise App.
-Please make sure to reload the Plugwise integration after the cooling-mode-switch is turned off after being on, or the other way around. This will ensure that the Plugwise integration is being adapted to the change in function of the Elga.
+#### Change boiler setpoint
 
-Smile P1 (DSMR):
+action: `number.set_value`
 
- - v4.x
- - v3.x
- - v2.x
+```yaml
+# Example script change the boiler setpoint
+script:
+  change_max_boiler_tempeture_setpoint:
+    sequence:
+      - action: number.set_value
+        target:
+          entity_id: number.opentherm_max_boiler_temperature_setpoint
+        data:
+          value: 60
+```
 
-Stretch (power switches):
+### Sensor
 
- - v3.x
- - v2.x
+A number of [sensors](/integrations/sensor) will be available, included but not limited to the examples shown below. By default not all sensors will be shown, for example; we disable the Anna's `outdoor_temperature` sensor in favor of the one provided by an auxiliary device if it has one.
+
+Example sensors (not extensive):
+
+|Sensor|Description|
+--- | ---
+|Outdoor temperature | For Anna, this will show the temperature it retrieves from the internet, unless you have an auxiliary device with a temperature sensor |
+|Indoor temperature | For Anna, Lisa or Jip this will show the temperature measured at the specific thermostat |
+|P1 Net Electricity Point | Your netto electricity use at this time, can be negative when producing energy, i.e. though solar panels |
+|P1 Electricity Produced off peak cumulative | The total produced electricity during off peak |
+|Gas Consumed Interval | The gas consumed since the last interval |
+
+### Select
+
+[Select](/integrations/select) allows for changing a thermostat schedule. If you have an Adam you can also select the regulation mode.
+
+Schedules can be created using the Plugwise App or the web-interface.
+
+#### Change climate schedule
+
+action: `select.select_option`
+
+```yaml
+# Example script change the thermostat schedule in the cinema
+script:
+  lisa_change_schedule:
+    sequence:
+      - action: select.select_option
+        target:
+          entity_id: select.cinema_thermostat_schedule
+        data:
+          option: "Cosy"
+```
+
+### Switch
+
+Allows commanding [switches](/integrations/switch), e.g. `on`/`off` for Plugs or Aqara Smart Plugs connected to Adam, or Circles and Stealths connected to a Stretch.
+
+### Troubleshooting
+
+#### Accessing the local device
+accessing-the-local-device
+
+If you need to configure the Smile directly, without using the Plugwise App, you can find the link to your device by:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
+2. If you have more than one Plugwise Smile, select the one to configure.
+3. Select the device with 'Smile' in it's name.
+4. On the integration entry, choose to open the configuration URL left of the {% icon "mdi:dots-vertical" %} icon.
+5. A new window/tab will open, enter `smile` (or `stretch`) as the username and your Smile ID as the password.
+6. Consult the manual or click the `search` button on the [Plugwise Support](https://plugwise.com/support/) page for interactive help.
+
+#### Modify the Smile update interval
+
+{% include common-tasks/define_custom_polling.md %}
+
+#### Diagnostic data
+
+If you need to create an issue to report a bug or want to inspect diagnostic data, use the below method to retrieve diagnostics:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
+2. If you have more than one Plugwise Smile, select the gateway that is experiencing issues.
+3. Select the device with 'Smile' in it's name.
+4. On the integration entry, select the {% icon "mdi:dots-vertical" %}.
+   - Then, select **Download diagnostics** and a JSON file will be downloaded.
+5. You can inspect the downloaded file or, when requested, upload it to your issue report.
+
+#### Adding a Smile reboot button
+
+action: `button.press`
+
+```yaml
+# Example script change the thermostat schedule
+script:
+  reboot_gateway:
+    sequence:
+      - action: button.press
+        target:
+          entity_id: button.adam_reboot
+```
+
+## Devices overview
+
+The Plugwise integration relies on the [plugwise](https://pypi.org/project/plugwise/) module for Python. It currently provides support for:
+
+### Adam
+
+A complete zone control system also known as Adam HA, supporting:
+
+- On/Off, OpenTherm or Loria/Thermastage heating and cooling support.
+- Running firmwares v3.x or v2.3
+- Additional devices:
+  - Zone thermostats such as Lisa or Anna (see warning below on Anna),
+  - A temperature sensor, Jip,
+  - Valve controllers called Floor or Tom,
+  - An under-floor heating controller Koen (always comes with a Plug as the active part),
+  - Smart switches, either Plug or Aqara Smart Plug.
+
+### Anna
+
+A smart thermostat, supporting:
+
+- OnOff, OpenTherm heating and Elga or Loria/Thermastage with heating and cooling support. (see [known limitations](#known-limitations) below for the Elga).
+- Running firmware v4.x, v3.x or v1.x.
+
+### P1 (DSMR)
+
+A smart meter monitor for single or multi-phase P1 monitoring with the P1 running firmware v4.x, v3.x or v2.x.
+
+### Stretch (end-of-sale)
+
+For legacy power switches, such as the Circles or Stealths, with v3.x or v2.x Stretch firmware.
+
+## Known limitations
+
+### Schedule configuration and pre-requisites
+
+Creation, modification or deleting of climate schedules is not supported through this integration. We recommend using the Plugwise App or visit the local device to configure schedules. See [accessing the local device](#accessing-the-local-device) above on how to access the local device from Home Assistant.
+
+To display your schedule as a valid `select` option for this integration ensure that the schedule has a minimal of two schedule points.
+
+### Anna as a zone thermostat
+
+If you are using your Anna as part of your adam zone control system, it can not be configured as a smart thermostat. The integration will not discover your Anna or allow manual configuration.
+
+### Anna with Elga
+
+The cooling mode can only be toggled via a physical switch on the device (not through the Plugwise App).
+After changing the cooling mode switch position, you must reload the Plugwise integration for the changes to take effect.
+
+### Legacy power devices
+
+Plugwise formerly sold Power based products comprised of a USB stick and smart plugs (amongst a few other items). This integration does **not** support the USB-stick. Reuse of the these products, such as Circles and Stealths using a Stretch or an Adam is supported. Work for USB support is in development by the community but not ready to become a formal Home Assistant integration just yet.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required within Home Assistant or on your Plugwise devices.
+
+{% include integrations/remove_device_service.md %}
+
+This will also remove all connected Adam devices (such as Anna, Tom or Lisa) or connected Adam/Stretch plugs.
+

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -38,11 +38,11 @@ This integration supports Plugwise devices connected to a network connected hub 
 
 - Full zonecontrol using the [Adam](https://www.plugwise.com/en_US/zonecontrol) using [additional devices](#devices-overview) such as smart valves and smart-plugs.
 - A stand-alone smart thermostat called [Anna](https://www.plugwise.com/en_US/products/anna).
-- For power monitoring there is one simply called the [P1](https://www.plugwise.com/en_US/products/smile-p1).
+- For power monitoring there is a device simply called the [P1](https://www.plugwise.com/en_US/products/smile-p1).
 - Although no longer sold, there also is support for Stretch, a gateway to create network connectivity for their older power products.
 - __Not supported yet__: The newest in the family, [Anna P1](https://www.plugwise.com/product/anna-p1/) cleverly uses energy (solar) information to transfer abundant energy in heatpump usage.
 
-Plugwise formerly sold power based products using a USB stick as the controller. This integration does not support the `Stick` directly, see [legacy power devices](#legacy-power-devices) for more information.
+Plugwise formerly sold power-based products using a USB stick as the controller. This integration does not support the `Stick` directly, see [legacy power devices](#legacy-power-devices) for more information.
 
 ## Platforms
 
@@ -231,7 +231,7 @@ script:
 
 ### Sensor
 
-A number of [sensors](/integrations/sensor) will be available, included but not limited to the examples shown below. By default not all sensors will be shown, for example; we disable the Anna's `outdoor_temperature` sensor in favor of the one provided by an auxiliary device if it has one.
+A number of [sensors](/integrations/sensor) will be available, included but not limited to the examples shown below. By default, not all sensors will be shown, for example; we disable the Anna's `outdoor_temperature` sensor in favor of the one provided by an auxiliary device if it has one.
 
 Example sensors (not extensive):
 
@@ -240,7 +240,7 @@ Example sensors (not extensive):
 |Outdoor temperature | For Anna, this will show the temperature it retrieves from the internet, unless you have an auxiliary device with a temperature sensor |
 |Indoor temperature | For Anna, Lisa or Jip this will show the temperature measured at the specific thermostat |
 |P1 Net Electricity Point | Your netto electricity use at this time, can be negative when producing energy, i.e. though solar panels |
-|P1 Electricity Produced off peak cumulative | The total produced electricity during off peak |
+|P1 Electricity Produced off-peak cumulative | The total produced electricity during off-peak |
 |Gas Consumed Interval | The gas consumed since the last interval |
 
 ### Select
@@ -272,13 +272,12 @@ Allows commanding [switches](/integrations/switch), e.g. `on`/`off` for Plugs or
 ### Troubleshooting
 
 #### Accessing the local device
-accessing-the-local-device
 
 If you need to configure the Smile directly, without using the Plugwise App, you can find the link to your device by:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
 2. If you have more than one Plugwise Smile, select the one to configure.
-3. Select the device with 'Smile' in it's name.
+3. Select the device with 'Smile' in its name.
 4. On the integration entry, choose to open the configuration URL left of the {% icon "mdi:dots-vertical" %} icon.
 5. A new window/tab will open, enter `smile` (or `stretch`) as the username and your Smile ID as the password.
 6. Consult the manual or click the `search` button on the [Plugwise Support](https://plugwise.com/support/) page for interactive help.

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -77,7 +77,7 @@ Password:
 2. **Control via Home Assistant**:
    - Use the [climate](#climate) card to activate/deactivate schedules.
    - `Auto` mode indicates the schedule is active.
-   - `Heat` mode signifies the schedule is ininactive.
+   - `Heat` mode signifies the schedule is inactive.
 3. **Changing Schedules**: Use the thermostat [select](#select) entity.
 
 {% note %}
@@ -98,7 +98,7 @@ The interval at which the integration fetches data from the gateway depends on t
 
 This integration displays all Plugwise devices in your configuration, including hardware devices, multi-thermostat climate zones, and virtual switch groups. Additionally, a device representing your Plugwise gateway (e.g., Adam, Smile-T, or P1) will be visible.
 
-For example, if you have an Adam setup with a Lisa named `Living` and a Tom named `Bathroom`, these will show up as individual devices. The heating/cooling device connected to your gateway will be shown as `OpenTherm` or `OnOff`, depending on how the gateway communicates with the device. If you have Plugs (as in, pluggable switches connecting to an Adam) or Aqara Smart Plugs those will be shown as devices as well.
+For example, if you have an Adam setup with a Lisa named `Living` and a Tom named `Bathroom`, these will show up as individual devices. The heating/cooling device connected to your gateway will be shown as `OpenTherm` or `OnOff`, depending on how the gateway communicates with the device. If you have Plugs (as in, pluggable switches connecting to an Adam) or Aqara Smart Plugs, those will be shown as devices as well.
 
 Each device will list entities such as `binary sensors`, `sensors`, etc., depending on its capabilities: for instance centralized measurements such as `power` for a P1, `outdoor_temperature` on Anna or Adam will be assigned to your gateway device. Heating/cooling device measurements such as `boiler_temperature` will be assigned to the OpenTherm/OnOff device.
 
@@ -174,7 +174,7 @@ mode: single
 Forced update of data from your gateway can be triggered by calling the generic `homeassistant.update_entity` action.
 
 ```yaml
-# Example script to retreive the latest living room temperature measurement
+# Example script to retrieve the latest living room temperature measurement
 script:
   force_adam_update:
     sequence:
@@ -237,7 +237,7 @@ Depending on your setup, a [binary sensor](/integrations/binary_sensor) will pro
 
 ### Button
 
-For each gateway a [button](/integrations/button) is added to trigger a restart (reboot) of physical device.
+For each gateway a [button](/integrations/button) is added to trigger a restart (reboot) of the physical device.
 
 ### Number
 
@@ -286,7 +286,7 @@ Schedules can be created using the Plugwise App or the web-interface.
 
 action: `select.select_option`
 
-Assuming you have something to indicate your current day of night shift based on a calendar you can automatically change the active schedule. The automation example below assumes an [`input_select`](/integrations/input_select/) helper is present, e.g., containing something like `Day shift`, `Night shift` and `Weekend shift`). Assuming you have created the appropriate schedules using your Plugwise App, your automation for night shifts could look like:
+Assuming you have something to indicate your current day or night shift based on a calendar you can automatically change the active schedule. The automation example below assumes an [`input_select`](/integrations/input_select/) helper is present, e.g., containing something like `Day shift`, `Night shift` and `Weekend shift`). Assuming you have created the appropriate schedules using your Plugwise App, your automation for night shifts could look like:
 
 ```yaml
 # Example automation change the thermostate schedule based on your shift
@@ -401,11 +401,11 @@ If you are using your Anna as part of your adam zone control system, it cannot b
 
 The cooling mode can only be toggled via a **physical switch** on the device (not through a toggle in the Plugwise App or using Home Assistant).
 
-The change in cooling mode should be detected by Home Assistant. If not, please try to **reload** the Plugwsie integration as indicated below and report your findings.
+The change in cooling mode should be detected by Home Assistant. If not, please try to **reload** the Plugwise integration as indicated below and report your findings.
 
 1. Create an issue including your [diagnostic data](#diagnostic-data).
 2. Go to {% my integrations title="**Settings** > **Devices & services**" %}, and select your integration.
-3. On the "**Hubs**" page, use the {% icon "mdi:dots-vertical" %} icon next to your Anna and choose "**Reload**"".
+3. On the "**Hubs**" page, use the {% icon "mdi:dots-vertical" %} icon next to your Anna and choose "**Reload**".
 
 ### Vacation preset
 
@@ -417,7 +417,7 @@ You can only stop climate actions on an Adam, see [Turn on / Turn off](#turn-on-
 
 ### Legacy power devices
 
-Plugwise formerly sold power-based products comprised of a USB stick and smart plugs (amongst a few other items). This integration does **not** support the USB-stick. Reuse of the these products, such as Circles and Stealths using a Stretch or an Adam is supported. Work for USB support is in development by the community, but not ready to become a formal Home Assistant integration just yet.
+Plugwise formerly sold power-based products comprised of a USB stick and smart plugs (amongs a few other items). This integration does **not** support the USB-stick. Reuse of the these products, such as Circles and Stealths using a Stretch or an Adam is supported. Work for USB support is in development by the community, but not ready to become a formal Home Assistant integration just yet.
 
 ## Removing the integration
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Overall improvements to the Plugwise documentation using the quality_scale as a guideline and improve readability for (and from) end-user perspective.

Starting with a better introduction and overview, before diving into platforms (which are now seperate sections). Moving troubleshooting items and removal more towards the final sections. Adding (some) tables for improved reading on data-updates and platforms as well as showing the action examples per platform. Improved troubleshooting/diagnostic instructions.

Overview as per requested changes from the initial benchmark by @joostlek

- [x] `docs-high-level-description` via https://github.com/home-assistant/core/pull/131888#discussion_r1865806781 - Improved introduction tekst and restructured/reordered accordingly for improved approach (by aligning with comparable integrations)
- [x] multiple docs related via https://github.com/home-assistant/core/pull/131888#discussion_r1865818063
  - [x] `docs-use-cases` - added through various sections and examples (and included gas explicitely)
  - [x] `docs-supported-devices` - reworked this section for improved reading including the top section to exclude formerly sold USB (directly)
  - [x] `docs-supported-functions` - reworked by platform section for clear structure
  - [x] `docs-data-update` - was already adjusted in earlier version, though reworked to include gas
  - [x] `docs-known-limitations` - added as a section, ingesting existing remarks and added new
  - [x] `docs-troubleshooting` - added as a section, ingesting existing
  - [x] `docs-examples` - the existing sample actions have been assigned to their respective platform sections, generally added more use-case directives

This continues on from #36087 effort on:

- [x] `docs-installation-instructions` via https://github.com/home-assistant/core/pull/131888#discussion_r1865811660 - implemented in docs PR 36087
- [x] `docs-removal-instructions` via https://github.com/home-assistant/core/pull/131888#discussion_r1865811759 - implemented in docs PR 36087
- [x] `docs-installation-parameters` via https://github.com/home-assistant/core/pull/131888#discussion_r1865813463 - implemented in docs PR 36087


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/pull/131888

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and detail in the Plugwise integration documentation.
	- Restructured sections for supported devices and platforms.
	- Clarified prerequisites for integration usage, including the need for Gateway ID as the password.
	- Reformatted data update intervals into a table for better readability.
	- Expanded actions and examples with clearer YAML script examples for functionalities.
	- Improved troubleshooting section with detailed steps for accessing local devices and modifying update intervals.
	- Specified lack of support for legacy power devices using a USB stick directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->