### PR TITLE
Document Secret Alerts automatically updating binary sensors

### DIFF
--- a/source/_integrations/simplisafe.markdown
+++ b/source/_integrations/simplisafe.markdown
@@ -157,7 +157,7 @@ triggers:
 
 For cases where the default {% term polling %} interval of 30 seconds is too long for automations, you can use secret alerts to get push notifications of a sensor being triggered.
 
-Home Assistant will automatically set the status to triggered for binary sensor devices that have secret alerts.  However, due to the way Simplisafe implements secret alerts, you can only receive push notifications when a device is triggered, not when they are cleared.   Clearing a binary sensor can only be accomplished by polling.
+Home Assistant will automatically set the status to triggered for binary sensor devices that have secret alerts. However, due to the way Simplisafe implements secret alerts, you can only receive push notifications when a device is triggered, not when they are cleared. Clearing a binary sensor can only be accomplished by polling.
 
 For cases where you wish to reliably determine each time a binary sensor is triggered, do the following:
 

--- a/source/_integrations/simplisafe.markdown
+++ b/source/_integrations/simplisafe.markdown
@@ -157,7 +157,9 @@ triggers:
 
 For cases where the default {% term polling %} interval of 30 seconds is too long for automations, you can use secret alerts to get push notifications of a sensor being triggered.
 
-To enable secret alerts for sensor changes, follow these steps:
+Home Assistant will automatically set the status to triggered for binary sensor devices that have secret alerts.  However, due to the way Simplisafe implements secret alerts, you can only receive push notifications when a device is triggered, not when they are cleared.   Clearing a binary sensor can only be accomplished by polling.
+
+For cases where you wish to reliably determine each time a binary sensor is triggered, do the following:
 
 1. Enable the secret alert for the device in the Simplisafe App.
 2. Make a note of the serial number of the device.
@@ -173,9 +175,6 @@ To enable secret alerts for sensor changes, follow these steps:
           last_event_sensor_serial: "abc123xyz"  # Replace with your device's serial number (use lowercase letters)
   ```
 
-{% note %}
-Due to the way Simplisafe implements secret alerts, you can only determine when a sensor is triggered, not when it is cleared.
-{% endnote %}
 
 ### `SIMPLISAFE_NOTIFICATION`
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Add documentation indicating change in functionality of binary sensors triggered by secret alerts


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/156848
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
