### PR TITLE
Add missing container capability requirements for Bluetooth docs

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -61,7 +61,7 @@ For Bluetooth to function on Linux systems:
 {% details "Container configuration for Bluetooth" %}
 
 {% note %}
-These configuration steps are only required for Home Assistant Container installations. Home Assistant Operating System automatically handles all Bluetooth configuration.
+You only need these configuration steps for Home Assistant Container installations. Home Assistant Operating System automatically handles all Bluetooth configuration.
 {% endnote %}
 
 Home Assistant Container requires specific configuration to access Bluetooth adapters.
@@ -86,16 +86,16 @@ docker run --cap-add=NET_ADMIN --cap-add=NET_RAW -v /run/dbus:/run/dbus:ro ...
 
 **D-Bus socket:**
 
-For most systems, the D-Bus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to connect to D-Bus and access the Bluetooth adapter. If the D-Bus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
+For most systems, the D-Bus socket is in `/run/dbus`. You need to make the socket available in the container for Home Assistant to connect to D-Bus and access the Bluetooth adapter. If the D-Bus socket is in `/var/run/dbus` on your host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
 
 **What happens without these capabilities:**
 
 If `NET_ADMIN` and `NET_RAW` capabilities are missing:
-- Bluetooth will operate in a degraded mode with limited functionality
-- Automatic adapter recovery is unavailable - adapters cannot be reset when they stop responding
+- Your Bluetooth will operate in a degraded mode with limited functionality
+- Automatic adapter recovery is unavailable - your adapters cannot be reset when they stop responding
 - Connection parameters and management API commands will fail
-- Raw advertising data will be missing, causing unreliable updates for some devices
-- An error will appear in the logs: "Missing required permissions for Bluetooth management"
+- Raw advertising data will be missing, causing unreliable updates for your devices
+- An error will appear in your logs: "Missing required permissions for Bluetooth management"
 
 {% enddetails %}
 

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -53,21 +53,49 @@ For Bluetooth to function on Linux systems:
 
 ### Additional requirements by install method
 
-- Home Assistant Operating System: Upgrade to Home Assistant OS version 9.0 or later.
-- Home Assistant Container: The host system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant **inside** the container.
+- Home Assistant Operating System: Upgrade to Home Assistant OS version 9.0 or later. All Bluetooth requirements are automatically configured.
+- Home Assistant Container: The host system must run BlueZ, and the D-Bus socket must be accessible to Home Assistant **inside** the container. Additional configuration is required (see below).
 
 ### Additional details for Container
 
-{% details "Making the DBus socket available in the Docker container" %}
+{% details "Container configuration for Bluetooth" %}
 
-For most systems, the Dbus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to be able to connect to Dbus and access the Bluetooth adapter. When starting with `docker run`, this can be accomplished by adding `-v /run/dbus:/run/dbus:ro` to the command. If the Dbus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
+{% note %}
+These configuration steps are only required for Home Assistant Container installations. Home Assistant Operating System automatically handles all Bluetooth configuration.
+{% endnote %}
 
-If you are using Docker Compose, add something like the following (adjust as necessary) to your `volumes` section:
+Home Assistant Container requires specific configuration to access Bluetooth adapters.
 
-```dockerfile
+**Required capabilities:**
+
+Add the following Linux capabilities to your container configuration to enable full Bluetooth management:
+
+**Docker Compose:**
+```yaml
+cap_add:
+  - NET_ADMIN
+  - NET_RAW
 volumes:
   - /run/dbus:/run/dbus:ro
 ```
+
+**Docker run:**
+```bash
+docker run --cap-add=NET_ADMIN --cap-add=NET_RAW -v /run/dbus:/run/dbus:ro ...
+```
+
+**D-Bus socket:**
+
+For most systems, the D-Bus socket is in `/run/dbus`. The socket must be available in the container for Home Assistant to connect to D-Bus and access the Bluetooth adapter. If the D-Bus socket is in `/var/run/dbus` on the host system, use `-v /var/run/dbus:/run/dbus:ro` instead.
+
+**What happens without these capabilities:**
+
+If `NET_ADMIN` and `NET_RAW` capabilities are missing:
+- Bluetooth will operate in a degraded mode with limited functionality
+- Automatic adapter recovery is unavailable - adapters cannot be reset when they stop responding
+- Connection parameters and management API commands will fail
+- Raw advertising data will be missing, causing unreliable updates for some devices
+- An error will appear in the logs: "Missing required permissions for Bluetooth management"
 
 {% enddetails %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds critical missing documentation about Linux capabilities required for Bluetooth functionality in Home Assistant Container installations.

Issue home-assistant/core#151738 revealed that users running Home Assistant Container were experiencing Bluetooth connectivity problems after updates. The root cause was missing `NET_ADMIN` and `NET_RAW` capabilities that weren't documented. 

Background: The degraded mode fallback for missing permissions was broken in 2025.9.0/2025.9.1 and fixed in 2025.9.2. However, even with the fix, running without these capabilities results in limited functionality:
- Adapters cannot be reset when they stop responding
- Connection parameters and management commands fail  
- Raw advertising data is missing, causing unreliable device updates

While the D-Bus socket requirement was documented, the capability requirements were not, making it understandable that users would miss this configuration. The updated documentation now clearly shows both requirements in a single section with complete Docker Compose and Docker run examples, and clarifies that Home Assistant Operating System users don't need any manual configuration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: Related to home-assistant/core#151738

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards