### PR TITLE
Fix Plex sensor documentation

### DIFF
--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -76,6 +76,9 @@ The library sensors show a count of items in each library. Depending on the libr
 In addition to the item count, the last added media item (movie, album, or episode) and a timestamp showing when it was added are also provided with each library sensor.
 
 Example automation to use the `last_added_item` attribute on library sensors to notify when new media has been added:
+
+{% raw %}
+
 ```yaml
 alias: "Plex - New media added"
 triggers:
@@ -96,8 +99,10 @@ actions:
       message: "{{ trigger.to_state.attributes.last_added_item }}"
 ```
 
+{% endraw %}
+
 {% important %}
-The library sensors are disabled by default, but can be enabled via the Plex integration page.
+The library sensors are disabled by default, but can be enabled via the Plex integration page. After the sensors are enabled, you may need to add a new item to your library before the last added media attribute is populated.
 {% endimportant %}
 
 ## Button


### PR DESCRIPTION
## Proposed change

* Add raw tags to the Plex > Sensors > Last Added Item example code block. This currently renders to readers without the {{ macros }}  the automation actually needs to produce a customized notification. https://www.home-assistant.io/integrations/plex/#sensor strips content and displays `message: ""`, even though the markdown contains the actual attributes needed.

* Add a hint about waiting until new content is added before the last_added_item attribute is populated



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist

- [ x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
