### PR TITLE
direction uses station id

### DIFF
--- a/source/_integrations/rmvtransport.markdown
+++ b/source/_integrations/rmvtransport.markdown
@@ -61,7 +61,7 @@ next_departure:
       required: false
       type: [string]
     direction:
-      description: "Name of a stop or station, e.g., 'Frankfurt (Main) Hauptbahnhof'. This can be used to only consider a particular direction of travel."
+      description: "ID of a stop or station, e.g., `3000912`. This can be used to only consider a particular direction of travel."
       required: false
       type: [string]
     lines:
@@ -116,6 +116,9 @@ sensor:
         lines: "S8"
         max_journeys: 5
         products: "S"
+      - station: 3001830
+        time_offset: 15
+        direction: 3000010
 ```
 
 The first sensor will return S-Bahn, bus, RB and RE trains departures from Frankfurt Hauptbahnhof to Frankfurt Airport or Stadium that are at least 5 minutes away.
@@ -123,3 +126,5 @@ The first sensor will return S-Bahn, bus, RB and RE trains departures from Frank
 The second sensor returns bus departures from Wiesbaden Hauptbahnhof going to Dernsches Gelände and Mainz Hauptbahnhof. To retrieve the time of the second departure, you would use `state_attr('sensor.ENTITY_NAME', 'departures')[1].time`.
 
 The third sensor returns all S-Bahn trains from Mainz Hauptbahnhof for line S8.
+
+The 4th sensor returns all connections from Niederrad Bahnhof going to or over Frankfurt Hauptbahnhof.

--- a/source/_integrations/rmvtransport.markdown
+++ b/source/_integrations/rmvtransport.markdown
@@ -21,7 +21,7 @@ The `rvmtransport` {% term integration %} will give you the departure time of th
 
 ## Setup
 
-Visit the [RMV OpenData web site](https://opendata.rmv.de) to find a list of valid station IDs.
+Visit the [RMV OpenData web site](https://opendata.rmv.de) to find a list of valid station IDs. You will need to use the "HAFAS_ID".
 
 ## Configuration
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
I changed the documentation so that it tells users to use the station id instead of the station name for "direction".

For the "direction" variable, the documentation tells me to use the station name. This never worked for me. When i tried using the station id it worked.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that station IDs must use the "HAFAS_ID" from the RMV OpenData website.
  - Updated the description for the `direction` option to require a station ID instead of a station name.
  - Added an example configuration demonstrating use of station IDs and time offsets.
  - Included explanatory text for the new example sensor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->