### PR TITLE
Add grace period options for device state control

### DIFF
--- a/source/_integrations/wake_on_lan.markdown
+++ b/source/_integrations/wake_on_lan.markdown
@@ -114,10 +114,18 @@ host:
   description: The IP address or hostname to check the state of the device (on/off). If this is not provided, the state of the switch will be assumed based on the last action that was taken.
   required: false
   type: string
+on_grace_period:
+  description: Calling `turn_on` forces the state to `on` for the specified duration (in seconds), regardless of the actual device status. Requires `host` to be configured.
+  required: false
+  type: float
 turn_off:
   description: Defines an [action](/getting-started/automation/) to run when the switch is turned off.
   required: false
   type: string
+off_grace_period:
+  description: Calling `turn_off` forces the state to `off` for the specified duration (in seconds), regardless of the actual device status. Requires `host` and `turn_off` to be configured.
+  required: false
+  type: float
 broadcast_address:
   description: The IP address of the host to send the magic packet to.
   required: false

--- a/source/_integrations/wake_on_lan.markdown
+++ b/source/_integrations/wake_on_lan.markdown
@@ -115,7 +115,7 @@ host:
   required: false
   type: string
 on_grace_period:
-  description: Calling `turn_on` forces the state to `on` for the specified duration (in seconds), regardless of the actual device status. Requires `host` to be configured.
+  description: The amount of time (in seconds) the state is set to `on` after `turn_on` has been triggered. The state is set to `on` for this time, irrespective of the actual device status. The `on_grace_period` reflects the amount of time it takes the system to boot. If no grace period is set, the system might show as `off` while it is actually in the process of starting up. `on_grace_period` requires `host` to be configured.
   required: false
   type: float
 turn_off:
@@ -123,7 +123,7 @@ turn_off:
   required: false
   type: string
 off_grace_period:
-  description: Calling `turn_off` forces the state to `off` for the specified duration (in seconds), regardless of the actual device status. Requires `host` and `turn_off` to be configured.
+  description: The amount of time (in seconds) the state is set to `off` after `turn_off` has been triggered. The state is set to `off` for this time, irrespective of the actual device status. The `off_grace_period` reflects the amount of time it takes the system to shutdown. If no grace period is set, the system might show as `on` while it is actually in the process of shutting down. `off_grace_period` requires `host` and `turn_off` to be configured.
   required: false
   type: float
 broadcast_address:


### PR DESCRIPTION
Added on_grace_period and off_grace_period options with descriptions for device state control.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/155256
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/86735

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
