### PR TITLE
Fix some typos in source/_integrations (found by codespell)

### DIFF
--- a/source/_integrations/apcupsd.markdown
+++ b/source/_integrations/apcupsd.markdown
@@ -179,7 +179,7 @@ Some sensors are disabled by default, since they provide information that is onl
 - **Transfer to Battery**
   - **Description**: Time and date of last transfer to batteries.
   - **Available for machines**: all
-  - **Remarks**: This entity only becomes available after a tranfer to battery event happens.
+  - **Remarks**: This entity only becomes available after a transfer to battery event happens.
 
 - **Battery Status**
   - **Description**: The status of the batteries.

--- a/source/_integrations/azure_data_explorer.markdown
+++ b/source/_integrations/azure_data_explorer.markdown
@@ -65,7 +65,7 @@ There are a few differences between the **PAYG** and **Free** versions:
 // Give the Service Principal write access to the database
 .add database ['<databasename>'] ingestors ('aadapp=<ApplicationID>;<DirectoryID>');
 
-// Give the Service Principal read access to database (used for connectivity checks)
+// Give the Service Principal read access to the database (used for connectivity checks)
 .add database ['<databasename>'] viewers ('aadapp=<ApplicationID>;<DirectoryID>');
 
 // Create a table for the data to be ingested into (replace the name and copy inserted *name* for later use)

--- a/source/_integrations/azure_data_explorer.markdown
+++ b/source/_integrations/azure_data_explorer.markdown
@@ -62,10 +62,10 @@ There are a few differences between the **PAYG** and **Free** versions:
 3. Write and perform the following statements one by one, replacing the placeholder content between the <> with the copied values (including the brackets).
 
 ```KQL
-// Give the Service Pricipal write access to the database
+// Give the Service Principal write access to the database
 .add database ['<databasename>'] ingestors ('aadapp=<ApplicationID>;<DirectoryID>');
 
-// Give the Service Pricipal read access to database (used for connectivity checks) 
+// Give the Service Principal read access to database (used for connectivity checks)
 .add database ['<databasename>'] viewers ('aadapp=<ApplicationID>;<DirectoryID>');
 
 // Create a table for the data to be ingested into (replace the name and copy inserted *name* for later use)

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -260,7 +260,7 @@ Enable/disable Smart Home/Away and Follow Me modes.
 
 ### Service `ecobee.set_sensors_in_climate`
 
-Set which sensors are active on a termostat for a specific climate program.
+Set which sensors are active on a thermostat for a specific climate program.
 
 | Service data attribute | Optional | Description                                                                                                                                         |
 | ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/source/_integrations/freedompro.markdown
+++ b/source/_integrations/freedompro.markdown
@@ -42,7 +42,7 @@ You will need to obtain an API key from Freedompro's app to use this integration
 2. Register and create your first home.
 3. Make sure you have at least one accessory paired with the Freedompro Cloud before starting integration.
 4. Switch to the **Profile** tab (bottom right corner).
-5. Scroll down to the **Developper tools** and tap **Api Key**.
+5. Scroll down to the **Developer tools** and tap **Api Key**.
 6. Generate an API key.
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/hassio.markdown
+++ b/source/_integrations/hassio.markdown
@@ -73,7 +73,7 @@ For Home Assistant Host, the following sensors are available:
 
 For each installed add-on Supervisor provides following binary sensors:
 
-(These entities are disabled by default and must be reenabled to appear)
+(These entities are disabled by default and must be re-enabled to appear)
 
 | Sensor | Enabled by default | Description |
 | ------- | ------------------ | ----------- |

--- a/source/_integrations/imeon_inverter.markdown
+++ b/source/_integrations/imeon_inverter.markdown
@@ -27,7 +27,7 @@ The Imeon Energy Inverter {% term integrations %} will poll an [Imeon](https://i
 
 - The Imeon inverter must be connected to the local network.
 - [OS One](https://imeon-energy.com/os-one/) version must be **1.8.1.4** or higher.
-- *ModuleAPI* application must be activated on the OS One pannel of your Imeon inverter.
+- *ModuleAPI* application must be activated on the OS One panel of your Imeon inverter.
    - To do so, connect to **OS One** > **Applications** and by hovering over *ModuleAPI*, select **Activate**.
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -602,7 +602,7 @@ knx:
     # time and date exposures
     - type: time
       address: "0/0/1"
-    # entitiy exposures
+    # entity exposures
     - type: temperature
       entity_id: sensor.owm_temperature
       address: "0/0/2"

--- a/source/_integrations/lcn.markdown
+++ b/source/_integrations/lcn.markdown
@@ -80,7 +80,7 @@ They are ideal to be used in automation scripts or for the `template` platforms.
 {% endnote %}
 
 
-## Setting up devices and entites
+## Setting up devices and entities
 
 The `lcn` hardware modules and groups are represented by Home Assistant *devices*. The periphery of each `lcn` module is represented by Home Assistant *entities*. Peripheries are, for example, the output ports, relays, and variables of a module. Refer to the description of each [platform](#platforms) to learn about which entity should be used for which periphery.
 

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -116,7 +116,7 @@ The first use of a light or switch will try to register with your Lightwave WiFi
 Lightwave Thermostatic Radiator Values (TRV) are supported.
 
 Earlier integrations required a proxy - See [LWProxy](https://github.com/ColinRobbins/Homeassistant-Lightwave-TRV).
-This capabilty is still supported, but no longer required.
+This capability is still supported, but no longer required.
 
 ```yaml
 # Example TRV configuration.yaml for TRVs

--- a/source/_integrations/livisi.markdown
+++ b/source/_integrations/livisi.markdown
@@ -30,7 +30,7 @@ The following devices are currently supported by this integration:
 - Wall Switches (ISS, ISS2)
 - Window-Door Sensor (WDS)
  
-## Prequisites
+## Prerequisites
  
 This integration communicates with the local version of LIVISI SmartHome only. 
  

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -378,7 +378,7 @@ device_address:
 unique_id:
   description: "ID that uniquely identifies this entity.
   Slaves will be given a unique_id of <<unique_id>>_<<slave_index>>.
-  If two enities have the same unique ID, Home Assistant will raise an exception."
+  If two entities have the same unique ID, Home Assistant will raise an exception."
   required: false
   type: string
 
@@ -1461,7 +1461,7 @@ sensors:
       required: false
       type: integer
     virtual_count:
-      description: "Generates x+1 sensors (master + slaves), allowing read of multiple registers with a single read messsage."
+      description: "Generates x+1 sensors (master + slaves), allowing read of multiple registers with a single read message."
       required: false
       type: integer
     state_class:

--- a/source/_integrations/mysensors.markdown
+++ b/source/_integrations/mysensors.markdown
@@ -794,7 +794,7 @@ void receive(const MyMessage &message)
     if ( dim_value == 0 ) {
       last_state = LIGHT_OFF;
 
-      //Update controller with dimmer value & status
+      // Update controller with dimmer value & status
       send_dimmer_message();
       send_status_message();
     } else {

--- a/source/_integrations/mysensors.markdown
+++ b/source/_integrations/mysensors.markdown
@@ -785,7 +785,7 @@ void receive(const MyMessage &message)
       last_dim=100;
     }
 
-    //Update controller status
+    // Update controller status
     send_status_message();
 
   } else if ( message.type == V_PERCENTAGE ) {

--- a/source/_integrations/mysensors.markdown
+++ b/source/_integrations/mysensors.markdown
@@ -801,7 +801,7 @@ void receive(const MyMessage &message)
       last_state = LIGHT_ON;
       last_dim = dim_value;
 
-      //Update controller with dimmer value
+      // Update controller with dimmer value
       send_dimmer_message();
     }
 

--- a/source/_integrations/mysensors.markdown
+++ b/source/_integrations/mysensors.markdown
@@ -785,7 +785,7 @@ void receive(const MyMessage &message)
       last_dim=100;
     }
 
-    //Update constroller status
+    //Update controller status
     send_status_message();
 
   } else if ( message.type == V_PERCENTAGE ) {
@@ -794,14 +794,14 @@ void receive(const MyMessage &message)
     if ( dim_value == 0 ) {
       last_state = LIGHT_OFF;
 
-      //Update constroller with dimmer value & status
+      //Update controller with dimmer value & status
       send_dimmer_message();
       send_status_message();
     } else {
       last_state = LIGHT_ON;
       last_dim = dim_value;
 
-      //Update constroller with dimmer value
+      //Update controller with dimmer value
       send_dimmer_message();
     }
 

--- a/source/_integrations/tuya.markdown
+++ b/source/_integrations/tuya.markdown
@@ -95,7 +95,7 @@ Tuya supports scenes in their app. These allow triggering some of the more compl
 
 ## Troubleshooting
 
-### Unsupported device or missing device functionnality
+### Unsupported device or missing device functionality
 
 This integration relies on the official [Python SDK provided by Tuya](https://github.com/tuya/tuya-device-sharing-sdk), which does not expose all functionality available in SmartLife.
 

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -292,7 +292,7 @@ utility_meter:
 
 Additionally, you can add template sensors to compute daily and monthly total usage. Important note, in these examples,
 we use the `is_number()` [function](/docs/configuration/templating/#numeric-functions-and-filters) to verify the values
-returned from the sensors are numeric. If this evalutes to false, `None` is returned.
+returned from the sensors are numeric. If this evaluates to false, `None` is returned.
 
 {% raw %}
 


### PR DESCRIPTION
## Proposed change
Fix some trivial typos in comments and documentation.


## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
