### PR TITLE
Documentation for time pattern triggers specified as ranges or sets of values

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -922,7 +922,7 @@ automation:
 
 ## Time pattern trigger
 
-With the time pattern trigger, you can match if the hour, minute or second of the current time matches a specific value. You can prefix the value with a `/` to match whenever the value is divisible by that number. You can specify `*` to match any value.
+With the time pattern trigger, you can match if the hour, minute or second of the current time matches a specific value. You can prefix the value with a `/` to match whenever the value is divisible by that number. You can specify `*` to match any value. You can specify `-` to specify a range. Multiple rules can be combined with `,`.
 
 ```yaml
 automation:
@@ -943,6 +943,24 @@ automation 3:
     - trigger: time_pattern
       # You can also match on interval. This will match every 5 minutes
       minutes: "/5"
+
+automation 4:
+  triggers:
+    - trigger: time_pattern
+      # You can also match on a range. This will match every hour between 5 and 9
+      hours: "5-9"
+
+automation 5:
+  triggers:
+    - trigger: time_pattern
+      # You can also match on a set of values. This will match on the hours specified:
+      minutes: "5,7,9"
+
+automation 6:
+  triggers:
+    - trigger: time_pattern
+      # Combine multiple rules with a comma. This will trigger every hour on the minutes between 5 and 15, and at 45
+      minutes: "5-15,45"
 ```
 
 {% note %}


### PR DESCRIPTION
This is documentation for https://github.com/home-assistant/core/pull/157094

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Time Pattern triggers are awesome. But they don't support expressions that are more restricted, such as "trigger every minute at 7am, 12pm, and 9pm" or "every 15 minutes between 1pm and 4pm" for which the division and * syntax don't support.

Ranges and sets of values further extend the ability of patterns to more closely match cron syntax (which I presume is the genesis of the syntax up until now). 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/157094
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
