### PR TITLE
itegration: husqvarna_automower_ble: Support battery level

### DIFF
--- a/source/_integrations/husqvarna_automower_ble.markdown
+++ b/source/_integrations/husqvarna_automower_ble.markdown
@@ -3,6 +3,7 @@ title: Husqvarna Automower BLE
 description: Instructions on how to integrate Husqvarna Automower BLE lawn mowers into Home Assistant.
 ha_category:
   - Lawn Mower
+  - Sensor
 ha_release: 2024.11
 ha_iot_class: Local Polling
 ha_config_flow: true
@@ -10,6 +11,7 @@ ha_codeowners:
   - '@alistair23'
 ha_platforms:
   - lawn_mower
+  - sensor
 ha_integration_type: integration
 ha_domain: husqvarna_automower_ble
 ---
@@ -18,16 +20,12 @@ The Husqvarna Automower BLE integration provides connectivity with Husqvarna Aut
 
 The integration is based on [AutoMower-BLE](https://github.com/alistair23/AutoMower-BLE), an unofficial reverse engineered Husqvarna Automower Connect BLE library.
 
-There is currently support for the following device types within Home Assistant:
-
-- Lawn Mower
-
 ### Prerequisites
 
 1. Setup a [Bluetooth controller](https://www.home-assistant.io/integrations/bluetooth/). An ESPHome Bluetooth proxy works well and allows locating a device close to the mower.
 2. Enter the pairing mode on the mower. Different models will do this in different ways. For the 305, for example, the mower will enter pairing mode for the first 3 minutes after powering on. Ensure the mower is in pairing mode when adding the integration. This only needs to be done once per BLE controller (so changing the ESPHome device will require a repair).
-3. When adding the integration to Home Assistant, you will need to enter the mower BLE Mac address. You can find this in the ESPHome logs, on an Android phone, or by some other means.
+3. When manually adding the integration to Home Assistant, you will need to enter the mower BLE Mac address. You can find this in the ESPHome logs, on an Android phone, or by some other means.
 
-Pairing can take a few goes. Even when using the official Android application, it can be tricky to get the first pair to succeed. If you are having issues, reboot the mower and try again.
+Pairing can take a few goes. Even when using the official Android application, it can be tricky to get the first pair to succeed. If you are having issues, reboot the mower and try again. The Mower must be paired, not just connected, to work.
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change

Add Sensor support (https://github.com/home-assistant/core/pull/146159) to the documentation and tidy up the instructions a little bit.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [X] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/146159
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified setup instructions, specifying that manual entry of the mower's BLE MAC address is required.
  - Updated pairing requirements to emphasize that the mower must be paired, not just connected.
  - Added "Sensor" as an additional category and platform.
  - Improved wording for clarity and removed the device type section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->