### PR TITLE
Update denonavr.markdown to add compatible model

### DIFF
--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -75,6 +75,7 @@ Known supported devices:
 - Denon AVR-S940H
 - Denon AVR-S950H
 - Denon AVR-S960H
+- Denon AVR-S970H
 - Denon DN-500AV
 - Denon DRA-800H
 - Marantz AV7702


### PR DESCRIPTION
Added S970H to list

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Adding compatible model to Denon list


## Type of change


- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
None

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: None

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the Denon AVR-S970H receiver in the Denon AVR integration, expanding device compatibility for Home Assistant users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->