### PR TITLE
docs: add port control section to UniFi integration documentation

### DIFF
--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -143,7 +143,7 @@ Provides per-port PoE control. Entities are disabled by default. This feature re
 
 ### Port control
 
-Provides individual control to enable or disable switch ports. Entities are enabled by default. This feature requires admin privileges.
+Provides individual control to enable or disable switch ports. Entities are disabled by default. This feature requires admin privileges.
 
 ### Control DPI Traffic Restrictions
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -141,6 +141,10 @@ Allow control of network access to clients configured in the {% term integration
 
 Provides per-port PoE control. Entities are disabled by default. This feature requires admin privileges.
 
+### Port control
+
+Provides individual control to enable or disable switch ports. Entities are enabled by default. This feature requires admin privileges.
+
 ### Control DPI Traffic Restrictions
 
 Entities appear automatically for each restriction group. If there are no restrictions in a group, no {% term entity %} will be visible. Toggling the switch in Home Assistant will enable or disable all restrictions inside a group.


### PR DESCRIPTION
## Proposed change

Added documentation for the new port control feature in the UniFi Network integration. This feature allows users to enable or disable individual switch ports on UniFi switches, which is separate from the existing PoE port control functionality. The documentation includes a new "Port control" section under the Switch category that follows the same format and style as other switch features in the integration.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/150152
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: fixes #[issue number if applicable]

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home