### PR TITLE
Update airthings.markdown to reflect the latency in adding the radon …

### DIFF
--- a/source/_integrations/airthings.markdown
+++ b/source/_integrations/airthings.markdown
@@ -26,7 +26,7 @@ While this integration works without an Airthings SmartLink hub, using one will 
 
 Requires Airthings hardware and a valid Airthings Dashboard login.
 
-{% tip %} Initially, the radon sensor not published by the Airthings API (it is considered "unknown"), and so you may have to wait 24 hours to see the radon sensor appear for a new device.{% endtip %}
+{% tip %} Initially, the radon sensor may not be published by the Airthings API (at device startup the value is considered "unknown"), and so you may have to wait for the radon sensor appear for a new device.{% endtip %}
 
 
 

--- a/source/_integrations/airthings.markdown
+++ b/source/_integrations/airthings.markdown
@@ -26,7 +26,6 @@ While this integration works without an Airthings SmartLink hub, using one will 
 
 Requires Airthings hardware and a valid Airthings Dashboard login.
 
-
 ## Prerequisites
 
 Airthings API setup (needed to acquire the required ID and Secret for the Home Assistant Airthings Integration).
@@ -51,6 +50,3 @@ The Airthings integration can now be activated using the generated id and secret
 ## Troubleshooting
 
 {% tip %} Initially, the radon sensor may not be published by the Airthings API (at device startup the value is considered "unknown"), and so you may have to wait for the radon sensor appear for a new device.{% endtip %}
-
-
-

--- a/source/_integrations/airthings.markdown
+++ b/source/_integrations/airthings.markdown
@@ -26,9 +26,6 @@ While this integration works without an Airthings SmartLink hub, using one will 
 
 Requires Airthings hardware and a valid Airthings Dashboard login.
 
-{% tip %} Initially, the radon sensor may not be published by the Airthings API (at device startup the value is considered "unknown"), and so you may have to wait for the radon sensor appear for a new device.{% endtip %}
-
-
 
 ## Prerequisites
 
@@ -50,3 +47,10 @@ Upon saving the settings, you will be presented with a generated id and secret.
 The Airthings integration can now be activated using the generated id and secret that you have just created.
 
 {% include integrations/config_flow.md %}
+
+## Troubleshooting
+
+{% tip %} Initially, the radon sensor may not be published by the Airthings API (at device startup the value is considered "unknown"), and so you may have to wait for the radon sensor appear for a new device.{% endtip %}
+
+
+

--- a/source/_integrations/airthings.markdown
+++ b/source/_integrations/airthings.markdown
@@ -49,4 +49,7 @@ The Airthings integration can now be activated using the generated id and secret
 
 ## Troubleshooting
 
-{% tip %} Initially, the radon sensor may not be published by the Airthings API (at device startup the value is considered "unknown"), and so you may have to wait for the radon sensor appear for a new device.{% endtip %}
+
+ ### The radon sensor does not show up
+ 
+ Initially, the radon sensor may not be published by the Airthings API (at device startup the value is considered "unknown"), and so you may have to wait for the radon sensor appear for a new device.

--- a/source/_integrations/airthings.markdown
+++ b/source/_integrations/airthings.markdown
@@ -52,4 +52,4 @@ The Airthings integration can now be activated using the generated id and secret
 
  ### The radon sensor does not show up
  
- Initially, the radon sensor may not be published by the Airthings API (at device startup the value is considered "unknown"), and so you may have to wait for the radon sensor appear for a new device.
+Initially, the radon sensor may not be published by the Airthings API (at device startup, the value is considered "unknown"), and so you may have to wait for the radon sensor to appear for a new device.

--- a/source/_integrations/airthings.markdown
+++ b/source/_integrations/airthings.markdown
@@ -50,6 +50,6 @@ The Airthings integration can now be activated using the generated id and secret
 ## Troubleshooting
 
 
- ### The radon sensor does not show up
+### The radon sensor does not show up
  
 Initially, the radon sensor may not be published by the Airthings API (at device startup, the value is considered "unknown"), and so you may have to wait for the radon sensor to appear for a new device.

--- a/source/_integrations/airthings.markdown
+++ b/source/_integrations/airthings.markdown
@@ -26,6 +26,10 @@ While this integration works without an Airthings SmartLink hub, using one will 
 
 Requires Airthings hardware and a valid Airthings Dashboard login.
 
+{% tip %} Initally, the radon sensor not published from the Airthings API (it is considered "unknown"), and so you may have to wait 24 hours to see the radon sensor appear for a new device.{% endtip %}
+
+
+
 ## Prerequisites
 
 Airthings API setup (needed to acquire the required ID and Secret for the Home Assistant Airthings Integration).

--- a/source/_integrations/airthings.markdown
+++ b/source/_integrations/airthings.markdown
@@ -26,7 +26,7 @@ While this integration works without an Airthings SmartLink hub, using one will 
 
 Requires Airthings hardware and a valid Airthings Dashboard login.
 
-{% tip %} Initally, the radon sensor not published from the Airthings API (it is considered "unknown"), and so you may have to wait 24 hours to see the radon sensor appear for a new device.{% endtip %}
+{% tip %} Initially, the radon sensor not published by the Airthings API (it is considered "unknown"), and so you may have to wait 24 hours to see the radon sensor appear for a new device.{% endtip %}
 
 
 


### PR DESCRIPTION
…sensor.

I noticed that the radon sensor entity was not created when the device was newly added - the Airthings API itself won't return a value until the sensor actually has a known value.  Since this could be confusing, I added a tip to the documention to try and help folks understand it.  This would only happen if you added a new device to Airthings and immediately added it to Home Assistant.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I noticed that the radon sensor entity was not created when the device was newly added - the Airthings API itself won't return a value until the sensor actually has a known value.  Since this could be confusing, I added a tip to the documention to try and help folks understand it.  This would only happen if you added a new device to Airthings and immediately added it to Home Assistant.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a tip explaining that radon sensor data may initially be "unknown" and take time to appear for new Airthings devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->