### PR TITLE
Remove duplicate and incorrect entries

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1475,14 +1475,6 @@ sensors:
       required: false
       type: string
       default: ">f"
-    slave_count:
-      description: "Identical to `virtual_count`."
-      required: false
-      type: integer
-    virtual_count:
-      description: Generates x-1 slave sensors, allowing read of multiple registers with a single read message.
-      required: false
-      type: integer
     swap:
       description: "Swap the order of bytes/words, **not valid with `custom` and `datatype: string`**"
       required: false
@@ -1499,10 +1491,6 @@ sensors:
       description: "Unit to attach to value."
       required: false
       type: string
-    zero_suppress:
-      description: "Suppress values close to zero. If -zero_suppress <= value <= +zero_suppress --> 0. Can be float or integer"
-      required: false
-      type: float
     unique_id:
       description: ID that uniquely identifies the entity. If two sensors have the same unique ID, Home Assistant will raise an exception.
       required: false


### PR DESCRIPTION
Removed duplicate entries for `slave_count`, `virtual_count` and `zero_suppress`. `virtual_count` was also incorrect since it stated "x-1" instead of "x+1"

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Today when setting up the Modbus integration, I noticed that I had more entities than expected. According to the documentation the `virtual_count` option should result in "x-1" slave sensors, which I understood to mean there will be x sensors in total. Instead, there were x+1 sensors. Looking at the source for the documentation, I found duplicate entries with conflicting information. There were also duplicate entries for `slave_count` and `zero_suppress`. I removed all of the duplicate entries.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
