### PR TITLE
Docs: Add automation example for new pull requests

### DIFF
--- a/source/_integrations/github.markdown
+++ b/source/_integrations/github.markdown
@@ -143,6 +143,32 @@ actions:
 
 {% endraw %}
 
+### Notify on new Pull Request
+
+This automation notifies you when a new pull request is created in a monitored repository.
+
+{% raw %}
+
+```yaml
+- id: 'notify_on_new_github_pull_request'
+  alias: "Notify on new GitHub Pull Request"
+  description: "Sends a notification when a new pull request is opened in a monitored GitHub repository."
+  trigger:
+    - platform: state
+      entity_id: sensor.YOUR_REPO_latest_pull_request
+  action:
+    - service: notify.YOUR_NOTIFY_SERVICE
+      data:
+        title: "New PR in {{ trigger.to_state.attributes.repository }}"
+        message: |
+          '{{ trigger.to_state.state }}' (#{{ trigger.to_state.attributes.number }})
+          was opened by {{ trigger.to_state.attributes.user }}.
+        data:
+          url: "{{ trigger.to_state.attributes.url }}"
+```
+
+{% endraw %}
+
 ### Notify new stars
 
 This example uses the [Stars](#diagnostic-entities) diagnostic entity provided by this integration, and a [notify](/integrations/notify) action,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->

## Proposed change

This pull request adds a new automation example to the documentation for the GitHub integration. The new example demonstrates how to create a notification when a new pull request is created in a monitored repository. It follows the existing formatting style for documentation examples.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

	•	This PR modifies the documentation page: `source/_integrations/github.markdown`
	•	The code follows the existing style and format.
	•	All links and entity references have been checked.


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
