### PR TITLE
Enhance multi-speaker support in Google Generative AI integration

### DIFF
--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -218,11 +218,29 @@ data:
 
 {% endraw %}
 
+You can also use the multi-speaker functionality and use multiple voices at the same time. Example in YAML:
+
+{% raw %}
+
+```yaml
+action: tts.speak
+target:
+  entity_id: tts.google_generative_ai_tts
+data:
+  media_player_entity_id: media_player.tv
+  message: Read aloud: Speaker 1: There is a person at the front door. Speaker 2: Delivery!
+  options:
+    voices: Speaker 1: zephyr; Speaker 2: achernar
+```
+
+{% endraw %}
+
 You can configure the following options:
 
 | Option attribute | Optional | Description                                                                                                                                                                    | Example                      |
 | ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
 | `voice`          | yes      | The [voice name](https://ai.google.dev/gemini-api/docs/speech-generation#voices) to be used for the generated speech. The default is `zephyr`.                                 | `achernar`                   |
+| `voices`         | yes      | The speakers [voice names](https://ai.google.dev/gemini-api/docs/speech-generation#voices) to be used for the generated speech, in the following format: `Speaker 1: voice1; Speaker 2: voice2`. The default is empty and will use the default voice for all speakers.                                 | `Speaker 1: zephyr; Speaker 2: achernar`                   |
 
 The input language is detected automatically. Check the [Google AI documentation](https://ai.google.dev/gemini-api/docs/speech-generation#languages) for the supported languages.
 

--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -230,7 +230,9 @@ data:
   media_player_entity_id: media_player.tv
   message: Read aloud: Speaker 1: There is a person at the front door. Speaker 2: Delivery!
   options:
-    voices: Speaker 1: zephyr; Speaker 2: achernar
+    voices:
+      Speaker1: zephyr
+      Speaker2: achernar
 ```
 
 {% endraw %}
@@ -240,7 +242,7 @@ You can configure the following options:
 | Option attribute | Optional | Description                                                                                                                                                                    | Example                      |
 | ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
 | `voice`          | yes      | The [voice name](https://ai.google.dev/gemini-api/docs/speech-generation#voices) to be used for the generated speech. The default is `zephyr`.                                 | `achernar`                   |
-| `voices`         | yes      | Maps speaker names to specific voice names. Use the format `Speaker 1: voice1; Speaker 2: voice2`. If not specified, all speakers use the default voice.                       | `Speaker 1: zephyr; Speaker 2: achernar`                   |
+| `voices`         | yes      | A list of speaker names with their specific voice names. If not specified, all speakers use the default voice.                                                                 | `Speaker1: zephyr`           |
 
 The input language is detected automatically. Check the [Google AI documentation](https://ai.google.dev/gemini-api/docs/speech-generation#languages) for the supported languages.
 

--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -240,7 +240,7 @@ You can configure the following options:
 | Option attribute | Optional | Description                                                                                                                                                                    | Example                      |
 | ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
 | `voice`          | yes      | The [voice name](https://ai.google.dev/gemini-api/docs/speech-generation#voices) to be used for the generated speech. The default is `zephyr`.                                 | `achernar`                   |
-| `voices`         | yes      | The speakers [voice names](https://ai.google.dev/gemini-api/docs/speech-generation#voices) to be used for the generated speech, in the following format: `Speaker 1: voice1; Speaker 2: voice2`. The default is empty and will use the default voice for all speakers.                                 | `Speaker 1: zephyr; Speaker 2: achernar`                   |
+| `voices`         | yes      | Maps speaker names to specific voice names. Use the format `Speaker 1: voice1; Speaker 2: voice2`. If not specified, all speakers use the default voice.                       | `Speaker 1: zephyr; Speaker 2: achernar`                   |
 
 The input language is detected automatically. Check the [Google AI documentation](https://ai.google.dev/gemini-api/docs/speech-generation#languages) for the supported languages.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added optional `voices` parameter to Google Generative AI integration TTS functionality, that can be used with multi-speakers messages.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/151876

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
