### PR TITLE
Add documentation for running Home Assistant OS on ARM Macs using VMware Fusion

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -345,15 +345,15 @@ Minimum recommended assignments:
     1. Start VMware Fusion and select **File > New** from the menu bar.
     2. Select **Create a custom virtual machine**, then select **Linux** > **Other Linux 6.x kernel 64-bit Arm**.
        - On Intel Macs, select **Other Linux 6.x kernel 64-bit**.
-    4. Select **Use an existing virtual disk** and locate the unzipped disk image file.
+    3. Select **Use an existing virtual disk** and locate the unzipped disk image file.
        - Ensure **Make a separate copy of the virtual disk** is selected in the file picker options.
-    5. Select **Customize Settings** at the "Finish" step.
-    6. Define the amount of memory and the number of cores the VM is allowed to use under **Processors & Memory**.
-    7. Under **General**, you may choose to start the VM when your Mac boots up if preferred.
-    8. Connect an Ethernet cable and ensure it is connected to your network.
-    9. Under **Network Adapter**, select **Ethernet** under **Bridged Networking**.
-    10. Under **Hard Disk**, increase the disk size to the recommended minimum.
-    11. Under **USB**, select any USB devices that you want to pass through to Home Assistant, such as Home Assistant Connect, or other Zigbee/Z-Wave dongles. You may also want to choose to always connect the device to Home Assistant by choosing **Connect to Linux** in the **Plug In Action** dropdown.
+    4. Select **Customize Settings** at the "Finish" step.
+    5. Define the amount of memory and the number of cores the VM is allowed to use under **Processors & Memory**.
+    6. Under **General**, you may choose to start the VM when your Mac boots up if preferred.
+    7. Connect an Ethernet cable and ensure it is connected to your network.
+    8. Under **Network Adapter**, select **Ethernet** under **Bridged Networking**.
+    9. Under **Hard Disk**, increase the disk size to the recommended minimum.
+    10. Under **USB**, select any USB devices that you want to pass through to Home Assistant, such as Home Assistant Connect, or other Zigbee/Z-Wave dongles. You may also want to choose to always connect the device to Home Assistant by choosing **Connect to Linux** in the **Plug In Action** dropdown.
 {% endif %}
 
 {% unless page.installation_type == 'macos' %}

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -275,6 +275,10 @@ If you are running an older Windows version or have a stricter network configura
 ### Download the appropriate image
 
 - [VirtualBox][vdi] (.vdi)
+{% if page.installation_type == 'macos' %}
+- [VMware Fusion (Apple Silicon)][generic-aarch64-vmdk] (.vmdk)
+- [VMware Fusion (Intel)][vmdk] (.vmdk)
+{% endif %}
 {% if page.installation_type == 'linux' %}
 - [KVM][qcow2] (.qcow2)
 {% elsif page.installation_type == 'alternative' %}
@@ -292,7 +296,7 @@ Follow this guide if you already are running a supported virtual machine hypervi
 
 {% if page.installation_type == 'macos' %}
 
-- If VirtualBox is not supported on your Mac, and you have experience using virtual machines, you can try running the Home Assistant Operating System on [UTM](https://mac.getutm.app/).
+- If VirtualBox is not supported on your Mac, and you'd rather not use VMWare Fusion, you can try running the Home Assistant Operating System on [UTM](https://mac.getutm.app/).
 {% endif %}
 
 ### Create the virtual machine
@@ -333,6 +337,22 @@ Minimum recommended assignments:
     ```
 
     More details can be found about the command can be found [here](https://www.virtualbox.org/manual/ch08.html#vboxmanage-storageattach).
+
+{% if page.installation_type == 'macos' %}
+
+- title: VMware Fusion
+  content: |
+    1. Start VMware Fusion and select **File > New** from the menu bar.
+    2. Select **Create a custom virtual machine**, then select **Linux** > **Other Linux 6.x kernel 64-bit Arm**.
+    3. Select **Use an existing virtual disk** and locate the unzipped disk image file. Keep the option to *Make a separate copy of the virtual disk* selected, as it is the default.
+    4. Select **Customize Settings** at the "Finish" step.
+    5. Define the amount of memory and the number of cores the VM is allowed to use under **Processors & Memory**.
+    6. Under **General**, you may choose to start the VM when your Mac boots up, which you can enable if preferred.
+    7. Connect an Ethernet cable and ensure it is connected to your network.
+    8. Under **Network Adapter**, select **Ethernet** under **Bridged Networking**.
+    9. Under **Hard Disk**, increase the disk size to the recommended minimum.
+    10. Under **USB**, select any USB devices that you want to pass through to Home Assistant, such as Home Assistant Connect or other Zigbee/Z-Wave dongles. You may also want to choose to always connect the device to Home Assistant via the **Plug In Action** dropdown.
+{% endif %}
 
 {% unless page.installation_type == 'macos' %}
 
@@ -480,6 +500,7 @@ With the Home Assistant Operating System installed and accessible, you can conti
 {% endif %}
 
 [generic-x86-64]: {{release_url}}/{{site.data.version_data.hassos['generic-x86-64']}}/haos_generic-x86-64-{{site.data.version_data.hassos['generic-x86-64']}}.img.xz
+[generic-aarch64-vmdk]: {{release_url}}/{{site.data.version_data.hassos['generic-aarch64']}}/haos_generic-aarch64-{{site.data.version_data.hassos['generic-aarch64']}}.vmdk.zip
 [vmdk]: {{release_url}}/{{site.data.version_data.hassos['ova']}}/haos_ova-{{site.data.version_data.hassos['ova']}}.vmdk.zip
 [vhdx]: {{release_url}}/{{site.data.version_data.hassos['ova']}}/haos_ova-{{site.data.version_data.hassos['ova']}}.vhdx.zip
 [vdi]: {{release_url}}/{{site.data.version_data.hassos['ova']}}/haos_ova-{{site.data.version_data.hassos['ova']}}.vdi.zip

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -296,7 +296,7 @@ Follow this guide if you already are running a supported virtual machine hypervi
 
 {% if page.installation_type == 'macos' %}
 
-- VirtualBox currently is not able to run ARM VMs on Apple Silicon Macs. Instructions for VMware Fusion are provided below, or you can try running the Home Assistant Operating System on [UTM](https://mac.getutm.app/) if you have experience using virtual machines.
+- On Apple Silicon Macs, you can use [VMware Fusion](https://www.vmware.com/products/desktop-hypervisor/workstation-and-fusion) to run the Home Assistant Operating System, instructions for which are provided below, or [UTM](https://mac.getutm.app/) as the FOSS alternative.
 {% endif %}
 
 ### Create the virtual machine
@@ -344,15 +344,16 @@ Minimum recommended assignments:
   content: |
     1. Start VMware Fusion and select **File > New** from the menu bar.
     2. Select **Create a custom virtual machine**, then select **Linux** > **Other Linux 6.x kernel 64-bit Arm**.
-    3. Select **Use an existing virtual disk** and locate the unzipped disk image file.
+       - On Intel Macs, select **Other Linux 6.x kernel 64-bit**.
+    4. Select **Use an existing virtual disk** and locate the unzipped disk image file.
        - Ensure **Make a separate copy of the virtual disk** is selected in the file picker options.
-    4. Select **Customize Settings** at the "Finish" step.
-    5. Define the amount of memory and the number of cores the VM is allowed to use under **Processors & Memory**.
-    6. Under **General**, you may choose to start the VM when your Mac boots up if preferred.
-    7. Connect an Ethernet cable and ensure it is connected to your network.
-    8. Under **Network Adapter**, select **Ethernet** under **Bridged Networking**.
-    9. Under **Hard Disk**, increase the disk size to the recommended minimum.
-    10. Under **USB**, select any USB devices that you want to pass through to Home Assistant, such as Home Assistant Connect, or other Zigbee/Z-Wave dongles. You may also want to choose to always connect the device to Home Assistant by choosing **Connect to Linux** in the **Plug In Action** dropdown.
+    5. Select **Customize Settings** at the "Finish" step.
+    6. Define the amount of memory and the number of cores the VM is allowed to use under **Processors & Memory**.
+    7. Under **General**, you may choose to start the VM when your Mac boots up if preferred.
+    8. Connect an Ethernet cable and ensure it is connected to your network.
+    9. Under **Network Adapter**, select **Ethernet** under **Bridged Networking**.
+    10. Under **Hard Disk**, increase the disk size to the recommended minimum.
+    11. Under **USB**, select any USB devices that you want to pass through to Home Assistant, such as Home Assistant Connect, or other Zigbee/Z-Wave dongles. You may also want to choose to always connect the device to Home Assistant by choosing **Connect to Linux** in the **Plug In Action** dropdown.
 {% endif %}
 
 {% unless page.installation_type == 'macos' %}

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -296,7 +296,7 @@ Follow this guide if you already are running a supported virtual machine hypervi
 
 {% if page.installation_type == 'macos' %}
 
-- If VirtualBox is not supported on your Mac, and you'd rather not use VMWare Fusion, you can try running the Home Assistant Operating System on [UTM](https://mac.getutm.app/).
+- VirtualBox currently is not able to run ARM VMs on Apple Silicon Macs. Instructions for VMware Fusion are provided below, or you can try running the Home Assistant Operating System on [UTM](https://mac.getutm.app/) if you have experience using virtual machines.
 {% endif %}
 
 ### Create the virtual machine
@@ -344,14 +344,15 @@ Minimum recommended assignments:
   content: |
     1. Start VMware Fusion and select **File > New** from the menu bar.
     2. Select **Create a custom virtual machine**, then select **Linux** > **Other Linux 6.x kernel 64-bit Arm**.
-    3. Select **Use an existing virtual disk** and locate the unzipped disk image file. Keep the option to *Make a separate copy of the virtual disk* selected, as it is the default.
+    3. Select **Use an existing virtual disk** and locate the unzipped disk image file.
+       - Ensure **Make a separate copy of the virtual disk** is selected in the file picker options.
     4. Select **Customize Settings** at the "Finish" step.
     5. Define the amount of memory and the number of cores the VM is allowed to use under **Processors & Memory**.
-    6. Under **General**, you may choose to start the VM when your Mac boots up, which you can enable if preferred.
+    6. Under **General**, you may choose to start the VM when your Mac boots up if preferred.
     7. Connect an Ethernet cable and ensure it is connected to your network.
     8. Under **Network Adapter**, select **Ethernet** under **Bridged Networking**.
     9. Under **Hard Disk**, increase the disk size to the recommended minimum.
-    10. Under **USB**, select any USB devices that you want to pass through to Home Assistant, such as Home Assistant Connect or other Zigbee/Z-Wave dongles. You may also want to choose to always connect the device to Home Assistant via the **Plug In Action** dropdown.
+    10. Under **USB**, select any USB devices that you want to pass through to Home Assistant, such as Home Assistant Connect, or other Zigbee/Z-Wave dongles. You may also want to choose to always connect the device to Home Assistant by choosing **Connect to Linux** in the **Plug In Action** dropdown.
 {% endif %}
 
 {% unless page.installation_type == 'macos' %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds instructions for how to set up Home Assistant OS on Apple Silicon Macs using VMware Fusion. I was motivated to make this PR after finding out that ARM VM images of Home Assistant OS exist, and since Apple Silicon Macs have been around for 4+ years, many macOS users might not be on x86 anymore. I considered writing instructions for UTM, but from my personal experience Fusion is easier to use and has convenient features like VM auto-start, in addition to becoming free in 2024.

Please let me know if you have any feedback or if you'd like any corrections.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated macOS installation guide with detailed VMware Fusion instructions for both Apple Silicon and Intel Macs.
  - Added new download links for VMware Fusion disk images tailored for Apple Silicon and Intel architectures.
  - Clarified that VirtualBox does not support running ARM VMs on Apple Silicon Macs.
  - Recommended VMware Fusion or UTM as alternatives for macOS virtualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->