### PR TITLE
Template: cover: add description and type

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -298,52 +298,53 @@ button:
 cover:
   description: Characteristics of a cover
   type: map
-  state:
-    description: Defines a template to get the state of the cover. Valid output values from the template are `open`, `opening`, `closing` and `closed` which are directly mapped to the corresponding states. In addition, `true` is valid as a synonym to `open` and `false` as a synonym to `closed`. If [both a `value_template` and a `position_template`](#combining-value_template-and-position_template) are specified, only `opening` and `closing` are set from the `value_template`. If the template produces a `None` value the state will be set to `unknown`.
-    required: false
-    type: template
-  position:
-    description: Defines a template to get the position of the cover. Legal values are numbers between `0` (closed) and `100` (open). If the template produces a `None` value the current position will be set to `unknown`.
-    required: false
-    type: template
-  device_class:
-    description: Sets the [class of the device](/integrations/cover/), changing the device state and icon that is displayed on the frontend.
-    required: false
-    type: string
-  open_cover:
-    description: Defines an action to open the cover. If [`open_cover`](#open_cover) is specified, [`close_cover`](#close_cover) must also be specified. At least one of [`open_cover`](#open_cover) and [`set_cover_position`](#set_cover_position) must be specified.
-    required: inclusive
-    type: action
-  close_cover:
-    description: Defines an action to close the cover.
-    required: inclusive
-    type: action
-  stop_cover:
-    description: Defines an action to stop the cover.
-    required: false
-    type: action
-  set_cover_position:
-    description: Defines an action to set to a cover position (between `0` and `100`). The variable `position` will contain the entity's set position.
-    required: false
-    type: action
-  set_cover_tilt_position:
-    description: Defines an action to set the tilt of a cover (between `0` and `100`). The variable `tilt` will contain the entity's set tilt position.
-    required: false
-    type: action
-  optimistic:
-    description: Force cover position to use [optimistic mode](#optimistic-mode).
-    required: false
-    type: boolean
-    default: false
-  tilt_optimistic:
-    description: Force cover tilt position to use [optimistic mode](#optimistic-mode).
-    required: false
-    type: boolean
-    default: false
-  tilt:
-    description: Defines a template to get the tilt state of the cover. Legal values are numbers between `0` (closed) and `100` (open).  If the template produces a `None` value, the current tilt state will be set to `unknown`.
-    required: false
-    type: template
+  keys:
+    state:
+      description: Defines a template to get the state of the cover. Valid output values from the template are `open`, `opening`, `closing` and `closed` which are directly mapped to the corresponding states. In addition, `true` is valid as a synonym to `open` and `false` as a synonym to `closed`. If [both a `value_template` and a `position_template`](#combining-value_template-and-position_template) are specified, only `opening` and `closing` are set from the `value_template`. If the template produces a `None` value the state will be set to `unknown`.
+      required: false
+      type: template
+    position:
+      description: Defines a template to get the position of the cover. Legal values are numbers between `0` (closed) and `100` (open). If the template produces a `None` value the current position will be set to `unknown`.
+      required: false
+      type: template
+    device_class:
+      description: Sets the [class of the device](/integrations/cover/), changing the device state and icon that is displayed on the frontend.
+      required: false
+      type: string
+    open_cover:
+      description: Defines an action to open the cover. If [`open_cover`](#open_cover) is specified, [`close_cover`](#close_cover) must also be specified. At least one of [`open_cover`](#open_cover) and [`set_cover_position`](#set_cover_position) must be specified.
+      required: inclusive
+      type: action
+    close_cover:
+      description: Defines an action to close the cover.
+      required: inclusive
+      type: action
+    stop_cover:
+      description: Defines an action to stop the cover.
+      required: false
+      type: action
+    set_cover_position:
+      description: Defines an action to set to a cover position (between `0` and `100`). The variable `position` will contain the entity's set position.
+      required: false
+      type: action
+    set_cover_tilt_position:
+      description: Defines an action to set the tilt of a cover (between `0` and `100`). The variable `tilt` will contain the entity's set tilt position.
+      required: false
+      type: action
+    optimistic:
+      description: Force cover position to use [optimistic mode](#optimistic-mode).
+      required: false
+      type: boolean
+      default: false
+    tilt_optimistic:
+      description: Force cover tilt position to use [optimistic mode](#optimistic-mode).
+      required: false
+      type: boolean
+      default: false
+    tilt:
+      description: Defines a template to get the tilt state of the cover. Legal values are numbers between `0` (closed) and `100` (open).  If the template produces a `None` value, the current tilt state will be set to `unknown`.
+      required: false
+      type: template
 image:
   description: List of images
   required: true

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -296,6 +296,8 @@ button:
       required: true
       type: action
 cover:
+  description: Characteristics of a cover
+  type: map
   state:
     description: Defines a template to get the state of the cover. Valid output values from the template are `open`, `opening`, `closing` and `closed` which are directly mapped to the corresponding states. In addition, `true` is valid as a synonym to `open` and `false` as a synonym to `closed`. If [both a `value_template` and a `position_template`](#combining-value_template-and-position_template) are specified, only `opening` and `closing` are set from the `value_template`. If the template produces a `None` value the state will be set to `unknown`.
     required: false


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration others adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: #38744 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Updated the template integration documentation to include a description and type declaration for the `cover` configuration section.
  - Reorganized the `cover` configuration keys into a nested structure for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->