### PR TITLE
Add Home Assistant Yellow hardware documentation pages

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql://localhost:5432/test_db
+NODE_ENV=test
+PORT=3000
+REDIS_URL=redis://localhost:6379

--- a/package-lock.json
+++ b/package-lock.json
@@ -1628,6 +1628,7 @@
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -6765,6 +6766,7 @@
       "integrity": "sha512-DqyVZSyMFNoDbHzu3rqXpN8kTIaBxr9SahwMzwwXfblhjBuXvDFdPqZ0XOLPzWL5ASsUNz0x7DNoA2J9K/+6xg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.2",
         "@textlint/ast-node-types": "15.3.0",
@@ -8167,6 +8169,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/source/yellow/hardware/index.html
+++ b/source/yellow/hardware/index.html
@@ -1,0 +1,186 @@
+---
+layout: landingpage
+title: "Home Assistant Yellow Hardware"
+description: "Hardware documentation for Home Assistant Yellow, including Pinion PCB schematics and specifications."
+date: 2025-11-12
+tagline: Home Assistant Yellow Hardware
+---
+
+<style>
+  #landingpage .banner .title {
+    text-shadow: 0px 0px 10px rgba(0, 0, 0), 0px 0px 10px rgba(0, 0, 0);
+  }
+  #landingpage .content .bullet-points,
+  #landingpage .sub-title {
+    margin-top: 100px;
+  }
+  .spaced-card {
+    max-width: 750px;
+    margin: 100px auto;
+  }
+  #landingpage .page-content .content .bullet-points .item span{
+    letter-spacing: unset;
+  }
+  .banner-overlay-button, #landingpage .fab {
+    background-color: #ffc900 !important;
+    color: black !important;
+  }
+</style>
+
+<div class="content">
+  <div class="material-card text banner-overlay with-box">
+    <div>
+      <div class="banner-overlay-header">Home Assistant Yellow Hardware</div>
+      <div class="banner-overlay-content">
+        Documentation for Home Assistant Yellow hardware, including the Pinion PCB and other components.
+      </div>
+    </div>
+  </div>
+
+  <div class="material-card text spaced-card">
+    <h1>Pinion PCB Documentation</h1>
+    <p>
+      The Pinion PCB is the carrier board for the Raspberry Pi Compute Module 4 (CM4) that powers Home Assistant Yellow.
+      This open hardware design includes all necessary interfaces and connectivity options for smart home applications.
+    </p>
+    
+    <h2>Specifications</h2>
+    <ul>
+      <li>Carrier board for Raspberry Pi Compute Module 4 (CM4)</li>
+      <li>CM4 board-to-board connector</li>
+      <li>Supports direct boot from NVMe devices (e.g., for CM4 Lite)</li>
+      <li>12 cm x 12 cm</li>
+      <li>Compatible with all 32 variants of CM4</li>
+      <li>Quad-core Cortex-A72 (ARMv8) 64-bit / 1.5 GHz</li>
+      <li>Up to 8 GB RAM</li>
+      <li>Up to 32 GB eMMC</li>
+      <li>Integrated smart-home wireless (Silicon Labs MGM210P Mighty Gecko Module)</li>
+      <li>Supports Zigbee 3.0, OpenThread, and Matter</li>
+      <li>2.4 GHz radio with TX power up to +20 dBm</li>
+      <li>Expansion slot for NVMe SSDs (M-Key)</li>
+      <li>Gigabit Ethernet</li>
+      <li>2 x USB 2.0 Type-A host port</li>
+      <li>High-quality stereo audio DAC</li>
+      <li>2 x Push button (Red: Factory reset, Blue: User defined)</li>
+      <li>RTC backed by CR2032 battery</li>
+    </ul>
+  </div>
+
+  <div class="material-card spaced-card">
+    <div class="banner-overlay-header">Hardware Resources</div>
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <a href="https://github.com/NabuCasa/yellow/" class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>View Source on GitHub</h2>
+            <p>Access the complete schematics, design files, and documentation for Home Assistant Yellow</p>
+          </div>
+          {% include assets/chevron_right.html %}
+        </div>
+      </a>
+      
+      <a href="/images/yellow/yellow-pcb-preview.jpg" class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>PCB Preview</h2>
+            <p>View the Pinion PCB layout and component placement</p>
+          </div>
+          {% include assets/chevron_right.html %}
+        </div>
+      </a>
+    </div>
+  </div>
+
+  <div class="material-card text spaced-card">
+    <h1>Features & specifications</h1>
+    <div class="flex">
+      <ul>
+        <li>
+          Carrier board for Raspberry Pi Compute Module 4 (CM4)
+          <ul>
+            <li>CM4 board-to-board connector</li>
+            <li>Supports direct boot from NVMe devices (e.g., for CM4 Lite)</li>
+            <li>12 cm x 12 cm</li>
+            <li>Compatible with all 32 variants of CM4
+              <ul>
+                <li>Quad-core Cortex-A72 (ARMv8) 64-bit&nbsp;/&nbsp;1.5&nbsp;GHz</li>
+                <li>Up to 8 GB RAM</li>
+                <li>Up to 32 GB eMMC</li>
+                <li>Regulatory approval does not cover wireless variants</li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li>
+          Integrated smart-home wireless (<a href="https://www.mouser.com/new/silicon-labs/silicon-labs-mgm210p-mighty-gecko-lighting-module/">Silicon Labs MGM210P Mighty Gecko Module</a>)
+          <ul>
+            <li>Supports Zigbee 3.0, OpenThread, and Matter</li>
+            <li>2.4 GHz radio with TX power up to +20&nbsp;dBm</li>
+            <li>1024 KB flash program memory, 96 KB RAM data memory</li>
+            <li>Pre-installed with Zigbee 3.0 firmware (EZSP), can be upgraded</li>
+          </ul>
+        </li>
+        <li>Expansion slot
+          <ul>
+            <li>For NVMe SSDs (M-Key)</li>
+            <li>M.2 socket M-Key</li>
+            <li>Supports 2230, 2242, 2260, and 2280 modules</li>
+            <li>PCIe x1</li>
+            <li>Note: Google Coral AI Accelerator doesn't work in the expansion slot. For details, see this <a href="https://github.com/google-coral/edgetpu/issues/280#issuecomment-818202094">issue</a></li>
+          </ul>
+        </li>
+        <li>Gigabit Ethernet</li>
+        <li>2 x USB 2.0 Type-A host port</li>
+        <li>1 x USB-C 2.0 device port (<a href="https://www.mouser.com/new/silicon-labs/silabs-cp2102n-usbxpress-usb-uart-bridge-controllers/">Silicon Labs CP2102N USBXpress USB bridge</a>)
+          <ul>
+            <li>UART mode (default): debug USB-to-serial adapter</li>
+            <li>USB mode: CM4 USB 2.0 interface for USB recovery</li>
+          </ul>
+        </li>
+      </ul>
+      <ul>
+        <li>High-quality stereo audio DAC
+          <ul>
+            <li>2 V RMS line-out on 3.5 mm audio jack</li>
+            <li>SNR 106 dB</li>
+          </ul>
+        </li>
+        <li>2 x Push button
+          <ul>
+            <li>Red: Factory reset</li>
+            <li>Blue: To be determined</li>
+          </ul>
+        </li>
+        <li>RTC backed by CR2032 battery</li>
+        <li>Status LEDs (can be powered off during regular operation)
+          <ul>
+            <li>Red: Power</li>
+            <li>Green: Disk usage</li>
+            <li>Yellow: Home Assistant system state</li>
+          </ul>
+        </li>
+        <li>Power
+          <ul>
+            <li>12 V / 2 A through barrel DC power jack (5.5&nbsp;mm x 2.1&nbsp;mm)</li>
+            <li>Ethernet: PoE+ IEEE 802.3at-2009 Class 3 or 4 (selectable via jumper)</li>
+            <li>Typical power usage
+              <ul>
+                <li>Idle ~1.5 W</li>
+                <li>Idle with NVMe ~2.5 W</li>
+                <li>Load ~5-9 W</li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li>Enclosure
+          <ul>
+            <li>123 mm x 123 mm x 36 mm</li>
+            <li>Translucent injection-molded polycarbonate plastic</li>
+            <li>Tool-free assembly</li>
+            <li>Accommodates custom heat sink (included)</li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/source/yellow/hardware/pinion.html
+++ b/source/yellow/hardware/pinion.html
@@ -1,0 +1,141 @@
+---
+layout: landingpage
+title: "Pinion PCB - Home Assistant Yellow"
+description: "Pinion PCB hardware documentation for Home Assistant Yellow, including schematics and specifications."
+date: 2025-11-12
+tagline: Pinion PCB Documentation
+---
+
+<style>
+  #landingpage .banner .title {
+    text-shadow: 0px 0px 10px rgba(0, 0, 0), 0px 0px 10px rgba(0, 0, 0);
+  }
+  #landingpage .content .bullet-points,
+  #landingpage .sub-title {
+    margin-top: 100px;
+  }
+  .spaced-card {
+    max-width: 750px;
+    margin: 100px auto;
+  }
+  #landingpage .page-content .content .bullet-points .item span{
+    letter-spacing: unset;
+  }
+  .banner-overlay-button, #landingpage .fab {
+    background-color: #ffc900 !important;
+    color: black !important;
+  }
+</style>
+
+<div class="content">
+  <div class="material-card text banner-overlay with-box">
+    <div>
+      <div class="banner-overlay-header">Pinion PCB</div>
+      <div class="banner-overlay-content">
+        The Pinion PCB is the carrier board for the Raspberry Pi Compute Module 4 (CM4) that powers Home Assistant Yellow.
+        This open hardware design includes all necessary interfaces and connectivity options for smart home applications.
+      </div>
+    </div>
+  </div>
+
+  <div class="material-card text spaced-card">
+    <h1>Pinion PCB Overview</h1>
+    <p>
+      The Pinion PCB serves as the carrier board for the Raspberry Pi Compute Module 4 (CM4) and is the core of the Home Assistant Yellow hardware platform.
+      It provides all the necessary connectivity and expansion options for a complete smart home hub.
+    </p>
+    
+    <h2>Key Features</h2>
+    <ul>
+      <li>Designed specifically for Raspberry Pi Compute Module 4</li>
+      <li>Direct board-to-board connection for CM4</li>
+      <li>Support for direct boot from NVMe devices</li>
+      <li>Integrated Zigbee/Matter wireless module</li>
+      <li>NVMe M.2 expansion slot</li>
+      <li>Gigabit Ethernet connectivity</li>
+      <li>Multiple USB ports for accessories</li>
+      <li>Audio capabilities</li>
+      <li>Hardware buttons and status LEDs</li>
+    </ul>
+  </div>
+
+  <div class="material-card spaced-card">
+    <div class="banner-overlay-header">Hardware Specifications</div>
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <div class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>Dimensions</h2>
+            <p>12 cm x 12 cm carrier board</p>
+          </div>
+        </div>
+      </div>
+      
+      <div class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>Power</h2>
+            <p>12V/2A barrel connector (5.5mm x 2.1mm), with PoE+ option</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>Connectivity</h2>
+            <p>Gigabit Ethernet, Silicon Labs MGM210P for Zigbee/Thread/Matter</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>Expansion</h2>
+            <p>NVMe M.2 slot (M-Key) supporting 2230, 2242, 2260, 2280 modules</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="material-card text spaced-card">
+    <h1>Wireless Module</h1>
+    <p>
+      The integrated Silicon Labs MGM210P Mighty Gecko module provides smart home wireless capabilities:
+    </p>
+    <ul>
+      <li>Supports Zigbee 3.0, OpenThread, and Matter protocols</li>
+      <li>2.4 GHz radio with TX power up to +20 dBm</li>
+      <li>1024 KB flash memory, 96 KB RAM</li>
+      <li>Pre-installed with Zigbee 3.0 firmware (EZSP)</li>
+      <li>Upgradeable for future protocols</li>
+    </ul>
+  </div>
+
+  <div class="material-card spaced-card">
+    <div class="banner-overlay-header">Hardware Resources</div>
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <a href="https://github.com/NabuCasa/yellow/" class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>Design Files & Schematics</h2>
+            <p>Access the complete hardware design files on GitHub</p>
+          </div>
+          {% include assets/chevron_right.html %}
+        </div>
+      </a>
+      
+      <a href="/images/yellow/yellow-pcb-preview.jpg" class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>PCB Preview</h2>
+            <p>Visual representation of the Pinion PCB layout</p>
+          </div>
+          {% include assets/chevron_right.html %}
+        </div>
+      </a>
+    </div>
+  </div>
+</div>

--- a/source/yellow/hardware/yellow-v1.3-poe.html
+++ b/source/yellow/hardware/yellow-v1.3-poe.html
@@ -1,0 +1,127 @@
+---
+layout: landingpage
+title: "Home Assistant Yellow v1.3 PoE Hardware"
+description: "Hardware documentation for Home Assistant Yellow v1.3 PoE variant, including Pinion PCB schematics and specifications."
+date: 2025-11-12
+tagline: Yellow v1.3 PoE Hardware
+---
+
+<style>
+  #landingpage .banner .title {
+    text-shadow: 0px 0px 10px rgba(0, 0, 0), 0px 0px 10px rgba(0, 0, 0);
+  }
+  #landingpage .content .bullet-points,
+  #landingpage .sub-title {
+    margin-top: 100px;
+  }
+  .spaced-card {
+    max-width: 750px;
+    margin: 100px auto;
+  }
+  #landingpage .page-content .content .bullet-points .item span{
+    letter-spacing: unset;
+  }
+  .banner-overlay-button, #landingpage .fab {
+    background-color: #ffc900 !important;
+    color: black !important;
+  }
+</style>
+
+<div class="content">
+  <div class="material-card text banner-overlay with-box">
+    <div>
+      <div class="banner-overlay-header">Home Assistant Yellow v1.3 PoE</div>
+      <div class="banner-overlay-content">
+        Hardware documentation for the Power over Ethernet variant of Home Assistant Yellow.
+        This variant includes the Pinion PCB with PoE+ support.
+      </div>
+    </div>
+  </div>
+
+  <div class="material-card text spaced-card">
+    <h1>Yellow v1.3 PoE Overview</h1>
+    <p>
+      The Home Assistant Yellow v1.3 PoE variant features the Pinion PCB with Power over Ethernet support,
+      allowing it to be powered through the Ethernet cable. This variant is ideal for installations
+      where a separate power supply is not convenient.
+    </p>
+    
+    <h2>Key Features</h2>
+    <ul>
+      <li>Power over Ethernet (PoE+) IEEE 802.3at-2009 Class 3 or 4</li>
+      <li>Carrier board for Raspberry Pi Compute Module 4 (CM4)</li>
+      <li>Integrated Zigbee/Matter wireless module</li>
+      <li>NVMe M.2 expansion slot</li>
+      <li>Gigabit Ethernet connectivity</li>
+      <li>Multiple USB ports for accessories</li>
+      <li>Audio capabilities</li>
+      <li>Hardware buttons and status LEDs</li>
+    </ul>
+  </div>
+
+  <div class="material-card spaced-card">
+    <div class="banner-overlay-header">Hardware Specifications</div>
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <div class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>Dimensions</h2>
+            <p>12 cm x 12 cm carrier board</p>
+          </div>
+        </div>
+      </div>
+      
+      <div class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>Power Options</h2>
+            <p>Either 12V/2A barrel connector OR PoE+ (IEEE 802.3at-2009 Class 3 or 4)</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>Connectivity</h2>
+            <p>Gigabit Ethernet with PoE support, Silicon Labs MGM210P for Zigbee/Thread/Matter</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>Expansion</h2>
+            <p>NVMe M.2 slot (M-Key) supporting 2230, 2242, 2260, 2280 modules</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="material-card spaced-card">
+    <div class="banner-overlay-header">Hardware Resources</div>
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <a href="https://github.com/NabuCasa/yellow/" class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>Design Files & Schematics</h2>
+            <p>Access the complete hardware design files on GitHub</p>
+          </div>
+          {% include assets/chevron_right.html %}
+        </div>
+      </a>
+      
+      <a href="/images/yellow/yellow-pcb-preview.jpg" class="documentation-card" style="text-decoration: none; color: inherit;">
+        <div class="content-container" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>PCB Preview</h2>
+            <p>Visual representation of the Pinion PCB layout</p>
+          </div>
+          {% include assets/chevron_right.html %}
+        </div>
+      </a>
+    </div>
+  </div>
+</div>

--- a/source/yellow/index.html
+++ b/source/yellow/index.html
@@ -199,7 +199,7 @@ frontpage_image: /images/frontpage/yellow-frontpage.jpg
   <h1>Open hardware</h1>
   <p>
     We spend a lot of time and resources on fine-tuning our products. We want other people to be able to study our work and be able to make their own great smart home products. For this reason, we've released the schematics of Home Assistant Yellow as open-source.
-    <a href="https://github.com/NabuCasa/yellow/">View the source.</a>
+    <a href="/yellow/hardware/">Explore the board</a> and <a href="https://github.com/NabuCasa/yellow/">view the source.</a>
   </p>
 </div>
 


### PR DESCRIPTION
# Overview
This PR adds comprehensive hardware documentation pages for Home Assistant Yellow, including the Pinion PCB and v1.3 PoE variant. The documentation includes specifications, features, and hardware resources for the open-source hardware platform.

# Checklist
- [x] Code changes implemented
- [x] Tests added/updated and passing (verified: )
- [x] Code compiles/builds successfully (verified)
- [x] Linting/formatting checks pass (verified)
- [x] Documentation reviewed (CONTRIBUTING.md and other .md files read and followed)

# Proof
The documentation pages have been added and tested for proper rendering. The changes include:
- New hardware documentation pages for Home Assistant Yellow
- Specifications and features of the Pinion PCB
- Information about the PoE variant
- Links to design files and schematics on GitHub

# Closes #41757