### PR TITLE
Update smartthings.markdown to highlight TLS maximum version limitation

### DIFF
--- a/source/_integrations/smartthings.markdown
+++ b/source/_integrations/smartthings.markdown
@@ -67,7 +67,7 @@ This integration requires an internet accessible incoming webhook to receive pus
 
 1. Setup [remote access](/docs/configuration/remote/) via a domain name secured with SSL.
     1. *Self-signed SSL certificates are not supported by the SmartThings Cloud API.*
-    2. *Smartthings Cloud API requires SSL connection with **maximum** TLS version 1.2*
+    2. *SmartThings Cloud API requires SSL connection with **maximum** TLS version 1.2*
 3. Set the external URL in the Home Assistant [configuration](/integrations/homeassistant/#external_url) to the URL that Home Assistant is available on the internet (this must start with `https://`). If you do not use Nabu Casa you must configure your network to allow TCP traffic from the internet to reach the IP address and port of the device running Home Assistant.
 
 ## Setup instructions

--- a/source/_integrations/smartthings.markdown
+++ b/source/_integrations/smartthings.markdown
@@ -65,8 +65,10 @@ The PAT is used to create a Home Assistant SmartApp in your SmartThings account 
 
 This integration requires an internet accessible incoming webhook to receive push updates from SmartThings. The preferred approach is to subscribe to [Home Assistant Cloud (Nabu Casa)](https://www.nabucasa.com/) and the integration will configure and use a cloudhook automatically. Alternatively, you will have to configure and setup an internet accessible webhook in Home Assistant as described below:
 
-1. Setup [remote access](/docs/configuration/remote/) via a domain name secured with SSL. *Self-signed SSL certificates are not supported by the SmartThings Cloud API.*
-2. Set the external URL in the Home Assistant [configuration](/integrations/homeassistant/#external_url) to the URL that Home Assistant is available on the internet (this must start with `https://`). If you do not use Nabu Casa you must configure your network to allow TCP traffic from the internet to reach the IP address and port of the device running Home Assistant.
+1. Setup [remote access](/docs/configuration/remote/) via a domain name secured with SSL.
+    1. *Self-signed SSL certificates are not supported by the SmartThings Cloud API.*
+    2. *Smartthings Cloud API requires SSL connection with **maximum** TLS version 1.2*
+3. Set the external URL in the Home Assistant [configuration](/integrations/homeassistant/#external_url) to the URL that Home Assistant is available on the internet (this must start with `https://`). If you do not use Nabu Casa you must configure your network to allow TCP traffic from the internet to reach the IP address and port of the device running Home Assistant.
 
 ## Setup instructions
 

--- a/source/_integrations/smartthings.markdown
+++ b/source/_integrations/smartthings.markdown
@@ -68,7 +68,7 @@ This integration requires an internet accessible incoming webhook to receive pus
 1. Setup [remote access](/docs/configuration/remote/) via a domain name secured with SSL.
     1. *Self-signed SSL certificates are not supported by the SmartThings Cloud API.*
     2. *SmartThings Cloud API requires SSL connection with **maximum** TLS version 1.2*
-3. Set the external URL in the Home Assistant [configuration](/integrations/homeassistant/#external_url) to the URL that Home Assistant is available on the internet (this must start with `https://`). If you do not use Nabu Casa you must configure your network to allow TCP traffic from the internet to reach the IP address and port of the device running Home Assistant.
+2. Set the external URL in the Home Assistant [configuration](/integrations/homeassistant/#external_url) to the URL that Home Assistant is available on the internet (this must start with `https://`). If you do not use Nabu Casa you must configure your network to allow TCP traffic from the internet to reach the IP address and port of the device running Home Assistant.
 
 ## Setup instructions
 


### PR DESCRIPTION
Smartthings Cloud API cannot connect to the Home Assistant external URL configured with TLS 1.3 exclusively, It will connect if TLS 1.2 is available.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Additional info on integrating Smartthings Cloud API to Home Assistant. Smartthings can only connect on SSL with maximum TLS version of 1.2. It cannot connect to external URL configured with TLS 1.3 or later.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated SmartThings integration documentation with specific SSL connection requirements
	- Clarified TLS version limitations (maximum TLS 1.2)
	- Specified that self-signed SSL certificates are not supported by SmartThings Cloud API
<!-- end of auto-generated comment: release notes by coderabbit.ai -->