### PR TITLE
Fix some more typos (found by codespell)

### DIFF
--- a/source/_redirects
+++ b/source/_redirects
@@ -495,7 +495,7 @@ layout: null
 
 # Removed documentation
 /docs/installation /getting-started
-/docs/installation/dokcer /getting-started
+/docs/installation/docker /getting-started
 /docs/installation/hassbian /getting-started
 /docs/installation/macos /docs/installation/virtualenv
 /docs/installation/raspberry-pi-all-in-one /getting-started

--- a/source/blueprints/blog/2023-07/notify_agent_agenda.yaml
+++ b/source/blueprints/blog/2023-07/notify_agent_agenda.yaml
@@ -120,8 +120,8 @@ action:
           {%- for event in agenda.events %}
           - Summary: {{ event.summary }}
             Start-End: {% if event.start is defined %}{{ event.start }} to {{ event.end }}{% else %}All Day{% endif %}
-            {%- if event.descripton is defined %}
-            Descripton: {{ event.descripton }}
+            {%- if event.description is defined %}
+            Description: {{ event.description }}
             {% endif -%}
             {%- if event.location is defined %}
               Location: {{ event.location }}

--- a/source/more-info/unsupported/docker_configuration.markdown
+++ b/source/more-info/unsupported/docker_configuration.markdown
@@ -31,6 +31,6 @@ following contents:
 When the Docker configuration file is changed and saved, you need to restart the
 Docker service on the host machine.
 
-To fix issues with the cgroup level, addjust the `/etc/default/grub` and add `systemd.unified_cgroup_hierarchy=false` to `GRUB_CMDLINE_LINUX_DEFAULT` and run `sudo update-grub`. After this change is made, you need to reboot the host completely.
+To fix issues with the cgroup level, adjust the `/etc/default/grub`, add `systemd.unified_cgroup_hierarchy=false` to `GRUB_CMDLINE_LINUX_DEFAULT` and run `sudo update-grub`. After this change is made, you need to reboot the host completely.
 
 You can also just re-run our [convenience installation script](https://github.com/home-assistant/supervised-installer).

--- a/source/voice_control/aliases.markdown
+++ b/source/voice_control/aliases.markdown
@@ -16,7 +16,7 @@ or when using a voice assistant in multiple languages at the same time.
 
 ## Adding an alias of an entity
 
-There are multliple ways to add an alias of an entity:
+There are multiple ways to add an alias of an entity:
 
 - **Option 1**: Go to **Settings** > **Voice assistants**. On the **Expose** tab, select the entity for which you want to add an alias.
 ![Screenshot showing the alias editing capabilities added to the more info dialog of entities, accessed from the Voice assistants page](/images/assist/assist_aliases.png)


### PR DESCRIPTION
## Proposed change
Fix some trivial typos in comments and documentation.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
