### PR TITLE
HomeKit Bridge: Adding `h264_qsv` as viable `VIDEO_CODEC` to doc

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -278,7 +278,7 @@ homekit:
               required: false
               type: string
               default: libx264
-              available options: copy, libx264, h264_v4l2m2m, h264_omx
+              available options: copy, libx264, h264_v4l2m2m, h264_omx, h264_qsv
             video_profile_names:
               description: Only for `camera` entities. FFmpeg video profile names for transcoding, only relevant if `video_codec` isn't `copy`. Some encoders, e.g., the Raspberry Pi's `h264_v4l2m2m`, don't use the standard `["baseline", "main", "high"]` profile names but expects `["0", "2", "4"]` instead. Use this option to override the default names, if needed.
               required: false


### PR DESCRIPTION
Retry of #39147 where I made a clumsy git flip flop
Follows home-assistant/core#145448

Adds `h264_qsv` as valid `VIDEO_CODEC` option.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated HomeKit integration documentation to include the new `h264_qsv` option for the `video_codec` configuration under camera entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->