### PR TITLE
Removed move_short_address from cover example config entry

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -1149,7 +1149,6 @@ knx:
   cover:
     - name: "Kitchen shutter"
       move_long_address: "3/0/0"
-      move_short_address: "3/0/1"
       stop_address: "3/0/4"
       position_address: "3/0/3"
       position_state_address: "3/0/2"


### PR DESCRIPTION

## Proposed change

This config produces errors from 2025.4 onwards with non tilt-able covers.

The sample config suggests a non tiltable cover (through presence of `position_address` and no presence of `angle_address`). It would be a more robust to reduce the attributes in this sample to `move_long_address` and `stop_address`



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

See the follow bug report at https://github.com/home-assistant/core/issues/142591

## Checklist

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the KNX cover platform configuration example by removing the `move_short_address` entry from the "Kitchen shutter" device section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->