### PR TITLE
2025.1.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -108,8 +108,8 @@ social:
 # Home Assistant release details
 current_major_version: 2025
 current_minor_version: 1
-current_patch_version: 1
-date_released: 2025-01-07
+current_patch_version: 2
+date_released: 2025-01-09
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.

--- a/source/_posts/2025-01-03-release-20251.markdown
+++ b/source/_posts/2025-01-03-release-20251.markdown
@@ -70,6 +70,7 @@ Enjoy the release!
 - [Media player volume feature for Tile card](#media-player-volume-feature-for-tile-card)
 - [Patch releases](#patch-releases)
   - [2025.1.1 - January 7](#202511---january-7)
+  - [2025.1.2 - January 9](#202512---january-9)
 - [Need help? Join the community!](#need-help-join-the-community)
 - [Backward-incompatible changes](#backward-incompatible-changes)
 - [All changes](#all-changes)
@@ -687,6 +688,60 @@ release every Friday.
 [@squishykid]: https://github.com/squishykid
 [@starkillerOG]: https://github.com/starkillerOG
 [@tr4nt0r]: https://github.com/tr4nt0r
+
+### 2025.1.2 - January 9
+
+- Fix Météo-France setup in non French cities (because of failed next rain sensor) ([@Quentame] - [#134782]) ([meteo_france docs])
+- Increase cloud backup download timeout ([@ludeeus] - [#134961]) ([cloud docs])
+- Fix ZHA "referencing a non existing `via_device`" warning ([@puddly] - [#135008]) ([zha docs])
+- Catch errors in automation (instead of raise unexpected error) in Overkiz ([@iMicknl] - [#135026]) ([overkiz docs])
+- Fix channel retrieval for Reolink DUO V1 connected to a NVR ([@starkillerOG] - [#135035]) ([reolink docs])
+- Bump aioautomower to 2025.1.0 ([@Thomas55555] - [#135039]) ([husqvarna_automower docs])
+- Bump cookidoo-api to 0.12.2 ([@miaucl] - [#135045]) ([cookidoo docs])
+- Implement upload retry logic in CloudBackupAgent ([@ludeeus] - [#135062]) ([cloud docs])
+- Add jitter to backup start time to avoid thundering herd ([@emontnemery] - [#135065]) ([backup docs])
+- Bump pysuezV2 to 2.0.3 ([@jb101010-2] - [#135080]) ([suez_water docs])
+- Fix Flick Electric Pricing ([@ZephireNZ] - [#135154]) ([flick_electric docs])
+- Update frontend to 20250109.0 ([@bramkragten] - [#135235]) ([frontend docs])
+
+[#134782]: https://github.com/home-assistant/core/pull/134782
+[#134961]: https://github.com/home-assistant/core/pull/134961
+[#135008]: https://github.com/home-assistant/core/pull/135008
+[#135026]: https://github.com/home-assistant/core/pull/135026
+[#135035]: https://github.com/home-assistant/core/pull/135035
+[#135039]: https://github.com/home-assistant/core/pull/135039
+[#135045]: https://github.com/home-assistant/core/pull/135045
+[#135062]: https://github.com/home-assistant/core/pull/135062
+[#135065]: https://github.com/home-assistant/core/pull/135065
+[#135080]: https://github.com/home-assistant/core/pull/135080
+[#135154]: https://github.com/home-assistant/core/pull/135154
+[#135235]: https://github.com/home-assistant/core/pull/135235
+[@Quentame]: https://github.com/Quentame
+[@Thomas55555]: https://github.com/Thomas55555
+[@ZephireNZ]: https://github.com/ZephireNZ
+[@bramkragten]: https://github.com/bramkragten
+[@emontnemery]: https://github.com/emontnemery
+[@iMicknl]: https://github.com/iMicknl
+[@jb101010-2]: https://github.com/jb101010-2
+[@ludeeus]: https://github.com/ludeeus
+[@miaucl]: https://github.com/miaucl
+[@puddly]: https://github.com/puddly
+[@starkillerOG]: https://github.com/starkillerOG
+[abode docs]: /integrations/abode/
+[acaia docs]: /integrations/acaia/
+[adax docs]: /integrations/adax/
+[backup docs]: /integrations/backup/
+[cloud docs]: /integrations/cloud/
+[cookidoo docs]: /integrations/cookidoo/
+[flick_electric docs]: /integrations/flick_electric/
+[frontend docs]: /integrations/frontend/
+[husqvarna_automower docs]: /integrations/husqvarna_automower/
+[meteo_france docs]: /integrations/meteo_france/
+[overkiz docs]: /integrations/overkiz/
+[reolink docs]: /integrations/reolink/
+[suez_water docs]: /integrations/suez_water/
+[zha docs]: /integrations/zha/
+
 
 ## Need help? Join the community!
 

--- a/source/changelogs/core-2025.1.markdown
+++ b/source/changelogs/core-2025.1.markdown
@@ -1139,6 +1139,60 @@ For a summary in a more readable format:
 [@starkillerOG]: https://github.com/starkillerOG
 [@tr4nt0r]: https://github.com/tr4nt0r
 
+## Release 2025.1.2 - January 9
+
+- Fix Météo-France setup in non French cities (because of failed next rain sensor) ([@Quentame] - [#134782]) ([meteo_france docs])
+- Increase cloud backup download timeout ([@ludeeus] - [#134961]) ([cloud docs])
+- Fix ZHA "referencing a non existing `via_device`" warning ([@puddly] - [#135008]) ([zha docs])
+- Catch errors in automation (instead of raise unexpected error) in Overkiz ([@iMicknl] - [#135026]) ([overkiz docs])
+- Fix channel retrieval for Reolink DUO V1 connected to a NVR ([@starkillerOG] - [#135035]) ([reolink docs])
+- Bump aioautomower to 2025.1.0 ([@Thomas55555] - [#135039]) ([husqvarna_automower docs])
+- Bump cookidoo-api to 0.12.2 ([@miaucl] - [#135045]) ([cookidoo docs])
+- Implement upload retry logic in CloudBackupAgent ([@ludeeus] - [#135062]) ([cloud docs])
+- Add jitter to backup start time to avoid thundering herd ([@emontnemery] - [#135065]) ([backup docs])
+- Bump pysuezV2 to 2.0.3 ([@jb101010-2] - [#135080]) ([suez_water docs])
+- Fix Flick Electric Pricing ([@ZephireNZ] - [#135154]) ([flick_electric docs])
+- Update frontend to 20250109.0 ([@bramkragten] - [#135235]) ([frontend docs])
+
+[#134782]: https://github.com/home-assistant/core/pull/134782
+[#134961]: https://github.com/home-assistant/core/pull/134961
+[#135008]: https://github.com/home-assistant/core/pull/135008
+[#135026]: https://github.com/home-assistant/core/pull/135026
+[#135035]: https://github.com/home-assistant/core/pull/135035
+[#135039]: https://github.com/home-assistant/core/pull/135039
+[#135045]: https://github.com/home-assistant/core/pull/135045
+[#135062]: https://github.com/home-assistant/core/pull/135062
+[#135065]: https://github.com/home-assistant/core/pull/135065
+[#135080]: https://github.com/home-assistant/core/pull/135080
+[#135154]: https://github.com/home-assistant/core/pull/135154
+[#135235]: https://github.com/home-assistant/core/pull/135235
+[@Quentame]: https://github.com/Quentame
+[@Thomas55555]: https://github.com/Thomas55555
+[@ZephireNZ]: https://github.com/ZephireNZ
+[@bramkragten]: https://github.com/bramkragten
+[@emontnemery]: https://github.com/emontnemery
+[@frenck]: https://github.com/frenck
+[@iMicknl]: https://github.com/iMicknl
+[@jb101010-2]: https://github.com/jb101010-2
+[@ludeeus]: https://github.com/ludeeus
+[@miaucl]: https://github.com/miaucl
+[@puddly]: https://github.com/puddly
+[@starkillerOG]: https://github.com/starkillerOG
+[abode docs]: /integrations/abode/
+[acaia docs]: /integrations/acaia/
+[adax docs]: /integrations/adax/
+[backup docs]: /integrations/backup/
+[cloud docs]: /integrations/cloud/
+[cookidoo docs]: /integrations/cookidoo/
+[flick_electric docs]: /integrations/flick_electric/
+[frontend docs]: /integrations/frontend/
+[husqvarna_automower docs]: /integrations/husqvarna_automower/
+[meteo_france docs]: /integrations/meteo_france/
+[overkiz docs]: /integrations/overkiz/
+[reolink docs]: /integrations/reolink/
+[suez_water docs]: /integrations/suez_water/
+[zha docs]: /integrations/zha/
+
 [#115483]: https://github.com/home-assistant/core/pull/115483
 [#117355]: https://github.com/home-assistant/core/pull/117355
 [#121371]: https://github.com/home-assistant/core/pull/121371


### PR DESCRIPTION
https://github.com/home-assistant/core/pull/135241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Home Assistant 2025.1.2

- **Bug Fixes**
  - Resolved Météo-France setup issues in non-French cities
  - Fixed channel retrieval for Reolink DUO V1 connected to NVR
  - Corrected ZHA integration warnings
  - Improved error handling in Overkiz integration

- **Enhancements**
  - Increased cloud backup download timeout
  - Added upload retry logic for backup operations
  - Updated frontend to latest version

- **Library Updates**
  - Bumped aioautomower and cookidoo-api to latest versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->