### PR TITLE
ZHA: Tuck caution alert inside the collapsed section

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -108,13 +108,21 @@ Newer coordinators generally support Zigbee 3.0 firmware, but it is up to the ma
 
 ### Other supported but not recommended Zigbee radio adapters or modules
 
-{% details "List of hardware that is not recommended" %}
-
-{% warning %}
-
 The following hardware is supported, but _not recommended_. Specific models and details are noted where available in each section.
 
-{% endwarning %}
+{% details "List of hardware that is not recommended" %}
+
+{% caution %}
+
+- It is **not recommended** to run a coordinator via **Serial-Proxy-Server** _(also called Serial-to-IP bridge or Ser2Net remote adapter)_ over:
+  
+  - **Wi-Fi**,
+  - **WAN**, or
+  - **VPN**
+
+- The coordinator requires a stable, local connection to its serial port interface without drops in communication with the Zigbee gateway application running on the host computer.
+- Serial protocols used by the coordinator do not have enough robustness, resilience, or fault tolerance to handle packet loss and latency delays that can occur over unstable connections.
+{% endcaution %}
 
 **Silicon Labs EmberZNet based radios using legacy hardware using the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy)**
 
@@ -164,18 +172,6 @@ The following hardware is supported, but _not recommended_. Specific models and 
 {% enddetails %}
 
 If you find an opportunity to improve this information, refer to the section on how to [add support for new and unsupported devices](#how-to-add-support-for-new-and-unsupported-devices).
-
-{% caution %}
-
-- It is **not recommended** to run a coordinator via **Serial-Proxy-Server** _(also called Serial-to-IP bridge or Ser2Net remote adapter)_ over:
-  
-  - **Wi-Fi**,
-  - **WAN**, or
-  - **VPN**
-
-- The coordinator requires a stable, local connection to its serial port interface without drops in communication with the Zigbee gateway application running on the host computer.
-- Serial protocols used by the coordinator do not have enough robustness, resilience, or fault tolerance to handle packet loss and latency delays that can occur over unstable connections.
-{% endcaution %}
 
 ## Configuration requirements
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
- Moves a large caution block out of the main content and into the collapsed list of "non-recommended hardware" 
  - Collapsing down super niche technical content can improve the general readability of the page without outright removing content that can be helpful to call still call attention to (avoid overwhelming the majority of users with a warning about hyper-specific, not-recommended-but-still-technically-supported compatibility notes)

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Revised cautionary messaging to more clearly advise against using unstable network connections (e.g., Wi-Fi, WAN, VPN) for running Zigbee coordinators. The updated note emphasizes the importance of a local, stable connection for optimal performance and mitigates risks related to packet loss and latency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->