### PR TITLE
Media player browse media action documentation

### DIFF
--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -206,7 +206,6 @@ Provides access to browsing the media tree provided by the integration. Similar 
 | `media_content_type`   |      yes | The type of media to browse such as music, playlist, video, etc. Integration specific.  |
 | `media_content_id`   |      yes | The content ID to browse. Integration specific. An empty content ID returns the top-level of the browse tree. |
 
-
 ```yaml
   # Get the top of the browse tree
   - action: media_player.browse_media
@@ -266,6 +265,7 @@ media_player.living_room:
       media_content_type: album
       media_content_id: A:ALBUMARTIST/Beatles/Abbey%20Road
 ```
+
 ## Device class
 
 {% include integrations/device_class_intro.md %}

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -199,7 +199,7 @@ Allows to group media players together for synchronous playback. Only works on s
 
 #### Action `media_player.browse_media`
 
-Provides access to browsing the media tree provided by the integration. Similar in functionality to browsing media through the media player UI.
+Provides access to browsing the media tree provided by the integration. Similar in functionality to browsing media through the media player UI. Common use cases include automations that need to navigate media libraries and find media by specific categories.
 
 | Data attribute | Optional | Description                                          |
 | ---------------------- | -------- | ---------------------------------------------------- |
@@ -208,12 +208,14 @@ Provides access to browsing the media tree provided by the integration. Similar 
 
 The action returns a media tree object that can be stored in a response variable for use in subsequent automation steps. The response includes:
 
-- `title`: Display name of the current level
-- `media_class`: Type of the current item (e.g., directory, music, video)
-- `media_content_type`: Content type identifier
-- `media_content_id`: Integration specific content ID
-- `children_media_class`: Types of items in the children array
-- `children`: Array of child items with similar properties
+| Field | Description |
+|-------|-------------|
+| `title` | Display name of the current level |
+| `media_class` | Type of the current item (e.g., directory, music, video) |
+| `media_content_type` | Content type identifier |
+| `media_content_id` | Integration specific content ID |
+| `children_media_class` | Types of items in the children array |
+| `children` | Array of child items with similar properties |
 
 Browse the root of the tree.
 
@@ -234,6 +236,7 @@ media_player.living_room:
   media_class: directory
   media_content_type: root
   media_content_id: ""
+  # children_media_class indicates that all items in the children array are directories  
   children_media_class: directory
   children:
     - title: Favorites

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -203,7 +203,7 @@ Provides access to browsing the media tree provided by the integration. Similar 
 
 | Data attribute | Optional | Description                                          |
 | ---------------------- | -------- | ---------------------------------------------------- |
-| `media_content_type`   |      yes | The type of media to browse such as music, playlist, video, etc. Integration specific.  |
+| `media_content_type`   |      yes | The type of media to browse such as music, playlist, and video. Integration specific.  |
 | `media_content_id`   |      yes | The content ID to browse. Integration specific. An empty content ID returns the top-level of the browse tree. |
 
 The action returns a media tree object that can be stored in a response variable for use in subsequent automation steps. The response includes:
@@ -211,7 +211,7 @@ The action returns a media tree object that can be stored in a response variable
 | Field | Description |
 |-------|-------------|
 | `title` | Display name of the current level |
-| `media_class` | Type of the current item (e.g., directory, music, video) |
+| `media_class` | Type of the current item (for example, directory, music, video) |
 | `media_content_type` | Content type identifier |
 | `media_content_id` | Integration specific content ID |
 | `children_media_class` | Types of items in the children array |
@@ -251,7 +251,7 @@ media_player.living_room:
 
 Example of browsing a specific artist with the Sonos Integration:
 
-Note: This example demonstrates browsing an artist's albums. The format of `media_content_id` (`A:ALBUMARTIST/artist_name`) is specific to Sonos. Notice how special characters in album names are URL-encoded in the response (e.g., `%20` for spaces).
+Note: This example demonstrates browsing an artist's albums. The format of `media_content_id` (`A:ALBUMARTIST/artist_name`) is specific to Sonos. Notice how special characters in album names are URL-encoded in the response (for example, `%20` for spaces).
 
 ```yaml
   - action: media_player.browse_media

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -212,6 +212,7 @@ Provides access to browsing the media tree provided by the integration. Similar 
   - action: media_player.browse_media
     target:
       entity_id: media_player.living_room
+    response_variable: top_level
 ```
 
 ```yaml

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -206,6 +206,14 @@ Provides access to browsing the media tree provided by the integration. Similar 
 | `media_content_type`   |      yes | The type of media to browse such as music, playlist, video, etc. Integration specific.  |
 | `media_content_id`   |      yes | The content ID to browse. Integration specific. An empty content ID returns the top-level of the browse tree. |
 
+The action returns a media tree object that can be stored in a response variable for use in subsequent automation steps. The response includes:
+- `title`: Display name of the current level
+- `media_class`: Type of the current item (e.g., directory, music, video)
+- `media_content_type`: Content type identifier
+- `media_content_id`: Integration specific content ID
+- `children_media_class`: Type of items in the children array
+- `children`: Array of child items with similar properties
+
 Browse the root of the tree.
 
 ```yaml
@@ -229,12 +237,10 @@ media_player.living_room:
       media_class: directory
       media_content_type: favorites
       media_content_id: ""
-      thumbnail: https://brands.home-assistant.io/_/sonos/logo.png
     - title: Music Library
       media_class: directory
       media_content_type: library
       media_content_id: ""
-      thumbnail: https://brands.home-assistant.io/_/sonos/logo.png  
 ```
 
 Browse a specific artist, integration dependent:

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -206,6 +206,8 @@ Provides access to browsing the media tree provided by the integration. Similar 
 | `media_content_type`   |      yes | The type of media to browse such as music, playlist, video, etc. Integration specific.  |
 | `media_content_id`   |      yes | The content ID to browse. Integration specific. An empty content ID returns the top-level of the browse tree. |
 
+Browse the root of the tree.
+
 ```yaml
   # Get the top of the browse tree
   - action: media_player.browse_media

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -206,7 +206,36 @@ Provides access to browsing the media tree provided by the integration. Similar 
 | `media_content_type`   |      yes | The type of media to browse such as music, playlist, video, etc. Integration specific.  |
 | `media_content_id`   |      yes | The content ID to browse. Integration specific. An empty content ID returns the top-level of the browse tree. |
 
-Example, integration dependent.
+
+```yaml
+  # Get the top of the browse tree
+  - action: media_player.browse_media
+    target:
+      entity_id: media_player.living_room
+```
+
+```yaml
+# abbreviated Example response
+media_player.living_room:
+  title: Sonos
+  media_class: directory
+  media_content_type: root
+  media_content_id: ""
+  children_media_class: directory
+  children:
+    - title: Favorites
+      media_class: directory
+      media_content_type: favorites
+      media_content_id: ""
+      thumbnail: https://brands.home-assistant.io/_/sonos/logo.png
+    - title: Music Library
+      media_class: directory
+      media_content_type: library
+      media_content_id: ""
+      thumbnail: https://brands.home-assistant.io/_/sonos/logo.png  
+```
+
+Browse a specific artist, integration dependent:
 
 ```yaml
   - action: media_player.browse_media
@@ -216,6 +245,25 @@ Example, integration dependent.
       media_content_id: A:ALBUMARTIST/Beatles
       media_content_type: album
     response_variable: albums
+```
+
+```yaml
+# Abbreviated Example response
+media_player.living_room:
+  title: Beatles
+  media_class: album
+  media_content_type: album
+  media_content_id: A:ALBUMARTIST/Beatles
+  children_media_class: directory
+  children:
+    - title: A Hard Day's Night
+      media_class: album
+      media_content_type: album
+      media_content_id: A:ALBUMARTIST/Beatles/A%20Hard%20Day's%20Night
+    - title: Abbey Road
+      media_class: album
+      media_content_type: album
+      media_content_id: A:ALBUMARTIST/Beatles/Abbey%20Road
 ```
 ## Device class
 

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -209,7 +209,7 @@ Provides access to browsing the media tree provided by the integration. Similar 
 Example, integration dependent.
 
 ```yaml
-  - service: media_player.browse_media
+  - action: media_player.browse_media
     target:
       entity_id: media_player.living_room
     data:

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -197,6 +197,26 @@ Allows to group media players together for synchronous playback. Only works on s
 | ---------------------- | -------- | ---------------------------------------------------- |
 | `entity_id`            |      yes | Unjoin this media player from any player groups.     |
 
+#### Action `media_player.browse_media`
+
+Provides access to browsing the media tree provided by the integration. Similar in functionality to browsing media through the media player UI.
+
+| Data attribute | Optional | Description                                          |
+| ---------------------- | -------- | ---------------------------------------------------- |
+| `media_content_type`   |      yes | The type of media to browse such as music, playlist, video, etc. Integration specific.  |
+| `media_content_id`   |      yes | The content ID to browse. Integration specific. An empty content ID returns the top-level of the browse tree. |
+
+Example, integration dependent.
+
+```yaml
+  - service: media_player.browse_media
+    target:
+      entity_id: media_player.living_room
+    data:
+      media_content_id: A:ALBUMARTIST/Beatles
+      media_content_type: album
+    response_variable: albums
+```
 ## Device class
 
 {% include integrations/device_class_intro.md %}

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -207,14 +207,17 @@ Provides access to browsing the media tree provided by the integration. Similar 
 | `media_content_id`   |      yes | The content ID to browse. Integration specific. An empty content ID returns the top-level of the browse tree. |
 
 The action returns a media tree object that can be stored in a response variable for use in subsequent automation steps. The response includes:
+
 - `title`: Display name of the current level
 - `media_class`: Type of the current item (e.g., directory, music, video)
 - `media_content_type`: Content type identifier
 - `media_content_id`: Integration specific content ID
-- `children_media_class`: Type of items in the children array
+- `children_media_class`: Types of items in the children array
 - `children`: Array of child items with similar properties
 
 Browse the root of the tree.
+
+Note: The following example shows a response from a Sonos device. The structure and content types may vary between different media player integrations. Media content IDs are often URL-encoded.
 
 ```yaml
   # Get the top of the browse tree
@@ -243,7 +246,9 @@ media_player.living_room:
       media_content_id: ""
 ```
 
-Browse a specific artist, integration dependent:
+Example of browsing a specific artist with the Sonos Integration:
+
+Note: This example demonstrates browsing an artist's albums. The format of `media_content_id` (`A:ALBUMARTIST/artist_name`) is specific to Sonos. Notice how special characters in album names are URL-encoded in the response (e.g., `%20` for spaces).
 
 ```yaml
   - action: media_player.browse_media


### PR DESCRIPTION
## Proposed change
Add documentation for the new media player action "browse_media" in PR https://github.com/home-assistant/core/pull/116452



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/116452
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `media_player.browse_media` action to media player integration.
	- Enables browsing media content by type and ID.
	- Supports retrieving top-level media tree when no content ID is specified.
	- Includes example usages for browsing specific artists and media types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->