### PR TITLE
Clarify KNX `respond_to_read`

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -555,7 +555,7 @@ address:
   required: true
   type: [string, list]
 remove:
-  description: If `True` the group address will be removed.
+  description: If `true` the group address will be removed.
   required: false
   type: boolean
   default: false
@@ -571,7 +571,7 @@ The `knx.exposure_register` action can be used to register (or unregister) expos
 
 {% configuration %}
 remove:
-  description: In addition to the configuration variables of [expose](#exposing-entity-states-entity-attributes-or-time-to-knx-bus) `remove` set to `True` can be used to remove exposures. Only `address` is required for removal.
+  description: In addition to the configuration variables of [expose](#exposing-entity-states-entity-attributes-or-time-to-knx-bus) `remove` set to `true` can be used to remove exposures. Only `address` is required for removal.
   required: false
   type: boolean
   default: false
@@ -1264,7 +1264,7 @@ state_address:
   required: false
   type: [string, list]
 respond_to_read:
-  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
+  description: If `true`, the entity will respond to GroupValueRead telegrams received on the configured `address` by sending a GroupValueResponse to the same `address`. This is typically used when Home Assistant acts as the state provider for the KNX bus. In such cases, only `address` is configured, and `state_address` is not set. Read-requests to passive or state addresses don't trigger responses.
   required: false
   type: boolean
   default: false
@@ -1331,7 +1331,7 @@ state_address:
   required: false
   type: [string, list]
 respond_to_read:
-  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
+  description: If `true`, the entity will respond to GroupValueRead telegrams received on the configured `address` by sending a GroupValueResponse to the same `address`. This is typically used when Home Assistant acts as the state provider for the KNX bus. In such cases, only `address` is configured, and `state_address` is not set. Read-requests to passive or state addresses don't trigger responses.
   required: false
   type: boolean
   default: false
@@ -1735,7 +1735,7 @@ type:
   required: true
   type: [string, integer]
 respond_to_read:
-  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
+  description: If `true`, the entity will respond to GroupValueRead telegrams received on the configured `address` by sending a GroupValueResponse to the same `address`. This is typically used when Home Assistant acts as the state provider for the KNX bus. In such cases, only `address` is configured, and `state_address` is not set. Read-requests to passive or state addresses don't trigger responses.
   required: false
   type: boolean
   default: false
@@ -1868,7 +1868,7 @@ options:
       required: true
       type: integer
 respond_to_read:
-  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
+  description: If `true`, the entity will respond to GroupValueRead telegrams received on the configured `address` by sending a GroupValueResponse to the same `address`. This is typically used when Home Assistant acts as the state provider for the KNX bus. In such cases, only `address` is configured, and `state_address` is not set. Read-requests to passive or state addresses don't trigger responses.
   required: false
   type: boolean
   default: false
@@ -2204,7 +2204,7 @@ invert:
   type: boolean
   default: false
 respond_to_read:
-  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
+  description: If `true`, the entity will respond to GroupValueRead telegrams received on the configured `address` by sending a GroupValueResponse to the same `address`. This is typically used when Home Assistant acts as the state provider for the KNX bus. In such cases, only `address` is configured, and `state_address` is not set. Read-requests to passive or state addresses don't trigger responses.
   required: false
   type: boolean
   default: false
@@ -2267,7 +2267,7 @@ type:
   type: [string, integer]
   default: latin_1
 respond_to_read:
-  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
+  description: If `true`, the entity will respond to GroupValueRead telegrams received on the configured `address` by sending a GroupValueResponse to the same `address`. This is typically used when Home Assistant acts as the state provider for the KNX bus. In such cases, only `address` is configured, and `state_address` is not set. Read-requests to passive or state addresses don't trigger responses.
   required: false
   type: boolean
   default: false
@@ -2320,7 +2320,7 @@ state_address:
   required: false
   type: [string, list]
 respond_to_read:
-  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
+  description: If `true`, the entity will respond to GroupValueRead telegrams received on the configured `address` by sending a GroupValueResponse to the same `address`. This is typically used when Home Assistant acts as the state provider for the KNX bus. In such cases, only `address` is configured, and `state_address` is not set. Read-requests to passive or state addresses don't trigger responses.
   required: false
   type: boolean
   default: false

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -1264,7 +1264,7 @@ state_address:
   required: false
   type: [string, list]
 respond_to_read:
-  description: Respond to GroupValueRead telegrams received to the configured `address`.
+  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
   required: false
   type: boolean
   default: false
@@ -1331,7 +1331,7 @@ state_address:
   required: false
   type: [string, list]
 respond_to_read:
-  description: Respond to GroupValueRead telegrams received to the configured `address`.
+  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
   required: false
   type: boolean
   default: false
@@ -1735,7 +1735,7 @@ type:
   required: true
   type: [string, integer]
 respond_to_read:
-  description: Respond to GroupValueRead telegrams received to the configured `address`.
+  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
   required: false
   type: boolean
   default: false
@@ -1868,7 +1868,7 @@ options:
       required: true
       type: integer
 respond_to_read:
-  description: Respond to GroupValueRead telegrams received to the configured `address`.
+  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
   required: false
   type: boolean
   default: false
@@ -2204,7 +2204,7 @@ invert:
   type: boolean
   default: false
 respond_to_read:
-  description: Respond to GroupValueRead telegrams received to the configured `address`.
+  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
   required: false
   type: boolean
   default: false
@@ -2267,7 +2267,7 @@ type:
   type: [string, integer]
   default: latin_1
 respond_to_read:
-  description: Respond to GroupValueRead telegrams received to the configured `address`.
+  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
   required: false
   type: boolean
   default: false
@@ -2320,7 +2320,7 @@ state_address:
   required: false
   type: [string, list]
 respond_to_read:
-  description: Respond to GroupValueRead telegrams received to the configured `address`.
+  description: If true, the entity will respond to received GroupValueRead telegrams by sending a GroupValueResponse to the configured `address`. This is used when Home Assistant acts as the state provider on the KNX bus. In such cases, typically only `address` is configured, and no `state_address` is set.
   required: false
   type: boolean
   default: false


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #39418

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved the description of the `respond_to_read` option for various KNX entity types, providing clearer guidance on its behavior and usage.
  - Standardized capitalization in the descriptions of the `remove` option for certain KNX actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->