### PR TITLE
Add number entity to Russound RIO

### DIFF
--- a/source/_integrations/russound_rio.markdown
+++ b/source/_integrations/russound_rio.markdown
@@ -9,6 +9,7 @@ ha_domain: russound_rio
 ha_platforms:
   - diagnostics
   - media_player
+  - number
 ha_codeowners:
   - '@noahhusby'
 ha_config_flow: true

--- a/source/_integrations/russound_rio.markdown
+++ b/source/_integrations/russound_rio.markdown
@@ -61,7 +61,7 @@ This integration follows standard integration removal. No extra steps are requir
 
 The integration provides a few entities to configure the device settings. The following entities are supported:
 
-- Bass & Treble
+- Bass and Treble
 - Balance
 - Turn on volume
 

--- a/source/_integrations/russound_rio.markdown
+++ b/source/_integrations/russound_rio.markdown
@@ -57,6 +57,14 @@ This integration follows standard integration removal. No extra steps are requir
 
 {% include integrations/remove_device_service.md %}
 
+## Available configuration entities
+
+The integration provides a few entities to configure the device settings. The following entities are supported:
+
+- Bass & Treble
+- Balance
+- Turn on volume
+
 ## Troubleshooting
 
 ### There is a delay on getting the current status


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds a list of configurable entities to Russound RIO (all number entities as of now).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/147228
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section detailing available configuration entities for the Russound RIO integration, including Bass & Treble, Balance, and Turn on volume settings.
  - Included the "number" platform in the list of supported platforms for the Russound RIO integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->