### PR TITLE
Add inline features position for tile card

### DIFF
--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -93,7 +93,7 @@ features:
   type: list
 features_position:
   required: false
-  description: Position of the features on the tile card. Can be `bottom` or `inline`. Only the first feature will be displayed when the option is set to `inline`. `inline` is not compatible with `vertical` option.
+  description: Position of the features on the tile card. Can be `bottom` or `inline`. Only the first feature will be displayed when the option is set to `inline`. `inline` is not compatible with the `vertical` option.
   type: string
   default: bottom
 

--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -91,6 +91,12 @@ features:
   required: false
   description: Additional widgets to control your entity. See [available features](/dashboards/features).
   type: list
+features_position:
+  required: false
+  description: Position of the features on the tile card. Can be `bottom` or `inline`. Only the first feature will be displayed when the option is set to `inline`. `inline` is not compatible with `vertical` option.
+  type: string
+  default: bottom
+
 {% endconfiguration %}
 
 ## Examples


### PR DESCRIPTION
## Proposed change

Add features position for tile card. It can be set either to side or bottom. Default is bottom.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/24199
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable option that allows users to adjust the positioning of features on tile cards. Users can choose between displaying features at the bottom or inline (showing only the first feature). Inline mode is not compatible with vertical layouts.

- **Documentation**
  - Updated the tile card documentation to clearly describe the new configuration option and its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->