### PR TITLE
Improve migration instructions for Z-Wave JS -> Z-Wave JS UI

### DIFF
--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1022,7 +1022,7 @@ All of your HA devices and entities will remain unchanged if you follow these st
    - Click **Install**, then **Start**.
    - It may take a while for the add-on to start up.
 
-3. Note the websocket URL that the HA integration will use to communicate with Z-Wave JS.
+3. Note the WebSocket URL that the HA integration will use to communicate with Z-Wave JS.
     - Within the same **Z-Wave JS UI** add-on from step 2, open the [Documentation tab](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/documentation).
     - Search (Ctrl-F) for a link that begins with "ws://".  For example, `ws://a0d7b954-zwavejs2mqtt:3000`.
     - Copy that URL somewhere safe.  You will need it later.

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1010,45 +1010,45 @@ You can switch between the official Z-Wave JS add-on and the Z-Wave JS UI add-on
 
 You can switch from the official **Z-Wave JS** add-on to the community **Z-Wave JS UI** add-on. However, you cannot run them both at the same time. Only one of the add-ons can be active at the same time.
 
-All of your HA devices and entities will remain unchanged if you follow these steps:
+Both add-ons communicate with Home Assistant via the same **Z-Wave** {% term integration %}.  So your devices and entities will remain unchanged if you follow these steps:
 
 1. Note your network security keys from the official add-on.
-   - In your browser, open **Settings** -> **Add-ons** -> **Z-Wave JS** -> **Configuration**.  ([direct link](http://homeassistant.local:8123/hassio/addon/core_zwave_js/config))
+   - In your browser, open **Settings** -> **Add-ons** -> **Z-Wave JS** -> [**Configuration**](http://homeassistant.local:8123/hassio/addon/core_zwave_js/config).  
    - From the three-dot {% icon "mdi:dots-vertical" %} menu, pick **Edit in YAML**.
    - You should see about 12 lines of YAML, including items like `device: xxx` and `s2_access_control_key: xxx`.  Select all and copy somewhere safe.  You will need them later.
 
 2. Install and start the community **Z-Wave JS UI** add-on.
-   - In your browser, open **Settings** -> **Add-ons** -> **Add-on Store** -> **Z-Wave JS UI**.  ([direct link](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/info))
-   - Click **Install**, then **Start**.
+   - In your browser, open **Settings** -> **Add-ons** -> **Add-on Store** -> [**Z-Wave JS UI**](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/info).
+   - Press **Install**, then **Start**.
    - It may take a while for the add-on to start up.
 
-3. Note the WebSocket URL that the HA integration will use to communicate with Z-Wave JS.
-    - Within the same **Z-Wave JS UI** add-on from step 2, open the [Documentation tab](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/documentation).
+3. Note the WebSocket URL that the integration will use to communicate with Z-Wave JS.
+    - Within the same **Z-Wave JS UI** add-on from step 2, open the [**Documentation tab**](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/documentation).
     - Search (Ctrl-F) for a link that begins with "ws://".  For example, `ws://a0d7b954-zwavejs2mqtt:3000`.
     - Copy that URL somewhere safe.  You will need it later.
 
-4. Start reconfiguring the adapter.
+4. Start reconfiguring the integration.
    - Open a new browser tab.
-   - Navigate to **Settings** -> **Devices & services** -> **Z-Wave**.  ([direct link](http://homeassistant.local:8123/config/integrations/integration/zwave_js))
-   - Click the three-dot {% icon "mdi:dots-vertical" %} menu next to the **Z-Wave JS** top row.
+   - Navigate to **Settings** -> **Devices & services** -> [**Z-Wave**](http://homeassistant.local:8123/config/integrations/integration/zwave_js).  
+   - Press the three-dot {% icon "mdi:dots-vertical" %} menu next to the **Z-Wave JS** top row.
    - From the menu, select **Reconfigure**, then **Reconfigure current adapter**.
    - Uncheck **Use the Z-Wave JS Supervisor add-on**.
    - Keep this tab open.
 
 5. Configure the new add-on using the information saved in step 1.
    - Switch back to your initial browser tab.
-   - Within the **Z-Wave JS UI** add-on, switch back to the [Info tab](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/info) and click **Open Web UI**.
+   - Within the **Z-Wave JS UI** add-on, switch back to the [**Info tab**](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/info) and press **Open Web UI**.
    - Open the **Settings** {% icon "mdi:cog" %} page and expand the **Z-Wave** section.
    - Fill out the subsections for **Serial Port**, **Security Keys**, and **RF Region**.
    - Save your changes.
 
-6. Finish reconfiguring the HA integration.
+6. Finish reconfiguring the integration.
    - Switch back to the tab from step 4.
    - Under **WebSocket URL**, enter the URL you saved in step 3.
 
 7. Uninstall the official add-on.
-   - Navigate to **Settings** -> *Add-ons** -> **Z-Wave JS**. ([direct link](http://homeassistant.local:8123/hassio/addon/core_zwave_js/info))
-   - Click **Uninstall**.
+   - Navigate to **Settings** -> **Add-ons** -> [**Z-Wave JS**](http://homeassistant.local:8123/hassio/addon/core_zwave_js/info).
+   - Press **Uninstall**.
    - When asked if you want to delete the related data, keep it if you think you might switch back to the **Z-Wave JS** add-on later.
 
 ### How to migrate from one adapter to a new adapter using Z-Wave JS UI?

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1013,31 +1013,31 @@ You can switch from the official **Z-Wave JS** add-on to the community **Z-Wave 
 Both add-ons communicate with Home Assistant via the same **Z-Wave** {% term integration %}.  So your devices and entities will remain unchanged if you follow these steps:
 
 1. Note your network security keys from the official add-on.
-   - In your browser, open **Settings** -> **Add-ons** -> **Z-Wave JS** -> [**Configuration**](http://homeassistant.local:8123/hassio/addon/core_zwave_js/config).  
-   - From the three-dot {% icon "mdi:dots-vertical" %} menu, pick **Edit in YAML**.
-   - You should see about 12 lines of YAML, including items like `device: xxx` and `s2_access_control_key: xxx`.  Select all and copy somewhere safe.  You will need them later.
+   - In your browser, open {% my supervisor_addon addon="core_zwave_js" title="**Settings** > **Add-ons** > **Z-Wave JS**" %}.  
+   - From the three dots {% icon "mdi:dots-vertical" %} menu, select **Edit in YAML**.
+   - You should see about 12 lines of YAML, including items like `device: xxx` and `s2_access_control_key: xxx`.  Select all and copy them somewhere safe.  You will need them later.
 
 2. Install and start the community **Z-Wave JS UI** add-on.
-   - In your browser, open **Settings** -> **Add-ons** -> **Add-on Store** -> [**Z-Wave JS UI**](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/info).
-   - Press **Install**, then **Start**.
+   - In your browser, open {% my supervisor_store title="**Settings** > **Add-ons** > **Add-on Store**" %}.
+   - Select **Install**, then **Start**.
    - It may take a while for the add-on to start up.
 
 3. Note the WebSocket URL that the integration will use to communicate with Z-Wave JS.
-    - Within the same **Z-Wave JS UI** add-on from step 2, open the [**Documentation tab**](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/documentation).
+    - Within the same **Z-Wave JS UI** add-on from step 2, open the **Documentation** tab.
     - Search (Ctrl-F) for a link that begins with "ws://".  For example, `ws://a0d7b954-zwavejs2mqtt:3000`.
     - Copy that URL somewhere safe.  You will need it later.
 
 4. Start reconfiguring the integration.
    - Open a new browser tab.
-   - Navigate to **Settings** -> **Devices & services** -> [**Z-Wave**](http://homeassistant.local:8123/config/integrations/integration/zwave_js).  
-   - Press the three-dot {% icon "mdi:dots-vertical" %} menu next to the **Z-Wave JS** top row.
+   - Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Z-Wave** integration.  
+   - Select the three-dot {% icon "mdi:dots-vertical" %} menu next to the **Z-Wave JS** top row.
    - From the menu, select **Reconfigure**, then **Reconfigure current adapter**.
    - Uncheck **Use the Z-Wave JS Supervisor add-on**.
    - Keep this tab open.
 
 5. Configure the new add-on using the information saved in step 1.
    - Switch back to your initial browser tab.
-   - Within the **Z-Wave JS UI** add-on, switch back to the [**Info tab**](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/info) and press **Open Web UI**.
+   - Within the **Z-Wave JS UI** add-on, switch back to the **Info tab** and select **Open Web UI**.
    - Open the **Settings** {% icon "mdi:cog" %} page and expand the **Z-Wave** section.
    - Fill out the subsections for **Serial Port**, **Security Keys**, and **RF Region**.
    - Save your changes.
@@ -1047,9 +1047,10 @@ Both add-ons communicate with Home Assistant via the same **Z-Wave** {% term int
    - Under **WebSocket URL**, enter the URL you saved in step 3.
 
 7. Uninstall the official add-on.
-   - Navigate to **Settings** -> **Add-ons** -> [**Z-Wave JS**](http://homeassistant.local:8123/hassio/addon/core_zwave_js/info).
-   - Press **Uninstall**.
-   - When asked if you want to delete the related data, keep it if you think you might switch back to the **Z-Wave JS** add-on later.
+   - Go to {% my supervisor_addon addon="core_zwave_js" title="**Settings** > **Add-ons** > **Z-Wave JS**" %}.
+   - Select **Uninstall**.
+   - You are asked if you want to delete the related data. 
+   - Keep it if you think you might switch back to the **Z-Wave JS** add-on later.
 
 ### How to migrate from one adapter to a new adapter using Z-Wave JS UI?
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1008,32 +1008,48 @@ You can switch between the official Z-Wave JS add-on and the Z-Wave JS UI add-on
 
 ### How to switch from Z-Wave JS to the Z-Wave JS UI add-on?
 
-You can switch from the official **Z-Wave JS** add-on to the **Z-Wave JS UI** add-on. However, you cannot run them both at the same time. Only one of the add-ons can be active at the same time.
+You can switch from the official **Z-Wave JS** add-on to the community **Z-Wave JS UI** add-on. However, you cannot run them both at the same time. Only one of the add-ons can be active at the same time.
 
-Switching does not require renaming your devices.
+All of your HA devices and entities will remain unchanged if you follow these steps:
 
 1. Note your network security keys from the official add-on.
+   - In your browser, open **Settings** -> **Add-ons** -> **Z-Wave JS** -> **Configuration**.  ([direct link](http://homeassistant.local:8123/hassio/addon/core_zwave_js/config))
+   - From the three-dot {% icon "mdi:dots-vertical" %} menu, pick **Edit in YAML**.
+   - You should see about 12 lines of YAML, including items like `device: xxx` and `s2_access_control_key: xxx`.  Select all and copy somewhere safe.  You will need them later.
 
-2. Install and start the **Z-Wave JS UI** add-on.
+2. Install and start the community **Z-Wave JS UI** add-on.
+   - In your browser, open **Settings** -> **Add-ons** -> **Add-on Store** -> **Z-Wave JS UI**.  ([direct link](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/info))
+   - Click **Install**, then **Start**.
    - It may take a while for the add-on to start up.
 
-3. Open the **Documentation** tab and copy the URL listed in the section **Setting up the Home Assistant Z-Wave JS integration**. You will need it later.
+3. Note the websocket URL that the HA integration will use to communicate with Z-Wave JS.
+    - Within the same **Z-Wave JS UI** add-on from step 2, open the [Documentation tab](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/documentation).
+    - Search (Ctrl-F) for a link that begins with "ws://".  For example, `ws://a0d7b954-zwavejs2mqtt:3000`.
+    - Copy that URL somewhere safe.  You will need it later.
+
 4. Start reconfiguring the adapter.
-   - In your browser, open Home Assistant in a new tab.
-   - Select the **Z-Wave** integration and select the three-dot {% icon "mdi:dots-vertical" %} menu.
+   - Open a new browser tab.
+   - Navigate to **Settings** -> **Devices & services** -> **Z-Wave**.  ([direct link](http://homeassistant.local:8123/config/integrations/integration/zwave_js))
+   - Click the three-dot {% icon "mdi:dots-vertical" %} menu next to the **Z-Wave JS** top row.
    - From the menu, select **Reconfigure**, then **Reconfigure current adapter**.
-   - Uncheck the **Use the Z-Wave JS Supervisor add-on**.
-   - Keep that tab open.
-5. Switch to the other tab to configure the **Z-Wave JS UI** add-on with the added control panel, including setting the location of your Z-Wave device and the network security keys.
-   - Open the **Z-Wave JS UI** web UI and go to **Settings** > **UI** > **Z-Wave**.
-   - Enter the security keys and region.
+   - Uncheck **Use the Z-Wave JS Supervisor add-on**.
+   - Keep this tab open.
+
+5. Configure the new add-on using the information saved in step 1.
+   - Switch back to your initial browser tab.
+   - Within the **Z-Wave JS UI** add-on, switch back to the [Info tab](http://homeassistant.local:8123/hassio/addon/a0d7b954_zwavejs2mqtt/info) and click **Open Web UI**.
+   - Open the **Settings** {% icon "mdi:cog" %} page and expand the **Z-Wave** section.
+   - Fill out the subsections for **Serial Port**, **Security Keys**, and **RF Region**.
    - Save your changes.
 
-6. Switch back to the tab where you started the reconfiguration of the integration.
-   - Under **WebSocket URL**, enter the URL you copied before.
+6. Finish reconfiguring the HA integration.
+   - Switch back to the tab from step 4.
+   - Under **WebSocket URL**, enter the URL you saved in step 3.
 
-7. Uninstall the official **Z-Wave JS** add-on.
-   - You are asked if you want to delete the related data. Keep it if you think you might switch back to the **Z-Wave JS** add-on later.
+7. Uninstall the official add-on.
+   - Navigate to **Settings** -> *Add-ons** -> **Z-Wave JS**. ([direct link](http://homeassistant.local:8123/hassio/addon/core_zwave_js/info))
+   - Click **Uninstall**.
+   - When asked if you want to delete the related data, keep it if you think you might switch back to the **Z-Wave JS** add-on later.
 
 ### How to migrate from one adapter to a new adapter using Z-Wave JS UI?
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1047,8 +1047,7 @@ Both add-ons communicate with Home Assistant via the same **Z-Wave** {% term int
    - Under **WebSocket URL**, enter the URL you saved in step 3.
 
 7. Uninstall the official add-on.
-   - Go to {% my supervisor_addon addon="core_zwave_js" title="**Settings** > **Add-ons** > **Z-Wave JS**" %}.
-   - Select **Uninstall**.
+   - Go to {% my supervisor_addon addon="core_zwave_js" title="**Settings** > **Add-ons** > **Z-Wave JS**" %} and select **Uninstall**.
    - You are asked if you want to delete the related data. 
    - Keep it if you think you might switch back to the **Z-Wave JS** add-on later.
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1010,7 +1010,7 @@ You can switch between the official Z-Wave JS add-on and the Z-Wave JS UI add-on
 
 You can switch from the official **Z-Wave JS** add-on to the community **Z-Wave JS UI** add-on. However, you cannot run them both at the same time. Only one of the add-ons can be active at the same time.
 
-Both add-ons communicate with Home Assistant via the same **Z-Wave** {% term integration %}.  So your devices and entities will remain unchanged if you follow these steps:
+Both add-ons communicate with Home Assistant via the same **Z-Wave** {% term integration %}.
 
 1. Note your network security keys from the official add-on.
    - In your browser, open {% my supervisor_addon addon="core_zwave_js" title="**Settings** > **Add-ons** > **Z-Wave JS**" %}.  


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Improve migration instructions for `Z-Wave JS` -> `Z-Wave JS UI`



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
