### PR TITLE
Use component and platform for link id in configuration blocks

### DIFF
--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -166,10 +166,16 @@ module Jekyll
 
       vars = SafeYAML.load(contents)
 
+      linkId = [component, platform, 'configuration-variables']
+        .compact
+        .reject(&:empty?)
+        .join('-')
+      
+
       <<~MARKUP
         <div class="config-vars">
           <h4>
-            Configuration Variables <a class="title-link" name="configuration-variables" href="#configuration-variables"></a>
+            Configuration Variables <a class="title-link" name="#{linkId}" href="##{linkId}"></a>
           </h4>
           <div class="configuration-link">
             <a href="/docs/configuration/" target="_blank">Looking for your configuration file?</a>

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -140,7 +140,7 @@ template:
 
 ### Configuration reference
 
-{% configuration %}
+{% configuration trigger-based %}
 actions:
   description: Define actions to be executed when the trigger fires (for trigger-based entities only). Optional. Variables set by the action script are available when evaluating entity templates. This can be used to interact with anything using actions, in particular actions with [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data). [See action documentation](/docs/automation/action).
   required: false
@@ -193,7 +193,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration device %}
   availability:
     description: Defines a template to get the `available` state of the entity. If the template either fails to render or returns `True`, `"1"`, `"true"`, `"yes"`, `"on"`, `"enable"`, or a non-zero number, the entity will be `available`. If the template returns any other value, the entity will be `unavailable`. If not configured, the entity will always be `available`. Note that the string comparison is not case sensitive; `"TrUe"` and `"yEs"` are allowed.
     required: false
@@ -268,7 +268,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration alarm_control_panel %}
 alarm_control_panel:
   description: List of alarm control panels
   required: true
@@ -349,7 +349,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration binary-sensor %}
 binary_sensor:
   description: List of binary sensors
   required: true
@@ -536,7 +536,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration button %}
 button:
   description: List of buttons
   required: true
@@ -591,7 +591,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration cover %}
 cover:
   description: Characteristics of a cover
   type: map
@@ -822,7 +822,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration fan %}
 fan:
   description: List of fans
   required: true
@@ -1028,7 +1028,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration image %}
 image:
   description: List of images
   required: true
@@ -1161,7 +1161,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration light %}
 light:
   description: List of your lights.
   required: true
@@ -1421,7 +1421,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration lock %}
 lock:
   description: List of locks
   required: true
@@ -1609,7 +1609,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration number %}
 number:
   description: List of numbers
   required: true
@@ -1717,7 +1717,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration select %}
 select:
   description: List of selects
   required: true
@@ -1808,7 +1808,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration sensor %}
 sensor:
   description: List of sensors
   required: true
@@ -1971,7 +1971,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration switch %}
 switch:
   description: List of switches
   required: true
@@ -2117,7 +2117,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration vacuum %}
 vacuum:
   description: List of vacuum entities
   required: true
@@ -2277,7 +2277,7 @@ template:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration weather %}
 weather:
   description: List of weather entities
   required: true
@@ -2647,7 +2647,7 @@ alarm_control_panel:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration legacy_alarm_control_panel %}
 panels:
   description: List of your panels.
   required: true
@@ -2731,7 +2731,7 @@ binary_sensor:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration legacy_binary_sensor %}
 sensors:
   description: List of your sensors.
   required: true
@@ -2818,7 +2818,7 @@ cover:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration legacy_cover %}
   covers:
     description: List of your covers.
     required: true
@@ -2942,7 +2942,7 @@ fan:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration legacy_fan %}
   fans:
     description: List of your fans.
     required: true
@@ -3078,7 +3078,7 @@ light:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration legacy_light %}
   lights:
     description: List of your lights.
     required: true
@@ -3225,7 +3225,7 @@ lock:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration legacy_lock %}
   name:
     description: Name to use in the frontend.
     required: false
@@ -3292,7 +3292,7 @@ sensor:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration legacy_sensor %}
   sensors:
     description: Map of your sensors.
     required: true
@@ -3375,7 +3375,7 @@ switch:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration legacy_switch %}
   switches:
     description: List of your switches.
     required: true
@@ -3437,7 +3437,7 @@ vacuum:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration legacy_vacuum %}
   vacuums:
     description: List of your vacuums.
     required: true
@@ -3533,7 +3533,7 @@ weather:
 
 {% endraw %}
 
-{% configuration %}
+{% configuration legacy_weather %}
 name:
   description: Name to use in the frontend.
   required: true


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
- A configuration block always had the heading id `configuration-variables`. With this change it prefixes component and platform if available to generate more unique ids.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
