### PR TITLE
2025.4.4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -108,8 +108,8 @@ social:
 # Home Assistant release details
 current_major_version: 2025
 current_minor_version: 4
-current_patch_version: 3
-date_released: 2025-04-19
+current_patch_version: 4
+date_released: 2025-04-25
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.

--- a/source/_posts/2025-04-02-release-20254.markdown
+++ b/source/_posts/2025-04-02-release-20254.markdown
@@ -71,6 +71,7 @@ Enjoy the release!
   - [2025.4.1 - April 4](#202541---april-4)
   - [2025.4.2 - April 12](#202542---april-12)
   - [2025.4.3 - April 19](#202543---april-19)
+  - [2025.4.4 - April 25](#202544---april-25)
 - [Need help? Join the community!](#need-help-join-the-community)
 - [Backward-incompatible changes](#backward-incompatible-changes)
 - [All changes](#all-changes)
@@ -778,6 +779,45 @@ release every Friday.
 [@starkillerOG]: https://github.com/starkillerOG
 [@tr4nt0r]: https://github.com/tr4nt0r
 [@tsvi]: https://github.com/tsvi
+
+### 2025.4.4 - April 25
+
+- Meteofrance: adding new states provided by MF API since mid April ([@vingerha] - [#143137])
+- Create Home Connect active and selected program entities only when there are programs ([@Diegorro98] - [#143185])
+- Météo-France: Additional states and change weather condition for "Ciel clair" ([@vingerha] - [#143198])
+- Update setuptools to 78.1.1 ([@cdce8p] - [#143275])
+- Fix licenses check for setuptools ([@cdce8p] - [#143292])
+- Add scan interval and parallel updates to LinkPlay media player ([@silamon] - [#143324])
+- Sync random sensor device classes ([@silamon] - [#143368])
+- Fix Vodafone Station config entry unload ([@chemelli74] - [#143371])
+- Bump aiohomekit to 3.2.14 ([@bdraco] - [#143440])
+- Bump dio-chacon-api to v1.2.2 ([@cnico] - [#143489])
+- Bump pysmartthings to 3.0.5 ([@joostlek] - [#143586])
+
+[#141505]: https://github.com/home-assistant/core/pull/141505
+[#142299]: https://github.com/home-assistant/core/pull/142299
+[#142755]: https://github.com/home-assistant/core/pull/142755
+[#143137]: https://github.com/home-assistant/core/pull/143137
+[#143185]: https://github.com/home-assistant/core/pull/143185
+[#143198]: https://github.com/home-assistant/core/pull/143198
+[#143253]: https://github.com/home-assistant/core/pull/143253
+[#143275]: https://github.com/home-assistant/core/pull/143275
+[#143292]: https://github.com/home-assistant/core/pull/143292
+[#143324]: https://github.com/home-assistant/core/pull/143324
+[#143368]: https://github.com/home-assistant/core/pull/143368
+[#143371]: https://github.com/home-assistant/core/pull/143371
+[#143440]: https://github.com/home-assistant/core/pull/143440
+[#143489]: https://github.com/home-assistant/core/pull/143489
+[#143586]: https://github.com/home-assistant/core/pull/143586
+[@Diegorro98]: https://github.com/Diegorro98
+[@bdraco]: https://github.com/bdraco
+[@cdce8p]: https://github.com/cdce8p
+[@chemelli74]: https://github.com/chemelli74
+[@cnico]: https://github.com/cnico
+[@frenck]: https://github.com/frenck
+[@joostlek]: https://github.com/joostlek
+[@silamon]: https://github.com/silamon
+[@vingerha]: https://github.com/vingerha
 
 ## Need help? Join the community!
 

--- a/source/changelogs/core-2025.4.markdown
+++ b/source/changelogs/core-2025.4.markdown
@@ -1221,6 +1221,45 @@ For a summary in a more readable format:
 [@tr4nt0r]: https://github.com/tr4nt0r
 [@tsvi]: https://github.com/tsvi
 
+## Release 2025.4.4 - April 25
+
+- Meteofrance: adding new states provided by MF API since mid April ([@vingerha] - [#143137])
+- Create Home Connect active and selected program entities only when there are programs ([@Diegorro98] - [#143185])
+- Météo-France: Additional states and change weather condition for "Ciel clair" ([@vingerha] - [#143198])
+- Update setuptools to 78.1.1 ([@cdce8p] - [#143275])
+- Fix licenses check for setuptools ([@cdce8p] - [#143292])
+- Add scan interval and parallel updates to LinkPlay media player ([@silamon] - [#143324])
+- Sync random sensor device classes ([@silamon] - [#143368])
+- Fix Vodafone Station config entry unload ([@chemelli74] - [#143371])
+- Bump aiohomekit to 3.2.14 ([@bdraco] - [#143440])
+- Bump dio-chacon-api to v1.2.2 ([@cnico] - [#143489])
+- Bump pysmartthings to 3.0.5 ([@joostlek] - [#143586])
+
+[#141505]: https://github.com/home-assistant/core/pull/141505
+[#142299]: https://github.com/home-assistant/core/pull/142299
+[#142755]: https://github.com/home-assistant/core/pull/142755
+[#143137]: https://github.com/home-assistant/core/pull/143137
+[#143185]: https://github.com/home-assistant/core/pull/143185
+[#143198]: https://github.com/home-assistant/core/pull/143198
+[#143253]: https://github.com/home-assistant/core/pull/143253
+[#143275]: https://github.com/home-assistant/core/pull/143275
+[#143292]: https://github.com/home-assistant/core/pull/143292
+[#143324]: https://github.com/home-assistant/core/pull/143324
+[#143368]: https://github.com/home-assistant/core/pull/143368
+[#143371]: https://github.com/home-assistant/core/pull/143371
+[#143440]: https://github.com/home-assistant/core/pull/143440
+[#143489]: https://github.com/home-assistant/core/pull/143489
+[#143586]: https://github.com/home-assistant/core/pull/143586
+[@Diegorro98]: https://github.com/Diegorro98
+[@bdraco]: https://github.com/bdraco
+[@cdce8p]: https://github.com/cdce8p
+[@chemelli74]: https://github.com/chemelli74
+[@cnico]: https://github.com/cnico
+[@frenck]: https://github.com/frenck
+[@joostlek]: https://github.com/joostlek
+[@silamon]: https://github.com/silamon
+[@vingerha]: https://github.com/vingerha
+
 [#106985]: https://github.com/home-assistant/core/pull/106985
 [#107635]: https://github.com/home-assistant/core/pull/107635
 [#122818]: https://github.com/home-assistant/core/pull/122818


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Release notes for https://github.com/home-assistant/core/pull/143653



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for new states from the Meteofrance API.
  - Enhanced LinkPlay media player integration with scan interval and parallel update features.

- **Bug Fixes**
  - Resolved issues with weather condition handling for "Ciel clair" in Météo-France.
  - Fixed unloading of Vodafone Station configuration entries and improved exception translations.
  - Synchronized random sensor device classes.
  - Conditional creation of Home Connect program entities only when programs exist.
  - Updated setuptools to version 78.1.1 with license check fixes.

- **Chores**
  - Updated dependencies: aiohomekit (3.2.14), dio-chacon-api (v1.2.2), pysmartthings (3.0.5).
  - Updated documentation and changelogs for the new patch release (2025.4.4).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->