### PR TITLE
Cookidoo subscription diagnostics sensors

### DIFF
--- a/source/_integrations/cookidoo.markdown
+++ b/source/_integrations/cookidoo.markdown
@@ -63,6 +63,21 @@ The _clear shopping list_ button entity allows you to clear both the shopping li
 
 This button entity will appear automatically in your Home Assistant instance after adding the integration. You can use it in automations or add it to your dashboard using the Button card.
 
+## Sensor entities
+
+### Diagnostics
+
+1. **Subscription**
+   - _Premium_: The premium subscription is obtained with a yearly fee and grants access to all recipes
+   - _Trial_: The same as the premium but limited in time and usually only available when creating the account or linking a new Vorwerk purchase
+   - _Free_: The free access still gives full access to the shopping list features but limits the access to most recipes
+
+2. **Subscription expiration date**
+   - _Timestamp_:  For premium and trial subscription, the expiration date is available as timestamp
+   - _Unknown_: For the free subscription it is not applicable
+
+These sensor entities will appear automatically in your Home Assistant instance after adding the integration.
+
 ## Known Limitations
 
 {% important %}

--- a/source/_integrations/cookidoo.markdown
+++ b/source/_integrations/cookidoo.markdown
@@ -68,15 +68,33 @@ This button entity will appear automatically in your Home Assistant instance aft
 ### Diagnostics
 
 1. **Subscription**
-   - _Premium_: The premium subscription is obtained with a yearly fee and grants access to all recipes
-   - _Trial_: The same as the premium but limited in time and usually only available when creating the account or linking a new Vorwerk purchase
-   - _Free_: The free access still gives full access to the shopping list features but limits the access to most recipes
+   - State: `premium`, `trial`, or `free`
+   - Description: Indicates the current subscription type
+     - `premium`: Yearly subscription with full recipe access
+     - `trial`: Time-limited premium access (available during account creation or new device linking)
+     - `free`: Limited recipe access with full shopping list features
 
 2. **Subscription expiration date**
-   - _Timestamp_:  For premium and trial subscription, the expiration date is available as timestamp
-   - _Unknown_: For the free subscription it is not applicable
+   - State: ISO 8601 timestamp or `unknown`
+   - Description: Shows when the current subscription expires
+     - For `premium` and `trial` subscriptions: Timestamp of expiration date
+     - For `free` subscriptions: Returns `unknown` state
 
 These sensor entities will appear automatically in your Home Assistant instance after adding the integration.
+
+{% details "Example state attributes" %}
+
+```yaml
+subscription:
+  state: premium
+  icon: mdi:account-star
+
+subscription_expiration_date:
+  state: "2025-01-15T23:59:59+00:00"
+  icon: mdi:clock-reactivate
+```
+
+{% enddetails %}
 
 ## Known Limitations
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add cookidoo subscription diagnostics sensors to track the state and expiration of the purchased subscription in the cookidoo app.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/136485
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Introduced a new section on "Sensor entities" for the Cookidoo integration.
	- Detailed the different subscription types: Premium, Trial, and Free.
	- Explained the states for subscription expiration date.
	- Provided example state attributes in YAML format.
	- Confirmed automatic appearance of sensor entities in Home Assistant after integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->