### PR TITLE
Add tip for obtaining the device_id

### DIFF
--- a/source/_integrations/lcn.markdown
+++ b/source/_integrations/lcn.markdown
@@ -433,6 +433,20 @@ Refer to the [Performing actions](/docs/scripts/service-calls) page for examples
 
 When actions are linked to a particular device, the device is identified by its `device_id`. This `device_id` is a unique identifier supplied by Home Assistant.
 
+{% tip %}
+A simple method to obtain the `device_id` for LCN modules in automations and scripts is to use a template with the `device_id()` function as detailed [here](/docs/configuration/templating/#devices). This allows for finding the `device_id` using the module name as shown in the frontend or configured in the LCN-PRO software.
+
+{% raw %}
+```yaml
+action: lcn.pck
+data:
+  device_id: "{{ device_id('Module name') }}"
+  pck: PIN4
+```
+{% endraw %}
+
+{% endtip %}
+
 ### Action: `output_abs`
 
 Set absolute brightness of output port in percent.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Add a tip to the LCN documentation how to easily obtain a LCN hardware module's `device_id` in automations or scripts.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added guidance for obtaining `device_id` for LCN modules in Home Assistant automations and scripts
	- Included example YAML snippet demonstrating how to use the `device_id()` function in actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->