### PR TITLE
Fix typo in SwitchBot Matter docs

### DIFF
--- a/source/_integrations/switchbot_matter.markdown
+++ b/source/_integrations/switchbot_matter.markdown
@@ -30,7 +30,7 @@ SwitchBot also has Matter devices that are certified for use via one of their Ma
 
 ### Via a Matter Hub
 
-- [SwitchBot Leak Detector](https://www.switch-bot.com/products/switchbot-water-leak-detector)
+- [SwitchBot Lock Ultra](https://www.switch-bot.com/products/switchbot-lock_ultra)
 - [SwitchBot Meter](https://www.switch-bot.com/products/switchbot-meter)
 - [SwitchBot Meter Pro](https://www.switch-bot.com/products/switchbot-meter-pro)
 - [SwitchBot Meter Pro CO2](https://www.switch-bot.com/products/switchbot-meter-pro-co2-monitor)


### PR DESCRIPTION
## Proposed change

Fix a small typo in the docs for SwitchBot Matter: 
- the Lock Ultra is a Bluetooth Device that can also be bridged to Matter with any of the hubs but the Leak detector is bluetooth only (for now).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the SwitchBot Matter devices documentation to replace the "SwitchBot Leak Detector" link with the "SwitchBot Lock Ultra" link in the "Via a Matter Hub" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->