### PR TITLE
Fix duplicate anchor link names

### DIFF
--- a/plugins/output_modder.rb
+++ b/plugins/output_modder.rb
@@ -41,28 +41,26 @@ module Jekyll
                 link.set_attribute('rel', rel.join(' ').strip)
             end
 
-            # Find all headers, make them linkable with hierarchical slug names
-            slug_parts = {}
+            # Find all headers, make them linkable with unique slug names
+            used_slugs = {}
             
             dom.css('h2,h3,h4,h5,h6,h7,h8').each do |header|
-
               # Skip linked headers
               next if header.at_css('a')
 
               title = header.content
-              level = header.name[1].to_i  # Extract number from h2, h3, etc.
               
-              # Clean the title to create a slug part
-              slug_part = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+              # Clean the title to create a slug
+              base_slug = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
               
-              # Reset deeper levels when we encounter a higher level header
-              slug_parts.delete_if { |key, _| key > level }
-              
-              # Set the current level
-              slug_parts[level] = slug_part
-              
-              # Build the full slug from all current levels
-              slug = slug_parts.sort.map { |_, part| part }.join('-')
+              # Make slug unique by adding counter if needed
+              if used_slugs[base_slug]
+                used_slugs[base_slug] += 1
+                slug = "#{base_slug}-#{used_slugs[base_slug] - 1}"
+              else
+                used_slugs[base_slug] = 1
+                slug = base_slug
+              end
               
               header.children = "#{title} <a class='title-link' name='#{slug}' href='\##{slug}'></a>"
             end

--- a/plugins/output_modder.rb
+++ b/plugins/output_modder.rb
@@ -41,15 +41,30 @@ module Jekyll
                 link.set_attribute('rel', rel.join(' ').strip)
             end
 
-            # Find all headers, make them linkable
+            # Find all headers, make them linkable with hierarchical slug names
+            slug_parts = {}
+            
             dom.css('h2,h3,h4,h5,h6,h7,h8').each do |header|
 
-                # Skip linked headers
-                next if header.at_css('a')
+              # Skip linked headers
+              next if header.at_css('a')
 
-                title = header.content
-                slug = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
-                header.children = "#{title} <a class='title-link' name='#{slug}' href='\##{slug}'></a>"
+              title = header.content
+              level = header.name[1].to_i  # Extract number from h2, h3, etc.
+              
+              # Clean the title to create a slug part
+              slug_part = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+              
+              # Reset deeper levels when we encounter a higher level header
+              slug_parts.delete_if { |key, _| key > level }
+              
+              # Set the current level
+              slug_parts[level] = slug_part
+              
+              # Build the full slug from all current levels
+              slug = slug_parts.sort.map { |_, part| part }.join('-')
+              
+              header.children = "#{title} <a class='title-link' name='#{slug}' href='\##{slug}'></a>"
             end
 
             dom.to_s

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -78,7 +78,7 @@ Home Assistant supports both _classic inclusion_ and _SmartStart_. _Classic incl
 
 For more Z-Wave term definitions, refer to the [terminology section](#z-wave-terminology).
 
-### Getting started with Z-Wave - Prerequisites
+### Prerequisites
 
 To run a Z-Wave network, you need the following elements:
 
@@ -178,7 +178,7 @@ Do this if you have an existing Z-Wave network and want to replace its adapter w
 You cannot run two Z-Wave adapters simultaneously using the same add-on. If you only run one add-on, you need to migrate the network. If you want to run two adapters, you would need to install another add-on, such as Z-Wave JS UI.
 {% endtip %}
 
-### Network migration - Prerequisites
+### Prerequisites
 
 - Administrator rights in Home Assistant
 - **Important**: If you want to migrate from a **500 series** adapter, before starting migration, you need to update the adapter to SDK 6.61+
@@ -215,7 +215,7 @@ The frequency used by Z-Wave devices depends on your region. For 700 and 800 ser
 
 If you are using the Z-Wave JS add-on, Home Assistant automatically changes the radio frequency region to match the region/country you're in. If needed, you can override this setting.
 
-### Overriding the frequency region - Prerequisites
+### Prerequisites
 
 - Administrator rights in Home Assistant
 - All your Z-Wave devices must be specified for that region
@@ -234,7 +234,7 @@ If you are using the Z-Wave JS add-on, Home Assistant automatically changes the 
 
 It's recommended to create a backup before making any major changes to your Z-Wave network. For example, before migrating from one adapter to another, or before resetting your adapter. The backup stores your Z-Wave adapter's non-volatile memory (NVM), which contains your network information including paired devices. It is stored in a binary file that you can download.
 
-### Backup - Prerequisites
+### Prerequisites
 
 - Administrator rights in Home Assistant
 
@@ -251,7 +251,7 @@ It's recommended to create a backup before making any major changes to your Z-Wa
 
 You can restore your Z-Wave network from a backup.
 
-### Restore network - Prerequisites
+### Prerequisites
 
 - Administrator rights in Home Assistant
 - Have a [backup](#backing-up-your-z-wave-network) downloaded
@@ -280,7 +280,7 @@ A firmware update can damage your Z-Wave device.
 The Home Assistant and Z-Wave JS teams do not take any responsibility for any damages to your device as a result of the firmware update and will not be able to help you if you render your device useless due to firmware update.
 {% endnote %}
 
-### Firmware update - Prerequisites
+### Prerequisites
 
 - Administrator rights in Home Assistant
 - Downloaded the firmware file from the manufacturer website
@@ -309,7 +309,7 @@ It is recommended to back up your Z-Wave network before resetting the device.
 - If there are any devices still paired with the adapter when it is reset, they will have to go through the exclusion process before they can be re-paired.
 - The device firmware will remain on the device.
 
-### Reset - Prerequisites
+### Prerequisites
 
 - Administrator rights on Home Assistant
 - [Backup your Z-Wave network](#backing-up-your-z-wave-network)


### PR DESCRIPTION
## Proposed change
- Add number prefix to duplicate (or more) anchor links, to provide a shareable link
  - this also fixes toc to open duplicate named links because it uses the same logic.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
