### PR TITLE
Fix ZBT-2 links on integration page

### DIFF
--- a/source/_integrations/homeassistant_connect_zbt2.markdown
+++ b/source/_integrations/homeassistant_connect_zbt2.markdown
@@ -18,8 +18,8 @@ ha_quality_scale: bronze
 
 The Home Assistant Connect ZBT-2 integration provides hardware information for the hardware configuration page.
 
-For documentation on the Home Assistant Connect ZBT-2, please visit the [documentation page](https://support.nabucasa.com/hc/en-us/categories/24734620813469).
-If you are looking to buy one, please visit the [product page](https://home-assistant.io/connectzbt2)
+For documentation on the Home Assistant Connect ZBT-2, please visit the [documentation page](https://support.nabucasa.com/hc/en-us/categories/29400540866973).
+If you are looking to buy one, please visit the [product page](https://home-assistant.io/connect/zbt-2/)
 
 ## Configuration
 

--- a/source/_integrations/homeassistant_connect_zbt2.markdown
+++ b/source/_integrations/homeassistant_connect_zbt2.markdown
@@ -19,7 +19,7 @@ ha_quality_scale: bronze
 The Home Assistant Connect ZBT-2 integration provides hardware information for the hardware configuration page.
 
 For documentation on the Home Assistant Connect ZBT-2, please visit the [documentation page](https://support.nabucasa.com/hc/en-us/categories/29400540866973).
-If you are looking to buy one, please visit the [product page](https://home-assistant.io/connect/zbt-2/)
+If you are looking to buy one, please visit the [product page](https://home-assistant.io/connect/zbt-2/).
 
 ## Configuration
 


### PR DESCRIPTION
## Proposed change

This fixes the product page link and support link on the ZBT-2's integration page. (cc @joostlek)


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
