### PR TITLE
Add  apple_tv `binary-sensor` docs

### DIFF
--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -176,11 +176,11 @@ data:
 
 The Apple TV remote platform will automatically create a Binary sensor entity
 for each Apple TV configured on your Home Assistant instance to determine if the
-on screen keyboard is active.
+on-screen keyboard is active.
 
 ### Example
 
-Create an automation that clears the search text whenever the on screen keyboard
+Create an automation that clears the search text whenever the on-screen keyboard
 is activated:
 
 ```yaml

--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -24,6 +24,7 @@ There is currently support for the following entities within the Apple TV device
 
 - [Media Player](#media-player)
 - [Remote](#remote)
+- [Keyboard focused](#keyboard-focused) `binary_sensor`
 
 {% include integrations/config_flow.md %}
 
@@ -171,6 +172,32 @@ data:
     - left
 ```
 
+## Keyboard focused
+
+The Apple TV remote platform will automatically create a Binary sensor entity
+for each Apple TV configured on your Home Assistant instance to determine if the
+on screen keyboard is active.
+
+### Example
+
+Create an automation that clears the search text whenever the on screen keyboard
+is activated:
+
+```yaml
+description: "Always start with clear Apple TV search text"
+mode: single
+triggers:
+  - trigger: state
+    entity_id:
+      - binary_sensor.my_apple_tv_keyboard_focused
+    from: "off"
+    to: "on"
+actions:
+  - action: apple_tv.clear_search_text
+    target:
+      entity_id: remote.my_apple_tv_remote
+```
+
 ## FAQ
 
 ### My Apple TV does not turn on/off when I press on/off in the frontend
@@ -200,9 +227,9 @@ and include logs (see Debugging below).
 
 ### Setting volume doesn't work on my Apple TV
 
-Volume control functionality depends on how the Apple TV is set up. 
-All volume controls should work if the Apple TV is connected to a 
-HomePod or HomePod stereo pair. If the Apple TV is connected to 
+Volume control functionality depends on how the Apple TV is set up.
+All volume controls should work if the Apple TV is connected to a
+HomePod or HomePod stereo pair. If the Apple TV is connected to
 TV speakers and with volume control
 over HDMI CEC (Settings -> Remotes and Devices -> Volume Control) only volume
 up/down controls will work. If volume control is over IR then volume cannot be


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add a new `binary_sensor` to the `apple_tv` integration.

- `binary_sensor.keyboard_focused` to indicate when keyboard entry is available on the Apple TV.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/152397
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
