### PR TITLE
Add text only option to markdown card

### DIFF
--- a/source/_dashboards/markdown.markdown
+++ b/source/_dashboards/markdown.markdown
@@ -58,6 +58,11 @@ show_empty:
   description: By default, an empty card will still be shown (resulting in a small empty box). Setting this to `false` hides that empty card instead.
   default: true
   type: boolean
+text_only:
+  required: false
+  description: Display the card without border, background, padding and title. 
+  default: false
+  type: boolean
 {% endconfiguration %}
 
 ### Example


### PR DESCRIPTION
## Proposed change

Add text only option to markdown card

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/24329
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional configuration to enable a minimalistic display mode for the Markdown card. When activated, the card appears without its border, background, padding, and title, providing users with a cleaner, more streamlined presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->