### PR TITLE
Correct path to default backup location setting

### DIFF
--- a/source/_includes/common-tasks/network_storage.md
+++ b/source/_includes/common-tasks/network_storage.md
@@ -77,7 +77,8 @@ By default, the first network storage of type **Backup** that you add is used as
 If you want to change the local network storage that is used to store your backups, follow these steps:
 
 1. Go to **{% my backup title="Settings > System > Backups" %}**.
-2. In the top-right corner, select the three dots {% icon "mdi:dots-vertical" %} menu and select **Change local backup location**.
-3. Select your preferred network location and save your changes.
+2. Select **Settings and history**.
+3. In the top-right corner, select the three dots {% icon "mdi:dots-vertical" %} menu and select **Change default action location**.
+4. Select your preferred network location and save your changes.
    ![Select default location used for local backup](/images/screenshots/network-storage/backup_select_local_default.png)
-4. **Troubleshooting**: Don't see your external storage location? This list contains only the network storage targets you have added of type **Backup**.
+5. **Troubleshooting**: Don't see your external storage location? This list contains only the network storage targets you have added of type **Backup**.


### PR DESCRIPTION
Current docs don't include the "Settings and history" selection, and also have the text different in the three-dot menu

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
This change corrects how to navigate to the setting for the location used in saving default backups. 
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
