### PR TITLE
Rename 'action' to 'target_state' in documentation

### DIFF
--- a/source/_integrations/manual.markdown
+++ b/source/_integrations/manual.markdown
@@ -108,7 +108,7 @@ The `manual_alarm_bad_code_attempt` event is fired when an attempt to change the
 #### Event data
 
 - **entity_id** (string): The entity ID of the alarm control panel (for example, `alarm_control_panel.my_alarm`).
-- **action** (string): The attempted action or target state (for example, `disarmed`, `armed_away`, `armed_home`).
+- **target_state** (string): The attempted target state (for example, `disarmed`, `armed_away`, `armed_home`).
 - **user_id** (string): The user ID who initiated the service call (if available).
 
 Example automation trigger:
@@ -125,7 +125,7 @@ automation:
           message: >
             Invalid alarm code attempt for {{ trigger.event.data.entity_id }}
             by user ID {{ trigger.event.data.user_id }}
-            while attempting action {{ trigger.event.data.action }}.
+            while attempting to set state {{ trigger.event.data.target_state }}.
 ```
 
 ## State machine


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Corrects the message string used for **invalid alarm code attempts** to accurately reflect that the event data contains the **attempted target state** and not the "action".


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/146315
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Link to merged commit: https://github.com/home-assistant/home-assistant.io/commit/e55457c7ab3c7560cda3cf2d670d8c594f685806

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
