### PR TITLE
Add HEOS media_player.group_volume_set documentation

### DIFF
--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -82,7 +82,7 @@ This integration follows standard integration removal. No extra steps are requir
 
 ## Actions
 
-The HEOS integration makes available the following actions in addition to the standard [Media Player actions](/integrations/media_player#actions).
+In addition to the standard [Media Player actions](/integrations/media_player#actions), the HEOS integration provides the following {% term actions %}:
 
 ### Action `media_player.group_volume_set`
 
@@ -90,7 +90,7 @@ Sets the group's volume while preserving member volume ratios. This action can b
 
 | Data attribute | Optional | Description                                      |
 |------------------------|----------|------------------------------------------------------------------|
-| `entity_id`            |      yes | A media player entity that is joined to a group                  |
+| `entity_id`            |      yes | A media player entity that is joined to a group.                  |
 | `volume_level`         |       no | The volume level, where 0 is inaudible, 1 is the maximum volume. |
 
 ## Examples

--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -80,9 +80,24 @@ This integration follows standard integration removal. No extra steps are requir
 1. Go to **{% my integrations icon title="Settings > Devices & Services" %}**.
 2. Select **Denon HEOS**. Click the three-dot {% icon "mdi:dots-vertical" %} menu and then select **Delete**.
 
-## Playing media
+## Actions
 
-### Play a favorite
+The HEOS integration makes available the following actions in addition to the standard [Media Player actions](/integrations/media_player#actions).
+
+### Action `media_player.group_volume_set`
+
+Sets the group's volume while preserving member volume ratios. This action can be called on any entity in a group.
+
+| Data attribute | Optional | Description                                      |
+|------------------------|----------|------------------------------------------------------------------|
+| `entity_id`            |      yes | A media player entity that is joined to a group                  |
+| `volume_level`         |       no | The volume level, where 0 is inaudible, 1 is the maximum volume. |
+
+## Examples
+
+### Playing media
+
+#### Play a favorite
 
 You can play a HEOS favorite by number or name with the `media_player.play_media` action. Example action data payload:
 
@@ -100,7 +115,7 @@ data:
 | `media_content_type`   | no       | Set to the value `favorite`                                         |
 | `media_content_id`     | no       | (e.g., `1`) or name (e.g., `Thumbprint Radio`) of the HEOS favorite |
 
-### Play a playlist
+#### Play a playlist
 
 You can play a HEOS playlist with the `media_player.play_media` action. Example action data payload:
 
@@ -118,7 +133,7 @@ data:
 | `media_content_type`   | no       | Set to the value `playlist`   |
 | `media_content_id`     | no       | The name of the HEOS playlist |
 
-### Play a Quick Select
+#### Play a Quick Select
 
 You can play a HEOS Quick Select by number or name with the `media_player.play_media` action. Example action data payload:
 
@@ -136,7 +151,7 @@ data:
 | `media_content_type`   | no       | Set to the value `quick_select`                                      |
 | `media_content_id`     | no       | The quick select number (e.g., `1`) or name (e.g., `Quick Select 1`) |
 
-### Play a URL
+#### Play a URL
 
 You can play a URL through a HEOS media player using the `media_player.play_media` action. The HEOS player must be able to reach the URL.
 
@@ -160,9 +175,9 @@ data:
 | `media_content_type`   | no       | Set to the value `url`                           |
 | `media_content_id`     | no       | The full URL to the stream (max 255 characters)  |
 
-## Grouping players
+### Grouping players
 
-### Join
+#### Join
 
 To group HEOS media players together for synchronous playback, use the `media_player.join` action.
 
@@ -186,7 +201,7 @@ data:
 | `entity_id`            | yes      | The media player entity whose playback will be expanded to the players specified in `group_members`. |
 | `group_members`        | no       | The player entities which will be synced with the playback from `entity_id`.                         |
 
-### Unjoin
+#### Unjoin
 
 For removing a HEOS player from a group, use the `media_player.unjoin` action.
 
@@ -200,9 +215,6 @@ data:
 | ---------------------- | -------- | ------------------------------------------------ |
 | `entity_id`            | yes      | Remove this media player from any player groups. |
 
-## Actions
-
-The HEOS integration makes available the standard [Media Player actions](/integrations/media_player#actions).
 
 ## Supported devices
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds documentation for the HEOS `media_player.group_volume_set` entity service. This also moves the Actions section up to before the examples and moves the examples into their own heading.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/136885
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Actions" section highlighting available HEOS integration capabilities, including a group volume control action that maintains member volume ratios.

- **Documentation**
	- Reorganized media playback options with updated descriptions and examples for favorites, playlists, Quick Select, and URLs.
	- Revised player grouping instructions to provide clearer guidance on join and unjoin actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->