### PR TITLE
Revert "Add ConBee thread enable link"

### DIFF
--- a/source/_integrations/thread.markdown
+++ b/source/_integrations/thread.markdown
@@ -29,8 +29,6 @@ related:
     title: Enabling Thread on Connect ZBT-1
   - url: https://support.nabucasa.com/hc/en-us/articles/25742476767517
     title: Enabling Thread on Yellow
-  - url: https://phoscon.de/en/openthread/doc
-    title: Enabling Thread on ConBee II or III
 ---
 
 The Thread integration helps you track the different Thread networks in your home and store the Thread network credentials (similar to a Wi-Fi password). The Thread integration in Home Assistant is currently still a work in progress.


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#41038

We had some discussions on how this might confuse people with this method being supported or not. We don't know... we do know, thread causes tons of issues for people accross the board.

We want to limit this part to the setups we have verified and know actually work well. Hence the revert of this pull request for now.

../Frenck