### PR TITLE
Clarify open behaviour for tedee

### DIFF
--- a/source/_integrations/tedee.markdown
+++ b/source/_integrations/tedee.markdown
@@ -59,7 +59,7 @@ This integration supports
 - **Lock uncalibrated** (disabled by default): Shows when the lock is in an "uncalibrated state".
 
 {% note %}
-The `lock.open` service will only pull the spring if the lock is configured with "auto pull-spring enabled" in the tedee app. That is due to a limitation in tedee's API.
+The `lock.open` service will only pull the spring if the lock is configured with "**auto pull-spring enabled**" in the tedee app. That is due to a limitation in tedee's API.
 {% endnote %}
 
 ## Sensors

--- a/source/_integrations/tedee.markdown
+++ b/source/_integrations/tedee.markdown
@@ -58,6 +58,10 @@ This integration supports
 - **Semi locked**: indicates whether the lock is in a "semi-locked" position. "Semi-locked" means the lock has been turned manually and is between its normal end positions. The lock itself will be unavailable in this position.
 - **Lock uncalibrated** (disabled by default): Shows when the lock is in an "uncalibrated state".
 
+{% note %}
+The `lock.open` service will only pull the spring if the lock is configured with "auto pull-spring enabled" in the tedee app. That is due to a limitation in tedee's API.
+{% endnote %}
+
 ## Sensors
 
 The integration currently offers two sensors: A **battery** sensor, indicating the charge of your lock, and a **"pull spring duration"** sensor, indicating how long (in seconds) your latch will stay pulled after a pull operation (if supported).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that the `lock.open` service only activates the spring pull mechanism if "auto pull-spring enabled" is set in the Tedee app, due to Tedee API limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->