### PR TITLE
Provide valid values in contour examples

### DIFF
--- a/source/_integrations/microsoft.markdown
+++ b/source/_integrations/microsoft.markdown
@@ -65,7 +65,7 @@ pitch:
   type: string
   default: "`default`"
 contour:
-  description: "Change the contour of the output in percentages. This overrides the pitch setting. See the [W3 SSML specification](https://www.w3.org/TR/speech-synthesis/#pitch_contour) for what it does. Example value: `(0,0) (100,100)`."
+  description: "Change the contour of the output in percentages. This overrides the pitch setting. See the [W3 SSML specification](https://www.w3.org/TR/speech-synthesis/#pitch_contour) for what it does. Example value: `(0%, -1st) (100%, +10st)`."
   required: false
   type: string
 region:
@@ -100,6 +100,6 @@ tts:
     rate: 20
     volume: -50
     pitch: high
-    contour: (0, 0) (100, 100)
+    contour: (0%, -1st) (100%, +10st)
     region: eastus
 ```


### PR DESCRIPTION
The current contour example values of (0,0) (0,0) do not work and are not valid. 

Per the documentation [linked](https://www.w3.org/TR/speech-synthesis/#pitch_contour) in this section, the first number of each pair should be followed by percent sign (%), and the second of each pair should be followed by "st" for relative change or "Hz" for specified pitch, as well as preceded by + or -. 

This change updates the documentation to provide valid example values.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
The current contour example values of (0,0) (0,0) do not work and are not valid. 
This change updates the documentation to provide valid example values.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration details for the Text-to-Speech integration.
  - Revised contour parameter examples to use percentage values and musical intervals for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->