### PR TITLE
Fix underlined space in author name

### DIFF
--- a/source/_includes/post/author.html
+++ b/source/_includes/post/author.html
@@ -9,7 +9,7 @@
   {% assign person = site.data.people[author] %}
   {% if person %}
     <span class="byline author vcard">
-      <a href="https://github.com/{{ person.github }}" target="_blank"><img class="author-avatar" src="https://avatars.githubusercontent.com/{{ person.github }}?size=64" alt="{{ person.name }}"/> {{ person.name }}</a>
+      <a href="https://github.com/{{ person.github }}" target="_blank"><img class="author-avatar" src="https://avatars.githubusercontent.com/{{ person.github }}?size=64" alt="{{ person.name }}"/>{{ person.name }}</a>
     </span>
   {% else %}
     <span class="byline author vcard">{% icon "mdi:person" %} {{ author }}</span>


### PR DESCRIPTION
## Proposed change

This PR fixes an issue that has existed for quite a while, where there's an underlined leading space in front of all author names which are associated with a person (i.e. profile picture + GitHub link).

(I unfortunately notice this every time)

### Details

Currently, the profile picture and author name in (e.g.) blog posts look like this. I've highlighted the leading space that's underlined, likely unintentional:
<img width="507" height="154" alt="image" src="https://github.com/user-attachments/assets/359d14d4-d971-4d20-bd45-b2770fab58d4" />

With this PR, this underlined leading space is removed completely:
<img width="511" height="137" alt="image" src="https://github.com/user-attachments/assets/1f937c5a-73d3-47d6-9bfd-977c654a889f" />

The `author-avatar` already has an 8px margin on the right (only), so that's likely all the padding ever wanted between the avatar and name, not requiring that additional space of padding. For the 8px margin, see:
https://github.com/home-assistant/home-assistant.io/blob/565bf6411027f3400fe563c37302bc66d8bc02a5/sass/homeassistant/_overrides.scss#L1488

### "What about the space in line 15?"

The space in line 15 needs to stay, since we only use an icon there. Since nothing is underlined there anyways, we can add the space just fine.

With and without this PR, it looks like this (already correct):

<img width="346" height="49" alt="image" src="https://github.com/user-attachments/assets/c73adb03-ccbf-4378-b3b6-4d55bdcb79d8" />

Removing the space would make it look like this, which is worse:

<img width="340" height="50" alt="image" src="https://github.com/user-attachments/assets/f2d6d85d-0fcc-4ac5-a375-4af6f93c014d" />



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
