### PR TITLE
Add warning that there is no way to obtain an API token

### DIFF
--- a/source/_integrations/juicenet.markdown
+++ b/source/_integrations/juicenet.markdown
@@ -22,7 +22,10 @@ ha_integration_type: integration
 
 The `juicenet` platform pulls data from a [JuiceNet](https://evcharging.enelx.com/products/juicebox) charging station equipped with a Wi-Fi connection. It will access and make available all of the devices attached to your account. It also exposes a switch allowing you to charge your car now instead of waiting for the pre-set schedule.
 
+> **⚠️ Warning:** This integration can no longer be set up as the required API token cannot be obtained. However, if you have it working, it may remain functional.
+
 {% include integrations/config_flow.md %}
+
 
 ## Sensor
 

--- a/source/_integrations/juicenet.markdown
+++ b/source/_integrations/juicenet.markdown
@@ -22,7 +22,9 @@ ha_integration_type: integration
 
 The `juicenet` platform pulls data from a [JuiceNet](https://evcharging.enelx.com/products/juicebox) charging station equipped with a Wi-Fi connection. It will access and make available all of the devices attached to your account. It also exposes a switch allowing you to charge your car now instead of waiting for the pre-set schedule.
 
-> **⚠️ Warning:** This integration can no longer be set up as the required API token cannot be obtained. However, if you have it working, it may remain functional.
+{% important %}
+This integration can no longer be set up as the required API token cannot be obtained. However, if you have it working, it may remain functional.
+{% endimportant %}
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
This integration cannot be set up for new users as the API token cannot be obtained.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
This integration cannot be set up for new users as the API token cannot be obtained.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
THE INTEGRATION REALLY SHOULD BE REMOVED BUT APPARENTLY, IT IS STILL WORKING FOR SOME. 
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a warning for the `juicenet` integration regarding API token configuration limitations
  - Clarified that existing setups may continue to function, but new configurations are not possible

<!-- end of auto-generated comment: release notes by coderabbit.ai -->