### PR TITLE
Docs for current and target temp scale/offset.

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -625,7 +625,7 @@ climates:
       type: float
       default: 0
     current_temp_scale:
-      description: "Scale factor for current temperature (output = current_temp_scale * value + current_temp_offset). Cannot be used together with *scale*."
+      description: "Scale factor for current temperature (output = `current_temp_scale` * `value` + `current_temp_offset`). Cannot be used together with `scale`"
       required: false
       type: float
       default: 1.0

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -614,11 +614,36 @@ climates:
           description: "Holding register."
         input:
           description: "Input register."
+    scale:
+      description: "Scale factor (output = scale * value + offset) for setting target and current temperature. Cannot be used together with *current_temp_scale* or *target_temp_scale*."
+      required: false
+      type: float
+      default: 1
     offset:
-      description: "Final offset for current temperature (output = scale * value + offset)."
+      description: "Final offset for target and current temperature (output = scale * value + offset). Cannot be used together with *current_temp_offset* or *target_temp_offset*."
       required: false
       type: float
       default: 0
+    current_temp_scale:
+      description: "Scale factor for current temperature (output = current_temp_scale * value + current_temp_offset). Cannot be used together with *scale*."
+      required: false
+      type: float
+      default: 1.0
+    current_temp_offset:
+      description: "Offset for current temperature (output = current_temp_scale * value + current_temp_offset). Cannot be used together with *offset*."
+      required: false
+      type: float
+      default: 0.0
+    target_temp_scale:
+      description: "Scale factor for target temperature (output = target_temp_scale * value + target_temp_offset). Cannot be used together with *scale*."
+      required: false
+      type: float
+      default: 1.0
+    target_temp_offset:
+      description: "Offset for target temperature (output = target_temp_scale * value + target_temp_offset). Cannot be used together with *offset*."
+      required: false
+      type: float
+      default: 0.0
     target_temp_register:
       description: "Register address for target temperature (Setpoint). Using a list, it is possible to define one register for each of the available HVAC Modes. The list has to have a fixed size of 7 registers corresponding to the 7 available HVAC Modes, as follows: Register **1: HVAC AUTO mode**; Register **2: HVAC Cool mode**; Register **3: HVAC Dry mode**; Register **4: HVAC Fan only mode**; Register **5: HVAC Heat mode**; Register **6: HVAC Heat Cool mode**; Register **7: HVAC OFF mode**. It is possible to set duplicated values for the modes where the devices don't have a related register."
       required: true
@@ -628,11 +653,6 @@ climates:
       required: false
       type: boolean
       default: false
-    scale:
-      description: "Scale factor (output = scale * value + offset) for setting target temperature."
-      required: false
-      type: float
-      default: 1
     structure:
       description: "If `data_type: custom` is specified a double-quoted Python struct is expected,
       to format the string to unpack the value. See Python documentation for details.

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -630,7 +630,7 @@ climates:
       type: float
       default: 1.0
     current_temp_offset:
-      description: "Offset for current temperature (output = current_temp_scale * value + current_temp_offset). Cannot be used together with *offset*."
+      description: "Offset for current temperature (output` = current_temp_scale` * `value` + `current_temp_offset`). Cannot be used together with *offset*."
       required: false
       type: float
       default: 0.0

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -615,12 +615,12 @@ climates:
         input:
           description: "Input register."
     scale:
-      description: "Scale factor (output = scale * value + offset) for setting target and current temperature. Cannot be used together with *current_temp_scale* or *target_temp_scale*."
+      description: "Scale factor (`output` = `scale` * `value` + offset) for setting target and current temperature. Cannot be used together with `current_temp_scale` or `target_temp_scale."
       required: false
       type: float
       default: 1
     offset:
-      description: "Final offset for target and current temperature (output = scale * value + offset). Cannot be used together with *current_temp_offset* or *target_temp_offset*."
+      description: "Final offset for target and current temperature (`output` = `scale` * `value` + `offset). Cannot be used together with current_temp_offset or target_temp_offset`."
       required: false
       type: float
       default: 0
@@ -635,12 +635,12 @@ climates:
       type: float
       default: 0.0
     target_temp_scale:
-      description: "Scale factor for target temperature (output = target_temp_scale * value + target_temp_offset). Cannot be used together with *scale*."
+      description: "Scale factor for target temperature (`output` = `target_temp_scale` * `value` + `target_temp_offset`). Cannot be used together with scale`."
       required: false
       type: float
       default: 1.0
     target_temp_offset:
-      description: "Offset for target temperature (output = target_temp_scale * value + target_temp_offset). Cannot be used together with *offset*."
+      description: "Offset for target temperature (`output` = `target_temp_scale` * `value` + `target_temp_offset`). Cannot be used together with offset`."
       required: false
       type: float
       default: 0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The documentation previously stated that scale and offset only applied to the target temperature.
This was incorrect: in reality they apply to both target and current temperature.

This fix corrects the documentation.

There are devices that require different scaling for target and current temperatures (for example, Cooper air conditioners). People have also reported this limitation on the forum:

https://community.home-assistant.io/t/wth-why-do-modbus-climate-entities-only-have-one-scale-setting-for-temperature-registers/803414

https://community.home-assistant.io/t/modbus-plataform-climate/323571

This was also discussed in PR: home-assistant/core#135848.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/150985
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://community.home-assistant.io/t/wth-why-do-modbus-climate-entities-only-have-one-scale-setting-for-temperature-registers/803414

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
