### PR TITLE
Fix automation templating formatting

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -7,10 +7,10 @@ Automations support the advanced features of [templating](/docs/configuration/te
 
 Example of variables used in templates:
 
-```jinja
- {{ this.name }} is the name of the automation executing from this trigger
- {{ trigger.platform }} is the type of trigger object, like `calendar`
- ```
+{% raw %}
+- `{{ this.name }}` is the name of the automation executing from this trigger
+- `{{ trigger.platform }}` is the type of trigger object, like `calendar`
+{% endraw %}
 
 ## Available state data
 


### PR DESCRIPTION
## Proposed change

The current syntax makes the documentation page appear as the following, which is obviously wrong:

> Example of variables used in templates:
> ```
> is the name of the automation executing from this trigger
> is the type of trigger object, like `calendar`
> ```

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository:  N/A
- This PR fixes or closes issue: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
