### PR TITLE
Clarify battery runtime definition in NUT

### DIFF
--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -156,7 +156,7 @@ The following diagnostic sensors may be available:
 - **Battery current (A)**: Battery current
 - **Battery date**: Battery installation or last change date (opaque by mfg)
 - **Battery manuf date**: Battery manufacturing date (opaque by mfg)
-- **Battery runtime (secs)**: Battery runtime
+- **Battery runtime (secs)**: Device's estimate for battery runtime remaining
 - **Battery temperature (°C)**: Battery temperature
 - **Battery voltage (V)**: Battery voltage
 - **Beeper status**: UPS beeper status, with the available states: `enabled`, `disabled`, and `muted`

--- a/source/_integrations/nut.markdown
+++ b/source/_integrations/nut.markdown
@@ -156,7 +156,7 @@ The following diagnostic sensors may be available:
 - **Battery current (A)**: Battery current
 - **Battery date**: Battery installation or last change date (opaque by mfg)
 - **Battery manuf date**: Battery manufacturing date (opaque by mfg)
-- **Battery runtime (secs)**: Device's estimate for battery runtime remaining
+- **Battery runtime (secs)**: Remaining battery runtime as estimated by the device
 - **Battery temperature (°C)**: Battery temperature
 - **Battery voltage (V)**: Battery voltage
 - **Beeper status**: UPS beeper status, with the available states: `enabled`, `disabled`, and `muted`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Clarify the "Battery runtime" definition to improve readability.  The value returns the device's estimate of the time remaining if the unit is running on battery.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes Home Assistant Core #[144479](https://github.com/home-assistant/core/issues/144479)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the description of the "Battery runtime (secs)" diagnostic sensor to specify that it represents the device's estimated remaining battery runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->