### PR TITLE
Revert "RPI GPIO: use with Core installation type only"

### DIFF
--- a/source/_integrations/remote_rpi_gpio.markdown
+++ b/source/_integrations/remote_rpi_gpio.markdown
@@ -18,7 +18,7 @@ related:
 ha_quality_scale: legacy
 ---
 
-If you run a {% term "Home Assistant Core" %} installation type, the `remote_rpi_gpio` {% term integration %} is the base for all related GPIO platforms in Home Assistant. For the platform configurations, please check their corresponding sections. Don't use this if you run an installation type other than {% term "Home Assistant Core" %}.
+The `remote_rpi_gpio` {% term integration %} is the base for all related GPIO platforms in Home Assistant. For the platform configurations, please check their corresponding sections.
 
 The remote Raspberry Pi, and the control computer where Home Assistant is running must be configured to be able to run `remote_rpi_gpio`, see [Configuring Remote GPIO](https://gpiozero.readthedocs.io/en/stable/remote_gpio.html) for more details. Unfortunately, this setup is not currently possible with remote, Raspberry Pi 5 hosts, [due to a lack of support in pigiod](https://github.com/joan2937/pigpio/issues/586).
 


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#37015

It was confused with the old gpio integration that has already been removed 

<https://github.com/home-assistant/architecture/blob/master/adr/0019-GPIO.md>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Simplified introductory text for the `remote_rpi_gpio` integration
	- Removed conditional language about Home Assistant installation types
	- Improved clarity of integration description for all users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->