### PR TITLE
Remove deprecated HEOS sign_in/out actions

### DIFF
--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -204,13 +204,13 @@ The HEOS integration makes various custom {% term actions %} available in additi
 
 ### Action `heos.sign_in`
 
+{% warning %}
+**This action is deprecated and will be removed in the 2025.8.0 release.** Enter your HEOS Account credentials in the [configuration options](#configuration-options) and the integration will manage authentication automatically.
+{% endwarning %}
+
 Use the sign-in action to sign the connected device into a HEOS account so that it can retrieve and play HEOS favorites and playlists. An error message is logged if sign-in is unsuccessful.
 
-{% note %}
-The [configuration options](#configuration-options) is the preferred method for managing your HEOS Account credentials. This service action will be deprecated in the future.
-
-&nbsp;
-
+{%note %}
 The device the integration connects to authenticates independently of other devices and the HEOS mobile app. When you first set up the integration, or after a device firmware update, the device will most likely not be logged in.
 {% endnote %}
 
@@ -232,11 +232,11 @@ data:
 
 ### Action `heos.sign_out`
 
-Use the sign-out action to sign the connected device out of a HEOS account. An error message is logged if sign-out is unsuccessful. There are no parameters to this action Example action data payload:
+{% warning %}
+**This action is deprecated and will be removed in the 2025.8.0 release.** Enter your HEOS Account credentials in the [configuration options](#configuration-options) and the integration will manage authentication automatically.
+{% endwarning %}
 
-{% note %}
-The [configuration options](#configuration-options) is the preferred method for managing your HEOS Account credentials. This service action will be deprecated in the future.
-{% endnote %}
+Use the sign-out action to sign the connected device out of a HEOS account. An error message is logged if sign-out is unsuccessful. There are no parameters to this action Example action data payload:
 
 ```yaml
 action: heos.sign_out

--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -200,48 +200,7 @@ data:
 
 ## Actions
 
-The HEOS integration makes various custom {% term actions %} available in addition to the standard [Media Player actions](/integrations/media_player#actions).
-
-### Action `heos.sign_in`
-
-{% warning %}
-**This action is deprecated and will be removed in the 2025.8.0 release.** Enter your HEOS Account credentials in the [configuration options](#configuration-options) and the integration will manage authentication automatically.
-{% endwarning %}
-
-Use the sign-in action to sign the connected device into a HEOS account so that it can retrieve and play HEOS favorites and playlists. An error message is logged if sign-in is unsuccessful.
-
-{%note %}
-The device the integration connects to authenticates independently of other devices and the HEOS mobile app. When you first set up the integration, or after a device firmware update, the device will most likely not be logged in.
-{% endnote %}
-
-To run, go to **Developer Tools** > **Actions** and then type in `heos.sign_in`. Then enter your HEOS account username and password, and click the Perform Action button. An error message is only logged if sign-in is unsuccessful.
-
-Example action data payload:
-
-```yaml
-action: heos.sign_in
-data:
-  username: "example@example.com"
-  password: "password"
-```
-
-| Data attribute | Optional | Description                                |
-| ---------------------- | -------- | ------------------------------------------ |
-| `username`             | no       | The username or email of the HEOS account. |
-| `password`             | no       | The password of the HEOS account.          |
-
-### Action `heos.sign_out`
-
-{% warning %}
-**This action is deprecated and will be removed in the 2025.8.0 release.** Enter your HEOS Account credentials in the [configuration options](#configuration-options) and the integration will manage authentication automatically.
-{% endwarning %}
-
-Use the sign-out action to sign the connected device out of a HEOS account. An error message is logged if sign-out is unsuccessful. There are no parameters to this action Example action data payload:
-
-```yaml
-action: heos.sign_out
-data: {% raw %}{}{% endraw %}
-```
+The HEOS integration makes available the standard [Media Player actions](/integrations/media_player#actions).
 
 ## Supported devices
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Removes documentation for the deprecated HEOS sign_in and sign_out actions that will be removed in 2025.8.0.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [X] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/134616
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Revised Denon HEOS integration documentation for clarity and readability.
  - Clarified that `heos.sign_in` and `heos.sign_out` actions are deprecated.
  - Updated guidance for managing HEOS Account credentials through configuration options.
  - Focused on standard Media Player actions, removing references to deprecated functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->