### PR TITLE
Document `object_id` is only updates Entity ID when the MQTT entity is added the first time and overrides user customizations

### DIFF
--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -195,7 +195,7 @@ name:
   type: string
   default: MQTT Alarm
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_arm_away:

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -195,7 +195,7 @@ name:
   type: string
   default: MQTT Alarm
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_arm_away:

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -169,7 +169,7 @@ name:
   type: string
   default: MQTT binary sensor
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 off_delay:

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -169,7 +169,7 @@ name:
   type: string
   default: MQTT binary sensor
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 off_delay:

--- a/source/_integrations/button.mqtt.markdown
+++ b/source/_integrations/button.mqtt.markdown
@@ -157,7 +157,7 @@ name:
   type: string
   default: MQTT Button
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/button.mqtt.markdown
+++ b/source/_integrations/button.mqtt.markdown
@@ -157,7 +157,7 @@ name:
   type: string
   default: MQTT Button
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -158,7 +158,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 topic:

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -158,7 +158,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 topic:

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -239,7 +239,7 @@ name:
   type: string
   default: MQTT HVAC
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -239,7 +239,7 @@ name:
   type: string
   default: MQTT HVAC
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -170,7 +170,7 @@ name:
   type: string
   default: MQTT Cover
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -170,7 +170,7 @@ name:
   type: string
   default: MQTT Cover
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -139,7 +139,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -139,7 +139,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/event.mqtt.markdown
+++ b/source/_integrations/event.mqtt.markdown
@@ -155,7 +155,7 @@ name:
   type: string
   default: MQTT Event
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/event.mqtt.markdown
+++ b/source/_integrations/event.mqtt.markdown
@@ -155,7 +155,7 @@ name:
   type: string
   default: MQTT Event
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -162,7 +162,7 @@ name:
   type: string
   default: MQTT Fan
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -162,7 +162,7 @@ name:
   type: string
   default: MQTT Fan
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -195,7 +195,7 @@ name:
   type: string
   default: MQTT humidifier
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -195,7 +195,7 @@ name:
   type: string
   default: MQTT humidifier
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/image.mqtt.markdown
+++ b/source/_integrations/image.mqtt.markdown
@@ -165,7 +165,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 unique_id:

--- a/source/_integrations/image.mqtt.markdown
+++ b/source/_integrations/image.mqtt.markdown
@@ -165,7 +165,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 unique_id:

--- a/source/_integrations/lawn_mower.mqtt.markdown
+++ b/source/_integrations/lawn_mower.mqtt.markdown
@@ -163,7 +163,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/lawn_mower.mqtt.markdown
+++ b/source/_integrations/lawn_mower.mqtt.markdown
@@ -163,7 +163,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -286,7 +286,7 @@ name:
   type: string
   default: MQTT Light
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 on_command_type:
@@ -717,7 +717,7 @@ name:
   type: string
   default: MQTT JSON Light
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:
@@ -1123,7 +1123,7 @@ name:
   type: string
   default: MQTT Template Light
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -286,7 +286,7 @@ name:
   type: string
   default: MQTT Light
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 on_command_type:
@@ -717,7 +717,7 @@ name:
   type: string
   default: MQTT JSON Light
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:
@@ -1123,7 +1123,7 @@ name:
   type: string
   default: MQTT Template Light
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -168,7 +168,7 @@ name:
   type: string
   default: MQTT Lock
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -168,7 +168,7 @@ name:
   type: string
   default: MQTT Lock
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/notify.mqtt.markdown
+++ b/source/_integrations/notify.mqtt.markdown
@@ -153,7 +153,7 @@ name:
   type: string
   default: MQTT notify
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/notify.mqtt.markdown
+++ b/source/_integrations/notify.mqtt.markdown
@@ -153,7 +153,7 @@ name:
   type: string
   default: MQTT notify
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -165,7 +165,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -165,7 +165,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -151,7 +151,7 @@ name:
   type: string
   default: MQTT Scene
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -151,7 +151,7 @@ name:
   type: string
   default: MQTT Scene
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -158,7 +158,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -158,7 +158,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -166,7 +166,7 @@ name:
   type: string
   default: MQTT Sensor
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 options:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -166,7 +166,7 @@ name:
   type: string
   default: MQTT Sensor
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 options:

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -170,7 +170,7 @@ name:
   type: string
   default: MQTT Siren
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -170,7 +170,7 @@ name:
   type: string
   default: MQTT Siren
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -165,7 +165,7 @@ name:
   type: string
   default: MQTT Switch
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -165,7 +165,7 @@ name:
   type: string
   default: MQTT Switch
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/text.mqtt.markdown
+++ b/source/_integrations/text.mqtt.markdown
@@ -166,7 +166,7 @@ name:
   type: string
   default: "MQTT Text"
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 pattern:

--- a/source/_integrations/text.mqtt.markdown
+++ b/source/_integrations/text.mqtt.markdown
@@ -166,7 +166,7 @@ name:
   type: string
   default: "MQTT Text"
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 pattern:

--- a/source/_integrations/update.mqtt.markdown
+++ b/source/_integrations/update.mqtt.markdown
@@ -168,7 +168,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_install:

--- a/source/_integrations/update.mqtt.markdown
+++ b/source/_integrations/update.mqtt.markdown
@@ -168,7 +168,7 @@ name:
   required: false
   type: string
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_install:

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -131,7 +131,7 @@ name:
   type: string
   default: MQTT Vacuum
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -131,7 +131,7 @@ name:
   type: string
   default: MQTT Vacuum
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 payload_available:

--- a/source/_integrations/water_heater.mqtt.markdown
+++ b/source/_integrations/water_heater.mqtt.markdown
@@ -189,7 +189,7 @@ name:
   type: string
   default: MQTT water heater
 object_id:
-  description: Used instead of `name` for automatic generation of `entity_id`
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:

--- a/source/_integrations/water_heater.mqtt.markdown
+++ b/source/_integrations/water_heater.mqtt.markdown
@@ -189,7 +189,7 @@ name:
   type: string
   default: MQTT water heater
 object_id:
-  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user customized Entity ID in case the entity was deleted and added again.
+  description: Used `object_id` instead of `name` for automatic generation of `entity_id`. This only works when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   required: false
   type: string
 optimistic:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document `object_id` is only updates Entity ID when the MQTT entity is added the first time and overrides user customizations


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/148484
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified the description of the `object_id` configuration option across all MQTT integration documentation. The updated text now explains that `object_id` is used for automatic entity ID generation only when the entity is first added, and that setting it will override a user-customized Entity ID if the entity is deleted and re-added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->