### PR TITLE
Update integration doc accuracy and completeness for NUT

### DIFF
--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -244,6 +244,8 @@ The possible diagnostic sensors are:
 | ups_type                  |      | UPS type (opaque by mfg)                 |
 | ups_watchdog_status       |      | UPS watchdog status                      |
 
+### Device actions
+
 {% important %}
 The username and password configured for the device must be granted
 `instcmds` permissions on the NUT server. No actions will be available if

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -335,9 +335,10 @@ Some users install a third-party Home Assistant Community add-on to
 provide their NUT server. These add-ons are not maintained or
 supported by Home Assistant.
 
-The add-on option is available for users running {% term "Home
-Assistant Operating System" %} or {% term "Home Assistant Supervised"
-%}. Please see the Home Assistant Community [Network UPS Tools (NUT)
+The add-on option is available for users running 
+{% term "Home Assistant Operating System" %} or 
+{% term "Home Assistant Supervised" %}. Please see the Home Assistant 
+Community [Network UPS Tools (NUT) 
 add-on](https://github.com/hassio-addons/addon-nut) for installation
 and configuration information, including the required hostname.
 

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -19,7 +19,7 @@ ha_platforms:
 ha_integration_type: device
 ---
 
-The **Network UPS Tools (NUT)** {% term integration %} allows you to monitor and manage an Uninterruptible Power Supply (UPS) for battery backup, a Power Distribution Unit (PDUs), or other similar electrical power source using a [NUT](https://networkupstools.org/) server. It lets you view the status, receive notifications about important events, and execute commands as device actions for one or more such devices.
+The **Network UPS Tools (NUT)** {% term integration %} allows you to monitor and manage an Uninterruptible Power Supply (UPS) for battery backup, a Power Distribution Unit (PDU), or other similar electrical power source using a [NUT](https://networkupstools.org/) server. It lets you view the status, receive notifications about important events, and execute commands as device actions for one or more such devices.
 
 ## Prerequisites
 
@@ -71,8 +71,8 @@ Scan Interval (seconds):
 ## Data updates
 
 The integration uses {% term polling %} to retrieve data from the NUT
-server. The frequency of updates is a configurable option. The
-default is to retrieve data every 60 seconds.
+server. The frequency of updates is a configurable option with a
+default of polling once every 60 seconds.
 
 ## Supported functionality
 
@@ -464,7 +464,7 @@ Only advanced users should perform these operations.
 
 For users running the Home Assistant Community NUT add-on, it may be
 necessary to execute command line instructions within the NUT Docker
-container.  This may be useful for running `upsc` or upscmd`. Enter
+container.  This may be useful for running `upsc` or `upscmd`. Enter
 the following command at the Home Assistant command line:
 
 ```bash

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -85,18 +85,18 @@ The possible sensors are:
 
 | name                      | Unit | Description                              |
 |---------------------------|------|:-----------------------------------------|
+| alarms                    |      | UPS alarms                               |
 | battery_charge            | %    | Battery charge                           |
 | charging_status           |      | Status of the battery charger            |
 | input_current             | A    | Input current                            |
 | input_load                | %    | Load on (ePDU) input                     |
 | input_voltage             | V    | Input voltage                            |
+| load                      | %    | Load on UPS                              |
 | outlet_voltage            | V    | Total output voltage                     |
 | output_phases             |      | Output phases                            |
 | output_voltage            | V    | Output voltage                           |
-| alarms                    |      | UPS alarms                               |
-| load                      | %    | Load on UPS                              |
+| status                    |      | Human-readable version of ups_status (see below) |
 | status_data               |      | UPS status                               |
-| status             |      | Human-readable version of ups_status (see below) |
 | watts                     | W    |                                          |
 
 {% note %}
@@ -138,26 +138,21 @@ The possible diagnostic sensors are:
 | ambient_humidity_status * |      | Ambient humidity status relative to the thresholds |
 | ambient_temperature *     | °C   | Ambient temperature                      |
 | ambient_temperature_status|      | Ambient temperature status relative to the thresholds |
+| apparent_power            | VA   | Current value of apparent power          |
 | battery_alarm_threshold * |      | Battery alarm threshold                  |
 | battery_capacity          | Ah   | Battery capacity                         |
-| low_battery_setpoint      | %    | Remaining battery level when UPS switches to LB |
-| minimum_battery_to_start  | %    | Minimum battery level for UPS restart after power-off |
-| warning_battery_setpoint    | %    | Battery level when UPS switches to "Warning" state |
+| battery_chemistry         |      | Battery chemistry (opaque by mfg)        |
 | battery_current           | A    | Battery current                          |
-| total_battery_current     | A    | Total battery current                    |
 | battery_date              |      | Battery installation or last change date (opaque by mfg) |
 | battery_manuf_date        |      | Battery manufacturing date (opaque by mfg) |
-| number_of_batteries       |      | Number of internal battery packs         |
-| number_of_bad_batteries   |      | Number of bad battery packs              |
 | battery_runtime           | secs | Battery runtime                          |
-| low_battery_runtime       | secs | Remaining battery runtime when UPS switches to LB |
-| minimum_battery_runtime_to_start | secs | Minimum battery runtime for UPS restart after power-off |
 | battery_temperature       | °C   | Battery temperature                      |
-| battery_chemistry         |      | Battery chemistry (opaque by mfg)        |
 | battery_voltage           | V    | Battery voltage                          |
+| beeper_status             |      | UPS beeper status                        |
+| efficiency                | %    | Efficiency of the UPS (ratio of output to input current) |
+| external_contacts         |      | UPS external contact sensors (opaque by mfg) |
 | high_battery_voltage      | V    | Maximum battery voltage (100% charge)    |
-| low_battery_voltage       | V    | Minimum battery voltage, that triggers FSD status |
-| nominal_battery_voltage   | V    | Nominal battery voltage                  |
+| high_voltage_transfer     | V    | High voltage transfer point              |
 | input_bypass_current      | A    | Input bypass current                     |
 | input_bypass_frequency    | Hz   | Input bypass line frequency              |
 | input_bypass_l1_current   | A    | Input bypass L1 current                  |
@@ -174,7 +169,6 @@ The possible diagnostic sensors are:
 | input_bypass_voltage      | V    | Input bypass voltage                     |
 | input_current_status      |      | Current status relative to the thresholds |
 | input_frequency           | Hz   | Input line frequency                     |
-| input_nominal_frequency   | Hz   | Nominal input line frequency             |
 | input_frequency_status    | Hz   | Frequency status                         |
 | input_l1_current          | A    | Input L1 current                         |
 | input_l1_line_frequency   | Hz   | Input L1 line frequency                  |
@@ -188,19 +182,36 @@ The possible diagnostic sensors are:
 | input_l3_line_frequency   | Hz   | Input L3 line frequency                  |
 | input_l3_n_voltage        | V    | Input L3-N voltage                       |
 | input_l3_real_power       | W    | Input L3 current sum value of all (ePDU) phases real power |
+| input_nominal_frequency   | Hz   | Nominal input line frequency             |
 | input_phases              |      | Input line phases                        |
 | input_power               |      | Current sum value of all (ePDU) phases apparent power |
-| input_real_power          | W    | Current sum value of all (ePDU) phases real power |
 | input_power_sensitivity   |      | Input power sensitivity                  |
-| high_voltage_transfer     | V    | High voltage transfer point              |
-| low_voltage_transfer      | V    | Low voltage transfer point               |
-| voltage_transfer_reason   |      | Reason for last transfer to battery (opaque by mfg) |
-| nominal_input_voltage     | V    | Nominal input voltage                    |
+| input_real_power          | W    | Current sum value of all (ePDU) phases real power |
 | input_voltage_status      |      | Status relative to the thresholds        |
-| output_current            | A    | Output current                           |
+| load_reboot_timer         | secs | Time before the load will be rebooted    |
+| load_restart_delay        | secs | Interval to wait before restarting the load |
+| load_shutdown_timer       | secs | Time before the load will be shutdown    |
+| load_start_timer          | secs | Time before the load will be started     |
+| low_battery_runtime       | secs | Remaining battery runtime when UPS switches to LB |
+| low_battery_setpoint      | %    | Remaining battery level when UPS switches to LB |
+| low_battery_voltage       | V    | Minimum battery voltage, that triggers FSD status |
+| low_voltage_transfer      | V    | Low voltage transfer point               |
+| minimum_battery_runtime_to_start | secs | Minimum battery runtime for UPS restart after power-off |
+| minimum_battery_to_start  | %    | Minimum battery level for UPS restart after power-off |
+| nominal_battery_voltage   | V    | Nominal battery voltage                  |
+| nominal_input_voltage     | V    | Nominal input voltage                    |
 | nominal_output_current    | A    | Nominal output current                   |
-| output_frequency          | Hz   | Output frequency                         |
 | nominal_output_frequency  | Hz   | Nominal output frequency                 |
+| nominal_output_power      | VA   |                                          |
+| nominal_output_real_power | W    |                                          |
+| nominal_output_voltage    | V    | Nominal output voltage                   |
+| nominal_power             | VA   | Nominal value of apparent power          |
+| nominal_real_power        | W    | Nominal value of real power              |
+| number_of_bad_batteries   |      | Number of bad battery packs              |
+| number_of_batteries       |      | Number of internal battery packs         |
+| output_apparent_power     | VA   | Output apparent power                    |
+| output_current            | A    | Output current                           |
+| output_frequency          | Hz   | Output frequency                         |
 | output_l1_current         | A    | Output L1 current                        |
 | output_l1_n_voltage       | V    | Output L1-N voltage                      |
 | output_l1_power_percent   | %    | Output L1 percentage of apparent power relative to maximum load |
@@ -214,36 +225,25 @@ The possible diagnostic sensors are:
 | output_l3_power_percent   | %    | Output L3 percentage of apparent power relative to maximum load |
 | output_l3_real_power      | W    | Output L3 real power                     |
 | output_phases             |      | Output phases                            |
-| output_apparent_power     | VA   | Output apparent power                    |
-| nominal_output_power      | VA   |                                          |
 | output_real_power         | W    | Output real power                        |
-| nominal_output_real_power | W    |                                          |
-| nominal_output_voltage    | V    | Nominal output voltage                   |
-| beeper_status             |      | UPS beeper status                        |
-| external_contacts         |      | UPS external contact sensors (opaque by mfg) |
-| ups_reboot_delay          | secs | Interval to wait before rebooting the UPS |
-| ups_shutdown_delay        | secs | Interval to wait after shutdown with delay command |
-| load_restart_delay        | secs | Interval to wait before restarting the load |
-| ups_display_language      |      | Language to use on front panel (opaque by mfg) |
-| efficiency                | %    | Efficiency of the UPS (ratio of output to input current) |
-| system_identifier         |      | UPS system identifier (opaque by mfg)    |
 | overload_setting          | %    | Load when UPS switches to overload condition |
-| apparent_power            | VA   | Current value of apparent power          |
-| nominal_power             | VA   | Nominal value of apparent power          |
 | real_power                | W    | Current value of real power              |
-| nominal_real_power        | W    | Nominal value of real power              |
-| shutdown_ability          |      | Enable or disable UPS shutdown ability   |
-| start_on_ac               |      | UPS starts when power is applied or re-applied |
-| start_on_battery          |      | Allow to start UPS from battery          |
 | reboot_on_battery         |      | UPS coldstarts from battery              |
-| ups_temperature           | °C  |  UPS temperature                          |
 | self_test_date            |      | Date of last self test (opaque by mfg)   |
 | self_test_interval        | secs | Interval between self tests              |
 | self_test_result          |      | Results of last self test (opaque by mfg) |
-| load_reboot_timer         | secs | Time before the load will be rebooted    |
-| load_shutdown_timer       | secs | Time before the load will be shutdown    |
-| load_start_timer          | secs | Time before the load will be started     |
+| shutdown_ability          |      | Enable or disable UPS shutdown ability   |
+| start_on_ac               |      | UPS starts when power is applied or re-applied |
+| start_on_battery          |      | Allow to start UPS from battery          |
+| system_identifier         |      | UPS system identifier (opaque by mfg)    |
+| total_battery_current     | A    | Total battery current                    |
+| ups_display_language      |      | Language to use on front panel (opaque by mfg) |
+| ups_reboot_delay          | secs | Interval to wait before rebooting the UPS |
+| ups_shutdown_delay        | secs | Interval to wait after shutdown with delay command |
+| ups_temperature           | °C  |  UPS temperature                          |
 | ups_type                  |      | UPS type (opaque by mfg)                 |
+| voltage_transfer_reason   |      | Reason for last transfer to battery (opaque by mfg) |
+| warning_battery_setpoint  | %    | Battery level when UPS switches to "Warning" state |
 | watchdog_status           |      | UPS watchdog status                      |
 
 ### Device actions

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -41,11 +41,14 @@ installing and configuring NUT.
 
 You will need to configure at least one NUT username and password for
 this integration to connect to the NUT server. You will also need to
-grant `instcmds` permissions in the NUT server to use device actions.
+grant `instcmds` permissions in the NUT server to use device
+actions. Please see [NUT
+upsd.users](https://networkupstools.org/docs/man/upsd.users.html) for
+more information.
 
 {% include integrations/config_flow.md %}
 
-To setup the integration you need the following information:
+Setting up the integration requires the following information:
 
 {% configuration_basic %}
 Host:
@@ -67,7 +70,7 @@ Scan Interval (seconds):
 
 ## Data updates
 
-The integration uses {% term polling %} to retrieves data from the NUT
+The integration uses {% term polling %} to retrieve data from the NUT
 server. The frequency of updates is a configurable option. The
 default is to retrieve data every 60 seconds.
 
@@ -103,8 +106,8 @@ returned by the NUT server.
 {% endnote %}
 
 {% note %}
-Some sensor values are described as being "opaque by mfg". This means the
-return result will vary by manufacturer.
+Some sensor values are described as "opaque by mfg," meaning the
+returned results may vary by manufacturer.
 {% endnote %}
 
 An additional virtual sensor `ups_status_display` is available to
@@ -274,7 +277,8 @@ automation.
 This example is just a starting point, and you can use it as
 inspiration to create your own automations.
 
-Feel free to contribute more examples to this documentation ❤️.
+Contributions of additional examples to enhance this documentation are
+welcome ❤️.
 
 ### UPS Power Failure Notification
 
@@ -298,7 +302,7 @@ automation:
 
    conditions: []
 
-   actions
+   actions:
      - action: notify.notify
        data:
           title: UPS Power Failure
@@ -347,7 +351,7 @@ server configuration instructions for additional information.
 Below are example configuration files that create the username
 `my_user` with a PASSWORD and permission to execute all commands.
 
-If you are using the Home Assistant Community NUT add-on, below is the
+If you are using the Home Assistant Community NUT add-on, below is 
 an example Configuration for the add-on's users list:
 
 ```yaml
@@ -383,7 +387,6 @@ device. If you have command line access to the system running your NUT
 server, you can query NUT directly using the `upsc` command.
 
 Below is an example where NUT is configured with a device named `my_ups`:
-
 
 ```bash
 $ upsc my_ups
@@ -430,7 +433,7 @@ provide a human-readable form of `ups.status`.
 ### Using NUT to list all commands
 
 {% important %}
-As noted above, NOT is not installed on Home Assistant. NUT commands
+As noted above, NUT is not installed on Home Assistant. NUT commands
 are therefore not available from the Home Assistant command
 line. These instructions apply to users running a separate NUT server
 or who are performing [advanced troubleshooting](#Advanced
@@ -464,7 +467,6 @@ For users running the Home Assistant Community NUT add-on, it may be
 necessary to execute command line instructions within the NUT Docker
 container.  This may be useful for running `upsc` or upscmd`. Enter
 the following command at the Home Assistant command line:
-
 
 ```bash
 docker exec -it $(docker ps -f name=nut -q) bash

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -233,7 +233,7 @@ The possible diagnostic sensors are:
 | ups_realpower             | W    | Current value of real power              |
 | ups_realpower_nominal     | W    | Nominal value of real power              |
 | ups_shutdown              |      | Enable or disable UPS shutdown ability   |
-| ups_start_auto            |      | UPS starts when mains is re(applied)     |
+| ups_start_auto            |      | UPS starts when mains is applied or re-applied) |
 | ups_start_battery         |      | Allow to start UPS from battery          |
 | ups_start_reboot          |      | UPS coldstarts from battery              |
 | ups_temperature           | °C  |  UPS temperature                          |
@@ -323,8 +323,8 @@ It is also important to know:
 
 - This integration does not manage any power sourcing devices
   directly. Instead, it calls a NUT server using the NUT protocol.
-- This integration does not install NUT on Home Assistant server. This
-  project is thereofre unable to update to a new version of NUT.
+- This integration does not install NUT on the Home Assistant server. This
+  project is therefore unable to update to a new version of NUT.
 
 ## Troubleshooting
 
@@ -334,11 +334,12 @@ Some users install a third-party Home Assistant Community add-on to
 provide their NUT server. These add-ons are not maintained or
 supported by Home Assistant.
 
-The add-on option is available for users running {% term "Home Assistant Operating System" %}
-or {% term "Home Assistant Supervised" %}. Please see the Home Assistant 
-Community [Network UPS Tools (NUT) add-on](https://github.com/hassio-addons/addon-nut)
-for installation and configuration information, including the required
-hostname.
+The add-on option is available for users running
+{% term "Home Assistant Operating System" %} or
+{% term "Home Assistant Supervised" %}. Please see the Home Assistant
+Community [Network UPS Tools (NUT)
+add-on](https://github.com/hassio-addons/addon-nut) for installation and
+configuration information, including the required hostname.
 
 ### Issues with user credentials and permissions
 
@@ -347,10 +348,10 @@ The username and password configured for the device must be granted
 no user credentials are specified for a given device. See the NUT
 server configuration instructions for additional information.
 
-Below are example configuration files that create the username
-`my_user` with a PASSWORD and permission to execute all commands.
+Below are example configurations that create the username `my_user`
+with a PASSWORD and permission to execute all commands.
 
-If you are using the Home Assistant Community NUT add-on, below is 
+If you are using the Home Assistant Community NUT add-on, below is
 an example Configuration for the add-on's users list:
 
 ```yaml
@@ -445,7 +446,6 @@ server, you can query NUT directly for the available commands using
 the `upscmd -l` command.
 
 Below is an example where NUT is configured with a device named `my_ups`:
-
 
 ```bash
 $ upscmd -l my_ups

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -25,7 +25,7 @@ The **Network UPS Tools (NUT)** {% term integration %} allows you to monitor and
 
 You must have a NUT server configured to monitor one or more
 supported power source devices. You will need at least one configured
-username and password on the NUT server.
+`username` and `password` configured on the NUT server.
 
 ## Supported devices
 

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -19,7 +19,7 @@ ha_platforms:
 ha_integration_type: device
 ---
 
-The **Network UPS Tools (NUT)** {% term integration %} allows you to monitor and manage Uninterruptible Power Supplies (UPSes for battery backup), Power Distribution Units (PDUs), or other similar electrical power sources using a [NUT](https://networkupstools.org/) server. It lets you view the status, receive notifications about important events, and execute commands as device actions for one or more such devices.
+The **Network UPS Tools (NUT)** {% term integration %} allows you to monitor and manage an Uninterruptible Power Supply (UPS) for battery backup, a Power Distribution Unit (PDUs), or other similar electrical power source using a [NUT](https://networkupstools.org/) server. It lets you view the status, receive notifications about important events, and execute commands as device actions for one or more such devices.
 
 ## Prerequisites
 
@@ -323,9 +323,8 @@ It is also important to know:
 
 - This integration does not manage any power sourcing devices
   directly. Instead, it calls a NUT server using the NUT protocol.
-- The NUT integration does not install NUT on Home Assistant server or
-provide any NUT services directly. The NUT integration therefore
-cannot be "updated" to include a new version of the NUT server.
+- This integration does not install NUT on Home Assistant server. This
+  project is thereofre unable to update to a new version of NUT.
 
 ## Troubleshooting
 
@@ -335,12 +334,11 @@ Some users install a third-party Home Assistant Community add-on to
 provide their NUT server. These add-ons are not maintained or
 supported by Home Assistant.
 
-The add-on option is available for users running 
-{% term "Home Assistant Operating System" %} or 
-{% term "Home Assistant Supervised" %}. Please see the Home Assistant 
-Community [Network UPS Tools (NUT) 
-add-on](https://github.com/hassio-addons/addon-nut) for installation
-and configuration information, including the required hostname.
+The add-on option is available for users running {% term "Home Assistant Operating System" %}
+or {% term "Home Assistant Supervised" %}. Please see the Home Assistant 
+Community [Network UPS Tools (NUT) add-on](https://github.com/hassio-addons/addon-nut)
+for installation and configuration information, including the required
+hostname.
 
 ### Issues with user credentials and permissions
 

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -357,10 +357,10 @@ an example Configuration for the add-on's users list:
 ```yaml
 - username: my_user
   password: [PASSWORD]
-    instcmds:
-      - all
-    actions:
-      - set
+  instcmds:
+    - all
+  actions:
+    - set
 ```
 
 If you are configuring NUT server directly, below is the example

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -266,9 +266,10 @@ allowing you to interact with your power source.
 
 ## Automation Examples
 
-Home Assistant automations can be created to monitor and take actions
-on power sources monitored by a NUT server. The following example
-shows how to use this integration in a Home Assistant automation.
+Home Assistant {% term automations %} can be created to monitor and
+take actions on power sources monitored by a NUT server. The following
+example shows how to use this integration in a Home Assistant
+automation.
 
 This example is just a starting point, and you can use it as
 inspiration to create your own automations.

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -52,7 +52,7 @@ Setting up the integration requires the following information:
 
 {% configuration_basic %}
 Host:
-  description: "The IP address or hostname of your NUT server.
+  description: "The IP address or hostname of your NUT server."
 Port:
   description: "The network port of your NUT server. The NUT server's default port is '3493'."
 Username:

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -97,7 +97,7 @@ The possible sensors are:
 | watts                     | W    |                                          |
 
 {% note %}
-The NUT integration uses the NUT protocol to retreive "variables" from
+The NUT integration uses the NUT protocol to retrieve "variables" from
 the NUT server. The NUT integration only adds sensors for variables
 returned by the NUT server.
 {% endnote %}

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -483,5 +483,3 @@ This integration follows standard integration removal. No extra steps
 are required.
 
 {% include integrations/remove_device_service.md %}
-
-

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -202,8 +202,8 @@ The possible diagnostic sensors are:
 | nominal_input_voltage     | V    | Nominal input voltage                    |
 | nominal_output_current    | A    | Nominal output current                   |
 | nominal_output_frequency  | Hz   | Nominal output frequency                 |
-| nominal_output_power      | VA   |                                          |
-| nominal_output_real_power | W    |                                          |
+| nominal_output_power      | VA   | Nominal output apparent power            |
+| nominal_output_real_power | W    | Nominal output real power                |
 | nominal_output_voltage    | V    | Nominal output voltage                   |
 | nominal_power             | VA   | Nominal value of apparent power          |
 | nominal_real_power        | W    | Nominal value of real power              |

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -233,7 +233,7 @@ The possible diagnostic sensors are:
 | ups_realpower             | W    | Current value of real power              |
 | ups_realpower_nominal     | W    | Nominal value of real power              |
 | ups_shutdown              |      | Enable or disable UPS shutdown ability   |
-| ups_start_auto            |      | UPS starts when mains is applied or re-applied |
+| ups_start_auto            |      | UPS starts when power is applied or re-applied |
 | ups_start_battery         |      | Allow to start UPS from battery          |
 | ups_start_reboot          |      | UPS coldstarts from battery              |
 | ups_temperature           | °C  |  UPS temperature                          |

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -19,7 +19,7 @@ ha_platforms:
 ha_integration_type: device
 ---
 
-The **Network UPS Tools (NUT)** {% term integration %} allows you to monitor and manage a UPS (battery backup), a Power Distribution Unit (PDU), or other similar electrical power sources using a [NUT](https://networkupstools.org/) server. It lets you view the status, receive notifications about important events, and execute commands as device actions for one or more such devices.
+The **Network UPS Tools (NUT)** {% term integration %} allows you to monitor and manage Uninterruptible Power Supplies (UPSes for battery backup), Power Distribution Units (PDUs), or other similar electrical power sources using a [NUT](https://networkupstools.org/) server. It lets you view the status, receive notifications about important events, and execute commands as device actions for one or more such devices.
 
 ## Prerequisites
 

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -233,7 +233,7 @@ The possible diagnostic sensors are:
 | ups_realpower             | W    | Current value of real power              |
 | ups_realpower_nominal     | W    | Nominal value of real power              |
 | ups_shutdown              |      | Enable or disable UPS shutdown ability   |
-| ups_start_auto            |      | UPS starts when mains is applied or re-applied) |
+| ups_start_auto            |      | UPS starts when mains is applied or re-applied |
 | ups_start_battery         |      | Allow to start UPS from battery          |
 | ups_start_reboot          |      | UPS coldstarts from battery              |
 | ups_temperature           | °C  |  UPS temperature                          |

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -86,17 +86,17 @@ The possible sensors are:
 | name                      | Unit | Description                              |
 |---------------------------|------|:-----------------------------------------|
 | battery_charge            | %    | Battery charge                           |
-| battery_charger_status    |      | Status of the battery charger            |
+| charging_status           |      | Status of the battery charger            |
 | input_current             | A    | Input current                            |
 | input_load                | %    | Load on (ePDU) input                     |
 | input_voltage             | V    | Input voltage                            |
 | outlet_voltage            | V    | Total output voltage                     |
 | output_phases             |      | Output phases                            |
 | output_voltage            | V    | Output voltage                           |
-| ups_alarm                 |      | UPS alarms                               |
-| ups_load                  | %    | Load on UPS                              |
-| ups_status                |      | UPS status                               |
-| ups_status_display        |      | Human-readable version of ups_status (see below) |
+| alarms                    |      | UPS alarms                               |
+| load                      | %    | Load on UPS                              |
+| status_data               |      | UPS status                               |
+| status             |      | Human-readable version of ups_status (see below) |
 | watts                     | W    |                                          |
 
 {% note %}
@@ -140,111 +140,111 @@ The possible diagnostic sensors are:
 | ambient_temperature_status|      | Ambient temperature status relative to the thresholds |
 | battery_alarm_threshold * |      | Battery alarm threshold                  |
 | battery_capacity          | Ah   | Battery capacity                         |
-| battery_charge_low        | %    | Remaining battery level when UPS switches to LB |
-| battery_charge_restart    | %    | Minimum battery level for UPS restart after power-off |
-| battery_charge_warning    | %    | Battery level when UPS switches to "Warning" state |
+| low_battery_setpoint      | %    | Remaining battery level when UPS switches to LB |
+| minimum_battery_to_start  | %    | Minimum battery level for UPS restart after power-off |
+| warning_battery_setpoint    | %    | Battery level when UPS switches to "Warning" state |
 | battery_current           | A    | Battery current                          |
-| battery_current_total     | A    | Total battery current                    |
+| total_battery_current     | A    | Total battery current                    |
 | battery_date              |      | Battery installation or last change date (opaque by mfg) |
-| battery_mfr_date          |      | Battery manufacturing date (opaque by mfg) |
-| battery_packs             |      | Number of internal battery packs         |
-| battery_packs_bad         |      | Number of bad battery packs              |
+| battery_manuf_date        |      | Battery manufacturing date (opaque by mfg) |
+| number_of_batteries       |      | Number of internal battery packs         |
+| number_of_bad_batteries   |      | Number of bad battery packs              |
 | battery_runtime           | secs | Battery runtime                          |
-| battery_runtime_low       | secs | Remaining battery runtime when UPS switches to LB |
-| battery_runtime_restart   | secs | Minimum battery runtime for UPS restart after power-off |
+| low_battery_runtime       | secs | Remaining battery runtime when UPS switches to LB |
+| minimum_battery_runtime_to_start | secs | Minimum battery runtime for UPS restart after power-off |
 | battery_temperature       | °C   | Battery temperature                      |
-| battery_type              |      | Battery chemistry (opaque by mfg)        |
+| battery_chemistry         |      | Battery chemistry (opaque by mfg)        |
 | battery_voltage           | V    | Battery voltage                          |
-| battery_voltage_high      | V    | Maximum battery voltage (100% charge)    |
-| battery_voltage_low       | V    | Minimum battery voltage, that triggers FSD status |
-| battery_voltage_nominal   | V    | Nominal battery voltage                  |
+| high_battery_voltage      | V    | Maximum battery voltage (100% charge)    |
+| low_battery_voltage       | V    | Minimum battery voltage, that triggers FSD status |
+| nominal_battery_voltage   | V    | Nominal battery voltage                  |
 | input_bypass_current      | A    | Input bypass current                     |
 | input_bypass_frequency    | Hz   | Input bypass line frequency              |
 | input_bypass_l1_current   | A    | Input bypass L1 current                  |
 | input_bypass_l1_n_voltage | V    | Input bypass L1-N voltage                |
-| input_bypass_l1_realpower | W    | Input bypass L1 value of real power      |
+| input_bypass_l1_real_power| W    | Input bypass L1 value of real power      |
 | input_bypass_l2_current   | A    | Input bypass L2 current                  |
 | input_bypass_l2_n_voltage | V    | Input bypass L2-N voltage                |
-| input_bypass_l2_realpower | W    | Input bypass L2 value of real power      |
+| input_bypass_l2_real_power| W    | Input bypass L2 value of real power      |
 | input_bypass_l3_current   | A    | Input bypass L3 current                  |
 | input_bypass_l3_n_voltage | V    | Input bypass L3-N voltage                |
-| input_bypass_l3_realpower | W    | Input bypass L3 value of real power      |
+| input_bypass_l3_real_power| W    | Input bypass L3 value of real power      |
 | input_bypass_phases       |      | Input bypass line phases                 |
-| input_bypass_realpower    | W    | Input bypass value of real power         |
+| input_bypass_real_power   | W    | Input bypass value of real power         |
 | input_bypass_voltage      | V    | Input bypass voltage                     |
 | input_current_status      |      | Current status relative to the thresholds |
 | input_frequency           | Hz   | Input line frequency                     |
-| input_frequency_nominal   | Hz   | Nominal input line frequency             |
+| input_nominal_frequency   | Hz   | Nominal input line frequency             |
 | input_frequency_status    | Hz   | Frequency status                         |
 | input_l1_current          | A    | Input L1 current                         |
-| input_l1_frequency        | Hz   | Input L1 line frequency                  |
+| input_l1_line_frequency   | Hz   | Input L1 line frequency                  |
 | input_l1_n_voltage        | V    | Input L1-N voltage                       |
-| input_l1_realpower        | W    | Input L1 current sum value of all (ePDU) phases real power |
+| input_l1_real_power       | W    | Input L1 current sum value of all (ePDU) phases real power |
 | input_l2_current          | A    | Input L2 current                         |
-| input_l2_frequency        | Hz   | Input L2 line frequency                  |
+| input_l2_line_frequency   | Hz   | Input L2 line frequency                  |
 | input_l2_n_voltage        | V    | Input L2-N voltage                       |
-| input_l2_realpower        | W    | Input L2 current sum value of all (ePDU) phases real power |
+| input_l2_real_power       | W    | Input L2 current sum value of all (ePDU) phases real power |
 | input_l3_current          | A    | Input L3 current                         |
-| input_l3_frequency        | Hz   | Input L3 line frequency                  |
+| input_l3_line_frequency   | Hz   | Input L3 line frequency                  |
 | input_l3_n_voltage        | V    | Input L3-N voltage                       |
-| input_l3_realpower        | W    | Input L3 current sum value of all (ePDU) phases real power |
+| input_l3_real_power       | W    | Input L3 current sum value of all (ePDU) phases real power |
 | input_phases              |      | Input line phases                        |
 | input_power               |      | Current sum value of all (ePDU) phases apparent power |
-| input_realpower           | W    | Current sum value of all (ePDU) phases real power |
-| input_sensitivity         |      | Input power sensitivity                  |
-| input_transfer_high       | V    | High voltage transfer point              |
-| input_transfer_low        | V    | Low voltage transfer point               |
-| input_transfer_reason     |      | Reason for last transfer to battery (opaque by mfg) |
-| input_voltage_nominal     | V    | Nominal input voltage                    |
+| input_real_power          | W    | Current sum value of all (ePDU) phases real power |
+| input_power_sensitivity   |      | Input power sensitivity                  |
+| high_voltage_transfer     | V    | High voltage transfer point              |
+| low_voltage_transfer      | V    | Low voltage transfer point               |
+| voltage_transfer_reason   |      | Reason for last transfer to battery (opaque by mfg) |
+| nominal_input_voltage     | V    | Nominal input voltage                    |
 | input_voltage_status      |      | Status relative to the thresholds        |
 | output_current            | A    | Output current                           |
-| output_current_nominal    | A    | Nominal output current                   |
+| nominal_output_current    | A    | Nominal output current                   |
 | output_frequency          | Hz   | Output frequency                         |
-| output_frequency_nominal  | Hz   | Nominal output frequency                 |
+| nominal_output_frequency  | Hz   | Nominal output frequency                 |
 | output_l1_current         | A    | Output L1 current                        |
 | output_l1_n_voltage       | V    | Output L1-N voltage                      |
 | output_l1_power_percent   | %    | Output L1 percentage of apparent power relative to maximum load |
-| output_l1_realpower       | W    | Output L1 real power                     |
+| output_l1_real_power      | W    | Output L1 real power                     |
 | output_l2_current         | A    | Output L2 current                        |
 | output_l2_n_voltage       | V    | Output L2-N voltage                      |
 | output_l2_power_percent   | %    | Output L2 percentage of apparent power relative to maximum load |
-| output_l2_realpower       | W    | Output L2 real power                     |
+| output_l2_real_power      | W    | Output L2 real power                     |
 | output_l3_current         | A    | Output L3 current                        |
 | output_l3_n_voltage       | V    | Output L3-N voltage                      |
 | output_l3_power_percent   | %    | Output L3 percentage of apparent power relative to maximum load |
-| output_l3_realpower       | W    | Output L3 real power                     |
+| output_l3_real_power      | W    | Output L3 real power                     |
 | output_phases             |      | Output phases                            |
-| output_power              | VA   | Output apparent power                    |
-| output_power_nominal      | VA   |                                          |
-| output_realpower          | W    | Output real power                        |
-| output_realpower_nominal  | W    |                                          |
-| output_voltage_nominal    | V    | Nominal output voltage                   |
-| ups_beeper_status         |      | UPS beeper status                        |
-| ups_contacts              |      | UPS external contact sensors (opaque by mfg) |
-| ups_delay_reboot          | secs | Interval to wait before rebooting the UPS |
-| ups_delay_shutdown        | secs | Interval to wait after shutdown with delay command |
-| ups_delay_start           | secs | Interval to wait before restarting the load |
+| output_apparent_power     | VA   | Output apparent power                    |
+| nominal_output_power      | VA   |                                          |
+| output_real_power         | W    | Output real power                        |
+| nominal_output_real_power | W    |                                          |
+| nominal_output_voltage    | V    | Nominal output voltage                   |
+| beeper_status             |      | UPS beeper status                        |
+| external_contacts         |      | UPS external contact sensors (opaque by mfg) |
+| ups_reboot_delay          | secs | Interval to wait before rebooting the UPS |
+| ups_shutdown_delay        | secs | Interval to wait after shutdown with delay command |
+| load_restart_delay        | secs | Interval to wait before restarting the load |
 | ups_display_language      |      | Language to use on front panel (opaque by mfg) |
-| ups_efficiency            | %    | Efficiency of the UPS (ratio of output to input current) |
-| ups_id                    |      | UPS system identifier (opaque by mfg)    |
-| ups_load_high             | %    | Load when UPS switches to overload condition |
-| ups_power                 | VA   | Current value of apparent power          |
-| ups_power_nominal         | VA   | Nominal value of apparent power          |
-| ups_realpower             | W    | Current value of real power              |
-| ups_realpower_nominal     | W    | Nominal value of real power              |
-| ups_shutdown              |      | Enable or disable UPS shutdown ability   |
-| ups_start_auto            |      | UPS starts when power is applied or re-applied |
-| ups_start_battery         |      | Allow to start UPS from battery          |
-| ups_start_reboot          |      | UPS coldstarts from battery              |
+| efficiency                | %    | Efficiency of the UPS (ratio of output to input current) |
+| system_identifier         |      | UPS system identifier (opaque by mfg)    |
+| overload_setting          | %    | Load when UPS switches to overload condition |
+| apparent_power            | VA   | Current value of apparent power          |
+| nominal_power             | VA   | Nominal value of apparent power          |
+| real_power                | W    | Current value of real power              |
+| nominal_real_power        | W    | Nominal value of real power              |
+| shutdown_ability          |      | Enable or disable UPS shutdown ability   |
+| start_on_ac               |      | UPS starts when power is applied or re-applied |
+| start_on_battery          |      | Allow to start UPS from battery          |
+| reboot_on_battery         |      | UPS coldstarts from battery              |
 | ups_temperature           | °C  |  UPS temperature                          |
-| ups_test_date             |      | Date of last self test (opaque by mfg)   |
-| ups_test_interval         | secs | Interval between self tests              |
-| ups_test_result           |      | Results of last self test (opaque by mfg) |
-| ups_timer_reboot          | secs | Time before the load will be rebooted    |
-| ups_timer_shutdown        | secs | Time before the load will be shutdown    |
-| ups_timer_start           | secs | Time before the load will be started     |
+| self_test_date            |      | Date of last self test (opaque by mfg)   |
+| self_test_interval        | secs | Interval between self tests              |
+| self_test_result          |      | Results of last self test (opaque by mfg) |
+| load_reboot_timer         | secs | Time before the load will be rebooted    |
+| load_shutdown_timer       | secs | Time before the load will be shutdown    |
+| load_start_timer          | secs | Time before the load will be started     |
 | ups_type                  |      | UPS type (opaque by mfg)                 |
-| ups_watchdog_status       |      | UPS watchdog status                      |
+| watchdog_status           |      | UPS watchdog status                      |
 
 ### Device actions
 

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -30,7 +30,7 @@ username and password on the NUT server.
 ## Supported devices
 
 This integration supports hardware devices compatible with
-NUT. NUT's hardware compatability list is available from the [Network
+NUT. NUT's hardware compatibility list is available from the [Network
 UPS Tools](https://networkupstools.org/) website.
 
 ## Setting up a NUT Server
@@ -42,7 +42,6 @@ installing and configuring NUT.
 You will need to configure at least one NUT username and password for
 this integration to connect to the NUT server. You will also need to
 grant `instcmds` permissions in the NUT server to use device actions.
-{% enddetails %}
 
 {% include integrations/config_flow.md %}
 
@@ -54,9 +53,9 @@ Host:
 Port:
   description: "The network port of your NUT server. The NUT server's default port is '3493'."
 Username:
-  description: "The username to log into the NUT server. This is configured in NUT or the NUT add-on."
+  description: "The username to log into the NUT server. This is configured in NUT."
 Password:
-  description: "The password associated with the username to log into the NUT server. This is configured in NUT or the NUT add-on."
+  description: "The password associated with the username to log into the NUT server. This is configured in NUT."
 {% endconfiguration_basic %}
 
 {% include integrations/option_flow.md %}
@@ -108,8 +107,8 @@ Some sensor values are described as being "opaque by mfg". This means the
 return result will vary by manufacturer.
 {% endnote %}
 
-An additional virtual sensor `ups.status.display` is available to
-translate the UPS status value retrieved from `ups.status` into a
+An additional virtual sensor `ups_status_display` is available to
+translate the UPS status value retrieved from `ups_status` into a
 human-readable format.
 
 Additional information about these sensors can be found in the Network
@@ -212,7 +211,7 @@ The possible diagnostic sensors are:
 | output_l3_power_percent   | %    | Output L3 percentage of apparent power relative to maximum load |
 | output_l3_realpower       | W    | Output L3 real power                     |
 | output_phases             |      | Output phases                            |
-| output_power              | VA   | Otuput apparent power                    |
+| output_power              | VA   | Output apparent power                    |
 | output_power_nominal      | VA   |                                          |
 | output_realpower          | W    | Output real power                        |
 | output_realpower_nominal  | W    |                                          |
@@ -269,7 +268,7 @@ allowing you to interact with your power source.
 
 Home Assistant automations can be created to monitor and take actions
 on power sources monitored by a NUT server. The following example
-shows how to use this integration in a Home Assistant automations.
+shows how to use this integration in a Home Assistant automation.
 
 This example is just a starting point, and you can use it as
 inspiration to create your own automations.
@@ -307,8 +306,8 @@ automation:
 
 ## Known limitations
 
-Not all NUT functionality is available through thi sintegration. The
-following limitations are known:
+Not all NUT functionality is available through this integration. The
+following are known limitations of this integration:
 
 - This NUT integration supports a subset of NUT "variables" and
 "commands".
@@ -320,10 +319,8 @@ It is also important to know:
 - This integration does not manage any power sourcing devices
   directly. Instead, it calls a NUT server using the NUT protocol.
 - The NUT integration does not install NUT on Home Assistant server or
-provide any NUT services directly. Instead, it retreives data from a
-NUT server. The NUT server may be running in an add-on container or
-another system. The NUT integration therefore cannot be "updated" to
-include a new version of the NUT server.
+provide any NUT services directly. The NUT integration therefore
+cannot be "updated" to include a new version of the NUT server.
 
 ## Troubleshooting
 
@@ -349,8 +346,8 @@ server configuration instructions for additional information.
 Below are example configuration files that create the username
 `my_user` with a PASSWORD and permission to execute all commands.
 
-If you are using the NUT add-on, below is the an example Configuration for
-the add-on's users list:
+If you are using the Home Assistant Community NUT add-on, below is the
+an example Configuration for the add-on's users list:
 
 ```yaml
 - username: my_user
@@ -374,15 +371,14 @@ If you are configuring NUT server directly, below is the example
 ### Using NUT to list all variables
 
 {% important %}
-The recommended configuration does not install NUT directly on Home
-Assistant. The NUT commands are therefore not available from the Home
-Assistant command line. These instructions apply to users running a
-separate NUT server or who are performing [advanced
-troubleshooting](#Advanced troubleshooting).
+The NUT package is not installed on Home Assistant. NUT commands are
+therefore not available from the Home Assistant command line. These
+instructions apply to users running a separate NUT server or who are
+performing [advanced troubleshooting](#Advanced troubleshooting).
 {% endimportant %}
 
 The NUT server provides "variables" regarding your power source
-device. If you have command line access to the system running NUT
+device. If you have command line access to the system running your NUT
 server, you can query NUT directly using the `upsc` command.
 
 Below is an example where NUT is configured with a device named `my_ups`:
@@ -433,17 +429,17 @@ provide a human-readable form of `ups.status`.
 ### Using NUT to list all commands
 
 {% important %}
-As noted above, the recommended configuration does not install NUT
-directly on Home Assistant. The NUT commands are therefore not
-available from the Home Assistant command line. These instructions
-apply to users running a separate NUT server or who are performing
-[advanced troubleshooting](#Advanced troubleshooting).
+As noted above, NOT is not installed on Home Assistant. NUT commands
+are therefore not available from the Home Assistant command
+line. These instructions apply to users running a separate NUT server
+or who are performing [advanced troubleshooting](#Advanced
+troubleshooting).
 {% endimportant %}
 
 The NUT server provides commands for controlling your power source
-device. If you have command line access to the system running NUT
-server, you can query NUT directly for the available using the `upscmd
--l` command.
+device. If you have command line access to the system running your NUT
+server, you can query NUT directly for the available commands using
+the `upscmd -l` command.
 
 Below is an example where NUT is configured with a device named `my_ups`:
 
@@ -463,10 +459,10 @@ test.battery.stop - Stop the battery test
 Only advanced users should perform these operations.
 {% endwarning %}
 
-For users of the NUT add-on, it is sometimes necessary to access the
-NUT Docker container directly to execute commands on the command line.
-This may be useful for running `upsc` or upscmd`. Enter the
-following command at the Home Assistant command line:
+For users running the Home Assistant Community NUT add-on, it may be
+necessary to execute command line instructions within the NUT Docker
+container.  This may be useful for running `upsc` or upscmd`. Enter
+the following command at the Home Assistant command line:
 
 
 ```bash

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -19,16 +19,375 @@ ha_platforms:
 ha_integration_type: device
 ---
 
-The Network UPS Tools (NUT) integration allows you to monitor and manage a UPS (battery backup) using a [NUT](https://networkupstools.org/) server. It lets you view their status, receives notifications about important events, and execute commands as device actions.
+The **Network UPS Tools (NUT)** {% term integration %} allows you to monitor and manage a UPS (battery backup), a Power Distribution Unit (PDU), or other similar electrical power sources using a [NUT](https://networkupstools.org/) server. It lets you view the status, receive notifications about important events, and execute commands as device actions for one or more such devices.
+
+## Prerequisites
+
+You must have a NUT server configured to monitor one or more
+supported power source devices. You will need at least one configured
+username and password on the NUT server.
+
+## Supported devices
+
+This integration supports hardware devices compatible with
+NUT. NUT's hardware compatability list is available from the [Network
+UPS Tools](https://networkupstools.org/) website.
+
+## Setting up a NUT Server
+
+There are many options for running a NUT server. Please see
+[NUT](https://networkupstools.org/) for general information on
+installing and configuring NUT.
+
+You will need to configure at least one NUT username and password for
+this integration to connect to the NUT server. You will also need to
+grant `instcmds` permissions in the NUT server to use device actions.
+{% enddetails %}
 
 {% include integrations/config_flow.md %}
 
-## Example Resources
+To setup the integration you need the following information:
 
-Given the following example output from NUT (your variables may differ):
+{% configuration_basic %}
+Host:
+  description: "The IP address or hostname of your NUT server.
+Port:
+  description: "The network port of your NUT server. The NUT server's default port is '3493'."
+Username:
+  description: "The username to log into the NUT server. This is configured in NUT or the NUT add-on."
+Password:
+  description: "The password associated with the username to log into the NUT server. This is configured in NUT or the NUT add-on."
+{% endconfiguration_basic %}
+
+{% include integrations/option_flow.md %}
+
+{% configuration_basic %}
+Scan Interval (seconds):
+  description: "Frequency of requesting updates from NUT server. The default frequency is to poll for data every 60 seconds."
+{% endconfiguration_basic %}
+
+## Data updates
+
+The integration uses {% term polling %} to retrieves data from the NUT
+server. The frequency of updates is a configurable option. The
+default is to retrieve data every 60 seconds.
+
+## Supported functionality
+
+### Sensors
+
+This NUT integration will only add sensors for variables returned by
+the NUT server as available for your device.
+
+The possible sensors are:
+
+| name                      | Unit | Description                              |
+|---------------------------|------|:-----------------------------------------|
+| battery_charge            | %    | Battery charge                           |
+| battery_charger_status    |      | Status of the battery charger            |
+| input_current             | A    | Input current                            |
+| input_load                | %    | Load on (ePDU) input                     |
+| input_voltage             | V    | Input voltage                            |
+| outlet_voltage            | V    | Total output voltage                     |
+| output_phases             |      | Output phases                            |
+| output_voltage            | V    | Output voltage                           |
+| ups_alarm                 |      | UPS alarms                               |
+| ups_load                  | %    | Load on UPS                              |
+| ups_status                |      | UPS status                               |
+| ups_status_display        |      | Human-readable version of ups_status (see below) |
+| watts                     | W    |                                          |
+
+{% note %}
+The NUT integration uses the NUT protocol to retreive "variables" from
+the NUT server. The NUT integration only adds sensors for variables
+returned by the NUT server.
+{% endnote %}
+
+{% note %}
+Some sensor values are described as being "opaque by mfg". This means the
+return result will vary by manufacturer.
+{% endnote %}
+
+An additional virtual sensor `ups.status.display` is available to
+translate the UPS status value retrieved from `ups.status` into a
+human-readable format.
+
+Additional information about these sensors can be found in the Network
+UPS Tools repository documentation on [variable
+names](https://github.com/networkupstools/nut/blob/master/docs/nut-names.txt).
+
+### Diagnostic Sensors
+
+Diagnostic sensors are available to provide additional information
+about the NUT device. Diagnostics are added only for variables
+returned by the NUT server as available for your device.
+
+This integration's diagnostic sensors are generally disabled by
+default to reduce storage overhead. If an entity listed below has an
+asterisk (*) next to its name, it means it is enabled by default. To
+use a disabled entity, you must [enable the
+entity](/common-tasks/general/#enabling-entities) first.
+
+The possible diagnostic sensors are:
+
+| name                      | Unit | Description                              |
+|---------------------------|------|:-----------------------------------------|
+| ambient_humidity *        | %    | Ambient relative humidity                |
+| ambient_humidity_status * |      | Ambient humidity status relative to the thresholds |
+| ambient_temperature *     | °C   | Ambient temperature                      |
+| ambient_temperature_status|      | Ambient temperature status relative to the thresholds |
+| battery_alarm_threshold * |      | Battery alarm threshold                  |
+| battery_capacity          | Ah   | Battery capacity                         |
+| battery_charge_low        | %    | Remaining battery level when UPS switches to LB |
+| battery_charge_restart    | %    | Minimum battery level for UPS restart after power-off |
+| battery_charge_warning    | %    | Battery level when UPS switches to "Warning" state |
+| battery_current           | A    | Battery current                          |
+| battery_current_total     | A    | Total battery current                    |
+| battery_date              |      | Battery installation or last change date (opaque by mfg) |
+| battery_mfr_date          |      | Battery manufacturing date (opaque by mfg) |
+| battery_packs             |      | Number of internal battery packs         |
+| battery_packs_bad         |      | Number of bad battery packs              |
+| battery_runtime           | secs | Battery runtime                          |
+| battery_runtime_low       | secs | Remaining battery runtime when UPS switches to LB |
+| battery_runtime_restart   | secs | Minimum battery runtime for UPS restart after power-off |
+| battery_temperature       | °C   | Battery temperature                      |
+| battery_type              |      | Battery chemistry (opaque by mfg)        |
+| battery_voltage           | V    | Battery voltage                          |
+| battery_voltage_high      | V    | Maximum battery voltage (100% charge)    |
+| battery_voltage_low       | V    | Minimum battery voltage, that triggers FSD status |
+| battery_voltage_nominal   | V    | Nominal battery voltage                  |
+| input_bypass_current      | A    | Input bypass current                     |
+| input_bypass_frequency    | Hz   | Input bypass line frequency              |
+| input_bypass_l1_current   | A    | Input bypass L1 current                  |
+| input_bypass_l1_n_voltage | V    | Input bypass L1-N voltage                |
+| input_bypass_l1_realpower | W    | Input bypass L1 value of real power      |
+| input_bypass_l2_current   | A    | Input bypass L2 current                  |
+| input_bypass_l2_n_voltage | V    | Input bypass L2-N voltage                |
+| input_bypass_l2_realpower | W    | Input bypass L2 value of real power      |
+| input_bypass_l3_current   | A    | Input bypass L3 current                  |
+| input_bypass_l3_n_voltage | V    | Input bypass L3-N voltage                |
+| input_bypass_l3_realpower | W    | Input bypass L3 value of real power      |
+| input_bypass_phases       |      | Input bypass line phases                 |
+| input_bypass_realpower    | W    | Input bypass value of real power         |
+| input_bypass_voltage      | V    | Input bypass voltage                     |
+| input_current_status      |      | Current status relative to the thresholds |
+| input_frequency           | Hz   | Input line frequency                     |
+| input_frequency_nominal   | Hz   | Nominal input line frequency             |
+| input_frequency_status    | Hz   | Frequency status                         |
+| input_l1_current          | A    | Input L1 current                         |
+| input_l1_frequency        | Hz   | Input L1 line frequency                  |
+| input_l1_n_voltage        | V    | Input L1-N voltage                       |
+| input_l1_realpower        | W    | Input L1 current sum value of all (ePDU) phases real power |
+| input_l2_current          | A    | Input L2 current                         |
+| input_l2_frequency        | Hz   | Input L2 line frequency                  |
+| input_l2_n_voltage        | V    | Input L2-N voltage                       |
+| input_l2_realpower        | W    | Input L2 current sum value of all (ePDU) phases real power |
+| input_l3_current          | A    | Input L3 current                         |
+| input_l3_frequency        | Hz   | Input L3 line frequency                  |
+| input_l3_n_voltage        | V    | Input L3-N voltage                       |
+| input_l3_realpower        | W    | Input L3 current sum value of all (ePDU) phases real power |
+| input_phases              |      | Input line phases                        |
+| input_power               |      | Current sum value of all (ePDU) phases apparent power |
+| input_realpower           | W    | Current sum value of all (ePDU) phases real power |
+| input_sensitivity         |      | Input power sensitivity                  |
+| input_transfer_high       | V    | High voltage transfer point              |
+| input_transfer_low        | V    | Low voltage transfer point               |
+| input_transfer_reason     |      | Reason for last transfer to battery (opaque by mfg) |
+| input_voltage_nominal     | V    | Nominal input voltage                    |
+| input_voltage_status      |      | Status relative to the thresholds        |
+| output_current            | A    | Output current                           |
+| output_current_nominal    | A    | Nominal output current                   |
+| output_frequency          | Hz   | Output frequency                         |
+| output_frequency_nominal  | Hz   | Nominal output frequency                 |
+| output_l1_current         | A    | Output L1 current                        |
+| output_l1_n_voltage       | V    | Output L1-N voltage                      |
+| output_l1_power_percent   | %    | Output L1 percentage of apparent power relative to maximum load |
+| output_l1_realpower       | W    | Output L1 real power                     |
+| output_l2_current         | A    | Output L2 current                        |
+| output_l2_n_voltage       | V    | Output L2-N voltage                      |
+| output_l2_power_percent   | %    | Output L2 percentage of apparent power relative to maximum load |
+| output_l2_realpower       | W    | Output L2 real power                     |
+| output_l3_current         | A    | Output L3 current                        |
+| output_l3_n_voltage       | V    | Output L3-N voltage                      |
+| output_l3_power_percent   | %    | Output L3 percentage of apparent power relative to maximum load |
+| output_l3_realpower       | W    | Output L3 real power                     |
+| output_phases             |      | Output phases                            |
+| output_power              | VA   | Otuput apparent power                    |
+| output_power_nominal      | VA   |                                          |
+| output_realpower          | W    | Output real power                        |
+| output_realpower_nominal  | W    |                                          |
+| output_voltage_nominal    | V    | Nominal output voltage                   |
+| ups_beeper_status         |      | UPS beeper status                        |
+| ups_contacts              |      | UPS external contact sensors (opaque by mfg) |
+| ups_delay_reboot          | secs | Interval to wait before rebooting the UPS |
+| ups_delay_shutdown        | secs | Interval to wait after shutdown with delay command |
+| ups_delay_start           | secs | Interval to wait before restarting the load |
+| ups_display_language      |      | Language to use on front panel (opaque by mfg) |
+| ups_efficiency            | %    | Efficiency of the UPS (ratio of output to input current) |
+| ups_id                    |      | UPS system identifier (opaque by mfg)    |
+| ups_load_high             | %    | Load when UPS switches to overload condition |
+| ups_power                 | VA   | Current value of apparent power          |
+| ups_power_nominal         | VA   | Nominal value of apparent power          |
+| ups_realpower             | W    | Current value of real power              |
+| ups_realpower_nominal     | W    | Nominal value of real power              |
+| ups_shutdown              |      | Enable or disable UPS shutdown ability   |
+| ups_start_auto            |      | UPS starts when mains is re(applied)     |
+| ups_start_battery         |      | Allow to start UPS from battery          |
+| ups_start_reboot          |      | UPS coldstarts from battery              |
+| ups_temperature           | °C  |  UPS temperature                          |
+| ups_test_date             |      | Date of last self test (opaque by mfg)   |
+| ups_test_interval         | secs | Interval between self tests              |
+| ups_test_result           |      | Results of last self test (opaque by mfg) |
+| ups_timer_reboot          | secs | Time before the load will be rebooted    |
+| ups_timer_shutdown        | secs | Time before the load will be shutdown    |
+| ups_timer_start           | secs | Time before the load will be started     |
+| ups_type                  |      | UPS type (opaque by mfg)                 |
+| ups_watchdog_status       |      | UPS watchdog status                      |
+
+{% important %}
+The username and password configured for the device must be granted
+`instcmds` permissions on the NUT server. No actions will be available if
+no user credentials are specified for a given device. See the NUT
+server configuration instructions for additional information.
+
+Home Assistant cannot determine whether a user can access a specific
+action without executing it. If you attempt to perform an action for
+which the user does not have permission, an exception will be thrown
+at runtime.
+{% endimportant %}
+
+A device action is available for each parameterless NUT
+[command](https://networkupstools.org/docs/user-manual.chunked/apcs03.html)
+supported by the device.
+
+These commands will be available as device actions in Home Assistant,
+allowing you to interact with your power source.
+
+## Automation Examples
+
+Home Assistant automations can be created to monitor and take actions
+on power sources monitored by a NUT server. The following example
+shows how to use this integration in a Home Assistant automations.
+
+This example is just a starting point, and you can use it as
+inspiration to create your own automations.
+
+Feel free to contribute more examples to this documentation ❤️.
+
+### UPS Power Failure Notification
+
+The following example sends a notification to your mobile device when
+a monitored UPS suffers a power loss and the state changes to
+battery. In this example, the NUT server is configured with a device
+named `ups` and it provides a `status` sensor.
 
 ```yaml
-$ upsc ups_name@192.168.11.5
+# Send notification on UPS Power Failure
+automation:
+ - alias: NUT Power Failure Notification
+   description: NUT Power Failure Notification
+   mode: single
+
+   triggers:
+    - trigger: state
+      entity_id:
+        - sensor.ups_status
+      to: On Battery Battery Discharging
+
+   conditions: []
+
+   actions
+     - action: notify.notify
+       data:
+          title: UPS Power Failure
+          message: The UPS lost power and is now on battery
+```
+
+## Known limitations
+
+Not all NUT functionality is available through thi sintegration. The
+following limitations are known:
+
+- This NUT integration supports a subset of NUT "variables" and
+"commands".
+- This NUT integration does not support setting of NUT "variables".
+- This NUT integration does not support NUT "commands" that require parameters.
+
+It is also important to know:
+
+- This integration does not manage any power sourcing devices
+  directly. Instead, it calls a NUT server using the NUT protocol.
+- The NUT integration does not install NUT on Home Assistant server or
+provide any NUT services directly. Instead, it retreives data from a
+NUT server. The NUT server may be running in an add-on container or
+another system. The NUT integration therefore cannot be "updated" to
+include a new version of the NUT server.
+
+## Troubleshooting
+
+### Third-party NUT server add-on hostname
+
+Some users install a third-party Home Assistant Community add-on to
+provide their NUT server. These add-ons are not maintained or
+supported by Home Assistant.
+
+The add-on option is available for users running {% term "Home
+Assistant Operating System" %} or {% term "Home Assistant Supervised"
+%}. Please see the Home Assistant Community [Network UPS Tools (NUT)
+add-on](https://github.com/hassio-addons/addon-nut) for installation
+and configuration information, including the required hostname.
+
+### Issues with user credentials and permissions
+
+The username and password configured for the device must be granted
+`instcmds` permissions on the NUT server. No actions will be available if
+no user credentials are specified for a given device. See the NUT
+server configuration instructions for additional information.
+
+Below are example configuration files that create the username
+`my_user` with a PASSWORD and permission to execute all commands.
+
+If you are using the NUT add-on, below is the an example Configuration for
+the add-on's users list:
+
+```yaml
+- username: my_user
+  password: [PASSWORD]
+    instcmds:
+      - all
+    actions:
+      - set
+```
+
+If you are configuring NUT server directly, below is the example
+`upsd.users` file:
+
+```text
+[my_user]
+    password = my_password
+    actions = SET
+    instcmds = ALL
+```
+
+### Using NUT to list all variables
+
+{% important %}
+The recommended configuration does not install NUT directly on Home
+Assistant. The NUT commands are therefore not available from the Home
+Assistant command line. These instructions apply to users running a
+separate NUT server or who are performing [advanced
+troubleshooting](#Advanced troubleshooting).
+{% endimportant %}
+
+The NUT server provides "variables" regarding your power source
+device. If you have command line access to the system running NUT
+server, you can query NUT directly using the `upsc` command.
+
+Below is an example where NUT is configured with a device named `my_ups`:
+
+
+```bash
+$ upsc my_ups
 ups.timer.reboot: 0
 battery.voltage: 27.0
 ups.firmware.aux: L3 -P
@@ -64,19 +423,28 @@ output.voltage: 121.50
 output.voltage.nominal: 120
 ```
 
-Use the values from the left hand column. Support is included for most
-values with `ups`, `battery`, `input` and `output` prefixes.
+The NUT integration supports many variables with the prefix `device`,
+`ups`, `battery`, `input`, `output`, and `outlet`. An additional
+sensor for `ups.status.display` is created by the NUT integration to
+provide a human-readable form of `ups.status`.
 
-## UPS Status - human-readable version
+### Using NUT to list all commands
 
-An additional virtual sensor type `ups.status.display` is available
-translating the UPS status value retrieved from `ups.status` into a
-human-readable version.
+{% important %}
+As noted above, the recommended configuration does not install NUT
+directly on Home Assistant. The NUT commands are therefore not
+available from the Home Assistant command line. These instructions
+apply to users running a separate NUT server or who are performing
+[advanced troubleshooting](#Advanced troubleshooting).
+{% endimportant %}
 
-## Device Actions
+The NUT server provides commands for controlling your power source
+device. If you have command line access to the system running NUT
+server, you can query NUT directly for the available using the `upscmd
+-l` command.
 
-A device action is available for each parameterless NUT [command](https://networkupstools.org/docs/user-manual.chunked/apcs03.html) supported by the device. To find the list of supported commands for 
-your specific UPS device, you can use the `upscmd -l` command followed by the UPS name:
+Below is an example where NUT is configured with a device named `my_ups`:
+
 
 ```bash
 $ upscmd -l my_ups
@@ -87,23 +455,33 @@ test.battery.start.quick - Start a quick battery test
 test.battery.stop - Stop the battery test
 ```
 
-These commands will be available as device actions in Home Assistant, allowing you to interact with your UPS.
+### Advanced troubleshooting
 
-### User Credentials and Permissions
+{% warning %}
+Only advanced users should perform these operations.
+{% endwarning %}
 
-To execute device actions through the NUT integration, you must specify user credentials in the configuration. These credentials are stored in the `upsd.users` file, part of the NUT server configuration. This file defines the usernames, passwords, and permissions for users accessing the UPS devices.
+For users of the NUT add-on, it is sometimes necessary to access the
+NUT Docker container directly to execute commands on the command line.
+This may be useful for running `upsc` or upscmd`. Enter the
+following command at the Home Assistant command line:
 
-No actions will be available if no user credentials are specified for a given device.
 
-Ensure the user you specify has the required permissions to execute the desired commands. Here's an example of a user with command permissions in the `upsd.users` file:
-
-```text
-[my_user]
-    password = my_password
-    actions = SET
-    instcmds = ALL
+```bash
+docker exec -it $(docker ps -f name=nut -q) bash
 ```
 
-In this example, the user `my_user` has permission to execute all commands (`instcmds = ALL`).
+After entering any commands, type the following to return:
 
-Please note that Home Assistant cannot determine whether a user can access a specific action without executing it. If you attempt to perform an action for which the user does not have permission, an exception will be thrown at runtime.
+```bash
+exit
+```
+
+## Remove integration
+
+This integration follows standard integration removal. No extra steps
+are required.
+
+{% include integrations/remove_device_service.md %}
+
+


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This is a significant update to the NUT integration doc.  The current document lacks many of the sections expected for integrations (including not even meeting Bronze on the quality scale).  The current page is also moderately confusing/misleading and contains errors.  Significant cleanup is needed in reference to NUT command line instructions, NUT variables, and NUT commands.

Given the number of changes to bring this page up to date, I propose addressing this through this single PR.  A single PR allows reviewers to read and edit the full set of proposed changes in context of all of the other changes.  The alternative, reading one paragraph or section at a time, will likely be more difficult to review since it will require 12+ individual PRs.  If there is a need to split these apart, I can try to do so over the coming months.

The primary changes being addressed in this PR include:
- Clarify the need for a NUT server through the addition of new "Prerequisites" and "Setting up a NUT Server" sections.  The current instructions are not very clear on this general topic, which may explain the high number of how-to videos and step-by-step instructions.  Personally, I think it would be helpful to also include a tip referencing the HACS add-on but it seems there is a general preference away from those so I have not done so in this PR.  These sections reference the username and password required for the integration installation.
- Add missing docs-removal-instructions required for Bronze quality. The "Remove integration" section has been added.
- Add missing docs-installation-parameters for Silver quality.  The four installation parameters are now documented.
- Add missing docs-configuration-parameters required for Silver quality.  I saw the prior PR comments that sensor platforms should not document the scan_interval but I believe that likely only applied to YAML configuration.  The configuration parameter for the UI variable is now documented.
- Add missing docs-data-update for Gold quality. The "Data updates" section has been added.
- Add missing docs-examples for Gold quality. An example automation has now been provided for sending notifications when the battery state changes.
- Add missing docs-known-limitations for Gold quality.  The "Known limitations" section has been added to both describe functionality not supported by the integration and address frequent/repeat user issues.
- Add missing docs-supported-devices for Gold quality.  The "Supported devices" section has been added to reference the NUT hardware compatibility list.  I do not believe an "Unsupported devices" section is needed.
- Add missing docs-supported-functions for Gold quality.  A "Supported functionality" section was added with information about Sensors and Diagnostic Sensors.  Portions of the existing Device Actions were also moved into this section.  The new Sensors and Diagnostic Sensors sections add a complete list of available sensors.  The sensor lists include name, units and a short description.  The sensor with a blank description is ones that is not actually a valid NUT variable.  Added descriptions for certain sensors that are not listed as valid in nut-names.txt but are used by devices anyway. Reference to disabled sensors and instructions on how to enable such entities has also been added.  A link to the NUT manual on variables has also been added.
- Add missing docs-troubleshooting for Gold quality.  A "Troubleshooting" section has been added.  Given the recurring questions about the HACS NUT add-on, I suggest adding a short section regarding the add-on with a specific reference to the hostname (without documenting the actual hostname per the prior PRs requesting such information not be included in these docs).  I also propose moving several existing sections into troubleshooting guides since they are not required to use the integration and create more confusion than clarity.  The sections moved include (i) credentials/permissions, (ii) using NUT `upsc` for listing variables, and (iii) using NUT `upscmd` for listing commands.  Since the existing docs provided NUT configuration to help users with user credentials, I hae added one for the HACS NUT add-on as well.  Finally, given the meaningful number of users using the HACS add-on, I suggest providing an advanced troubleshooting section for accessing the docker container command line.  Including this in the documentation is likely worth of debate.  I note that one other integration provides similar instructions.  This is an area of frequent questions from users in Issues and Community posts.

A few additional changes to note:
- Add glossary markup for term "integration" on first use.
- Add glossary markup for term "automations" on first use.
- Expand applications of NUT to include PDUs and other devices to better align with the underlying NUT package.
- Added links to NUT's variables documentation.

I recognize the large number of changes and welcome improvements.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [X] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #36729, #38008 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Expanded the integration guide for Network UPS Tools (NUT) to include support for UPSes, PDUs, and similar devices.
	- Added new sections covering prerequisites, supported devices, and detailed instructions for setting up a NUT server, including required credentials.
	- Included comprehensive sensor information, featuring a new virtual sensor that presents UPS status in a human-readable format.
	- Enhanced guidance on automations, troubleshooting, and the proper removal process for the integration.
	- Specified configurable polling frequency for data updates from the NUT server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->