### PR TITLE
Change config_entry_id to be optional within Mealie actions where only one instance

### DIFF
--- a/source/_integrations/mealie.markdown
+++ b/source/_integrations/mealie.markdown
@@ -8,8 +8,8 @@ ha_config_flow: true
 ha_release: 2024.7
 ha_iot_class: Local Polling
 ha_codeowners:
-  - "@joostlek"
-  - "@andrew-codechimp"
+  - '@joostlek'
+  - '@andrew-codechimp'
 ha_domain: mealie
 ha_platforms:
   - calendar

--- a/source/_integrations/mealie.markdown
+++ b/source/_integrations/mealie.markdown
@@ -8,8 +8,8 @@ ha_config_flow: true
 ha_release: 2024.7
 ha_iot_class: Local Polling
 ha_codeowners:
-  - '@joostlek'
-  - '@andrew-codechimp'
+  - "@joostlek"
+  - "@andrew-codechimp"
 ha_domain: mealie
 ha_platforms:
   - calendar
@@ -80,53 +80,53 @@ The Mealie integration has the following actions:
 
 Get the meal plan for a specified range.
 
-| Data attribute | Optional | Description                                              |
-|------------------------|----------|----------------------------------------------------------|
-| `config_entry_id`      | No       | The ID of the Mealie config entry to get data from.      |
-| `start_date`           | Yes      | The start date of the meal plan. (today if not supplied) |
-| `end_date`             | Yes      | The end date of the meal plan. (today if not supplied)   |
+| Data attribute    | Optional | Description                                                                                         |
+| ----------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `config_entry_id` | Yes      | The ID of the Mealie config entry to get data from. Required if you have multiple Mealie instances. |
+| `start_date`      | Yes      | The start date of the meal plan. (today if not supplied)                                            |
+| `end_date`        | Yes      | The end date of the meal plan. (today if not supplied)                                              |
 
 ### Action `mealie.get_recipe`
 
 Get the recipe for a specified recipe ID or slug.
 
-| Data attribute | Optional | Description                                         |
-|------------------------|----------|-----------------------------------------------------|
-| `config_entry_id`      | No       | The ID of the Mealie config entry to get data from. |
-| `recipe_id`            | No       | The ID or the slug of the recipe to get.            |
+| Data attribute    | Optional | Description                                                                                         |
+| ----------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `config_entry_id` | Yes      | The ID of the Mealie config entry to get data from. Required if you have multiple Mealie instances. |
+| `recipe_id`       | No       | The ID or the slug of the recipe to get.                                                            |
 
 ### Action `mealie.import_recipe`
 
 Import the recipe into Mealie from a URL.
 
-| Data attribute | Optional | Description                                                     |
-|------------------------|----------|-----------------------------------------------------------------|
-| `config_entry_id`      | No       | The ID of the Mealie config entry to get data from.             |
-| `url`                  | No       | The URL of the recipe.                                          |
-| `include_tags`         | Yes      | Include tags from the website to the recipe. (false by default) |
+| Data attribute    | Optional | Description                                                                                         |
+| ----------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `config_entry_id` | Yes      | The ID of the Mealie config entry to get data from. Required if you have multiple Mealie instances. |
+| `url`             | No       | The URL of the recipe.                                                                              |
+| `include_tags`    | Yes      | Include tags from the website to the recipe. (false by default)                                     |
 
 ### Action `mealie.set_mealplan`
 
 Set a mealplan on a specific date.
 
-| Data attribute    | Optional | Description                                         |
-|-------------------|----------|-----------------------------------------------------|
-| `config_entry_id` | No       | The ID of the Mealie config entry to get data from. |
-| `date`            | No       | The date that should be filled.                     |
-| `entry_type`      | No       | One of "breakfast", "lunch", "dinner", or "side".    |
-| `recipe_id`       | Yes      | The recipe to plan.                                 |
-| `note_title`      | Yes      | The title of the meal note.                         |
-| `note_text`       | Yes      | The description of the meal note.                   |
+| Data attribute    | Optional | Description                                                                                         |
+| ----------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `config_entry_id` | Yes      | The ID of the Mealie config entry to get data from. Required if you have multiple Mealie instances. |
+| `date`            | No       | The date that should be filled.                                                                     |
+| `entry_type`      | No       | One of "breakfast", "lunch", "dinner", or "side".                                                   |
+| `recipe_id`       | Yes      | The recipe to plan.                                                                                 |
+| `note_title`      | Yes      | The title of the meal note.                                                                         |
+| `note_text`       | Yes      | The description of the meal note.                                                                   |
 
 ### Action `mealie.set_random_mealplan`
 
 Set a random mealplan on a specific date.
 
-| Data attribute    | Optional | Description                                         |
-|-------------------|----------|-----------------------------------------------------|
-| `config_entry_id` | No       | The ID of the Mealie config entry to get data from. |
-| `date`            | No       | The date that should be filled.                     |
-| `entry_type`      | No       | One of "breakfast", "lunch", "dinner" or "side".    |
+| Data attribute    | Optional | Description                                                                                         |
+| ----------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `config_entry_id` | Yes      | The ID of the Mealie config entry to get data from. Required if you have multiple Mealie instances. |
+| `date`            | No       | The date that should be filled.                                                                     |
+| `entry_type`      | No       | One of "breakfast", "lunch", "dinner" or "side".                                                    |
 
 {% tip %}
 You can get your `config_entry_id` by using actions within [Developer Tools](/docs/tools/dev-tools/), using one of the above actions and viewing the YAML.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Change all actions that required a config_entry_id to now be optional where there is only one config_entry (Mealie instance).
It is unlikely that users have more than one Mealie instance so this will make it easier than referencing uid's within automations.
Inspired by the recent Telegram Bot actions which implemented this pattern.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/148413
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified when the config_entry_id attribute is required for Mealie integration actions.
  * Standardized formatting of data attribute tables for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->