### PR TITLE
Add supported device to Russound RIO

### DIFF
--- a/source/_integrations/russound_rio.markdown
+++ b/source/_integrations/russound_rio.markdown
@@ -27,6 +27,7 @@ This integration allows you to connect the following controllers:
 
 - Russound MBX-PRE
 - Russound MBX-AMP
+- Russound ACA-E5
 - Russound MCA-C3
 - Russound MCA-C5
 - Russound MCA-66

--- a/source/_integrations/russound_rnet.markdown
+++ b/source/_integrations/russound_rnet.markdown
@@ -27,7 +27,6 @@ Connecting to the Russound device is only possible by TCP, you can make use of a
 
 This integration allows you to connect the following controllers:
 
-- Russound ACA-E5
 - Russound CAS44
 - Russound CAA66
 - Russound CAM6.6


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fixes the supported devices list for Russound RIO and RNET integrations. Moved the ACA-E5 from being supported by Russound RNET (not technically correct) to Russound RIO.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Russound RIO integration documentation to include support for the Russound ACA-E5 controller.
  - Updated Russound RNET integration documentation to remove the Russound ACA-E5 controller from the list of supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->