### PR TITLE
Add documentation for Roborock buttons for routines

### DIFF
--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -34,7 +34,7 @@ ha_integration_type: integration
 
 The Roborock integration allows you to control your [Roborock](https://us.roborock.com/pages/robot-vacuum-cleaner) vacuum while using the Roborock app.
 
-This integration requires a continuous cloud connection while using the device. However, excluding map data, communication between the integration and the device is conducted locally.
+This integration requires a continuous cloud connection while using the device. However, excluding map data and scenes, communication between the integration and the device is conducted locally.
 
 Once you log in with your Roborock account, the integration will automatically discover your Roborock devices and get the needed information to communicate locally with them. Please ensure your Home Assistant instance can communicate with the local IP of your device. We recommend setting a static IP for your Roborock Vacuum to help prevent future issues. The device communicates on port 58867. Depending on your firewall, you may need to allow communication from Home Assistant to your vacuum on that port.
 
@@ -131,6 +131,10 @@ Reset side brush consumable - The side brush is expected to be replaced every 20
 Reset main brush consumable - The main brush/ roller is expected to be replaced every 300 hours.
 
 Reset air filter - The air filter is expected to be replaced every 150 hours.
+
+### Scene
+
+For every scene/routine/program you define for your vacuum, a scene entity will be created to activate it.
 
 ### Actions
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -132,7 +132,7 @@ Reset main brush consumable - The main brush/ roller is expected to be replaced 
 
 Reset air filter - The air filter is expected to be replaced every 150 hours.
 
-In addition, some vacuums allow routines to be set up in the app. A button entity will be created for each routine created.
+In addition, some vacuums allow routines to be set up in the app. For each of those routines, a button entity will be created, allowing you to trigger it.
 
 ### Actions
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -132,7 +132,7 @@ Reset main brush consumable - The main brush/ roller is expected to be replaced 
 
 Reset air filter - The air filter is expected to be replaced every 150 hours.
 
-In addition, for every routine you define for your vacuum, a button entity will be created to start it.
+In addition, for every routine you define for your vacuum in the Roborock app, a button entity will be created to start it.
 
 ### Actions
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -34,7 +34,7 @@ ha_integration_type: integration
 
 The Roborock integration allows you to control your [Roborock](https://us.roborock.com/pages/robot-vacuum-cleaner) vacuum while using the Roborock app.
 
-This integration requires a continuous cloud connection while using the device. However, excluding map data and scenes, communication between the integration and the device is conducted locally.
+This integration requires a continuous cloud connection while using the device. However, excluding map data and routines, communication between the integration and the device is conducted locally.
 
 Once you log in with your Roborock account, the integration will automatically discover your Roborock devices and get the needed information to communicate locally with them. Please ensure your Home Assistant instance can communicate with the local IP of your device. We recommend setting a static IP for your Roborock Vacuum to help prevent future issues. The device communicates on port 58867. Depending on your firewall, you may need to allow communication from Home Assistant to your vacuum on that port.
 
@@ -132,7 +132,7 @@ Reset main brush consumable - The main brush/ roller is expected to be replaced 
 
 Reset air filter - The air filter is expected to be replaced every 150 hours.
 
-In addition, for every scene/routine/program you define for your vacuum, a button entity will be created to start it.
+In addition, for every routine you define for your vacuum, a button entity will be created to start it.
 
 ### Actions
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -132,9 +132,7 @@ Reset main brush consumable - The main brush/ roller is expected to be replaced 
 
 Reset air filter - The air filter is expected to be replaced every 150 hours.
 
-### Scene
-
-For every scene/routine/program you define for your vacuum, a scene entity will be created to activate it.
+In addition, for every scene/routine/program you define for your vacuum, a button entity will be created to start it.
 
 ### Actions
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -132,7 +132,7 @@ Reset main brush consumable - The main brush/ roller is expected to be replaced 
 
 Reset air filter - The air filter is expected to be replaced every 150 hours.
 
-In addition, for every routine you define for your vacuum in the Roborock app, a button entity will be created to start it.
+In addition, some vacuums allow routines to be set up in the app. A button entity will be created for each routine created.
 
 ### Actions
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Describe the new feature introduced in https://github.com/home-assistant/core/pull/139845

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/139845
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that both map data and routines require a cloud connection.
  - Added details noting that a control button is now created for each routine, allowing users to initiate these routines directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->