### PR TITLE
Add description of new sensor states in MotionMount integration

### DIFF
--- a/source/_integrations/motionmount.md
+++ b/source/_integrations/motionmount.md
@@ -83,6 +83,9 @@ The following devices are *not* supported:
   - **Description**: The error status of the MotionMount.
     - None: There is no error.
     - Motor: There is a problem communicating with the motor.
+    - HDMI CEC: There is a problem communicating with the TV. Check the HDMI cable.
+    - Obstruction: The MotionMount detected an obstacle and stopped moving.
+    - TV Width Constraint: The MotionMount detected that the TV moved too close to the wall and stopped moving.
     - Internal: There is an internal error. Refer to the MotionMount app for support.
 
 #### Numbers


### PR DESCRIPTION
## Proposed change
Add descriptions of new states in error sensor


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/137006
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded error reporting for the MotionMount integration with additional error indicators for HDMI connectivity issues, obstructions, and TV positioning constraints, giving users clearer guidance for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->