### PR TITLE
Allow MQTT platform integration pages to link to main integration and hide integration owners

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -88,7 +88,7 @@
   <div class='section'>
     {% if page.ha_main_integration %}
       <div class="section">
-        {{ page.title | default: page.name }} is part of the <a href="/integrations/{{ page.ha_domain }}">{{ page.ha_main_integration }} integration</a> integration.
+        {{ page.title | default: page.name }} is part of the <a href="/integrations/{{ page.ha_domain }}">{{ page.ha_main_integration }}</a> integration.
       </div>
 
     {% else %}

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -88,7 +88,7 @@
   <div class='section'>
     {% if page.ha_main_integration %}
       <div class="section">
-        The {{ page.title | default: page.name }} integration is part of the <a href="/integrations/{{ page.ha_domain }}">{{ page.ha_main_integration }} integration</a> integration.
+        {{ page.title | default: page.name }} is part of the <a href="/integrations/{{ page.ha_domain }}">{{ page.ha_main_integration }} integration</a> integration.
       </div>
 
     {% else %}

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -86,35 +86,42 @@
 
 <section class="aside-module grid__item one-whole lap-one-half">
   <div class='section'>
-    <h1 class="title epsilon">{% icon "mdi:person-heart" %} Integration owners</h1>
-    {% if page.ha_codeowners %}
-        {% assign ha_project = false %}
-        {% for codeowner in page.ha_codeowners %}
-            {% if codeowner contains "@home-assistant/" %}
-                {% assign ha_project = true %}
-            {% endif %}
-        {% endfor %}
-
-          {% if ha_project %}
-          <div class="section">
-            This integration is being maintained by the Home Assistant project.
-          </div>
-        {% else %}
-          <div class="section">
-            We are incredibly grateful to the following contributors who currently maintain this integration:<br />
-          </div>
-          <div class="section">
-            {%- for codeowner in page.ha_codeowners -%}
-            {%- assign clean_codeowner = codeowner | replace: "@", "" -%}
-            <a href="https://github.com/{{ clean_codeowner }}" target="_blank"><img class="codeowner-avatar" src="https://avatars.githubusercontent.com/{{ codeowner | replace: "@", "" }}?size=96" alt="{{ codeowner }}"/> {{ codeowner }}</a><br />
-            {%- endfor -%}
-          </div>
-        {% endif %}
-    {% else %}
+    {% if page.ha_main_integration %}
       <div class="section">
-        This integration is community maintained.<br />
-        If you are a developer and would like to help, feel free to contribute!
+        The {{ page.title | default: page.name }} integration is part of the <a href="/integrations/{{ page.ha_domain }}">{{ page.ha_main_integration }} integration</a> integration.
       </div>
+
+    {% else %}
+      <h1 class="title epsilon">{% icon "mdi:person-heart" %} Integration owners</h1>
+      {% if page.ha_codeowners %}
+          {% assign ha_project = false %}
+          {% for codeowner in page.ha_codeowners %}
+              {% if codeowner contains "@home-assistant/" %}
+                  {% assign ha_project = true %}
+              {% endif %}
+          {% endfor %}
+
+            {% if ha_project %}
+            <div class="section">
+              This integration is being maintained by the Home Assistant project.
+            </div>
+          {% else %}
+            <div class="section">
+              We are incredibly grateful to the following contributors who currently maintain this integration:<br />
+            </div>
+            <div class="section">
+              {%- for codeowner in page.ha_codeowners -%}
+              {%- assign clean_codeowner = codeowner | replace: "@", "" -%}
+              <a href="https://github.com/{{ clean_codeowner }}" target="_blank"><img class="codeowner-avatar" src="https://avatars.githubusercontent.com/{{ codeowner | replace: "@", "" }}?size=96" alt="{{ codeowner }}"/> {{ codeowner }}</a><br />
+              {%- endfor -%}
+            </div>
+          {% endif %}
+      {% else %}
+        <div class="section">
+          This integration is community maintained.<br />
+          If you are a developer and would like to help, feel free to contribute!
+        </div>
+      {% endif %}
     {% endif %}
   </div>
 </section>

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -4,8 +4,9 @@ description: "Instructions on how to integrate MQTT capable alarm panels into Ho
 ha_category:
   - Alarm
 ha_release: 0.7.4
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
 related:
   - docs: /docs/configuration/
     title: Configuration file

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT binary sensors within Home A
 ha_category:
   - Binary sensor
 ha_release: 0.9
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` binary sensor platform uses an MQTT message received to set the binary sensor's state to `on`, `off` or `unknown`.

--- a/source/_integrations/button.mqtt.markdown
+++ b/source/_integrations/button.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT buttons into Home Assistant.
 ha_category:
   - Button
 ha_release: 2021.12
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` button platform lets you send an MQTT message when the button is pressed in the frontend or the button press action is called. This can be used to expose some service of a remote device, for example reboot.

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to use an MQTT image message as a Camera withi
 ha_category:
   - Camera
 ha_release: 0.43
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` camera platform allows you to integrate the content of an image file sent through MQTT into Home Assistant as a camera. Every time a message under the `topic` in the configuration is received, the image displayed in Home Assistant will also be updated. Messages received on `topic` should contain the full contents of an image file, for example, a JPEG image, without any additional encoding or metadata.

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT climate into Home Assistant.
 ha_category:
   - Climate
 ha_release: 0.55
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` climate platform lets you control your MQTT enabled HVAC devices.

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -3,9 +3,13 @@ title: "MQTT Cover"
 description: "Instructions on how to integrate MQTT covers into Home Assistant."
 ha_category:
   - Cover
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_release: 0.18
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` cover platform allows you to control an MQTT cover (such as blinds, a roller shutter or a garage door).

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -3,9 +3,10 @@ title: "MQTT device tracker"
 description: "Instructions on how to use MQTT to track devices in Home Assistant."
 ha_category:
   - Presence detection
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_release: 0.7.3
 ha_domain: mqtt
+ha_main_integration: MQTT
 related:
   - docs: /docs/configuration/
     title: Configuration file

--- a/source/_integrations/device_trigger.mqtt.markdown
+++ b/source/_integrations/device_trigger.mqtt.markdown
@@ -4,7 +4,8 @@ description: "Instructions on how to integrate MQTT device triggers within Home 
 ha_category:
   - Device automation
 ha_release: 0.106
-ha_iot_class: Configurable
+ha_iot_class: Local Push
+ha_main_integration: MQTT
 ha_domain: mqtt
 ---
 

--- a/source/_integrations/event.mqtt.markdown
+++ b/source/_integrations/event.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT events into Home Assistant."
 ha_category:
   - Event
 ha_release: 2023.8
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` event platform allows you to process event info from an MQTT message. Events are signals that are emitted when something happens, for example, when a user presses a physical button like a doorbell or when a button on a remote control is pressed. With the event some event attributes can be sent to become available as an attribute on the entity. MQTT events are stateless. For example, a doorbell does not have a state like being "on" or "off" but instead is momentarily pressed.

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT fans into Home Assistant."
 ha_category:
   - Fan
 ha_release: 0.27
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` fan platform lets you control your MQTT enabled fans.

--- a/source/_integrations/humidifier.mqtt.markdown
+++ b/source/_integrations/humidifier.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT humidifiers into Home Assist
 ha_category:
   - Humidifier
 ha_release: 2021.8
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` humidifier platform lets you control your MQTT enabled humidifiers.

--- a/source/_integrations/image.mqtt.markdown
+++ b/source/_integrations/image.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to use an MQTT image message as an Image withi
 ha_category:
   - Image
 ha_release: 2023.7
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` image platform allows you to integrate the content of an image file sent through MQTT into Home Assistant as an image.

--- a/source/_integrations/lawn_mower.mqtt.markdown
+++ b/source/_integrations/lawn_mower.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT lawn mowers into Home Assist
 ha_category:
   - Lawn mower
 ha_release: 2023.9
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` `lawn_mower` platform allows controlling a lawn mower over MQTT.

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -3,9 +3,13 @@ title: "MQTT Light"
 description: "Instructions on how to setup MQTT lights using default schema within Home Assistant."
 ha_category:
   - Light
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_release: 0.8
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` light platform lets you control your MQTT enabled lights through one of the supported message schemas, `default`, `json` or `template`.

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT locks into Home Assistant."
 ha_category:
   - Lock
 ha_release: 0.15
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` lock platform lets you control your MQTT enabled locks.

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -3,7 +3,6 @@ title: MQTT
 description: Instructions on how to setup MQTT within Home Assistant.
 ha_category:
   - Hub
-  - Update
 featured: true
 ha_release: pre 0.7
 ha_iot_class: Local Push

--- a/source/_integrations/notify.mqtt.markdown
+++ b/source/_integrations/notify.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT notify entities into Home As
 ha_category:
   - Notifications
 ha_release: 2024.5
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The **MQTT notify** platform lets you send an MQTT message when the `send_message` action is called. This can be used to expose a action of a remote device that allows processing a message, such as showing it on a screen.

--- a/source/_integrations/number.mqtt.markdown
+++ b/source/_integrations/number.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to interact with a device exposing a Number th
 ha_category:
   - Number
 ha_release: 2021.2
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` Number platform allows you to integrate devices that might expose configuration options through MQTT into Home Assistant as a Number. Every time a message under the `topic` in the configuration is received, the number entity will be updated in Home Assistant and vice-versa, keeping the device and Home Assistant in-sync.

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT scenes into Home Assistant."
 ha_category:
   - Scene
 ha_release: 2020.12
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` scene platform lets you control your MQTT enabled scenes.

--- a/source/_integrations/select.mqtt.markdown
+++ b/source/_integrations/select.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to interact with a device exposing a Select th
 ha_category:
   - Select
 ha_release: 2021.7
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` Select platform allows you to integrate devices that might expose configuration options through MQTT into Home Assistant as a Select. Every time a message under the `topic` in the configuration is received, the select entity will be updated in Home Assistant and vice-versa, keeping the device and Home Assistant in sync.

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT sensors within Home Assistan
 ha_category:
   - Sensor
 ha_release: 0.7
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 This `mqtt` sensor platform uses the MQTT message payload as the sensor value. If messages in this `state_topic` are published with *RETAIN* flag, the sensor will receive an instant update with last known value. Otherwise, the initial state will be undefined.

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT sirens into Home Assistant."
 ha_category:
   - Siren
 ha_release: 2022.3
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` siren platform lets you control your MQTT enabled sirens and text based notification devices.

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to integrate MQTT switches into Home Assistant
 ha_category:
   - Switch
 ha_release: 0.7
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` switch platform lets you control your MQTT enabled switches.

--- a/source/_integrations/tag.mqtt.markdown
+++ b/source/_integrations/tag.mqtt.markdown
@@ -4,8 +4,9 @@ description: "Instructions on how to integrate MQTT scanner within Home Assistan
 ha_category:
   - Tag scanner
 ha_release: 0.116
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
 ---
 
 The `mqtt` tag scanner platform uses an MQTT message payload to generate tag scanned events.

--- a/source/_integrations/text.mqtt.markdown
+++ b/source/_integrations/text.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to interact with a device exposing text capabi
 ha_category:
   - Text
 ha_release: "2022.12"
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` Text platform allows you to integrate devices that show text that can be set remotely. Optionally the text state can be monitored too using MQTT.

--- a/source/_integrations/update.mqtt.markdown
+++ b/source/_integrations/update.mqtt.markdown
@@ -4,8 +4,12 @@ description: "Instructions on how to interact with a device exposing an Update e
 ha_category:
   - Update
 ha_release: "2021.11"
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` Update platform allows you to integrate devices that might expose firmware/software installed and the latest versions through MQTT into Home Assistant as an Update entity. Every time a message under the `topic` in the configuration is received, the entity will be updated in Home Assistant.

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -5,6 +5,10 @@ ha_category:
   - Vacuum
 ha_release: 0.54
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` vacuum {% term integration %} allows you to control your MQTT-enabled vacuum.

--- a/source/_integrations/valve.mqtt.markdown
+++ b/source/_integrations/valve.mqtt.markdown
@@ -3,9 +3,13 @@ title: "MQTT Valve"
 description: "Instructions on how to integrate MQTT valves into Home Assistant."
 ha_category:
   - Valve
-ha_iot_class: Configurable
+ha_iot_class: Local Push
 ha_release: 2024.1
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` valve platform allows you to control an MQTT valve (such a gas or water valve).

--- a/source/_integrations/water_heater.mqtt.markdown
+++ b/source/_integrations/water_heater.mqtt.markdown
@@ -6,6 +6,10 @@ ha_category:
 ha_release: 2023.7
 ha_iot_class: Local Polling
 ha_domain: mqtt
+ha_main_integration: MQTT
+related:
+  - docs: /docs/configuration/
+    title: Configuration file
 ---
 
 The `mqtt` water heater platform lets you control your MQTT enabled water heater devices.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Allow MQTT platform integration pages to link to main integration and hide integration owners.
All MQTT platforms have their own integration page.
An issue is that the `ha_codeowners` tag is not set as this is automatically maintained, but the status on the platform integration pages shows that they are community maintained, which is not correct.

This PR add a new page variable `ha_main_integration` that will hide the code owners block and add a reference to the main integration, "MQTT".

The IOT class has been corrected, which should be "Local Push" and not "Configuration".
A reference to `/docs/configuration/` is added for platforms that support setting configuration options via `configuration.yaml`.

Before:
<img width="358" height="632" alt="afbeelding" src="https://github.com/user-attachments/assets/632f0c03-8161-4267-9da6-716447709211" />

After:
<img width="339" height="518" alt="afbeelding" src="https://github.com/user-attachments/assets/d86ca4c3-9321-4656-9fa6-42185b0a7c2f" />

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
