### PR TITLE
Update basics.markdown

### DIFF
--- a/source/_docs/automation/basics.markdown
+++ b/source/_docs/automation/basics.markdown
@@ -15,24 +15,31 @@ We can break up this automation into the following three parts:
 (action)     Turn the lights on in the living room
 ```
 
-The first part is the [trigger](/docs/automation/trigger/) of the automation rule. Triggers describe {% term events %} that should trigger the automation rule. In this case, it is a person arriving home, which can be observed in Home Assistant using {% term devices %}/{% term sensors %} by observing the state of Paulus changing from `not_home` to `home`.
+The first part is the [trigger](/docs/automation/trigger/) of the automation. Triggers describe {% term events %} that should trigger the automation. In this case, it is a person arriving home, which can be observed in Home Assistant using {% term devices %}/{% term sensors %} by observing the state of Paulus changing from `not_home` to `home`.
 
-The second part is the [condition](/docs/automation/condition/). Conditions are optional tests that can limit an automation rule to only work in your specific use cases. A condition will test against the current state of the system. This includes the current time, devices, people and other things like the sun. In this case, we only want to act when the sun has set.
+The second part is the [condition](/docs/automation/condition/). Conditions are optional tests that can limit an automation to only work in your specific use cases. A condition will test against the current state of the system. This includes the current time, devices, people and other things like the sun. In this case, we only want to act when the sun has set.
 
-The third part is the [action](/docs/automation/action/), which will be performed when a rule is triggered and all conditions are met. For example, it can turn a light on, set the temperature on your thermostat or activate a scene.
+The third part is the [action](/docs/automation/action/), which will be performed when an automation is triggered and all conditions are met. For example, it can turn a light on, set the temperature on your thermostat or activate a scene.
 
 {% note %}
-The difference between a condition and a trigger can be confusing as they are very similar. Triggers look at the actions, while conditions look at the current state: turning a light on versus a light being on.
+The difference between a trigger and a condition can be confusing as they are very similar.
+
+Triggers require an event to happen for the conditions to be evaluated using current state information.
+
+Event: Arrive home \
+Condition: After Sunset? \
+Action: Turn lights on
+
 {% endnote %}
 
 ## Exploring the internal state
 
-Automation rules interact directly with the internal state of Home Assistant, so you'll need to familiarize yourself with it. Home Assistant exposes its current state via the developer tools. These are available at the bottom of the sidebar in the frontend. **{% my developer_states title="Developer Tools > States" %}** will show all currently available states. An entity can be anything. A light, a switch, a person and even the sun. A state consists of the following parts:
+Automations interact directly with the internal state of Home Assistant, so you'll need to familiarize yourself with it. Home Assistant exposes its current state via the developer tools. These are available at the bottom of the sidebar in the frontend. **{% my developer_states title="Developer Tools > States" %}** will show all currently available states. An entity can be anything. A light, a switch, a person and even the sun. A state consists of the following parts:
 
 | Name | Description | Example |
 | ---- | ----- | ---- |
-| Entity ID | Unique identifier for the entity. | `light.kitchen`
-| State | The current state of the device. | `home`
+| Entity ID | Unique identifier for the entity. | `light.living_room`
+| State | The current state of the device. | `off`
 | Attributes | Extra data related to the device and/or current state. | `brightness`
 
 State changes can be used as the source of triggers and the current state can be used in conditions.


### PR DESCRIPTION
After automation is defined, the word 'rule' appears with no prior definition.
This extra concept of a 'rule' is confusing and unnecessary.
The word 'rule' appears in only two documents, this one and Actions page. Removing the undefined concept of a 'rule' improves 
comprehension of the two pages affected.

The note to clarify similar terms 'trigger' & 'condition' refers to content that does not appear 
on the page and is inconsistent with the definition of 'trigger' on the same page.

The example table showing internal state seems to be 3 random state examples. 
It is more helpful to the reader to be relevant to the example discussed on the page.
Make consistent with the topic example using 'living room' light
and show a valid value for state of a light.


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and consistency in automation documentation.
	- Unified terminology by replacing "automation rule" with "automation."
	- Enhanced explanations of triggers, conditions, and actions, including a clearer distinction between triggers and conditions with examples.
	- Updated example entity and state values for better relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->