### PR TITLE
Add remaining Binary Sensor entities to Teslemetry

### DIFF
--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -84,6 +84,8 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Binary sensor|Guest mode enabled|No|
 |Binary sensor|High beams|No|
 |Binary sensor|Homelink nearby|No|
+|Binary sensor|HVAC auto mode|No|
+|Binary sensor|High voltage interlock loop fault|No|
 |Binary sensor|Located at favorite|Yes|
 |Binary sensor|Located at home|Yes|
 |Binary sensor|Located at work|Yes|
@@ -97,6 +99,7 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Binary sensor|Rear driver window|Yes|
 |Binary sensor|Rear passenger door|Yes|
 |Binary sensor|Rear passenger window|Yes|
+|Binary sensor|Remote start|No|
 |Binary sensor|Right hand drive|No|
 |Binary sensor|Scheduled charging pending|No|
 |Binary sensor|Seat vent enabled|No|

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -64,10 +64,12 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Binary sensor|Brake pedal|No|
 |Binary sensor|Cabin overheat protection actively cooling|No|
 |Binary sensor|Charge cable|Yes|
+|Binary sensor|Charge enable request|No|
 |Binary sensor|Charge port cold weather mode|No|
 |Binary sensor|Charger has multiple phases|No|
 |Binary sensor|Dashcam|No|
 |Binary sensor|DC DC|No|
+|Binary sensor|Defrost for preconditioning|No|
 |Binary sensor|Drive rail|No|
 |Binary sensor|Driver seat belt|No|
 |Binary sensor|Driver seat occupied|No|
@@ -80,6 +82,7 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Binary sensor|Front passenger window|Yes|
 |Binary sensor|GPS state|No|
 |Binary sensor|Guest mode enabled|No|
+|Binary sensor|High beams|No|
 |Binary sensor|Homelink nearby|No|
 |Binary sensor|Located at favorite|Yes|
 |Binary sensor|Located at home|Yes|
@@ -96,7 +99,9 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Binary sensor|Rear passenger window|Yes|
 |Binary sensor|Right hand drive|No|
 |Binary sensor|Scheduled charging pending|No|
+|Binary sensor|Seat vent enabled|No|
 |Binary sensor|Service mode|No|
+|Binary sensor|Speed limited|No|
 |Binary sensor|Status|Yes|
 |Binary sensor|Supercharger session trip planner|No|
 |Binary sensor|Tire pressure warning front left|No|


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add remaining Binary Sensor entities to Teslemetry 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/143384
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Teslemetry integration documentation to include additional binary sensor entities: Charge enable request, Defrost for preconditioning, High beams, HVAC auto mode, High voltage interlock loop fault, Remote start, Seat vent enabled, and Speed limited. These sensors are not enabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->