### PR TITLE
Z-Wave controller reset: add prereq steps

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -274,7 +274,8 @@ It is recommended to back up your Z-Wave network before resetting the device.
 
 - Administrator rights on Home Assistant
 - [Backup your Z-Wave network](#backing-up-your-z-wave-network)
-- [Remove all devices that are paired with your controller from the network](#removing-a-device-from-the-z-wave-network)
+- [Remove all devices that are paired with your controller from the network](#removing-a-device-from-the-z-wave-network).
+  - Removing can be done by any controller, not just the one that originally managed the network. In theory, this could also be done later.
 
 ### To reset a Z-Wave controller
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -267,7 +267,7 @@ It is recommended to back up your Z-Wave network before resetting the device.
 
 - The controller will forget all devices it is paired with.
 - All Z-Wave devices for this network will be removed from Home Assistant.
-- If there are any devices still paired with the controller when it is reset, they will have to be removed from the network before they can be re-paired.
+- If there are any devices still paired with the controller when it is reset, they will have to be removed from their old network before they can be re-paired.
 - The device firmware will remain on the device.
 
 ### Prerequisites

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -267,12 +267,14 @@ It is recommended to back up your Z-Wave network before resetting the device.
 
 - The controller will forget all devices it is paired with.
 - All Z-Wave devices for this network will be removed from Home Assistant.
-- If there are any devices still paired with the controller when it is reset, they will have to go through the exclusion process before they can be re-paired.
+- If there are any devices still paired with the controller when it is reset, they will have to be removed from the network before they can be re-paired.
 - The device firmware will remain on the device.
 
 ### Prerequisites
 
 - Administrator rights on Home Assistant
+- [Backup your Z-Wave network](#backing-up-your-z-wave-network)
+- [Remove all devices that are paired with your controller from the network](#removing-a-device-from-the-z-wave-network)
 
 ### To reset a Z-Wave controller
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified instructions for resetting a Z-Wave controller, specifying that devices must be removed from their old network before re-pairing.
  * Expanded prerequisites section with explicit links for backing up the Z-Wave network and removing all paired devices.
  * Added note that device removal can be performed by any controller and may be done later in the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->