### PR TITLE
flux: document how the "mired" mode actually sets kelvin

### DIFF
--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -84,7 +84,7 @@ disable_brightness_adjust:
   type: boolean
   default: false
 mode:
-  description: Select how color temperature is passed to lights. Valid values are `xy`, `mired` and `rgb`.
+  description: Select how color temperature is passed to lights. Valid values are `xy`, `mired` (alias to kelvin) and `rgb`.
   required: false
   default: xy
   type: string


### PR DESCRIPTION
Since https://github.com/home-assistant/core/pull/132839 the Flux integration is using the value in kelvin to set the light temperature.

Let's reflect this in the documentation while preserving existing installations.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
As Home Assistant is switching to kelvin over mired, some components still refer to mired. I know Flux is not the most popular integration, but as someone who is starting to equip with smart lights, automatic colour temperature and brightness (aka circadian lighting) was one of my main motivations.

I started with modifying the Flux integration itself, but then found the change was trivial and kind of useless, as the code works the same, whether the mode is "mired", "kelvin", or even "foobar" if that value was allowed.

So I thought it's more a matter of adjusting the documentation than bothering the core repository with yet another PR to review.

I can still push my PR to core if you want to go the long way and actually add "kelvin" as a possible configuration value. Or do it yourself, which will probably be faster than reviewing me doing so.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated documentation for the `flux` integration to clarify that `mired` is an alias for `kelvin` in the `mode` configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->