### PR TITLE
REST: add missing documentation on 'encoding'

### DIFF
--- a/source/_integrations/sensor.rest.markdown
+++ b/source/_integrations/sensor.rest.markdown
@@ -64,6 +64,11 @@ device_class:
   description: Sets the [class of the device](/integrations/sensor#device-class), changing the device state and icon that is displayed on the frontend.
   required: false
   type: string
+encoding:
+  description: The character encoding to use if none provided in the header of the shared data.
+  required: false
+  type: string
+  default: UTF-8
 force_update:
   description: Sends update events even if the value hasn't changed. Useful if you want to have meaningful value graphs in history.
   required: false


### PR DESCRIPTION
## Proposed change

Similar to the RESTful integration, the RESTful sensor also provides an 'encoding' option (see https://github.com/home-assistant/core/blob/fea7dc7eba402c42b31d104707eaa3097217830a/homeassistant/components/rest/schema.py#L73), but this was not documented, yet.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: does not apply
- Link to parent pull request in the Brands repository: does not apply
- This PR fixes or closes issue: does not apply

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about a new optional `encoding` parameter for the RESTful sensor integration, allowing users to specify character encoding (defaulting to "UTF-8") if not provided in the data header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->