### PR TITLE
Add section with examples

### DIFF
--- a/source/_docs/configuration/state_object.markdown
+++ b/source/_docs/configuration/state_object.markdown
@@ -84,3 +84,11 @@ Context is a property used in state objects and events. It ties {% term events %
 | `context_id` | Unique identifier for the context.                                                                                                                                           |
 | `user_id`    | Unique identifier of the user that started the change. Will be `None` if the action was not started by a user (for example, started by an automation).                       |
 | `parent_id`  | Unique identifier of the parent context that started the change, if available. For example, if an automation is triggered, the context of the trigger will be set as parent. |
+
+## Examples
+
+Evaluate the `state.last_changed` of a switch entity: `{{ states.switch.my_switch.last_changed }}` result type: `string` representing date and time e.g. `2025-11-11 12:56:10.244125+00:00`
+
+Evaluate the `state.context.id` of this switch: `{{ states.switch.my_switch.context.id }}` result type: `string` representing an id code e.g. `01K9SFSRTSKRV5NXPTC38S6KJRF`
+
+If the switch was changed by a user you can read the `state.context.user_id` as well `{{ states.switch.my_switch.context.user_id }}`


### PR DESCRIPTION
Throughout the page state and the state-object are explained but it was missing a clear example how to code access to that state object

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The state object is explained on this documentation page.
I found it hard to actually retain information from an entity like e.g. a switch
That is why I added a section of examples in the end, similar to a linux man page

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
