### PR TITLE
Improve Overkiz integration documentation to clarify unsupported hardware

### DIFF
--- a/source/_integrations/overkiz.markdown
+++ b/source/_integrations/overkiz.markdown
@@ -99,7 +99,13 @@ This integration retrieves data from Overkiz every 30 seconds to ensure timely u
 
 ## Known limitations
 
-### Zigbee, Z-Wave, Hue, and Sonos devices not supported
+### Unsupported hardware
+
+Some devices that appear in your vendor app may not use the Overkiz platform and are not accessible through the Overkiz API. For example, Somfy Protect devices and some Atlantic Cozytouch devices are not supported by this integration.
+
+If you have a Cozytouch device that is not supported by the Overkiz integration, you can explore [custom components](https://github.com/gduteil/cozytouch) created by the community. These may provide support for additional Cozytouch devices.
+
+### Zigbee, Z-Wave, Hue, and Sonos devices are not supported
 
 Even though most Overkiz hubs support adding Zigbee, Z-Wave, Hue, and Sonos devices, this isn't supported in the Overkiz integration. All these platforms have native integrations in Home Assistant, which provide more frequent state updates and are more feature-rich.
 


### PR DESCRIPTION
## Proposed change

There are quite some issues created about unsupported Atlantic hardware which we can't support due it not being available in the Overkiz platform. This PR improves the documentation to mention this.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
