### PR TITLE
Fix wrong Leviton Decora model number

### DIFF
--- a/source/_integrations/decora_wifi.markdown
+++ b/source/_integrations/decora_wifi.markdown
@@ -24,7 +24,7 @@ Supported devices (tested):
 - [DW15S-1BZ](https://leviton.com/products/dw15s-1bz) (Decora Smart Wi-Fi 15A Switch)
 - [D215S-2RW](https://store.leviton.com/products/decora-smart-wi-fi-switch-2nd-gen-d215s-2rw) (Decora Smart Wi-Fi 15A Switch - 2nd Gen)
 - [DN15S-1BW](https://leviton.com/products/dn15s-1bw) (Decora Smart No-Neutral Switch) via [MLWSB-1BW](https://leviton.com/products/mlwsb-1bw) (Decora Smart Wi-Fi Bridge for No-Neutral Switch and Dimmer)
-- [DW15S-1BZ](https://leviton.com/products/d2msd-1bw) (Decora Smart Motion Sensing Dimmer Switch, Wi-Fi 2nd Gen)
+- [D2MSD-1BW](https://leviton.com/products/d2msd-1bw) (Decora Smart Motion Sensing Dimmer Switch, Wi-Fi 2nd Gen)
 
 To enable these lights, add the following lines to your {% term "`configuration.yaml`" %} file.
 {% include integrations/restart_ha_after_config_inclusion.md %}


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
In a recent change I accidentally left the model number that I copied from the line above. This corrects it.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the device identifier for the Leviton Decora Smart Motion Sensing Dimmer Switch from `DW15S-1BZ` to `D2MSD-1BW`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->