### PR TITLE
Fix wrong statement on HERE paid plans

### DIFF
--- a/source/_integrations/here_travel_time.markdown
+++ b/source/_integrations/here_travel_time.markdown
@@ -20,7 +20,9 @@ The `here_travel_time` sensor provides travel time from the [HERE Routing API](h
 
 You need to register for an API key by following the instructions in the [API Developer Guide](https://www.here.com/docs/bundle/routing-api-developer-guide-v8/page/topics/send-request.html).
 
-HERE offers a Limited Plan which includes 1000 free transactions per day. If you are not [updating sensors on demand](#updating-sensors-on-demand-using-automation), you can track 3 routes without exceeding the limit. You can provide payment details to increase this to 5000 free transactions per day. More information can be found [on the pricing page](https://www.here.com/get-started/pricing)
+HERE offers a Limited Plan which includes 1000 free transactions per day. If you are not [updating sensors on demand](#updating-sensors-on-demand-using-automation), you can track 3 routes without exceeding the limit.
+
+You can provide payment details if you want to pay for unlimited transactions. Be aware that the amount of transactions included for free in the paid plan might be _less_ than the 1000 transactions per day in the free plan. More information can be found [on the pricing page](https://www.here.com/get-started/pricing)
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
While the free plan includes 1k transactions per DAY, the paid plan distinguishes between types of requests. For car or pedestrian it states 30k free requests per MONTH but others e.g. truck it is 5k per MONTH.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #37790

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised the HERE Limited Plan details to clarify payment options and transaction limits.
  - Updated information now indicates that paid plans offer unlimited transactions, with a note highlighting that the free allocation in the paid plan may be less than that provided by the free plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->