### PR TITLE
Update yalexs_ble documentation for secure mode support

### DIFF
--- a/source/_integrations/yalexs_ble.markdown
+++ b/source/_integrations/yalexs_ble.markdown
@@ -36,8 +36,8 @@ Devices must have a Yale Access module installed to function with this {% term i
 - YRD256 (Yale Assure Lock Keypad)
 - YRD420 (Yale Assure Lock 2)
 - YRD450 (Yale Assure Lock 2 Key Free)
-- YUR/SSDL/1/SIL (Yale Unity Screen Door Lock - Australia)
-- YUR/DEL/1/SIL (Yale Unity Entrance Lock - Australia)
+- YUR/SSDL/1/SIL and MBK (Yale Unity Screen Door Lock - Australia)
+- YUR/DEL/1/SIL and MBK (Yale Unity Entrance Lock - Australia)
 - IES-D210W-G0 (Yale Smart Safe)
 - YRSM-1 (Yale Smart Safe)
 - ASL-05 (August WiFi Smart Lock - Gen 4)
@@ -50,6 +50,10 @@ These devices do not send updates, but can be locked and unlocked.
 
 - MD-04I (Yale Conexis L1 (requires yale access module), Yale Conexis L2)
 - YRCB-490 (Yale Smart Cabinet Lock)
+
+## Deadlock support
+
+Some Yale locks support a deadlock function (secure mode) for locking both the inside and outside. A secure mode lock entity (initially disabled) is exposed for all locks and can be enabled where the lock is known to support this capability.
 
 ## Troubleshooting
 
@@ -77,11 +81,11 @@ The offline key and slot number are required to operate the lock. These credenti
 
 ### Yale Access, Yale Home, or August Cloud
 
-The [August](/integrations/august) {% term integration %} can automatically provision the offline key if the configured account has the key loaded. You may need to create or use a non-primary existing account with owner-level access to the lock, as not all accounts will have the key loaded. If the lock was not discovered by Home Assistant when the cloud {% term integration %} was loaded, reload the cloud {% term integration %} once the lock has been discovered.
+The [Yale](/integrations/yale) or [August](/integrations/august) cloud {% term integration %} can automatically provision the offline key if the configured account has the key loaded. You may need to create or use a non-primary existing account with owner-level access to the lock, as not all accounts will have the key loaded. If the lock was not discovered by Home Assistant when the cloud {% term integration %} was loaded, reload the cloud {% term integration %} once the lock has been discovered.
 
 If the offline key can automatically be provisioned, you will not be asked to enter it and the {% term integration %} should be automatically added, configured and running.
 
-Most Yale branded locks can use the August cloud to obtain the keys. Accessing the August cloud to receive the key may not work unless the lock was purchased in a market that sells under both brands.
+Most Yale branded locks can use the cloud {% term integration %} to obtain the offline key. Accessing the August cloud to receive the key may only work if the lock was purchased in a market that sells under both brands and the Yale cloud should be tried for other markets.
 
 ### iOS - Yale Access App or August App
 
@@ -106,6 +110,6 @@ Root access is required to copy the `ModelDatabase.sql` from `/data/data/com.ass
 
 ### Lock frequently requires re-authentication
 
-If you use the key from an iOS or Android device that you also frequently use to operate the lock, you may find that the key is rotated, and the integration can no longer authenticate. If you are using the [August](/integrations/august) integration to keep the key up to date, it may need to be reloaded to update the key. 
+If you use the key from an iOS or Android device that you also frequently use to operate the lock, you may find that the key is rotated, and the integration can no longer authenticate. If you are using the [Yale](/integrations/yale) or [August](/integrations/august) integration to keep the key up to date, it may need to be reloaded to update the key. 
 
-To avoid the problem, create a second owner account in the August app, log in to it once on your iOS or Android device, operate the locks, log out of the account, remove the August integration, and set up the August integration with the secondary owner account. This method avoids the problem because there is no longer an iOS or Android device logged into the secondary owner account that can rotate the key unexpectedly.
+To avoid the problem, create a second owner account in the Yale Home or August app, log in to it once on your iOS or Android device, operate the locks, log out of the account, remove the Yale or August integration from Home Assistant, and set up the integration again with the secondary owner account. This method avoids the problem because there is no longer an iOS or Android device logged into the secondary owner account that can rotate the key unexpectedly.


### PR DESCRIPTION
Updates the Yale Access Bluetooth integration documentation to include secure mode support. 

Also updates references to August cloud to include the Yale cloud integration for clarity as the August brand is not used in all markets

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/144107https://github.com/home-assistant/core/pull/144107
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Yale Access Bluetooth integration documentation to describe new deadlock support and secure mode lock entity.
  - Clarified supported device models, specifying both SIL and MBK variants for certain locks.
  - Generalized cloud integration references to include both Yale and August clouds for offline key provisioning.
  - Enhanced troubleshooting instructions to cover both Yale and August integrations, including revised steps for key rotation and re-authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->