### PR TITLE
Add object_id to modern template syntax as default_entity_id

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -180,7 +180,8 @@ Each entity platform has its own set of configuration options, but there are som
 template:
   - binary_sensor:
       # Common configuration options
-    - unique_id: my_unique_sensor_id
+    - default_entity_id: binary_sensor.my_alert
+      unique_id: my_unique_sensor_id
       variables:
         my_entity: sensor.watts
       availability: "{{ my_entity | has_value }}"
@@ -199,6 +200,10 @@ template:
     required: false
     type: template
     default: true
+  default_entity_id:
+    description: Use `default_entity_id` instead of name for automatic generation of the entity id. E.g. `sensor.my_awesome_sensor`. When used without a `unique_id`, the entity id will update during restart or reload if the entity id is available.  If the entity id already exists, the entity id will be created with a number at the end. When used with a `unique_id`, the `default_entity_id` is only used when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
+    required: false
+    type: string
   icon:
     description: Defines a template for the icon of the entity.
     required: false
@@ -211,10 +216,8 @@ template:
     description: Defines a template to get the name of the entity.
     required: false
     type: template
-  object_id:
-    description: Use `object_id` instead of name for automatic generation of the entity id.  When used without a `unique_id`, the entity id will update during restart or reload if the entity id is available.  If the entity id already exists, the entity id will be created with a number at the end. When used with a `unique_id`, the `object_id` is only used when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   unique_id:
-    description: An ID that uniquely identifies this entity. Will be combined with the unique ID of the configuration block if available. This allows changing the `name`, `icon` and `entity_id` from the web interface.
+    description: An ID that uniquely identifies this entity. Will be combined with the unique ID of the configuration block if available. This allows changing the `name`, `icon` and `entity_id` from the web interface.  Changing the `entity_id` from the web interface will overwrite the value in `default_entity_id`.
     required: false
     type: string
   variables:

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -211,6 +211,8 @@ template:
     description: Defines a template to get the name of the entity.
     required: false
     type: template
+  object_id:
+    description: Used `object_id` instead of name for automatic generation of entity_id.  When used without a `unique_id`, the entity id will update if the entity is available.  If the entity id already exists, the entity id will be created with a number at the end. When used with a `unique_id`, the `object_id` is only used when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   unique_id:
     description: An ID that uniquely identifies this entity. Will be combined with the unique ID of the configuration block if available. This allows changing the `name`, `icon` and `entity_id` from the web interface.
     required: false

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -212,7 +212,7 @@ template:
     required: false
     type: template
   object_id:
-    description: Used `object_id` instead of name for automatic generation of entity_id.  When used without a `unique_id`, the entity id will update if the entity is available.  If the entity id already exists, the entity id will be created with a number at the end. When used with a `unique_id`, the `object_id` is only used when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
+    description: Use `object_id` instead of name for automatic generation of the entity id.  When used without a `unique_id`, the entity id will update during restart or reload if the entity id is available.  If the entity id already exists, the entity id will be created with a number at the end. When used with a `unique_id`, the `object_id` is only used when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
   unique_id:
     description: An ID that uniquely identifies this entity. Will be combined with the unique ID of the configuration block if available. This allows changing the `name`, `icon` and `entity_id` from the web interface.
     required: false


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->


Allow users to set `object_id` in modern template syntax to suggest a possible `entity_id`.

E.g.

```
template:
- sensor:
  - name: Foo Bar
    default_entity_id: sensor.my_foobar_sensor
```
will create the entity_id `sensor.my_foobar_sensor` instead of `sensor.foo_bar`


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/150489
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
