### PR TITLE
Remove discovery key information from Tradfri 

### DIFF
--- a/source/_integrations/tradfri.markdown
+++ b/source/_integrations/tradfri.markdown
@@ -23,7 +23,7 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-The IKEA TRÅDFRI integration allows you to connect your IKEA Trådfri Gateway to Home Assistant. The gateway can control compatible Zigbee-based lights (certified Zigbee Light Link products) connected to it. Home Assistant will automatically discover the gateway's presence on your local network if `discovery:` is present in your {% term "`configuration.yaml`" %} file.
+The IKEA TRÅDFRI integration allows you to connect your IKEA Trådfri Gateway to Home Assistant. The gateway can control compatible Zigbee-based lights (certified Zigbee Light Link products) connected to it.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
The Discovery integration, previously configured using the `discovery:` key has been removed in 2023.8 in https://github.com/home-assistant/core/pull/96856. (https://www.home-assistant.io/blog/2023/08/02/release-20238/#farewell-to-the-following).

The bridge is currently autodiscovered by homekit, so no clue why this was still here
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the IKEA TRÅDFRI integration documentation to simplify the description by removing details about the automatic discovery of the gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->