### PR TITLE
Z-Wave adapters: add Connect ZWA-2 to list of supported adapters

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -45,6 +45,7 @@ Firmware can be upgraded using the below directions:
 {% endwarning %}
 
 - 800 series USB adapters (with some caveats, see notes)
+  - [Home Assistant Connect ZWA-2](https://www.home-assistant.io/connect/zwa-2/)
   - HomeSeer SmartStick G8
   - Zooz 800 Series Z-Wave Long Range S2 Stick (ZST39 LR)
 

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -4,6 +4,8 @@ description: "Extended instructions how to set up Z-Wave."
 related:
   - docs: /integrations/zwave_js/
     title: Z-Wave integration
+  - docs: /connect/zwa-2/
+    title: Home Assistant Connect ZWA-2
 ---
 
 ## Supported Z-Wave adapters
@@ -45,7 +47,7 @@ Firmware can be upgraded using the below directions:
 {% endwarning %}
 
 - 800 series USB adapters (with some caveats, see notes)
-  - [Home Assistant Connect ZWA-2](https://www.home-assistant.io/connect/zwa-2/)
+  - [Home Assistant Connect ZWA-2](/connect/zwa-2/)
   - HomeSeer SmartStick G8
   - Zooz 800 Series Z-Wave Long Range S2 Stick (ZST39 LR)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
