### PR TITLE
Improving Webhook docs

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -868,7 +868,7 @@ See the [Persistent Notification](/integrations/persistent_notification/) integr
 
 ## Webhook trigger
 
-Webhook trigger fires when a web request is made to the webhook endpoint: `/api/webhook/<webhook_id>`. The webhook endpoint is created automatically when you set it as the `webhook_id` in an automation trigger.
+Webhook trigger fires when a web request is made to the webhook endpoint: `/api/webhook/<webhook_id>`. The webhook endpoint is created automatically when you set it as the `webhook_id` in an automation trigger. You may need to restart home assistant if you are setting up webhook for very first time.
 
 ```yaml
 automation:
@@ -904,6 +904,12 @@ Note that to use JSON encoded payloads, the `Content-Type` header must be set to
 ```bash
 curl -X POST -H "Content-Type: application/json" -d '{ "key": "value" }' https://your-home-assistant:8123/api/webhook/some_hook_id
 ```
+If you want to pass webhook data to action, you will need to use something like this in your action
+```yaml
+data_template:
+  payload: "{{trigger.json}}"
+```
+Note: if you pass json when template is expecting non-json data or vice versa, then automation will trigger but payload will be empty.
 
 ### Webhook security
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -868,8 +868,7 @@ See the [Persistent Notification](/integrations/persistent_notification/) integr
 
 ## Webhook trigger
 
-Webhook trigger fires when a web request is made to the webhook endpoint: `/api/webhook/<webhook_id>`. The webhook endpoint is created automatically when you set it as the `webhook_id` in an automation trigger. You may need to restart home assistant if you are setting up webhook for very first time.
-
+Webhook trigger fires when a web request is made to the webhook endpoint: `/api/webhook/<webhook_id>`. The webhook endpoint is created automatically when you set it as the `webhook_id` in an automation trigger. You may need to restart Home Assistant if you are setting up a webhook for the first time.
 ```yaml
 automation:
   triggers:


### PR DESCRIPTION

## Proposed change
1. added note about restarting haas after setting up webhook. 
2. added note on how to access webhook payload in automation.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
none

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced guidance on setting up webhook triggers.
	- Added a note that a Home Assistant restart may be required during initial setup.
	- Provided an example for correctly passing JSON data to automation actions.
	- Included a caution about potential issues when the payload data type does not match expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->