### PR TITLE
Fix Russound RIO credit in 2025.9 release

### DIFF
--- a/source/_posts/2025-09-03-release-20259.markdown
+++ b/source/_posts/2025-09-03-release-20259.markdown
@@ -222,7 +222,7 @@ changes to existing integrations:
 - Network admins will love [@Tomeroeni] bringing individual (enable/disable) switch port control to [UniFi] switches!
 - The [OpenWeatherMap] integration now includes a wind gust sensor, thanks to [@gjohansson-ST]!
 - [@kizovinh] added support for battery status and online status sensors to the [EZVIZ] integration, making it easier to monitor your EZVIZ cameras. Nice!
-- If you own a [Russound Rio] device, you can now browse your device's saved presets directly from the media browser! Thanks, [@hanwg]!
+- If you own a [Russound RIO] device, you can now browse your device's saved presets directly from the media browser! Thanks, [@noahhusby]!
 - [@mbo18] added an absolute humidity sensor to the [Awair] integration. Nice!
 - The [Teslemetry] integration added charging and preconditioning actions for your Tesla vehicle. Thanks, [@Bre77]!
 - [@catsmanac] added [IQ Meter Collar] and [C6 Combiner] support to the [Enphase Envoy] integration. Good work!
@@ -230,9 +230,9 @@ changes to existing integrations:
 [@Bre77]: https://github.com/Bre77
 [@catsmanac]: https://github.com/catsmanac
 [@gjohansson-ST]: https://github.com/gjohansson-ST
-[@hanwg]: https://github.com/hanwg
 [@kizovinh]: https://github.com/kizovinh
 [@mbo18]: https://github.com/mbo18
+[@noahhusby]: https://github.com/noahhusby
 [@starkillerOG]: https://github.com/starkillerOG
 [@Thomas55555]: https://github.com/Thomas55555
 [@Tomeroeni]: https://github.com/Tomeroeni
@@ -246,7 +246,7 @@ changes to existing integrations:
 [OpenWeatherMap]: /integrations/openweathermap
 [PlayStation Network]: /integrations/playstation_network
 [Reolink]: /integrations/reolink
-[Russound Rio]: /integrations/russound_rio
+[Russound RIO]: /integrations/russound_rio
 [Teslemetry]: /integrations/teslemetry
 [UniFi]: /integrations/unifi
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fixes the capitalization and credit for Russound RIO improvement in latest 2025.9 release.
Core PR for improvement: https://github.com/home-assistant/core/pull/148248


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
