### PR TITLE
Rename RuuviTag BLE to Ruuvi BLE

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -439,7 +439,7 @@ The following integrations are automatically discovered by the Bluetooth integra
  - [Probe Plus](/integrations/probe_plus/)
  - [Qingping](/integrations/qingping/)
  - [RAPT Bluetooth](/integrations/rapt_ble/)
- - [RuuviTag BLE](/integrations/ruuvitag_ble/)
+ - [Ruuvi BLE](/integrations/ruuvitag_ble/)
  - [Sensirion BLE](/integrations/sensirion_ble/)
  - [SensorPro](/integrations/sensorpro/)
  - [SensorPush](/integrations/sensorpush/)

--- a/source/_integrations/ruuvitag_ble.markdown
+++ b/source/_integrations/ruuvitag_ble.markdown
@@ -1,6 +1,6 @@
 ---
-title: RuuviTag BLE
-description: Instructions on how to integrate RuuviTag BLE devices into Home Assistant.
+title: Ruuvi BLE
+description: Instructions on how to integrate Ruuvi BLE devices into Home Assistant.
 ha_category:
   - Sensor
 ha_bluetooth: true
@@ -15,14 +15,16 @@ ha_platforms:
 ha_integration_type: integration
 ---
 
-Integrates [Ruuvi](https://ruuvi.com/)'s RuuviTag BLE devices into Home Assistant.
+Integrates [Ruuvi](https://ruuvi.com/)'s BLE devices into Home Assistant.
 
 {% include integrations/config_flow.md %}
 
-The RuuviTag BLE integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
+The Ruuvi BLE integration will automatically discover supported devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
 
-If your RuuviTags are not discovered, please make sure to update them to [the latest firmware](https://ruuvi.com/software-update/).
+If your Ruuvi devices are not discovered, please make sure to update them to [the latest firmware](https://ruuvi.com/software-update/).
 
 ## Supported devices
 
-- [RuuviTag](https://ruuvi.com/ruuvitag/)
+- [RuuviTag](https://ruuvi.com/ruuvitag/) - Environmental sensor tags
+- [RuuviTag Pro](https://ruuvi.com/ruuvitag-pro/) - Heavy-duty environmental sensor tags
+- [Ruuvi Air](https://ruuvi.com/air/) - Air quality monitors (since Home Assistant 2025.11)


### PR DESCRIPTION
## Proposed change

Sibling PR of https://github.com/home-assistant/core/pull/156504.

This PR changes the human-readable name of the `ruuvitag_ble` integration from "RuuviTag BLE" to "Ruuvi BLE", since the scope of the integration increased to other Ruuvi devices (Ruuvi Air) in 2025.11.

It also notes this new device support.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/156504
- Link to parent pull request in the Brands repository: –
- This PR fixes or closes issue: –

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
