### PR TITLE
Improve accessibility of page feedback links by using semantic list and ARIA label

### DIFF
--- a/sass/homeassistant/_overrides.scss
+++ b/sass/homeassistant/_overrides.scss
@@ -574,6 +574,14 @@ a.material-card:hover {
     font-weight: 400;
     text-transform: none;
   }
+
+  .links ul {
+    list-style: none
+}
+
+  .links li {
+    display: inline
+}
 }
 
 .installation-survey {

--- a/sass/homeassistant/_overrides.scss
+++ b/sass/homeassistant/_overrides.scss
@@ -576,11 +576,12 @@ a.material-card:hover {
   }
 
   .links ul {
-    list-style: none
+    list-style: none;
+    margin: 0;
 }
 
   .links li {
-    display: inline
+    display: inline;
 }
 }
 

--- a/source/_includes/feedback.html
+++ b/source/_includes/feedback.html
@@ -3,36 +3,43 @@
   <h4>{% icon "mdi:feedback" %} <b> Help us improve our documentation</b><a href="#feedback_section" class="title-link" name="feedback_section"></a></h4>
   Suggest an edit to this page, or provide/view feedback for this page.
   <div class="links">
-    <a
+    <ul aria-label="Page feedback options">
+    <li><a
       href="{{ site.netlify.repository_url }}/tree/{{ site.netlify.head }}/source/{{ page.path }}"
       target="_blank"
+      title="Edit this page"
       ><iconify-icon inline icon="mdi:edit" /> Edit</a
-    >
+    ></li>
     {% if page.ha_domain %}
-    <a
+    <li><a
       href="{{ site.netlify.repository_url }}/issues/new?template=feedback.yml&url={{ site.netlify.url | url_encode }}{{ page.url | url_encode }}&version={{ site.current_major_version }}.{{
         site.current_minor_version }}.{{ site.current_patch_version }}&labels={{ site.netlify.branch }},integration%3A%20{{ page.ha_domain }}"
       target="_blank"
+      title="Provide feedback on this page"
       ><iconify-icon inline icon="mdi:comment-edit-outline" /> Provide feedback</a
-    >
-    <a
+    ></li>
+    <li><a
       href="{{ site.netlify.repository_url }}/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22integration%3A+{{ page.ha_domain }}%22"
       target="_blank"
+      title="View pending feedback for this page"
       ><iconify-icon inline icon="mdi:comment-text-multiple-outline" /> View pending feedback</a
-    >
+    ></li>
     {% else %}
-    <a
+    <li><a
       href="{{ site.netlify.repository_url }}/issues/new?template=feedback.yml&url={{ site.netlify.url | url_encode }}{{ page.url | url_encode }}&version={{ site.current_major_version }}.{{
         site.current_minor_version }}.{{ site.current_patch_version }}&labels={{ site.netlify.branch }}"
       target="_blank"
+      title="Provide feedback on this page"
       ><iconify-icon inline icon="mdi:comment-edit-outline" /> Provide feedback</a
-    >
-    <a
+    ></li>
+    <li><a
       href="{{ site.netlify.repository_url }}/issues?utf8=%E2%9C%93&q=%22{{ page.url | url_encode }}%22&in=body"
       target="_blank"
+      title="View given feedback for this page"
       ><iconify-icon inline icon="mdi:comment-text-multiple-outline" /> View given feedback</a
-    >
+    ></li>
     {% endif %}
+  </ul>
   </div>
 </div>
 {% endunless %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Improve the accessibility and semantics of the page feedback component:

- Convert the group of links from a generic `<div>` container to a semantic `<ul>` list.
- Add `aria-label="Page feedback options"` to the list to provide better context for screen reader users.
- Update link title to be more descriptive (e.g., "Edit this page" instead of "Edit").
- Add supporting CSS in `screen.css`:
  ```css
  .feedback .links ul {
      list-style: none;
  }

  .feedback .links li {
      display: inline;
  }

These changes improve semantic structure and relationships for assistive technologies, aligning with [WCAG 2.1 A 1.3.1 (Info and Relationships)](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository:  N/A
- This PR fixes or closes issue: fixes # N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
