### PR TITLE
Document Enphase_envoy collar grid status issues

### DIFF
--- a/source/_integrations/enphase_envoy.markdown
+++ b/source/_integrations/enphase_envoy.markdown
@@ -425,7 +425,7 @@ The IQ Meter Collar has the net-consumption CT integrated. The CT data is report
 - **Collar <abbr title="Collar serial number">SN</abbr> Communicating**: Communication status of the collar, Connected / Disconnected. This is a diagnostics entity.
 
 {% note %}
-Practical use learned that `Grid state` does not reflect actual grid state changes. Off/On grid state rather seems to be reflected in Admin state values ENCMN_MDE_ON_GRID and ENCMN_MDE_OFF_GRID. Be aware when using these entities. With time, more accurate details for these Collar entities may become available.
+Practical use learned that "Grid state" does not reflect actual grid state changes. Off/On grid state rather seems to be reflected in Admin state values ENCMN_MDE_ON_GRID for on grid state and ENCMN_MDE_OFF_GRID for off grid state. Be aware when using these entities. With time, more accurate details for these Collar entities may become available.
 {% endnote %}
 
 ### C6 Combiner Controller data

--- a/source/_integrations/enphase_envoy.markdown
+++ b/source/_integrations/enphase_envoy.markdown
@@ -417,11 +417,16 @@ The IQ Meter Collar has the net-consumption CT integrated. The CT data is report
 
 #### Collar status entities
 
+- **Collar <abbr title="Collar serial number">SN</abbr> Admin state**: Collar state, ENCMN_MDE_ON_GRID and ENCMN_MDE_OFF_GRID.
 - **Collar <abbr title="Collar serial number">SN</abbr> Grid state**: Grid connection status, on_grid / off_grid / synchronizing / manual override active.
 - **Collar <abbr title="Collar serial number">SN</abbr> MID State**: Status of enphase Microgrid Interconnection Device, open / close.
 - **Collar <abbr title="Collar serial number">SN</abbr> Temperature**: Current temperature in degrees C or F, based on your localization.
 - **Collar <abbr title="Collar serial number">SN</abbr> Last reported**: Time when Envoy received last update from the collar device.
 - **Collar <abbr title="Collar serial number">SN</abbr> Communicating**: Communication status of the collar, Connected / Disconnected. This is a diagnostics entity.
+
+{% note %}
+Practical use learned that `Grid state` does not reflect actual grid state changes. Off/On grid state rather seems to be reflected in Admin state values ENCMN_MDE_ON_GRID and ENCMN_MDE_OFF_GRID. Be aware when using these entities. With time, more accurate details for these Collar entities may become available.
+{% endnote %}
 
 ### C6 Combiner Controller data
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

In HA version 2025.9 support for the Enphase Collar was added to the enphase_envoy integration. Collar support included display of grid_state as on/off grid. After some time of field use, it turns out the grid_state field of the envoy does not reflect the actual grid connection status, but rather the admin_state_str field of the Collar device does.

This PR describes this issue, where to get the grid status and some caution with these status until time will learn more.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/153766
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
