### PR TITLE
Add SensorPush Cloud integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -746,6 +746,7 @@ source/_integrations/sensor.markdown @home-assistant/core
 source/_integrations/sensorblue.markdown @bdraco
 source/_integrations/sensorpro.markdown @bdraco
 source/_integrations/sensorpush.markdown @bdraco
+source/_integrations/sensorpush_cloud.markdown @sstallion
 source/_integrations/sensoterra.markdown @markruys
 source/_integrations/sentry.markdown @dcramer @frenck
 source/_integrations/senz.markdown @milanmeu

--- a/source/_integrations/sensorpush_cloud.markdown
+++ b/source/_integrations/sensorpush_cloud.markdown
@@ -1,0 +1,49 @@
+---
+title: SensorPush Cloud
+description: Instructions on how to integrate SensorPush Cloud devices into Home Assistant.
+ha_category:
+  - Sensor
+ha_release: 2025.1
+ha_iot_class: Cloud Polling
+ha_codeowners:
+  - '@sstallion'
+ha_domain: sensorpush_cloud
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_integration_type: integration
+---
+
+Integrates [SensorPush Cloud](https://www.sensorpush.com/) devices into Home Assistant.
+
+## Prerequisites
+
+Sensor entities (temperature, humidity, barometric pressure) will not be available to Home Assistant until you have activated the device with the SensorPush app on iOS or Android.
+
+To activate API access, log in to the [Gateway Cloud Dashboard](https://dashboard.sensorpush.com/) and agree to the terms of service.
+
+## Supported devices
+
+- [G1 WiFi Gateway](https://www.sensorpush.com/products/p/g1-gateway)
+- [HT1 Temperature and Humidity Smart Sensor](https://www.sensorpush.com/products/p/ht1)
+- [HT.w Water-Resistant Temperature / Humidity Smart Sensor](https://www.sensorpush.com/products/p/ht-w)
+- [HTP.xw Extreme Accuracy Water-Resistant Temperature / Humidity / Barometric Pressure Smart Sensor](https://www.sensorpush.com/products/p/htp-xw)
+
+{% include integrations/config_flow.md %}
+
+## Sensors
+
+For each device, the following *sensors* are created:
+
+| Sensor               | Description                                                   |
+| :------------------- | :------------------------------------------------------------ |
+| altitude             | Measures the altitude. (disabled by default)                  |
+| atmospheric_pressure | Measures the barometric pressure. (disabled by default)       |
+| battery_voltage      | Measures the battery voltage. (disabled by default)           |
+| dewpoint             | Measures the dew point. (disabled by default)                 |
+| humidity             | Measures the relative humidity.                               |
+| signal_strength      | Measures the Bluetooth signal strength. (disabled by default) |
+| temperature          | Measures the temperature.                                     |
+| vapor_pressure       | Measures the vapor-pressure deficit. (disabled by default)    |
+
+**Note**: atmospheric_pressure is not available in HT1 series devices.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds cloud integration for SensorPush devices. It communicates with the publicly available [Cloud API](https://www.sensorpush.com/gateway-cloud-api) using the [sensorpush-api](https://pypi.org/project/sensorpush-api/) and [sensorpush-ha](https://pypi.org/project/sensorpush-ha/) Python packages. Care was taken to ensure that presented devices appeared the same as those created by the existing SensorPush integration. A [G1 WiFi Gateway](https://www.sensorpush.com/products/p/g1-gateway) is required to make use of the Cloud API.

Note: This PR is a re-submission of https://github.com/home-assistant/core/pull/121890, which fixes several issues reported by reviewers. I would like to send a heartfelt apology to @joostlek, @edenhaus, and @frenck - I was caught between dueling schedules and I wasn't able to do the work needed to get it over the finish line. I was finally able to put in the time over the holiday break to make requested changes in addition to improved unit tests, strict typing, async dependencies, and websession injection (whew!)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/134181
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/6299
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added SensorPush Cloud integration for Home Assistant
  - Supports various SensorPush device models
  - Provides sensors for temperature, humidity, pressure, and more
  - Configurable through Home Assistant's configuration flow

- **Documentation**
  - Comprehensive documentation added for SensorPush Cloud integration
  - Detailed device and sensor information included

<!-- end of auto-generated comment: release notes by coderabbit.ai -->