### PR TITLE
Add Beoremote One documentation to Bang & Olufsen

### DIFF
--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -103,7 +103,7 @@ All devices except the [Beoconnect Core](https://www.bang-olufsen.com/en/dk/acce
 
 #### Beoremote One
 
-A Home Assistant device is created for each paired Beoremote One, via their paired Mozart device. Event entities, that are disabled by default, are created for each of the compatible keys on the remote.
+A Home Assistant device is created for each paired Beoremote One via their paired Mozart device. Event entities are created for each of the compatible keys on the remote. These event entities are disabled by default.
 
 Beoremote One devices are automatically added as they are detected.
 
@@ -127,18 +127,18 @@ Each of these triggers have two different event states:
 
 In total, this amounts to 90 different remote key Event entities per remote.
 
-##### Configuring Light / Control functions
+##### Configuring light and control functions
 
-A number of functions are available on the Beoremote One. These are available as `function` 1-17 for the Light submenu and 1-27 for the Control submenu.
+A number of functions are available on the Beoremote One. These are available as `function` 1-17 for the **Light** submenu and 1-27 for the **Control** submenu.
 
-Only a subset of these functions are enabled by default. Change settings for the `Control` and `Light` submenus following these steps:
+Only a subset of these functions are enabled by default. Change settings for the **Control** and **Light** submenus following these steps:
 
-- Press up and select the name of currently selected paired device. This will show a list of the paired devices.
-- Select `Beovision`
-- Navigate to `Settings` → `Advanced` → `Light menu` / `Control menu`
-  - Use the `Show` setting to change which functions are visible
-  - Use the `Rename` setting to rename the visible functions
-  - Use the `Move` setting to reorder the visible functions
+- Press up and select the name of the currently selected paired device. This will show a list of the paired devices.
+- Select **Beovision**
+- Navigate to **Settings** > **Advanced** > **Light menu** / **Control menu**.
+  - Use the **Show** setting to change which functions are visible.
+  - Use the **Rename** setting to rename the visible functions.
+  - Use the **Move** setting to reorder the visible functions.
 
 The function names are not available to the Mozart device, so enable [debug logging](#diagnostics-and-troubleshooting) and trigger functions to see what function IDs are associated with which functions on the remote.
 

--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -35,7 +35,7 @@ Devices that have been tested and _should_ work without any trouble are:
 - [Beosound Emerge](https://www.bang-olufsen.com/en/dk/speakers/beosound-emerge)
 - [Beosound Level](https://www.bang-olufsen.com/en/dk/speakers/beosound-level)
 - [Beosound Theatre](https://www.bang-olufsen.com/en/dk/soundbars/beosound-theatre)
-- [Beoremote One](https://www.bang-olufsen.com/en/dk/accessories/beoremote-one)
+- [Beoremote One](https://www.bang-olufsen.com/en/dk/accessories/beoremote-one) through paired devices
 
 and any other [Mozart](https://support.bang-olufsen.com/hc/en-us/articles/24766979863441-Which-platform-is-my-Connected-Audio-product-based-on) based products. This means all [Connected Speakers](https://www.bang-olufsen.com/en/dk/story/connected-speakers) that have been launched after 2020.
 
@@ -67,10 +67,10 @@ A number of features are available through the media player entity:
   - Control with Home Assistant media_player grouping.
   - Monitor current [Beolink state](#beolink) through media player properties.
   - For more advanced usage, [custom Beolink services](#custom-actions) have been defined:
-    - Connect or expand to [ASE](https://support.bang-olufsen.com/hc/en-us/articles/24766979863441-Which-platform-is-my-Connected-Audio-product-based-on) products not available in Home Assistant.
-    - Expand sessions to all discovered devices.
-    - Connect to, expand to or unexpand devices.
-    - Set all connected Beolink devices to standby.
+     - Connect or expand to [ASE](https://support.bang-olufsen.com/hc/en-us/articles/24766979863441-Which-platform-is-my-Connected-Audio-product-based-on) products not available in Home Assistant.
+     - Expand sessions to all discovered devices.
+     - Connect to, expand to or unexpand devices.
+     - Set all connected Beolink devices to standby.
 
 ### Events
 
@@ -103,20 +103,22 @@ All devices except the [Beoconnect Core](https://www.bang-olufsen.com/en/dk/acce
 
 #### Beoremote One
 
-A Home Assistant device is created for each of any paired Beoremote One via their connected Mozart device. Beoremote One devices are automatically added as they are detected.
+A Home Assistant device is created for each of any paired Beoremote One, via their paired Mozart device. Event entities, that are disabled by default, are created for each of the compatible keys on the remote.
+
+Beoremote One devices are automatically added as they are detected.
 
 ##### Triggering events
 
 There are 4 different types of key events:
 
-- Light functions
-- Light keys
 - Control functions
 - Control keys
+- Light functions
+- Light keys
 
-Functions can be accessed by pressing the `Right` key while either `Control` or `Light` are higlighted and can be triggered by pressing `Select`.
+Functions can be accessed by pressing the `Right` key while either `Control` or `Light` are highlighted and can be triggered by pressing `Select`.
 
-Keys can be triggered by pressing the `Select` key while either `Control` or `Light` are higlighted and then pressing one of the compatible keys. The `Select` press can also be skipped, by simply pressing one of the compatible keys while the desired submenu is highlighted.
+Keys can be triggered by pressing the `Select` key while either `Control` or `Light` are highlighted and then pressing one of the compatible keys. The `Select` press can also be skipped, by simply pressing one of the compatible keys while the desired submenu is highlighted.
 
 Each of these triggers have two different event states:
 
@@ -138,7 +140,7 @@ Only a subset of these functions are enabled by default. Change settings for the
   - Use the `Rename` setting to rename the visible functions
   - Use the `Move` setting to reorder the visible functions
 
-The function names are not available to the Mozart device, so enable [debug logging](#diagnostics-and-troubleshooting) and trigger functions to see what function ID is associated with which function.
+The function names are not available to the Mozart device, so enable [debug logging](#diagnostics-and-troubleshooting) and trigger functions to see what function IDs are associated with which functions on the remote.
 
 ## Limitations
 

--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -103,7 +103,7 @@ All devices except the [Beoconnect Core](https://www.bang-olufsen.com/en/dk/acce
 
 #### Beoremote One
 
-A Home Assistant device is created for each of any paired Beoremote One, via their paired Mozart device. Event entities, that are disabled by default, are created for each of the compatible keys on the remote.
+A Home Assistant device is created for each paired Beoremote One, via their paired Mozart device. Event entities, that are disabled by default, are created for each of the compatible keys on the remote.
 
 Beoremote One devices are automatically added as they are detected.
 
@@ -133,7 +133,7 @@ A number of functions are available on the Beoremote One. These are available as
 
 Only a subset of these functions are enabled by default. Change settings for the `Control` and `Light` submenus following these steps:
 
-- Press up and select the name of currently selected paired device. This will show a list the paired devices.
+- Press up and select the name of currently selected paired device. This will show a list of the paired devices.
 - Select `Beovision`
 - Navigate to `Settings` → `Advanced` → `Light menu` / `Control menu`
   - Use the `Show` setting to change which functions are visible
@@ -160,7 +160,9 @@ And more advanced app-centric features such as:
 
 ### Beoremote One
 
-Remote controls paired to the same device are created as Home Assistant devices and Event entities. These remote controls will trigger the same WebSocket notification, meaning that a press on remote A will also trigger Remote B's associated Event entity. This has the benefit of being able to trigger automations mapped to remote A with remote B, but also means that up to 90 Event entities are "lost", when remotes are paired to the same device.
+Several remote controls can be paired to the same Mozart device and are still created as Home Assistant devices and Event entities. These remote controls will trigger the same WebSocket notification, meaning that a press on remote A will also trigger Remote B's associated Event entity. 
+
+This has the benefit of being able to trigger automations mapped to remote A with remote B, but also means that each Mozart device _only_ supports the 90 Event entities that a single remote provides.
 
 ## Actions
 

--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -35,6 +35,7 @@ Devices that have been tested and _should_ work without any trouble are:
 - [Beosound Emerge](https://www.bang-olufsen.com/en/dk/speakers/beosound-emerge)
 - [Beosound Level](https://www.bang-olufsen.com/en/dk/speakers/beosound-level)
 - [Beosound Theatre](https://www.bang-olufsen.com/en/dk/soundbars/beosound-theatre)
+- [Beoremote One](https://www.bang-olufsen.com/en/dk/accessories/beoremote-one)
 
 and any other [Mozart](https://support.bang-olufsen.com/hc/en-us/articles/24766979863441-Which-platform-is-my-Connected-Audio-product-based-on) based products. This means all [Connected Speakers](https://www.bang-olufsen.com/en/dk/story/connected-speakers) that have been launched after 2020.
 
@@ -66,12 +67,14 @@ A number of features are available through the media player entity:
   - Control with Home Assistant media_player grouping.
   - Monitor current [Beolink state](#beolink) through media player properties.
   - For more advanced usage, [custom Beolink services](#custom-actions) have been defined:
-     - Connect or expand to [ASE](https://support.bang-olufsen.com/hc/en-us/articles/24766979863441-Which-platform-is-my-Connected-Audio-product-based-on) products not available in Home Assistant.
-     - Expand sessions to all discovered devices.
-     - Connect to, expand to or unexpand devices.
-     - Set all connected Beolink devices to standby.
+    - Connect or expand to [ASE](https://support.bang-olufsen.com/hc/en-us/articles/24766979863441-Which-platform-is-my-Connected-Audio-product-based-on) products not available in Home Assistant.
+    - Expand sessions to all discovered devices.
+    - Connect to, expand to or unexpand devices.
+    - Set all connected Beolink devices to standby.
 
 ### Events
+
+#### Device controls
 
 Event entities are created for each of the physical controls on your device. These controls usually have their own behaviors, so using them for automations is not always ideal.
 Available event entities:
@@ -97,6 +100,45 @@ All of these event entities support the following event types:
 
 All devices except the [Beoconnect Core](https://www.bang-olufsen.com/en/dk/accessories/beoconnect-core) support device controls.
 
+#### Beoremote One
+
+A Home Assistant device is created for each of any paired Beoremote One via their connected Mozart device. Beoremote One devices are automatically added as they are detected.
+
+##### Triggering events
+
+There are 4 different types of key events:
+
+- Light functions
+- Light keys
+- Control functions
+- Control keys
+
+Functions can be accessed by pressing the `Right` key while either `Control` or `Light` are higlighted and can be triggered by pressing `Select`.
+
+Keys can be triggered by pressing the `Select` key while either `Control` or `Light` are higlighted and then pressing one of the compatible keys. The `Select` press can also be skipped, by simply pressing one of the compatible keys while the desired submenu is highlighted.
+
+Each of these triggers have two different event states:
+
+- key_press
+- key_release
+
+In total this amounts to 90 different remote key Event entities per remote.
+
+##### Configuring Light / Control functions
+
+A number of functions are available on the Beoremote One. These are available as `function` 1-17 for the Light submenu and 1-27 for the Control submenu.
+
+Only a subset of these functions are enabled by default. Change settings for the `Control` and `Light` submenus following these steps:
+
+- Press up and select the name of currently selected paired device. This will show a list the paired devices.
+- Select `Beovision`
+- Navigate to `Settings` → `Advanced` → `Light menu` / `Control menu`
+  - Use the `Show` setting to change which functions are visible
+  - Use the `Rename` setting to rename the visible functions
+  - Use the `Move` setting to reorder the visible functions
+
+The function names are not available to the Mozart device, so enable [debug logging](#diagnostics-and-troubleshooting) and trigger functions to see what function ID is associated with which function.
+
 ## Limitations
 
 Currently, some features of the Mozart platform are not available through the [public API](https://github.com/bang-olufsen/mozart-open-api). Some may become available at a later point, but until then the [Bang & Olufsen App](https://www.bang-olufsen.com/en/dk/story/apps) can be used to configure these settings and features:
@@ -112,6 +154,10 @@ And more advanced app-centric features such as:
 - Creating stereo pairs
 - Adjusting specific sound settings
 - Pairing remotes
+
+### Beoremote One
+
+Remote controls paired to the same device are created as Home Assistant devices and Event entities. These remote controls will trigger the same WebSocket notification, meaning that a press on remote A will also trigger Remote B's associated Event entity. This has the benefit of being able to trigger automations mapped to remote A with remote B, but also means that up to 90 Event entities are "lost", when remotes are paired to the same device.
 
 ## Actions
 

--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -74,7 +74,7 @@ A number of features are available through the media player entity:
 
 ### Events
 
-#### Device controls
+#### Mozart device controls
 
 Event entities are created for each of the physical controls on your device. These controls usually have their own behaviors, so using them for automations is not always ideal.
 
@@ -118,14 +118,14 @@ There are 4 different types of key events:
 
 Functions can be accessed by pressing the `Right` key while either `Control` or `Light` are highlighted and can be triggered by pressing `Select`.
 
-Keys can be triggered by pressing the `Select` key while either `Control` or `Light` are highlighted and then pressing one of the compatible keys. The `Select` press can also be skipped, by simply pressing one of the compatible keys while the desired submenu is highlighted.
+Keys can be triggered by pressing the `Select` key while either `Control` or `Light` are highlighted, and then pressing one of the compatible keys. The `Select` press can also be skipped, by simply pressing one of the compatible keys while the desired submenu is highlighted.
 
 Each of these triggers have two different event states:
 
 - key_press
 - key_release
 
-In total this amounts to 90 different remote key Event entities per remote.
+In total, this amounts to 90 different remote key Event entities per remote.
 
 ##### Configuring Light / Control functions
 
@@ -160,7 +160,7 @@ And more advanced app-centric features such as:
 
 ### Beoremote One
 
-Several remote controls can be paired to the same Mozart device and are still created as Home Assistant devices and Event entities. These remote controls will trigger the same WebSocket notification, meaning that a press on remote A will also trigger Remote B's associated Event entity. 
+Several remote controls can be paired to the same Mozart device and are still created as Home Assistant devices and Event entities. These remote controls will trigger the same WebSocket notification, meaning that a press on remote A will also trigger Remote B's associated Event entity.
 
 This has the benefit of being able to trigger automations mapped to remote A with remote B, but also means that each Mozart device _only_ supports the 90 Event entities that a single remote provides.
 

--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -77,6 +77,7 @@ A number of features are available through the media player entity:
 #### Device controls
 
 Event entities are created for each of the physical controls on your device. These controls usually have their own behaviors, so using them for automations is not always ideal.
+
 Available event entities:
 
 - Bluetooth


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the [Beoremote One](https://www.bang-olufsen.com/en/dk/accessories/beoremote-one)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/138857
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Introduced new content for the Beoremote One device in the Bang & Olufsen integration guide.
  - Expanded details on triggering key events (control functions, control keys, light functions, and light keys) and configuring settings.
  - Added notes on the behavior when multiple devices are paired, ensuring clarity on event notifications.
  - Specified the creation of event entities for each compatible key on the Beoremote One, which are disabled by default.
  - Detailed the total number of different remote key event entities available per remote (90).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->