### PR TITLE
Adding missing data property "hold_secs"

### DIFF
--- a/source/_integrations/harmony.markdown
+++ b/source/_integrations/harmony.markdown
@@ -99,6 +99,7 @@ Send a single command or a set of commands to one device, device ID and availabl
 | `command`              | no       | A single command or a list of commands to send.     |
 | `num_repeats`          | yes      | The number of times to repeat the command(s).       |
 | `delay_secs`           | yes      | The number of seconds between sending each command. |
+| `hold_secs`            | yes      | The number of seconds the button on the remoe is held before the release is send. |
 
 In the file 'harmony_REMOTENAME.conf' you can find the available devices and commands, for example:
 

--- a/source/_integrations/harmony.markdown
+++ b/source/_integrations/harmony.markdown
@@ -99,7 +99,7 @@ Send a single command or a set of commands to one device, device ID and availabl
 | `command`              | no       | A single command or a list of commands to send.     |
 | `num_repeats`          | yes      | The number of times to repeat the command(s).       |
 | `delay_secs`           | yes      | The number of seconds between sending each command. |
-| `hold_secs`            | yes      | The number of seconds the button on the remoe is held before the release is send. |
+| `hold_secs`            | yes      | The number of seconds the button on the remote is held before the release is sent. |
 
 In the file 'harmony_REMOTENAME.conf' you can find the available devices and commands, for example:
 


### PR DESCRIPTION
The property  "hold_secs" is not mentioned in the documentation. However it can be included in the action call and seems to work as expected ("long press")

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
The property  "hold_secs" is not mentioned in the documentation. However it can be included in the action call and seems to work as expected ("long press")

-->



## Type of change
<!--
The property  "hold_secs" is not mentioned in the documentation. However it can be included in the action call and seems to work as expected ("long press")

-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Harmony integration documentation to include the new optional `hold_secs` attribute for the `remote.send_command` action, allowing users to specify how long a button is held before release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->