### PR TITLE
Update number device classes

### DIFF
--- a/source/_integrations/number.markdown
+++ b/source/_integrations/number.markdown
@@ -42,37 +42,38 @@ The following device classes are supported for numbers:
 - **apparent_power**: Apparent power in VA.
 - **aqi**: Air Quality Index (unitless).
 - **area**: Area in m², cm², km², mm², in², ft², yd², mi², ac, ha
-- **atmospheric_pressure**: Atmospheric pressure in cbar, bar, hPa, inHg, kPa, mbar, Pa, psi
-- **battery**: Percentage of battery that is left
-- **blood_glocose_concentration**: Blood glucose concentration in mg/dL, mmol/L
-- **carbon_dioxide**: Carbon Dioxide in CO2 (Smoke)
-- **carbon_monoxide**: Carbon Monoxide in CO (Gas CNG/LPG)
+- **atmospheric_pressure**: Atmospheric pressure in cbar, bar, hPa, mmHg, inHg, kPa, mbar, Pa or psi
+- **battery**: Percentage of battery that is left in %
+- **blood_glucose_concentration**: Blood glucose concentration in mg/dL, mmol/L
+- **carbon_dioxide**: Carbon Dioxide in CO2 (Smoke) in ppm
+- **carbon_monoxide**: Carbon Monoxide in CO (Gas CNG/LPG) in ppm
 - **current**: Current in A, mA
-- **data_rate**: Data rate in bit/s, kbit/s, Mbit/s, Gbit/s, B/s, kB/s, MB/s, GB/s, KiB/s, MiB/s, or GiB/s
-- **data_size**: Data size in bit, kbit, Mbit, Gbit, B, kB, MB, GB, TB, PB, EB, ZB, YB, KiB, MiB, GiB, TiB, PiB, EiB, ZiB, or YiB
-- **distance**: Generic distance in km, m, cm, mm, mi, yd, or in
+- **data_rate**: Data rate in bit/s, kbit/s, Mbit/s, Gbit/s, B/s, kB/s, MB/s, GB/s, KiB/s, MiB/s or GiB/s
+- **data_size**: Data size in bit, kbit, Mbit, Gbit, B, kB, MB, GB, TB, PB, EB, ZB, YB, KiB, MiB, GiB, TiB, PiB, EiB, ZiB or YiB
+- **distance**: Generic distance in km, m, cm, mm, mi, nmi, yd, or in
+- **duration**: Duration in d, h, min, s, or ms
 - **energy**: Energy in J, kJ, MJ, GJ, mWh, Wh, kWh, MWh, GWh, TWh, cal, kcal, Mcal, or Gcal
 - **energy_storage**: Stored energy in J, kJ, MJ, GJ, mWh, Wh, kWh, MWh, GWh, TWh, cal, kcal, Mcal, or Gcal
 - **frequency**: Frequency in Hz, kHz, MHz, or GHz
-- **gas**: Gasvolume in m³, ft³, or CCF
-- **humidity**: Percentage of humidity in the air
+- **gas**: Gasvolume in m³, ft³ or CCF
+- **humidity**: Percentage of humidity in the air in %
 - **illuminance**: The current light level in lx
 - **irradiance**: Irradiance in W/m² or BTU/(h⋅ft²)
-- **moisture**: Percentage of water in a substance
-- **monetary**: The monetary value
+- **moisture**: Percentage of water in a substance in %
+- **monetary**: The monetary value ([ISO 4217](https://en.wikipedia.org/wiki/ISO_4217#Active_codes))
 - **nitrogen_dioxide**: Concentration of Nitrogen Dioxide in µg/m³
 - **nitrogen_monoxide**: Concentration of Nitrogen Monoxide in µg/m³
 - **nitrous_oxide**: Concentration of Nitrous Oxide in µg/m³
 - **ozone**: Concentration of Ozone in µg/m³
 - **ph**: Potential hydrogen (pH) value of a water solution
 - **pm1**: Concentration of particulate matter less than 1 micrometer in µg/m³
-- **pm10**: Concentration of particulate matter less than 10 micrometers in µg/m³
 - **pm25**: Concentration of particulate matter less than 2.5 micrometers in µg/m³
-- **power_factor**: Power factor(unitless), unit may be `None` or %
+- **pm10**: Concentration of particulate matter less than 10 micrometers in µg/m³
+- **power_factor**: Power factor (unitless), unit may be `None` or %
 - **power**: Power in mW, W, kW, MW, GW or TW
 - **precipitation**: Accumulated precipitation in cm, in or mm
-- **precipitation_intensity**: Precipitation intensity in in/d, in/h, mm/d, or mm/h
-- **pressure**: Pressure in Pa, kPa, hPa, bar, cbar, mbar, mmHg, inHg, or psi
+- **precipitation_intensity**: Precipitation intensity in in/d, in/h, mm/d or mm/h
+- **pressure**: Pressure in Pa, kPa, hPa, bar, cbar, mbar, mmHg, inHg or psi
 - **reactive_power**: Reactive power in var
 - **signal_strength**: Signal strength in dB or dBm
 - **sound_pressure**: Sound pressure in dB or dBA
@@ -80,13 +81,14 @@ The following device classes are supported for numbers:
 - **sulphur_dioxide**: Concentration of sulphur dioxide in µg/m³
 - **temperature**: Temperature in °C, °F or K
 - **volatile_organic_compounds**: Concentration of volatile organic compounds in µg/m³
+- **volatile_organic_compounds_parts**: Ratio of volatile organic compounds in ppm or ppb
 - **voltage**: Voltage in V, mV, µV, kV, MV
 - **volume**: Generic volume in L, mL, gal, fl. oz., m³, ft³, or CCF
 - **volume_flow_rate**: Volume flow rate in m³/h, ft³/min, L/min, gal/min, or mL/s
 - **volume_storage**: Generic stored volume in L, mL, gal, fl. oz., m³, ft³, or CCF
 - **water**: Water consumption in L, gal, m³, ft³, or CCF
 - **weight**: Generic mass in kg, g, mg, µg, oz, lb, or st
-- **wind_speed**: Wind speed in ft/s, km/h, kn, m/s, or mph
+- **wind_speed**: Wind speed in Beaufort, ft/s, km/h, kn, m/s, or mph
  
 ## Actions
 


### PR DESCRIPTION
## Proposed change
This PR updates the docs for all number device classes. These should mostly match sensor device classes, but the docs weren't being updated as well as the docs for the sensor device classes. The following is done:

- add missing `duration`
- add missing `volatile_organic_compounds_parts`
- fix `blood_glucose_concentration` spelling
- update description of all device classes to match descriptions from the [`SensorDeviceClass` docs](https://github.com/home-assistant/home-assistant.io/blob/current/source/_integrations/sensor.markdown#device-class)

If we want to revert some of the changes (i.e. revert removal of oxford commas), we should also change them for the sensor device class docs (linked above). I've removed them for now to match with the more up-to-date sensor docs.

This PR is similar to the matching dev docs PR: https://github.com/home-assistant/developers.home-assistant/pull/2580

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new measurement types for duration (d, h, min, s, ms) and volatile organic compounds (ppm/ppb).

- **Documentation**
	- Expanded unit options for atmospheric pressure (now including mmHg), distance (added nmi), and wind speed (added Beaufort).
	- Clarified descriptions for battery, carbon dioxide, carbon monoxide, humidity, moisture, and monetary values (now referencing the ISO 4217 standard).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->