### PR TITLE
Z-Wave backup: implement review feedback

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -172,7 +172,7 @@ Do this before using the device with another adapter, or when you don't use the 
 
 ## Migrating a Z-Wave network to a new adapter
 
-Do this if you have an existing Z-Wave network and want to use a new adapter. This will reset your current adapter (remove all network information from it) and remove the adapter from Home Assistant. The Z-Wave integration with all its entities will stay in Home Assistant. The new adapter is added to Home Assistant and paired with the existing network.
+Do this if you have an existing Z-Wave network and want to use a new adapter. The Z-Wave integration with all its entities will stay in Home Assistant. The new adapter is added to Home Assistant and paired with the existing network.
 
 ### Prerequisites
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -172,7 +172,7 @@ Do this before using the device with another adapter, or when you don't use the 
 
 ## Migrating a Z-Wave network to a new adapter
 
-Do this if you have an existing Z-Wave network and want to use a new adapter. The Z-Wave integration with all its entities will stay in Home Assistant. The new adapter is added to Home Assistant and paired with the existing network.
+Do this if you have an existing Z-Wave network and want to replace its adapter with a new adapter. The Z-Wave integration with all its entities will stay in Home Assistant. The new adapter is added to Home Assistant and paired with the existing network.
 
 ### Prerequisites
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -189,8 +189,8 @@ Do this if you have an existing Z-Wave network and want to use a new adapter. Th
 3. Under **Backup and restore**, select **Migrate adapter**.
 4. Select **Migrate to a new adapter**.
 
-   - To confirm device reset, select **Submit**.
-   - **Info**: This will initiate a backup of the network information. All the stored network information will be removed.
+   - To confirm, select **Submit**.
+   - **Info**: This will initiate a backup of the network information.
 5. When the **Unplug your adapter** dialog shows up, unplug your old adapter.
    - Connect the new adapter.
    - Confirm that you connected the new adapter by selecting **Submit**.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified instructions for confirming actions during Z-Wave network migration.
  * Shortened the informational note to focus on network backup initiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->