### PR TITLE
Replace still image example in generic camera

### DIFF
--- a/source/_integrations/generic.markdown
+++ b/source/_integrations/generic.markdown
@@ -59,11 +59,11 @@ Use wallclock as timestamps:
 
 In this section, you find some real-life examples of how to use this camera platform.
 
-### Weather graph from yr.no
+### Weather graph from USA National Weather Service
 
-- Still Image URL: `https://www.yr.no/en/content/1-72837/meteogram.svg`
+You can display a GIF from the web as a still image.
 
-Instructions on how to locate the SVG for your location are available at [developer.yr.no](https://developer.yr.no/doc/guides/available-widgets/)
+- Still Image URL: `https://radar.weather.gov/ridge/standard/CONUS_0.gif`
 
 ### Local image
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

As per #35819, one of the still image examples for the generic camera integration does not work. This PR swaps to another example weather map which does ok.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
The reason for the previous yr.no svg file not working is because of a slightly abnormal svg format which fails the image verification.

Since IP cameras are not expected to be displaying svg files, it was [decided](https://github.com/home-assistant/core/pull/80810) not to add that capability.

If users want to display svg files, they should use a picture entity card, rather than setting up a generic camera.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #35819

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example for the generic camera integration, modifying the header to highlight the USA National Weather Service.
  - Replaced the previous static weather image example with a new animated GIF display.
  - Removed outdated instructions related to the earlier weather service setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->