### PR TITLE
Improve documentation for signal_messenger integration

### DIFF
--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -42,11 +42,14 @@ notify:
     platform: signal_messenger
     url: "http://127.0.0.1:8080" # the URL where the Signal Messenger REST API is listening 
     number: "YOUR_PHONE_NUMBER" # the sender number
-    recipients: # one or more recipients
+    recipients: # one or more default recipients (can be overwritten per message)
       - "RECIPIENT1"
 ```
 
-Both phone numbers and Signal Messenger groups can be added to the `recipients`list. However, it's not possible to mix phone numbers and Signal Messenger groups in a single notifier. If you would like to send messages to individual phone numbers and Signal Messenger groups, separate notifiers need to be created.
+Both phone numbers and Signal Messenger groups can be added to the default `recipients` list.
+However, it's not possible to mix phone numbers and Signal Messenger groups in a single notifier.
+If you would like to have individual phone numbers and Signal Messenger groups in the default `recipients` list,
+separate notifiers need to be created.
 
 To obtain the Signal Messenger group ids, follow [this guide]( https://github.com/bbernhard/signal-cli-rest-api/blob/master/doc/HOMEASSISTANT.md).
 
@@ -65,7 +68,7 @@ number:
   required: true
   type: string
 recipients:
-  description: A list of recipients (either phone numbers or Signal Messenger group ids).
+  description: A list of default recipients (either phone numbers or Signal Messenger group ids). Can be overwritten for individual messages.
   required: true
   type: string
 {% endconfiguration %}
@@ -85,14 +88,20 @@ actions:
   - action: notify.NOTIFIER_NAME
     data:
       message: "That's an example that sends a simple text message to the recipients specified in the configuration.yaml. If text mode is 'styled', you can use *italic*, **bold** or ~strikethrough~ ."
-      ## Optional
+      # optional: custom recipients list
+      target:
+        - '+4917011111111'
+      # optional: formatted mode
       data:
         text_mode: styled
 ```
+| Attribute | Optional   | Default                                         | Description                                                                                                       |
+|-----------|------------|-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| target    | *optional* | as configured via `recipients` for the `notify` | a list of strings, containing either fully-qualified phone numbers (including country prefix) or Signal group IDs |
 
-| Attribute   | Optional | Default |Description                                                                                                                                                                                          |
-| ----------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `text_mode` | *optional* | normal | Accepted values are `normal` or `styled`. If set to `styled`, additional text formatting is enabled (*`*italic*`*, **`**bold**`**, and ~~`~strikethrough~`~~). |
+| Data Attribute | Optional | Default |Description                                                                                                                                                                                          |
+|----------------| -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text_mode`    | *optional* | normal | Accepted values are `normal` or `styled`. If set to `styled`, additional text formatting is enabled (*`*italic*`*, **`**bold**`**, and ~~`~strikethrough~`~~). |
 
 #### Text message with an attachment
 
@@ -176,19 +185,23 @@ actions:
       message: "Message received!"
 ```
 
-**NOTE** If the parameter `mode` is set to `json-rpc`, then you can use [signal-api-receiver](https://github.com/kalbasit/signal-api-receiver) to receive from Signal as follows:
+**NOTE** If the parameter `mode` is set to `json-rpc`, then you can use one of these solutions:
+1. employ [signal-api-receiver](https://github.com/kalbasit/signal-api-receiver) to receive from Signal as follows:
 
-```yaml
-- resource: "http://127.0.0.1:8105/receive/pop"
-  sensor:
-    - name: "Signal message received"
-      value_template: >
-        {{ value_json['envelope']['dataMessage']['message'] }}
-      json_attributes_path: envelope
-      json_attributes:
-        - source
-        - sourceNumber
-        - sourceUuid
-        - sourceDevice
-        - timestamp
-```
+   ```yaml
+   - resource: "http://127.0.0.1:8105/receive/pop"
+     sensor:
+       - name: "Signal message received"
+         value_template: >
+           {{ value_json['envelope']['dataMessage']['message'] }}
+         json_attributes_path: envelope
+         json_attributes:
+           - source
+           - sourceNumber
+           - sourceUuid
+           - sourceDevice
+           - timestamp
+   ```
+2. use a Python script with AppDaemon like
+   [described here](https://community.home-assistant.io/t/signal-messenger-using-received-message/858118/2)
+   (this has the advantage that no extra Docker container is needed, everything is inside Home Assistant)

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -189,7 +189,6 @@ actions:
 **NOTE** If the parameter `mode` is set to `json-rpc`, then you can use one of these solutions:
 
 1. employ [signal-api-receiver](https://github.com/kalbasit/signal-api-receiver) to receive from Signal as follows:
-
    ```yaml
    - resource: "http://127.0.0.1:8105/receive/pop"
      sensor:

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -70,7 +70,9 @@ number:
 recipients:
   description: A list of default recipients (either phone numbers or Signal Messenger group ids). It can be overwritten for individual messages.
   required: true
-  type: string
+  type: list
+  items:
+    type: string
 {% endconfiguration %}
 
 

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -68,7 +68,7 @@ number:
   required: true
   type: string
 recipients:
-  description: A list of default recipients (either phone numbers or Signal Messenger group ids). Can be overwritten for individual messages.
+  description: A list of default recipients (either phone numbers or Signal Messenger group ids). It can be overwritten for individual messages.
   required: true
   type: string
 {% endconfiguration %}
@@ -95,9 +95,10 @@ actions:
       data:
         text_mode: styled
 ```
+
 | Attribute | Optional   | Default                                         | Description                                                                                                       |
 |-----------|------------|-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| target    | *optional* | as configured via `recipients` for the `notify` | a list of strings, containing either fully-qualified phone numbers (including country prefix) or Signal group IDs |
+| target    | *optional* | as configured via `recipients` for the `notify` | a list of strings, containing either fully qualified phone numbers (including country prefix) or Signal group IDs |
 
 | Data Attribute | Optional | Default |Description                                                                                                                                                                                          |
 |----------------| -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -186,6 +187,7 @@ actions:
 ```
 
 **NOTE** If the parameter `mode` is set to `json-rpc`, then you can use one of these solutions:
+
 1. employ [signal-api-receiver](https://github.com/kalbasit/signal-api-receiver) to receive from Signal as follows:
 
    ```yaml

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -187,6 +187,7 @@ actions:
     data:
       message: "Message received!"
 ```
+
 **NOTE** If the parameter `mode` is set to `json-rpc`, then you can use [signal-api-receiver](https://github.com/kalbasit/signal-api-receiver) to receive from Signal as follows:
 
 ```yaml

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -187,3 +187,19 @@ actions:
     data:
       message: "Message received!"
 ```
+**NOTE** If the parameter `mode` is set to `json-rpc`, then you can use [signal-api-receiver](https://github.com/kalbasit/signal-api-receiver) to receive from Signal as follows:
+
+```yaml
+- resource: "http://127.0.0.1:8105/receive/pop"
+  sensor:
+    - name: "Signal message received"
+      value_template: >
+        {{ value_json['envelope']['dataMessage']['message'] }}
+      json_attributes_path: envelope
+      json_attributes:
+        - source
+        - sourceNumber
+        - sourceUuid
+        - sourceDevice
+        - timestamp
+```

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -187,24 +187,3 @@ actions:
     data:
       message: "Message received!"
 ```
-
-**NOTE** If the parameter `mode` is set to `json-rpc`, then you can use one of these solutions:
-
-1. employ [signal-api-receiver](https://github.com/kalbasit/signal-api-receiver) to receive from Signal as follows:
-   ```yaml
-   - resource: "http://127.0.0.1:8105/receive/pop"
-     sensor:
-       - name: "Signal message received"
-         value_template: >
-           {{ value_json['envelope']['dataMessage']['message'] }}
-         json_attributes_path: envelope
-         json_attributes:
-           - source
-           - sourceNumber
-           - sourceUuid
-           - sourceDevice
-           - timestamp
-   ```
-2. use a Python script with AppDaemon like
-   [described here](https://community.home-assistant.io/t/signal-messenger-using-received-message/858118/2)
-   (this has the advantage that no extra Docker container is needed, everything is inside Home Assistant)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This is the documentation for [this PR in the core repo](https://github.com/home-assistant/core/pull/145654).

It documents the possibility to overwrite the default recipient list (which is configured globally) on a per-message basis by using the `target` attribute inherited from `notify`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/145654
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the use of the `recipients` option and restrictions on mixing phone numbers and Signal groups.
  - Enhanced notification action example with an optional `target` field and usage table.
  - Reformatted `text_mode` attribute description for consistency.
  - Expanded guidance for receiving messages in `json-rpc` mode, providing multiple solutions and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->