### PR TITLE
Replaced Optional with Required in Climate Integration

### DIFF
--- a/source/_integrations/climate.markdown
+++ b/source/_integrations/climate.markdown
@@ -43,10 +43,10 @@ Not all climate {% term actions %}  may be available for your platform. You can 
 
 Turn auxiliary heater on/off for climate device
 
-| Data attribute | Optional | Description |
+| Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
-| `aux_heat` | no | New value of auxiliary heater.
+| `entity_id` | No | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+| `aux_heat` | Yes | New value of auxiliary heater.
 
 #### Automation example
 
@@ -69,10 +69,10 @@ Set preset mode for climate device. Away mode changes the target temperature per
 reflecting a situation where the climate device is set to save energy. For example, this may be used to emulate a
 "vacation mode."
 
-| Data attribute | Optional | Description |
+| Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
-| `preset_mode` | no | New value of preset mode.
+| `entity_id` | No | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+| `preset_mode` | Yes | New value of preset mode.
 
 #### Automation example
 
@@ -93,13 +93,13 @@ automation:
 
 Set target temperature of climate device
 
-| Data attribute | Optional | Description |
+| Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
-| `temperature` | yes | New target temperature for climate device (commonly referred to as a *setpoint*). Do not use if `hvac_mode` is `heat_cool`.
-| `target_temp_high` | yes | The highest temperature that the climate device will allow. Required if `hvac_mode` is `heat_cool`. Required together with `target_temp_low`.
-| `target_temp_low` | yes | The lowest temperature that the climate device will allow. Required if `hvac_mode` is `heat_cool`.  Required together with `target_temp_high`.
-| `hvac_mode` | yes | HVAC mode to set the climate device to. This defaults to current HVAC mode if not set, or set incorrectly.
+| `entity_id` | No | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+| `temperature` | No | New target temperature for climate device (commonly referred to as a *setpoint*). Do not use if `hvac_mode` is `heat_cool`.
+| `target_temp_high` | No | The highest temperature that the climate device will allow. Required if `hvac_mode` is `heat_cool`. Required together with `target_temp_low`.
+| `target_temp_low` | No | The lowest temperature that the climate device will allow. Required if `hvac_mode` is `heat_cool`.  Required together with `target_temp_high`.
+| `hvac_mode` | No | HVAC mode to set the climate device to. This defaults to current HVAC mode if not set, or set incorrectly.
 
 #### Automation examples
 
@@ -138,10 +138,10 @@ automation:
 
 Set target humidity of climate device
 
-| Data attribute | Optional | Description |
+| Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
-| `humidity` | no | New target humidity for climate device
+| `entity_id` | No | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+| `humidity` | Yes | New target humidity for climate device
 
 #### Automation example
 
@@ -162,10 +162,10 @@ automation:
 
 Set fan operation for climate device
 
-| Data attribute | Optional | Description |
+| Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
-| `fan_mode` | no | New value of fan mode
+| `entity_id` | No | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+| `fan_mode` | Yes | New value of fan mode
 
 #### Automation example
 
@@ -186,10 +186,10 @@ automation:
 
 Set climate device's HVAC mode
 
-| Data attribute | Optional | Description |
+| Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
-| `hvac_mode` | no | New value of HVAC mode
+| `entity_id` | No | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+| `hvac_mode` | Yes | New value of HVAC mode
 
 #### Automation example
 
@@ -210,10 +210,10 @@ automation:
 
 Set swing operation mode for climate device
 
-| Data attribute | Optional | Description |
+| Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
-| `swing_mode` | no | New value of swing mode: `off`, `horizontal`, `vertical` or `both`.
+| `entity_id` | No | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+| `swing_mode` | Yes | New value of swing mode: `off`, `horizontal`, `vertical` or `both`.
 
 #### Automation example
 
@@ -234,10 +234,10 @@ automation:
 
 Set horizontal swing operation mode for climate device
 
-| Data attribute          | Optional | Description                                                                                                                       |
+| Data attribute          | Required | Description                                                                                                                       |
 | ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id`             | yes      | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`. |
-| `swing_horizontal_mode` | no       | New value of horizontal swing mode.                                                                                               |
+| `entity_id`             | No      | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`. |
+| `swing_horizontal_mode` | Yes       | New value of horizontal swing mode.                                                                                               |
 
 #### Automation example
 
@@ -258,25 +258,25 @@ automation:
 
 Turn climate device on. This is only supported if the climate device supports being turned off.
 
-| Data attribute | Optional | Description |
+| Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+| `entity_id` | No | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
 
 ### Action `climate.turn_off`
 
 Turn climate device off. This is only supported if the climate device has the HVAC mode `off`.
 
-| Data attribute | Optional | Description |
+| Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+| `entity_id` | No | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
 
 ### Action `climate.toggle`
 
 Toggle climate device. This is only supported if the climate device supports being turned on and off.
 
-| Data attribute | Optional | Description |
+| Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+| `entity_id` | No | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
 
 ## Attributes
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Inverted the documentation logic for attributes which are required rather than saying what's optional.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #28629

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
