### PR TITLE
Remove stale binary sensor documentation

### DIFF
--- a/source/_integrations/playstation_network.markdown
+++ b/source/_integrations/playstation_network.markdown
@@ -71,7 +71,6 @@ The **PlayStation Network** {% term integration %} lets you integrate informatio
 
 ### Binary sensors
 
-- **Online**: Indicates if you are actively using a device that is connected to the PlayStation Network.
 - **Subscribed to PlayStation Plus**: Indicates if you have an active PlayStation Plus membership.
 
 ## Data updates


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
This PR removes the documentation string pertaining to a binary sensor that was moved to a sensor. 
Online Status was originally binary and is now (and already is in the documentation) a sensor.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [Related PR, already merged](https://github.com/home-assistant/core/pull/147639)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PlayStation Network integration documentation by removing the description for the "Online" binary sensor. The "Subscribed to PlayStation Plus" sensor documentation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->