### PR TITLE
Rephrase in positive form in General recommendations

### DIFF
--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -387,7 +387,7 @@ NOTE for Android users: You need to follow the instructions at the bottom of the
 
 ### General recommendations
 
-- Using Thread-based Matter devices in Home Assistant requires Home Assistant OS version 10 and above. Not using Home Assistant OS is at your own risk. We do provide some [documentation](https://github.com/home-assistant-libs/python-matter-server/blob/main/README.md) on how to run the Matter Server as a Docker container. The documentation includes a description of the host and networking requirements.
+- Using Thread-based Matter devices in Home Assistant requires Home Assistant OS version 10 and above. Home Assistant OS with the Matter Server add-on is the supported path for using Matter with Home Assistant. Running Matter Server as a standalone Docker container is unsupported, but we provide [documentation](https://github.com/home-assistant-libs/python-matter-server/blob/main/README.md) including a description of the host and networking requirements.
 
 - To use {% term Thread %} devices you will need a {% term Thread %} network with at least one Thread border router in your network nearby the {% term Thread %} device(s). Apple users, for example, need the Apple TV 4K or the HomePod Mini, while Google users need a Nest Hub (2nd Gen). Use the Thread integration in Home Assistant to diagnose your {% term Thread %} network(s).
 


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

"General recommendations" contains a confusing series of sentences contained in the first bullet point:

> Using Thread-based Matter [...] requires Home Assistant OS [...]. Not using Home Assistant OS is at your own risk. We do provide some documentation on how to run the Matter Server as a docker container. The documentation includes a description of the host and networking requirements.

This is ambiguous:

- Is using anything other than Home Assistant OS "at your own risk" for Thread-based Matter? Or in general?
- Is the docker container documentation needed for Home Assistant OS? Or is it the thing that's "at your own risk"?
- Is the documentation for the container? Or for Thread-based Matter in HA OS?

The Strunk and White recommendation for this class of problem is "Put statements in positive form." I've attempted to rephrase this recommendation in positive form and remove the ambiguity, but I may have gotten it wrong (since I don't know for sure the answers to the questions above, this is my best guess).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

NA

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

(aside: Microsoft Style Guide referred to in the Home Assistant documentation standards says, "Phrase statements in the positive form, and emphasize what users can accomplish, rather than what they can't."—bonus points!)

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the supported installation method for Thread-based Matter devices in Home Assistant, specifying that only Home Assistant OS with the Matter Server add-on is supported, while standalone Docker installations are not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->