### PR TITLE
Update nest.markdown - troubleshooting entry

### DIFF
--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -602,7 +602,7 @@ The *OAuth Client ID* used must be consistent, so check these:
 
 - *Not receiving updates* typically means a problem with the subscriber configuration. Make sure to check the logs for any error messages. Changes for things like sensors or thermostat temperature set points should be instantly published to a topic and received by the Home Assistant subscriber when everything is configured correctly.
 
-- *Cannot create project with Pub/Sub or cannot enable it*: Device Access Console has a [known issue](https://issuetracker.google.com/issues/348675996) with enabling pub/sub. If you're having issues enabling pub/sub, refer to [this comment](https://issuetracker.google.com/issues/348675996#comment145) on the issue tracker page and create your topic manually.
+- *Cannot create project with Pub/Sub or cannot enable it*: Device Access Console has a [known issue](https://issuetracker.google.com/issues/348675996) with enabling Pub/Sub. If you're having issues enabling Pub/Sub, refer to [this comment](https://issuetracker.google.com/issues/348675996#comment145) on the Google IssueTracker page and create your topic manually before trying to enable Pub/Sub topic again.
 
 - You can see stats about your subscriber in the [Cloud Console](https://console.cloud.google.com/cloudpubsub/subscription/list) which includes counts of messages published by your devices, and how many have been acknowledged by your Home Assistant subscriber. You can also `View Messages` to see examples of published. Many old unacknowledged messages indicate the subscriber is not receiving the messages and working properly or not connected at all.
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -602,7 +602,7 @@ The *OAuth Client ID* used must be consistent, so check these:
 
 - *Not receiving updates* typically means a problem with the subscriber configuration. Make sure to check the logs for any error messages. Changes for things like sensors or thermostat temperature set points should be instantly published to a topic and received by the Home Assistant subscriber when everything is configured correctly.
 
-- *Cannot create project with Pub/Sub or cannot enable it*: Device Access Console has a [known issue](https://issuetracker.google.com/issues/348675996) with enabling Pub/Sub. If you're having issues enabling Pub/Sub, refer to [this comment](https://issuetracker.google.com/issues/348675996#comment145) on the Google IssueTracker page and create your topic manually before trying to enable Pub/Sub topic again.
+- *Cannot create project with Pub/Sub or cannot enable it*: Device Access Console has an unpredictable [known issue](https://issuetracker.google.com/issues/348675996) with enabling Pub/Sub.
 
 - You can see stats about your subscriber in the [Cloud Console](https://console.cloud.google.com/cloudpubsub/subscription/list) which includes counts of messages published by your devices, and how many have been acknowledged by your Home Assistant subscriber. You can also `View Messages` to see examples of published. Many old unacknowledged messages indicate the subscriber is not receiving the messages and working properly or not connected at all.
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -602,6 +602,8 @@ The *OAuth Client ID* used must be consistent, so check these:
 
 - *Not receiving updates* typically means a problem with the subscriber configuration. Make sure to check the logs for any error messages. Changes for things like sensors or thermostat temperature set points should be instantly published to a topic and received by the Home Assistant subscriber when everything is configured correctly.
 
+- *Cannot create project with Pub/Sub or cannot enable it*: Device Access Console has a [known issue](https://issuetracker.google.com/issues/348675996) with enabling pub/sub. If you're having issues enabling pub/sub, refer to [this comment](https://issuetracker.google.com/issues/348675996#comment145) on the issue tracker page and create your topic manually.
+
 - You can see stats about your subscriber in the [Cloud Console](https://console.cloud.google.com/cloudpubsub/subscription/list) which includes counts of messages published by your devices, and how many have been acknowledged by your Home Assistant subscriber. You can also `View Messages` to see examples of published. Many old unacknowledged messages indicate the subscriber is not receiving the messages and working properly or not connected at all.
 
 - To aid in diagnosing subscriber problems or camera stream issues it may help to turn up verbose logging by adding some or all of these to your {% term "`configuration.yaml`" %} depending on where you are having trouble:


### PR DESCRIPTION
## Proposed change
Add a Troubleshooting entry to the Google Nest integration page regarding a Device Access Console bug which prevents Pub/Sub topic from being enabled

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
n/a

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added troubleshooting note regarding issues with enabling Pub/Sub in the Device Access Console for the Google Nest integration.
	- Highlighted known issues with creating a project and enabling Pub/Sub.
	- Referenced Google IssueTracker for further information and support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->