### PR TITLE
Add assumed optimistic state to template numbers

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -1638,7 +1638,7 @@ number:
       description: Template for the number's current value.  When omitted, the state will be set to the `value` provided by the `set_value` action.
       required: false
       type: template
-      default: None
+      default: optimistic
     unit_of_measurement:
       description: Defines the units of measurement of the number, if any.
       required: false

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -1635,9 +1635,10 @@ number:
       required: true
       type: action
     state:
-      description: Template for the number's current value.
-      required: true
+      description: Template for the number's current value.  When omitted, the state will be set to the `value` provided by the `set_value` action.
+      required: false
       type: template
+      default: None
     unit_of_measurement:
       description: Defines the units of measurement of the number, if any.
       required: false
@@ -1645,8 +1646,9 @@ number:
       default: None
     step:
       description: Template for the number's increment/decrement step.
-      required: true
+      required: false
       type: template
+      default: 1.0
 
 {% endconfiguration %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add assumed optimistic state to template numbers.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/148499
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to indicate that the `state` and `step` configuration keys for the template integration's number platform are now optional, with clear default values and expanded descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->