### PR TITLE
Add timeout to Google Cloud configuration

### DIFF
--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -111,7 +111,7 @@ text_type:
 tts_timeout:
    description: "Time in seconds to wait for the TTS response generation. The default timeout of 10 seconds is sufficient for most text (up to 600-800 characters). For longer text, increase this value to allow more time for audio file generation."
    required: false
-   type: integer?
+   type: integer
    default: 10
    selector:
      number:

--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -111,7 +111,7 @@ text_type:
 tts_timeout:
    description: "Time in seconds to wait for the TTS response generation. The default timeout of 10 seconds is sufficient for most text (up to 600-800 characters). For longer text, increase this value to allow more time for audio file generation. Configurable through the UI."
    required: false
-   type: int
+   type: integer
    default: 10
    selector:
      number:

--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -109,9 +109,9 @@ text_type:
   type: string
   default: "text"
 tts_timeout:
-   description: "Time in seconds to wait for the TTS response generation. The default timeout of 10 seconds is sufficient for most text (up to 600-800 characters). For longer text, increase this value to allow more time for audio file generation. Configurable through the UI."
+   description: "Time in seconds to wait for the TTS response generation. The default timeout of 10 seconds is sufficient for most text (up to 600-800 characters). For longer text, increase this value to allow more time for audio file generation."
    required: false
-   type: integer
+   type: int
    default: 10
    selector:
      number:

--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -109,10 +109,15 @@ text_type:
   type: string
   default: "text"
 tts_timeout:
-  description: "Time in seconds to wait for the TTS response generation. Increasing this value will allow to generate longer audio files from Google Cloud TTS"
-  required: false
-  type: int
-  default: 10
+   description: "Time in seconds to wait for the TTS response generation. The default timeout of 10 seconds is sufficient for most text (up to 600-800 characters). For longer text, increase this value to allow more time for audio file generation. Configurable through the UI."
+   required: false
+   type: int
+   default: 10
+   selector:
+     number:
+       min: 1
+       max: 60
+       unit_of_measurement: seconds
 {% endconfiguration %}
 
 ### Action speak

--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -109,7 +109,7 @@ text_type:
   type: string
   default: "text"
 timeout:
-   description: "Time in seconds to wait for the SST/TTS response generation. The default timeout of 10 seconds is sufficient in most of the cases."
+   description: "Time in seconds to wait for the STT/TTS response generation. The default timeout of 10 seconds is sufficient in most of the cases."
    required: false
    type: integer
    default: 10

--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -111,7 +111,7 @@ text_type:
 tts_timeout:
    description: "Time in seconds to wait for the TTS response generation. The default timeout of 10 seconds is sufficient for most text (up to 600-800 characters). For longer text, increase this value to allow more time for audio file generation."
    required: false
-   type: int
+   type: integer?
    default: 10
    selector:
      number:

--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -108,8 +108,8 @@ text_type:
   required: false
   type: string
   default: "text"
-tts_timeout:
-   description: "Time in seconds to wait for the TTS response generation. The default timeout of 10 seconds is sufficient for most text (up to 600-800 characters). For longer text, increase this value to allow more time for audio file generation."
+timeout:
+   description: "Time in seconds to wait for the SST/TTS response generation. The default timeout of 10 seconds is sufficient in most of the cases."
    required: false
    type: integer
    default: 10

--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -108,6 +108,11 @@ text_type:
   required: false
   type: string
   default: "text"
+tts_timeout:
+  description: "Time in seconds to wait for the TTS response generation. Increasing this value will allow to generate longer audio files from Google Cloud TTS"
+  required: false
+  type: int
+  default: 10
 {% endconfiguration %}
 
 ### Action speak


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This is updated documentation for the change proposed [here](https://github.com/home-assistant/core/pull/136575).

The existing implementation has a hard-coded 10s timeout when waiting for the generated speech from Google Cloud TTS.
Because of that, the integration fails (error "400 Request contains an invalid argument") when you try to generate outputs larger than roughly 600-800 characters, since it would take longer than that for Google Cloud TTS to return a response. I've been hitting this issue constantly when trying to announce long responses coming from my LLM, for example.

The proposed change makes both STT and TTS Timeout configurable in the UI along with the existing model options. The default value is set at 10 seconds (same as the existing implementation), but now users can increase it if needed to generate longer output. The tests have been updated, too.

This updates the documentation to add the `timeout` option (used by both STT and TTS).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/136575
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable timeout option for Google Cloud text-to-speech integration.
  - Users can now adjust the waiting time for TTS response generation (default: 10 seconds), with a range from 1 to 60 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->