### PR TITLE
Configuration check: remove Core and Supervised steps

### DIFF
--- a/source/_includes/common-tasks/configuration_check.md
+++ b/source/_includes/common-tasks/configuration_check.md
@@ -1,6 +1,6 @@
 ## Configuration check
 
-{% if page.installation == "os" or page.installation == "supervised" %}
+{% if page.installation == "os" %}
 
 After changing configuration or automation files, check if the configuration is valid before restarting Home Assistant Core.
 
@@ -55,55 +55,5 @@ You can get help from the command line using:
 ```bash
 docker exec homeassistant python -m homeassistant --script check_config --help
 ```
-
-{% elsif page.installation == "core" %}
-
-After changing configuration files, check if the configuration is valid before restarting Home Assistant Core.
-
-1. Switch to the user that is running Home Assistant.
-
-    ```bash
-    sudo -u homeassistant -H -s
-    ```
-
-2. Activate the virtual environment that Home Assistant is running in.
-
-    ```bash
-    source /srv/homeassistant/bin/activate
-    ```
-
-3. Run the configuration check.
-
-    Run the full check:
-
-    ```bash
-    hass --script check_config
-    ```
-
-    Listing all loaded files:
-
-    ```bash
-    hass --script check_config --files
-    ```
-
-    Viewing a integration’s configuration ([`light`](/integrations/light) in this example):
-
-    ```bash
-    hass --script check_config --info light
-    ```
-
-    Or all integrations’ configuration
-
-    ```bash
-    hass --script check_config --info all
-    ```
-
-    You can get help from the command line using:
-
-    ```bash
-    hass --script check_config --help
-    ```
-
-4. When that is complete, restart the service for it to use the new files.
 
 {% endif %}


### PR DESCRIPTION
- remove steps specific to Core and Supervised

As per architecture discussion on

home-assistant/architecture#1197,
and home-assistant/architecture#1198

https://www.home-assistant.io/blog/2025/05/22/deprecating-core-and-supervised-installation-methods-and-32-bit-systems

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration check instructions to only include guidance for "os" and "container" installation types, removing information specific to the "core" installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->