### PR TITLE
Unify action headings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -278,7 +278,7 @@ The **My integration** integration provides the following entities.
 
 The integration provides the following actions.
 
-### Action: Get schedule
+### Action `my_integration.get_schedule`
 
 The `my_integration.get_schedule` action is used to fetch a schedule from the integration.
 

--- a/source/_integrations/_integration_docs_template.markdown
+++ b/source/_integrations/_integration_docs_template.markdown
@@ -136,7 +136,7 @@ The **My integration** integration provides the following entities.
 
 The integration provides the following actions.
 
-### Action: Get schedule
+### Action `my_integration.get_schedule`
 
 The `my_integration.get_schedule` action is used to fetch a schedule from the integration.
 

--- a/source/_integrations/abode.markdown
+++ b/source/_integrations/abode.markdown
@@ -88,9 +88,9 @@ and the inferred groups and their ranges of event codes are defined in
 
 ## Actions
 
-Available {% term actions %}: `change_setting`, `capture_image`, `trigger_automation`
+Available {% term actions %}: `abode.change_setting`, `abode.capture_image`, `abode.trigger_automation`
 
-### Action `change_setting`
+### Action `abode.change_setting`
 
 Change settings on your Abode system.
 For a full list of settings and valid values, consult the
@@ -101,7 +101,7 @@ For a full list of settings and valid values, consult the
 | `setting` | No | The setting you wish to change. |
 | `value` | No | The value you wish to change the setting to. |
 
-### Action `capture_image`
+### Action `abode.capture_image`
 
 Request a new still image from your Abode camera.
 
@@ -109,7 +109,7 @@ Request a new still image from your Abode camera.
 | ---------------------- | -------- | ----------- |
 | `entity_id` | No | String or list of strings that point at `entity_id`s of Abode cameras. |
 
-### Action `trigger_automation`
+### Action `abode.trigger_automation`
 
 Trigger an automation on your Abode system.
 

--- a/source/_integrations/ads.markdown
+++ b/source/_integrations/ads.markdown
@@ -72,6 +72,8 @@ ip_address:
 <!-- omit in toc -->
 ## Actions
 
+The integration provides the following actions.
+
 ### Action `ads.write_by_name`
 
 The ADS integration will register the `write_by_name` action allowing you to write a value to a variable on your ADS device.

--- a/source/_integrations/ads.markdown
+++ b/source/_integrations/ads.markdown
@@ -70,7 +70,9 @@ ip_address:
 {% endconfiguration %}
 
 <!-- omit in toc -->
-## Action
+## Actions
+
+### Action `ads.write_by_name`
 
 The ADS integration will register the `write_by_name` action allowing you to write a value to a variable on your ADS device.
 

--- a/source/_integrations/aftership.markdown
+++ b/source/_integrations/aftership.markdown
@@ -28,6 +28,8 @@ AfterShip removed the Tracking API functionality from the Forever Free plan, and
 
 ## Actions
 
+The integration provides the following actions.
+
 ### Action `aftership.add_tracking`
 
  You can use the `aftership.add_tracking` action to add trackings to AfterShip.

--- a/source/_integrations/aftership.markdown
+++ b/source/_integrations/aftership.markdown
@@ -26,7 +26,9 @@ AfterShip removed the Tracking API functionality from the Forever Free plan, and
 
 {% include integrations/config_flow.md %}
 
-## Action `add_tracking`
+## Actions
+
+### Action `aftership.add_tracking`
 
  You can use the `aftership.add_tracking` action to add trackings to AfterShip.
 
@@ -36,7 +38,7 @@ AfterShip removed the Tracking API functionality from the Forever Free plan, and
 | `slug` | `False` | string | Carrier e.g.,  `fedex`
 | `title` | `False` | string | Friendly name of package
 
-## Action `remove_tracking`
+### Action `aftership.remove_tracking`
 
  You can use the `aftership.remove_tracking` action to remove trackings from AfterShip.
 

--- a/source/_integrations/agent_dvr.markdown
+++ b/source/_integrations/agent_dvr.markdown
@@ -35,11 +35,12 @@ Reports on the current alarm status and can be used to arm and disarm the system
 Once loaded, the `agent_dvr` integration will expose actions that can be used. The `entity_id` action attribute can specify one or more specific cameras.
 
 Available actions:
-`enable_alerts`, `disable_alerts`,
-`start_recording`, `stop_recording`,
-`turn_on`, `turn_off`, `toggle`, `enable_motion_detection`,`disable_motion_detection`
+`agent_dvr.enable_alerts`, `agent_dvr.disable_alerts`,
+`agent_dvr.start_recording`, `agent_dvr.stop_recording`,
 
-### Action `enable_alerts`/`disable_alerts`
+Camera entities can also be controlled by action provided by [Camera integration](/integrations/camera/#actions).
+
+### Action `agent_dvr.enable_alerts`/`agent_dvr.disable_alerts`
 
 These actions enable or disable the device's alert events within Agent DVR.
 
@@ -47,17 +48,9 @@ Data attribute | Optional | Description
 -|-|-
 `entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
 
-### Action `start_recording`/`stop_recording`
+### Action `agent_dvr.start_recording`/`agent_dvr.stop_recording`
 
 These actions start or stop the device recording.
-
-Data attribute | Optional | Description
--|-|-
-`entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
-
-### Action `turn_on`/`turn_off`/`toggle`
-
-These actions turn on, off or toggle the device enabled state within Agent DVR
 
 Data attribute | Optional | Description
 -|-|-

--- a/source/_integrations/alexa_devices.markdown
+++ b/source/_integrations/alexa_devices.markdown
@@ -68,11 +68,9 @@ Open a issue with all details to investigate
 
 ## Actions
 
-### Available Actions
-
 Available actions: `notify.send_message`, `alexa_devices.send_sound`, `alexa_devices.send_text_command`
 
-#### Action `notify.send_message`
+### Action `notify.send_message`
 
 Devices with appropriate functionality will have speak and announce notify entities created. These can be used as the target for the `notify.send_message` action.
 
@@ -94,7 +92,7 @@ Amazon provide a set of [sounds you can use](https://developer.amazon.com/en-US/
 
 {% enddetails %}
 
-#### Action `alexa_devices.send_text_command`
+### Action `alexa_devices.send_text_command`
 
 This action essentially allows you to control Alexa using text commands rather than speech. You should be able to request anything you would via speech using this action.
 
@@ -103,7 +101,7 @@ This action essentially allows you to control Alexa using text commands rather t
 | `device_id` | no | Device on which you want to run action |
 | `text_command` | no | Command to send |
 
-#### Action `alexa_devices.send_sound`
+### Action `alexa_devices.send_sound`
 
 This action allows you to play one of the built-in Alexa sounds. The full list of sounds is available in [Amazon's documentation (needs authentication)](https://alexa.amazon.com/api/behaviors/entities?skillId=amzn1.ask.1p.sound)
 

--- a/source/_integrations/amberelectric.markdown
+++ b/source/_integrations/amberelectric.markdown
@@ -53,6 +53,9 @@ There are two additional sensors:
 - **Renewables** - The percentage of renewable energy currently in the grid.
 
 ## Actions
+
+The integration provides the following action.
+
 ### `amberelectric.get_forecasts`
 
 The `amberelectric.get_forecasts` action returns an array of forecasts for the requested channel type.

--- a/source/_integrations/amberelectric.markdown
+++ b/source/_integrations/amberelectric.markdown
@@ -53,9 +53,9 @@ There are two additional sensors:
 - **Renewables** - The percentage of renewable energy currently in the grid.
 
 ## Actions
-### `get_forecasts`
+### `amberelectric.get_forecasts`
 
-The `get_forecasts` action returns an array of forecasts for the requested channel type.
+The `amberelectric.get_forecasts` action returns an array of forecasts for the requested channel type.
 
 | Data attribute    | Optional | Description                                                           |
 | ----------------- | -------- | --------------------------------------------------------------------- |

--- a/source/_integrations/amcrest.markdown
+++ b/source/_integrations/amcrest.markdown
@@ -198,14 +198,14 @@ The event code is sent by Amcrest or Dahua devices in the payload as a "Code" me
 Once loaded, the `amcrest` integration will expose {% term actions %} that can be called to perform various actions. The `entity_id` action attribute can specify one or more specific cameras, or `all` can be used to specify all configured Amcrest cameras.
 
 Available {% term actions %}:
-`enable_audio`, `disable_audio`,
-`enable_motion_recording`, `disable_motion_recording`,
-`enable_recording`, `disable_recording`,
-`goto_preset`, `set_color_bw`,
-`start_tour`, `stop_tour`, and
-`ptz_control`
+`amcrest.enable_audio`, `amcrest.disable_audio`,
+`amcrest.enable_motion_recording`, `amcrest.disable_motion_recording`,
+`amcrest.enable_recording`, `amcrest.disable_recording`,
+`amcrest.goto_preset`, `amcrest.set_color_bw`,
+`amcrest.start_tour`, `amcrest.stop_tour`, and
+`amcrest.ptz_control`
 
-### Action `enable_audio`/`disable_audio`
+### Action `amcrest.enable_audio`/`amcrest.disable_audio`
 
 These {% term actions %} enable or disable the camera's audio stream.
 
@@ -213,7 +213,7 @@ These {% term actions %} enable or disable the camera's audio stream.
 | ---------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | no       | The entity ID of the camera to control. May be a list of multiple entity IDs. To target all cameras, set entity ID to `all`. |
 
-### Action `enable_motion_recording`/`disable_motion_recording`
+### Action `amcrest.enable_motion_recording`/`amcrest.disable_motion_recording`
 
 These {% term actions %} enable or disable the camera to record a clip to its configured storage location when motion is detected.
 
@@ -221,7 +221,7 @@ These {% term actions %} enable or disable the camera to record a clip to its co
 | ---------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | no       | The entity ID of the camera to control. May be a list of multiple entity IDs. To target all cameras, set entity ID to `all`. |
 
-### Action `enable_recording`/`disable_recording`
+### Action `amcrest.enable_recording`/`amcrest.disable_recording`
 
 These actions enable or disable the camera to continuously record to its configured storage location.
 
@@ -229,7 +229,7 @@ These actions enable or disable the camera to continuously record to its configu
 | ---------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | no       | The entity ID of the camera to control. May be a list of multiple entity IDs. To target all cameras, set entity ID to `all`. |
 
-### Action `goto_preset`
+### Action `amcrest.goto_preset`
 
 This action will cause the camera to move to one of the <abbr title="pan, tilt, and zoom">PTZ</abbr> locations configured within the camera.
 
@@ -238,7 +238,7 @@ This action will cause the camera to move to one of the <abbr title="pan, tilt, 
 | `entity_id`            | no       | The entity ID of the camera to control. May be a list of multiple entity IDs. To target all cameras, set entity ID to `all`. |
 | `preset`               | no       | Preset number, starting from 1.                                                                                              |
 
-### Action `set_color_bw`
+### Action `amcrest.set_color_bw`
 
 This action will set the color mode of the camera.
 
@@ -247,7 +247,7 @@ This action will set the color mode of the camera.
 | `entity_id`            | no       | The entity ID of the camera to control. May be a list of multiple entity IDs. To target all cameras, set entity ID to `all`. |
 | `color_bw`             | no       | One of `auto`, `bw` or `color`.                                                                                              |
 
-### Action `start_tour`/`stop_tour`
+### Action `amcrest.start_tour`/`amcrest.stop_tour`
 
 These actions start or stop the camera's <abbr title="pan, tilt, and zoom">PTZ</abbr> tour function.
 
@@ -255,7 +255,7 @@ These actions start or stop the camera's <abbr title="pan, tilt, and zoom">PTZ</
 | ---------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | no       | The entity ID of the camera to control. May be a list of multiple entity IDs. To target all cameras, set entity ID to `all`. |
 
-### Action `ptz_control`
+### Action `amcrest.ptz_control`
 
 If your Amcrest or Dahua camera supports <abbr title="pan, tilt, and zoom">PTZ</abbr>, you will be able to pan, tilt or zoom your camera.  
 

--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -112,7 +112,7 @@ Some devices, such as the Insignia F30 series, disappear from the network when t
 
 ## Actions
 
-### `media_player.select_source`
+### Action `media_player.select_source`
 
 You can launch an app on your device using the `media_player.select_source` command. Simply provide the app ID as the `source`.  You can also stop an app by prefixing the app ID with a `!`. For example, you could define [scripts](/docs/scripts) to start and stop Netflix as follows:
 
@@ -134,7 +134,7 @@ stop_netflix:
       source: "!com.netflix.ninja"
 ```
 
-### `androidtv.adb_command`
+### Action `androidtv.adb_command`
 
 The `androidtv.adb_command` action allows you to send either keys or ADB shell commands to your Android / Fire TV device. If there is any output, it will be stored in the `'adb_response'` attribute (i.e., `state_attr('media_player.android_tv_living_room', 'adb_response')` in a template) and logged at the INFO level.
 
@@ -173,7 +173,7 @@ You can also use the command `GET_PROPERTIES` to retrieve the properties used by
 
 A list of various intents can be found [here](https://gist.github.com/mcfrojd/9e6875e1db5c089b1e3ddeb7dba0f304).
 
-### `androidtv.learn_sendevent` (for faster ADB commands)
+### Action `androidtv.learn_sendevent` (for faster ADB commands)
 
 When sending commands like UP, DOWN, HOME, etc. via ADB, the device can be slow to respond. The problem isn't ADB, but rather the Android command `input` that is used to perform those actions. A faster way to send these commands is using the Android `sendevent` command. The challenge is that these commands are device-specific. To assist users in learning commands for their device, the Android debug bridge integration provides the `androidtv.learn_sendevent` action. Its usage is as follows:
 
@@ -207,7 +207,7 @@ to this:
     command: "sendevent /dev/input/event4 4 4 786979 && sendevent /dev/input/event4 1 172 1 && sendevent /dev/input/event4 0 0 0 && sendevent /dev/input/event4 4 4 786979 && sendevent /dev/input/event4 1 172 0 && sendevent /dev/input/event4 0 0 0"
 ```
 
-### `androidtv.download` and `androidtv.upload`
+### Action `androidtv.download` and `androidtv.upload`
 
 You can use the `androidtv.download` action to download a file from your Android / Fire TV device to your Home Assistant instance.
 

--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -112,6 +112,8 @@ Some devices, such as the Insignia F30 series, disappear from the network when t
 
 ## Actions
 
+The integration provides the following actions.
+
 ### Action `media_player.select_source`
 
 You can launch an app on your device using the `media_player.select_source` command. Simply provide the app ID as the `source`.  You can also stop an app by prefixing the app ID with a `!`. For example, you could define [scripts](/docs/scripts) to start and stop Netflix as follows:

--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -109,7 +109,7 @@ The following commands are currently available:
 
 **NOTE:** Not all commands are supported by all Apple TV versions.
 
-### Action `send_command`
+### Action `remote.send_command`
 
 | Service data<br>attribute | Optional | Description                                                                                                                   |
 | ------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |

--- a/source/_integrations/backup.markdown
+++ b/source/_integrations/backup.markdown
@@ -38,7 +38,7 @@ process.
 
 However, it is no longer needed to create your own automation. Follow these steps to [set up an automatic backup from the UI](/common-tasks/general/#setting-up-an-automatic-backup-process).
 
-### Action backup.create_automatic
+### Action `backup.create_automatic`
 
 The {% my developer_call_service service="backup.create_automatic" %} action can be used
 to create a backup of your Home Assistant instance.
@@ -56,7 +56,7 @@ Example action:
 action: backup.create_automatic
 ```
 
-### Action backup.create
+### Action `backup.create`
 
 The {% my developer_call_service service="backup.create" %} action can be used
 to create a backup of your Home Assistant instance.

--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -115,7 +115,7 @@ And more advanced app-centric features such as:
 
 ## Actions
 
-### `play_media` actions
+### Action `media_player.play_media`
 
 The Bang & Olufsen integration supports different playback types in the `media_player.play_media` action: playback from URL, activating a favorite, playback from a local file, playing a radio station, activating a Deezer flow and Deezer playlists, albums, tracks, and playing files and text-to-speech (TTS) as an overlay.
 

--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -115,7 +115,7 @@ And more advanced app-centric features such as:
 
 ## Actions
 
-### play_media actions
+### `play_media` actions
 
 The Bang & Olufsen integration supports different playback types in the `media_player.play_media` action: playback from URL, activating a favorite, playback from a local file, playing a radio station, activating a Deezer flow and Deezer playlists, albums, tracks, and playing files and text-to-speech (TTS) as an overlay.
 
@@ -319,7 +319,7 @@ The Bang & Olufsen integration additionally supports different custom actions fo
 
 Attempting to execute an invalid Beolink action will result in either a Home Assistant error or an audible error indication from your device.
 
-#### `bang_olufsen.beolink_join`
+#### Action `bang_olufsen.beolink_join`
 
 Join a Beolink experience.
 
@@ -378,7 +378,7 @@ A limited selection of `source_id`s are available. The below table shows which `
 | Mozart                  | `tidal`                                    |
 | Beolink Converter NL/ML | `radio`, `tp1`, `tp2`, `cd`, `aux_a`, `ph` |
 
-#### `bang_olufsen.beolink_expand`
+#### Action `bang_olufsen.beolink_expand`
 
 Expand current Beolink experience.
 
@@ -443,7 +443,7 @@ data:
     - media_player.beosound_balance_66666666
 ```
 
-#### `bang_olufsen.beolink_unexpand`
+#### Action `bang_olufsen.beolink_unexpand`
 
 Unexpand from current Beolink experience.
 
@@ -474,7 +474,7 @@ data:
     - 4444.5555555.66666666@products.bang-olufsen.com
 ```
 
-#### `bang_olufsen.beolink_leave`
+#### Action `bang_olufsen.beolink_leave`
 
 Leave a Beolink experience.
 
@@ -494,7 +494,7 @@ target:
   entity_id: media_player.beosound_balance_12345678
 ```
 
-#### `bang_olufsen.beolink_allstandby`
+#### Action `bang_olufsen.beolink_allstandby`
 
 Set all connected Beolink devices to standby.
 

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -62,15 +62,15 @@ Please note that each camera reports two different states: one as `sensor.blink_
 
 Any sequential calls to {% term actions %} relating to blink should have a minimum of a 5 second delay in between them to prevent the calls from being throttled and ignored. The actions that act on a camera needs a target parameter.
 
-### `blink.record`
+### Action `blink.record`
 
 Trigger a camera to record a new video clip.
 
-### `blink.trigger_camera`
+### Action `blink.trigger_camera`
 
 Trigger a camera to take a new still image.
 
-### `blink.save_video`
+### Action `blink.save_video`
 
 Save the last recorded video of a camera to a local file. Note that in most cases, Home Assistant will need to know that the directory is writable via the `allowlist_external_dirs` in your {% term "`configuration.yaml`" %} file (see example below).
 
@@ -84,7 +84,8 @@ homeassistant:
     - '/tmp'
     - '/path/to/whitelist'
 ```
-### `blink.save_recent_clips`
+
+### Action `blink.save_recent_clips`
 
 Save the recent video clips of a camera to a local file in the pattern `%Y%m%d_%H%M%S_{name}.mp4`. Note that in most cases, Home Assistant will need to know that the directory is writable via the `allowlist_external_dirs` in your {% term "`configuration.yaml`" %} file.
 
@@ -92,7 +93,7 @@ Save the recent video clips of a camera to a local file in the pattern `%Y%m%d_%
 | ---------------------- | -------- | ----------------------- |
 | `file_path`            | no       | Location of save files. |
 
-### `blink.send_pin`
+### Action `blink.send_pin`
 
 Send a new pin to blink.  Since Blink's 2FA implementation is new and changing, this is to allow the integration to continue to work with user intervention.  The intent is to handle all of this behind the scenes, but until the login implementation is settled this was added. To use it, perform the action with the pin you receive from Blink as the payload (for a simple "Allow this Device" email, you may keep the `pin` value empty).
 

--- a/source/_integrations/blue_current.markdown
+++ b/source/_integrations/blue_current.markdown
@@ -81,9 +81,10 @@ The Blue Current integration provides the following buttons:
 - Stop charge session
 
 ## Actions
+
 The following actions are provided by the Blue Current integration:
 
-### Action start_charge_session
+### Action `blue_current.start_charge_session`
 
 Starts a new charge session. When no charging card ID is provided, no charging card will be used.
 

--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -63,6 +63,8 @@ upgrade your firmware from Bond app before adding this integration.
 Firmware version 2.10.8 or newer is required for push updates. The integration
 will fallback to polling for 2.10.x versions lower than .8
 
+## Actions
+
 ### Action `bond.set_fan_speed_tracked_state`
 
 Sets the tracked fan speed for a bond fan.

--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -65,6 +65,8 @@ will fallback to polling for 2.10.x versions lower than .8
 
 ## Actions
 
+The integration provides the following actions.
+
 ### Action `bond.set_fan_speed_tracked_state`
 
 Sets the tracked fan speed for a bond fan.

--- a/source/_integrations/bosch_alarm.markdown
+++ b/source/_integrations/bosch_alarm.markdown
@@ -111,7 +111,7 @@ Three switches are added per door, which allow for locking, securing, or momenta
 
 The integration provides the following actions.
 
-### Action: Set panel date and time
+### Action `bosch_alarm.set_date_time`
 
 The `bosch_alarm.set_date_time` action is used to update the date and time on the panel.
 

--- a/source/_integrations/bring.markdown
+++ b/source/_integrations/bring.markdown
@@ -81,7 +81,7 @@ Password:
 
 You can use the actions from the [to-do list](/integrations/todo/) to create, update, or delete items on your Bring! shopping lists.
 
-### Notifications
+### Action `bring.send_message`
 
 The **Bring!** integration offers an action to send push notifications to the Bring! mobile apps of other members of a shared shopping list. The Bring! mobile app has 4 predefined notification types.
 
@@ -148,7 +148,7 @@ actions:
 
 {% enddetails %}
 
-### Action: Send reaction
+### Action `bring.send_reaction`
 
 Reactions in **Bring!** let users quickly acknowledge shopping list updates with emojis. The action `bring.send_reaction` in Home Assistant allows sending reactions like 👍 or ❤️ to the latest event from the [Activities entity](#events).
 

--- a/source/_integrations/browser.markdown
+++ b/source/_integrations/browser.markdown
@@ -25,11 +25,13 @@ To load this integration, add the following lines to your {% term "`configuratio
 browser:
 ```
 
-### Actions
+## Actions
 
 Once loaded, the `browser` platform will expose {% term actions %} that can be called to perform various {% term actions %}.
 
-Available actions: `browser/browse_url`.
+### Action `browser.browse_url`
+
+This will open the given URL on the host machine.
 
 | Data attribute | Optional | Description      |
 | ---------------------- | -------- | ---------------- |
@@ -42,5 +44,3 @@ To use this {% term action %}, select the **Actions** tab from the **Developer T
 ```json
 {"url": "http://www.google.com"}
 ```
-
-This will open the given URL on the host machine.

--- a/source/_integrations/camera.markdown
+++ b/source/_integrations/camera.markdown
@@ -43,9 +43,7 @@ A camera can have the following states. Not all camera integrations support all 
 
 Once loaded, the `camera` platform will expose actions that can be called to perform various actions.
 
-Available actions: `enable_motion_detection`, `disable_motion_detection`, `play_stream`, `record`, `snapshot`, `turn_off` and `turn_on`.
-
-### Action `enable_motion_detection`
+### Action `camera.enable_motion_detection`
 
 Enable the motion detection in a camera.
 
@@ -53,7 +51,7 @@ Enable the motion detection in a camera.
 | -------------- | -------- | ---------------------------------------------------------------------------------- |
 | `entity_id`    | yes      | Name(s) of entities to enable motion detection, e.g., `camera.living_room_camera`. |
 
-### Action `disable_motion_detection`
+### Action `camera.disable_motion_detection`
 
 Disable the motion detection in a camera.
 
@@ -61,7 +59,7 @@ Disable the motion detection in a camera.
 | -------------- | -------- | ----------------------------------------------------------------------------------- |
 | `entity_id`    | yes      | Name(s) of entities to disable motion detection, e.g., `camera.living_room_camera`. |
 
-### Action `play_stream`
+### Action `camera.play_stream`
 
 Play a live stream from a camera to selected media player(s). Requires [`stream`](/integrations/stream) integration to be set up.
 
@@ -82,7 +80,7 @@ actions:
       media_player: media_player.chromecast
 ```
 
-### Action `record`
+### Action `camera.record`
 
 Make a `.mp4` recording from a camera stream. Requires `stream` integration to be set up.
 
@@ -114,7 +112,7 @@ actions:
 
 {% endraw %}
 
-### Action `snapshot`
+### Action `camera.snapshot`
 
 Take a snapshot from a camera.
 
@@ -142,7 +140,7 @@ actions:
 
 {% endraw %}
 
-### Action `turn_off`
+### Action `camera.turn_off`
 
 Turn off camera. Not all camera models support this action, please consult individual camera page.
 
@@ -150,7 +148,7 @@ Turn off camera. Not all camera models support this action, please consult indiv
 | -------------- | -------- | ------------------------------------------------------------------- |
 | `entity_id`    | yes      | Name(s) of entities to turn off, e.g., `camera.living_room_camera`. |
 
-### Action `turn_on`
+### Action `camera.turn_on`
 
 Turn on camera. Not all camera models support this action, please consult individual camera page.
 

--- a/source/_integrations/channels.markdown
+++ b/source/_integrations/channels.markdown
@@ -49,7 +49,9 @@ name:
   type: string
 {% endconfiguration %}
 
-### Action `seek_forward`
+## Actions
+
+### Action `media_player.seek_forward`
 
 Seek forward by the number of seconds currently set in settings on the instance of Channels.
 
@@ -57,7 +59,7 @@ Seek forward by the number of seconds currently set in settings on the instance 
 | ---------------------- | -------- | -------------------------------------------------- |
 | `entity_id`            | no       | String that points at `entity_id` of Channels app. |
 
-### Action `seek_backward`
+### Action `media_player.seek_backward`
 
 Seek backward by the number of seconds currently set in settings on the instance of Channels.
 
@@ -65,7 +67,7 @@ Seek backward by the number of seconds currently set in settings on the instance
 | ---------------------- | -------- | -------------------------------------------------- |
 | `entity_id`            | no       | String that points at `entity_id` of Channels app. |
 
-### Action `seek_by`
+### Action `media_player.seek_by`
 
 Seek forward or backward by a provided number of seconds.
 

--- a/source/_integrations/channels.markdown
+++ b/source/_integrations/channels.markdown
@@ -51,6 +51,8 @@ name:
 
 ## Actions
 
+The integration provides the following actions.
+
 ### Action `media_player.seek_forward`
 
 Seek forward by the number of seconds currently set in settings on the instance of Channels.

--- a/source/_integrations/duckdns.markdown
+++ b/source/_integrations/duckdns.markdown
@@ -44,7 +44,7 @@ duckdns:
     type: string
 {% endconfiguration %}
 
-## Action `set_txt`
+## Action `duckdb.set_txt`
 
 Set the TXT record of your DuckDNS subdomain.
 

--- a/source/_integrations/file.markdown
+++ b/source/_integrations/file.markdown
@@ -31,9 +31,9 @@ file:
   
 {% include integrations/config_flow.md %}
 
-## Action: Read file
+## Action `file.read_file`
 
-The `file.read_file` action reads a file and returns the data in a response.
+The action reads a file and returns the data in a response.
 
 | Data attribute | Optional | Description |
 | -------------- | -------- | ----------- |

--- a/source/_integrations/flo.markdown
+++ b/source/_integrations/flo.markdown
@@ -32,18 +32,18 @@ There is currently support for the following device types within Home Assistant:
 
 ## Actions
 
-### `flo.run_health_test`
+### Action `flo.run_health_test`
 
 Run a health test for the Flo device.
 
-### `flo.set_away_mode`
+### Action `flo.set_away_mode`
 
 Set the Flo device to away mode.
 
-### `flo.set_home_mode`
+### Action `flo.set_home_mode`
 
 Set the Flo device to home mode.
 
-### `flo.set_sleep_mode`
+### Action `flo.set_sleep_mode`
 
 Set the Flo device to sleep mode.

--- a/source/_integrations/flo.markdown
+++ b/source/_integrations/flo.markdown
@@ -32,6 +32,8 @@ There is currently support for the following device types within Home Assistant:
 
 ## Actions
 
+The integration provides the following actions.
+
 ### Action `flo.run_health_test`
 
 Run a health test for the Flo device.

--- a/source/_integrations/frontend.markdown
+++ b/source/_integrations/frontend.markdown
@@ -161,7 +161,7 @@ There are two themes-related actions:
 - `frontend.reload_themes`: Reloads theme configuration from your {% term "`configuration.yaml`" %} file.
 - `frontend.set_theme`: Sets backend-preferred theme name.
 
-### Action `set_theme`
+### Action `frontend.set_theme`
 
 | Data attribute | Description                                                                                         |
 | -------------- | --------------------------------------------------------------------------------------------------- |

--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -101,6 +101,8 @@ The Fully Kiosk Browser app does not provide feedback on the device volume or me
 
 ## Actions
 
+The integration provides the following actions.
+
 ### Action `fully_kiosk.load_url`
 
 You can use the `fully_kiosk.load_url` action to have the tablet open the specified URL.

--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -101,7 +101,7 @@ The Fully Kiosk Browser app does not provide feedback on the device volume or me
 
 ## Actions
 
-**Action `load_url`**
+### Action `fully_kiosk.load_url`
 
 You can use the `fully_kiosk.load_url` action to have the tablet open the specified URL.
 
@@ -120,7 +120,7 @@ target:
   device_id: a674c90eca95eca91f6020415de07713
 ```
 
-**Action `set_config`**
+### Action `fully_kiosk.set_config`
 
 You can use the `fully_kiosk.set_config` action to change the many configuration parameters of Fully Kiosk Browser.
 
@@ -141,7 +141,7 @@ target:
   device_id: a674c90eca95eca91f6020415de07713
 ```
 
-**Action `start_application`**
+### Action `fully_kiosk.start_application`
 
 You can use the `fully_kiosk.start_application` action to have the tablet launch the specified app.
 

--- a/source/_integrations/google.markdown
+++ b/source/_integrations/google.markdown
@@ -80,6 +80,10 @@ Using the entity state and attributes is more error prone and less flexible than
 
 {% enddetails %}
 
+## Actions
+
+The integration provides the following action.
+
 ### Action `google.create_event`
 
 You can use the `google.create_event` action to create a new calendar event in a calendar.

--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -110,7 +110,7 @@ text_type:
   default: "text"
 {% endconfiguration %}
 
-### Action speak
+### Action `tts.speak`
 
 The `tts.speak` action is the modern way to use Google Cloud TTS action. Add the `speak` action, select the entity for your Google Cloud TTS, select the media player entity or group to send the TTS audio to, and enter the message to speak.
 
@@ -140,7 +140,7 @@ data:
       - wearable-class-device
 ```
 
-## Action say (legacy)
+## Action `tts.google_cloud_say` (legacy)
 
 The `tts.google_cloud_say` action can be used when configuring the legacy `google_cloud` text-to-speech platform in `configuration.yaml`. We recommend new users to instead set up the integration in the UI and use the `tts.speak` action with the corresponding Google Cloud text-to-speech entity as target. If you are an existing user of `tts.google_cloud_say`, you can still use it but don't remove the legacy `google_cloud` text-to-speech platform in `configuration.yaml`. If you remove it, you will have to manually migrate to `tts.speak`.
 

--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -143,7 +143,7 @@ The tutorial is using OpenAI, but this could also be done with the Google Gemini
 
 ## Actions
 
-### Generate content
+### Action `google_generative_ai_conversation.generate_content`
 
 {% tip %}
 This action isn't tied to any integration entry, so it won't use the model, prompt, or any of the other settings in your options. If you only want to pass text, you should use the `conversation.process` action.

--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -143,6 +143,8 @@ The tutorial is using OpenAI, but this could also be done with the Google Gemini
 
 ## Actions
 
+The integration provides the following actions.
+
 ### Action `google_generative_ai_conversation.generate_content`
 
 {% tip %}
@@ -194,7 +196,7 @@ response_variable: generated_content
 
 {% endraw %}
 
-### Speak
+### Action `tts.speak`
 
 The `tts.speak` action is the modern way to use TTS. Add the `speak` action, select the Google Gemini TTS entity, select the media player entity or group to send the TTS audio to, and enter the message to speak.
 

--- a/source/_integrations/google_sheets.markdown
+++ b/source/_integrations/google_sheets.markdown
@@ -45,6 +45,8 @@ This video tutorial explains how to set up the Google Sheets integration and how
 
 <lite-youtube videoid="hgGMgoxLYwo" videotitle="How to use Google Sheets in Home Assistant - TUTORIAL" posterquality="maxresdefault"></lite-youtube>
 
+## Actions
+
 ### Action `google_sheets.append_sheet`
 
 You can use the `google_sheets.append_sheet` action to add rows of data to the Sheets document created at setup.
@@ -87,7 +89,7 @@ data:
 {% enddetails %}
 
 
-### Action: Get sheet
+### Action `google_sheets.get_sheet`
 
 You can use the `google_sheets.get_sheet` action to retrieve rows of [data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) from a Sheets document.
 

--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -130,7 +130,7 @@ data:
   message: Hello, can you hear me now?
 ```
 
-## Action `tts.google_translate_say` (legacy)
+### Action `tts.google_translate_say` (legacy)
 
 {% tip %}
 The `google_translate_say` action can be used when configuring the legacy `google_translate` text-to-speech platform in `configuration.yaml`. We recommend new users to instead set up the integration in the UI and use the `tts.speak` action with the corresponding Google Translate text-to-speech entity as target.

--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -112,8 +112,9 @@ You can also use supported BCP 47 tags like the below or the 2-2 digit format fo
 | es-es   | es       | es     |
 | es-us   | es       | com    |
 
+## Actions
 
-## Action speak
+### Action `tts.speak`
 
 The `tts.speak` action is the modern way to use Google translate TTS action. Add the `speak` action, select the entity for your Google translate TTS (it's named for the language you created it with), select the media player entity or group to send the TTS audio to, and enter the message to speak.
 
@@ -129,7 +130,7 @@ data:
   message: Hello, can you hear me now?
 ```
 
-## Action say (legacy)
+## Action `tts.google_translate_say` (legacy)
 
 {% tip %}
 The `google_translate_say` action can be used when configuring the legacy `google_translate` text-to-speech platform in `configuration.yaml`. We recommend new users to instead set up the integration in the UI and use the `tts.speak` action with the corresponding Google Translate text-to-speech entity as target.

--- a/source/_integrations/guardian.markdown
+++ b/source/_integrations/guardian.markdown
@@ -40,7 +40,7 @@ There is currently support for the following device types within Home Assistant:
 
 ## Actions
 
-### `guardian.pair_sensor`
+### Action `guardian.pair_sensor`
 
 Add a new paired sensor to the valve controller.
 
@@ -48,7 +48,7 @@ Add a new paired sensor to the valve controller.
 | ---------------------- | -------- | ------------------------------------------------ |
 | `uid`                    | yes      | The unique device ID on the bottom of the sensor.|
 
-### `guardian.unpair_sensor`
+### Action `guardian.unpair_sensor`
 
 Remove a paired sensor from the valve controller.
 
@@ -56,7 +56,7 @@ Remove a paired sensor from the valve controller.
 | ---------------------- | -------- | ------------------------------------------------ |
 | `uid`                    | yes      | The unique device ID on the bottom of the sensor.|
 
-### `guardian.upgrade_firmware`
+### Action `guardian.upgrade_firmware`
 
 Upgrade the device firmware.
 

--- a/source/_integrations/guardian.markdown
+++ b/source/_integrations/guardian.markdown
@@ -40,6 +40,8 @@ There is currently support for the following device types within Home Assistant:
 
 ## Actions
 
+The integration provides the following actions.
+
 ### Action `guardian.pair_sensor`
 
 Add a new paired sensor to the valve controller.

--- a/source/_integrations/habitica.markdown
+++ b/source/_integrations/habitica.markdown
@@ -201,6 +201,8 @@ For details about each of these entities, see the descriptions above under [**Se
 
 ## Actions
 
+The following actions are provided by the Habitica integration:
+
 ### Action `habitica.cast_skill`
 
 Use a skill or spell from your Habitica character on a specific task to affect its progress or status.

--- a/source/_integrations/hassio.markdown
+++ b/source/_integrations/hassio.markdown
@@ -100,7 +100,7 @@ For all your installed add-ons, Home Assistant Core, Home Assistant Supervisor, 
 
 ## Actions
 
-### Action hassio.addon_start
+### Action `hassio.addon_start`
 
 Start an add-on.
 
@@ -108,7 +108,7 @@ Start an add-on.
 | ---------------------- | -------- | ----------- |
 | `addon` | no | Add-on slug
 
-### Action hassio.addon_stop
+### Action `hassio.addon_stop`
 
 Stop an add-on.
 
@@ -116,7 +116,7 @@ Stop an add-on.
 | ---------------------- | -------- | ----------- |
 | `addon` | no | Add-on slug
 
-### Action hassio.addon_restart
+### Action `hassio.addon_restart`
 
 Restart an add-on.
 
@@ -124,7 +124,7 @@ Restart an add-on.
 | ---------------------- | -------- | ----------- |
 | `addon` | no | Add-on slug
 
-### Action hassio.addon_stdin
+### Action `hassio.addon_stdin`
 
 Write data to add-on stdin.
 
@@ -132,15 +132,15 @@ Write data to add-on stdin.
 | ---------------------- | -------- | ----------- |
 | `addon` | no | Add-on slug
 
-### Action hassio.host_reboot
+### Action `hassio.host_reboot`
 
 Reboot the host system.
 
-### Action hassio.host_shutdown
+### Action `hassio.host_shutdown`
 
 Shutdown the host system.
 
-### Action hassio.backup_full
+### Action `hassio.backup_full`
 
 Create a full backup.
 
@@ -152,7 +152,7 @@ Create a full backup.
 | `location` | yes | Alternate backup location instead of using the default location for backups
 | `homeassistant_exclude_database` | yes | Exclude the Home Assistant database file from backup
 
-### Action hassio.backup_partial
+### Action `hassio.backup_partial`
 
 Create a partial backup.
 
@@ -167,7 +167,7 @@ Create a partial backup.
 | `homeassistant` | yes | Include Home Assistant and associated config in backup
 | `homeassistant_exclude_database` | yes | Exclude the Home Assistant database file from backup
 
-### Action hassio.restore_full
+### Action `hassio.restore_full`
 
 Restore from full backup.
 
@@ -176,7 +176,7 @@ Restore from full backup.
 | `slug` | no | Slug of backup to restore from
 | `password` | yes | Optional password for backup
 
-### Action hassio.restore_partial
+### Action `hassio.restore_partial`
 
 Restore from partial backup.
 

--- a/source/_integrations/hassio.markdown
+++ b/source/_integrations/hassio.markdown
@@ -100,6 +100,8 @@ For all your installed add-ons, Home Assistant Core, Home Assistant Supervisor, 
 
 ## Actions
 
+The following actions are provided by this integration:
+
 ### Action `hassio.addon_start`
 
 Start an add-on.

--- a/source/_integrations/hdmi_cec.markdown
+++ b/source/_integrations/hdmi_cec.markdown
@@ -152,7 +152,7 @@ hdmi_cec:
 
 ## Actions
 
-### Select Device
+### Action `hdmi_cec.select_device`
 
 Use the `hdmi_cec.select_device` action with the name of the device from configuration or entity_id or physical address"to select it, for example:
 
@@ -177,7 +177,7 @@ actions:
       device: Chromecast
 ```
 
-### Power On
+### `hdmi_cec.power_on`
 
 Use the `hdmi_cec.power_on` action (no arguments) to power on any devices that support this function.
 
@@ -188,7 +188,7 @@ actions:
   - action: hdmi_cec.power_on
 ```
 
-### Standby
+### Action `hdmi_cec.standby`
 
 Use the `hdmi_cec.standby` action (no arguments) to place in standby any devices that support this function.
 
@@ -199,9 +199,9 @@ actions:
   - action: hdmi_cec.standby
 ```
 
-### Change volume level
+### Action `hdmi_cec.volume`
 
-Use the `hdmi_cec.volume` action with one of following commands:
+To change volume level, use the `hdmi_cec.volume` action with one of following commands:
 
 #### Volume up
 

--- a/source/_integrations/hdmi_cec.markdown
+++ b/source/_integrations/hdmi_cec.markdown
@@ -152,6 +152,8 @@ hdmi_cec:
 
 ## Actions
 
+The following actions are provided by this integration:
+
 ### Action `hdmi_cec.select_device`
 
 Use the `hdmi_cec.select_device` action with the name of the device from configuration or entity_id or physical address"to select it, for example:

--- a/source/_integrations/hive.markdown
+++ b/source/_integrations/hive.markdown
@@ -49,6 +49,8 @@ Menu: *Configuration* > *Integrations* > *Select your new integration* > *Press 
   
 ## Actions
 
+The following actions are provided by this integration:
+
 ### Action `hive.boost_heating_on`
 
 You can use the action `hive.boost_heating_on` to set your heating to boost for a period of time at a certain target temperature". Individual TRVs can also be boosted in the same way, using this action.

--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -295,6 +295,8 @@ To get the `homematic.keypress` event for some Homematic IP devices like WRC2 / 
 
 ### Actions
 
+The following actions are provided by this integration:
+
 ### Action `homematic.virtualkey`
 
 Simulate a keypress (or other valid action) on CCU/Homegear with device or virtual keys.

--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -295,11 +295,25 @@ To get the `homematic.keypress` event for some Homematic IP devices like WRC2 / 
 
 ### Actions
 
-- *homematic.virtualkey*: Simulate a keypress (or other valid action) on CCU/Homegear with device or virtual keys.
-- *homematic.reconnect*: Reconnect to CCU/Homegear without restarting Home Assistant (useful when CCU has been restarted)
-- *homematic.set_variable_value*: Set the value of a system variable.
-- *homematic.set_device_value*: Control a device manually (even devices without support). Equivalent to setValue-method from XML-RPC.
-- *homematic.put_paramset*: Manually change a device's paramset (even devices without support). Equivalent to putParamset-method from XML-RPC.
+### Action `homematic.virtualkey`
+
+Simulate a keypress (or other valid action) on CCU/Homegear with device or virtual keys.
+
+### Action `homematic.reconnect`
+
+Reconnect to CCU/Homegear without restarting Home Assistant (useful when CCU has been restarted)
+
+### Action `homematic.set_variable_value`
+
+Set the value of a system variable.
+
+### Action `homematic.set_device_value`
+
+Control a device manually (even devices without support). Equivalent to setValue-method from XML-RPC.
+
+### Action `homematic.put_paramset`
+
+Manually change a device's paramset (even devices without support). Equivalent to putParamset-method from XML-RPC.
 
 #### Examples
 

--- a/source/_integrations/homeworks.markdown
+++ b/source/_integrations/homeworks.markdown
@@ -31,7 +31,7 @@ The protocol for automatically extracting device information from the controller
 
 ## Actions
 
-### Action `send_command`
+### Action `homeworks.send_command`
 
 Send a custom command to the Lutron Homeworks controller.
 

--- a/source/_integrations/homeworks.markdown
+++ b/source/_integrations/homeworks.markdown
@@ -31,6 +31,8 @@ The protocol for automatically extracting device information from the controller
 
 ## Actions
 
+The following actions are provided by this integration:
+
 ### Action `homeworks.send_command`
 
 Send a custom command to the Lutron Homeworks controller.

--- a/source/_integrations/husqvarna_automower.markdown
+++ b/source/_integrations/husqvarna_automower.markdown
@@ -214,7 +214,7 @@ The integration will create a switch for each work area defined for your mower. 
 
 The integration offers the following actions:
 
-### Override schedule
+### Action `husqvarna_automower.override_schedule`
 
 With this action, you can let your mower mow or park for a given time. You can select the override mode with the `override_mode´ attribute. This will override all your schedules during this time. The duration can be given in days, hours and/or minutes. The values for the duration have to be between 1 minute and 42 days. Seconds will be ignored.
 
@@ -231,7 +231,7 @@ data:
   override_mode: mow  ### alternative: `park`
 ```
 
-### Override schedule work area (if available)
+### Action `husqvarna_automower.override_schedule_work_area`
 
 With this action, you can let your mower mow for a given time in a certain work area. You can enter the work area with the `work_area_id` attribute. You can get the `work_area_id` from the `Work area` sensor.
 ![Work area sensor](/images/integrations/husqvarna_automower/work_area_sensor.png)

--- a/source/_integrations/image.markdown
+++ b/source/_integrations/image.markdown
@@ -28,9 +28,9 @@ In addition, the entity can have the following states:
 
 Once loaded, the `image` platform will expose services that can be called to perform various actions.
 
-Available services: `snapshot`.
+Available services: `image.snapshot`.
 
-#### Action `snapshot`
+#### Action `image.snapshot`
 
 Take a snapshot from an image.
 

--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -173,18 +173,22 @@ template:
 
 {% endraw %}
 
-### Actions for post-processing
+## Actions
 
 The IMAP integration has some actions for post-pressing email messages. The actions are intended to be used in automations as actions after an "imap_content" event. The actions require the IMAP `entry_id` and the `uid` of the message's event data. You can use a template for the `entry_id` and the `uid`. When the action is set up as a trigger action, you can easily select the correct entry from the UI. You will find the `entry_id` in YAML mode. It is highly recommended you filter the events by the `entry_id`.
 
-#### Action `seen` - Mark the message as seen
+### Action `imap.seen`
+
+Mark the message as seen
 
 | Data attribute | Type | Optional | Description |
 | -- | -- | -- | -- |
 | `entry_id` | string | no | The IMAP config entry ID. |
 | `uid` | string |  no | The `uid` of the message to be marked as "seen". To be found in the message's event data. |
 
-#### Action `move` - Move the IMAP message
+### Action `imap.move`
+
+Move the IMAP message
 
 | Data attribute | Type | Optional | Description |
 | -- | -- | -- | -- |
@@ -193,7 +197,9 @@ The IMAP integration has some actions for post-pressing email messages. The acti
 | `target_folder` | string | no | The name of the target folder, for example `INBOX.Trash` where the message should be moved to. |
 | `seen` | boolean | yes | If set to `true` this will mark the message as "seen". |
 
-#### Action `delete` - Delete the IMAP message
+### Action `imap.delete`
+
+Delete the IMAP message
 
 | Data attribute | Type | Optional | Description |
 | -- | -- | -- | -- |
@@ -204,7 +210,9 @@ The IMAP integration has some actions for post-pressing email messages. The acti
 When these actions are used in an automation, make sure the right triggers and filtering are set up. When messages are deleted or modified, they cannot be recovered. When multiple IMAP entries are set up, make sure the messages are filtered by the `entry_id` as well to ensure the correct messages are processed. Do not use these actions unless you know what you are doing.
 {% endcaution %}
 
-#### Action `fetch` - Fetch the an IMAP message
+### Action `imap.fetch`
+
+Fetch the an IMAP message
 
 Fetches the text body and retrieves metadata about the parts inside the IMAP message.
 
@@ -213,7 +221,7 @@ Fetches the text body and retrieves metadata about the parts inside the IMAP mes
 | `entry_id` | string | no | The IMAP config entry ID. |
 | `uid` | string |  no | The `uid` of the message to be marked as seen. To be found in the message's event data. |
 
-##### Return values for the `fetch` action
+#### Return values for the `fetch` action
 
 {% configuration_basic %}
 text:
@@ -236,7 +244,7 @@ parts:
       description: The file name of the message. The file name is only available if it is available.
 {% endconfiguration_basic %}
 
-##### Example of `parts` data in the return variable for a multipart message:
+#### Example of `parts` data in the return variable for a multipart message:
 
 ```json
 {
@@ -256,7 +264,9 @@ parts:
 }
 ```
 
-#### Action `fetch_part` - Fetch a part or attachement from an IMAP message
+### Action `imap.fetch_part`
+
+Fetch a part or attachment from an IMAP message
 
 | Data attribute | Type | Optional | Description |
 | -- | -- | -- | -- |
@@ -264,7 +274,7 @@ parts:
 | `uid` | string |  no | The `uid` of the message to be marked as seen. To be found in the message's event data. |
 | `part` | string |  no | The index of the message part that is to be returned. Use the `part` info in the message's event data or from the `fetch` action, to receive the available parts. |
 
-##### Return values for the `fetch_part` action
+#### Return values for the `fetch_part` action
 
 {% configuration_basic %}
 part_data:

--- a/source/_integrations/immich.markdown
+++ b/source/_integrations/immich.markdown
@@ -87,7 +87,7 @@ An {% term update %} entity is created to inform about a new available Immich se
 
 ## Actions
 
-### Upload file
+### Action `immich.upload_file`
 
 This action allows you to upload a media file to your Immich instance. It takes the following arguments:
 

--- a/source/_integrations/immich.markdown
+++ b/source/_integrations/immich.markdown
@@ -87,6 +87,8 @@ An {% term update %} entity is created to inform about a new available Immich se
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `immich.upload_file`
 
 This action allows you to upload a media file to your Immich instance. It takes the following arguments:

--- a/source/_integrations/insteon.markdown
+++ b/source/_integrations/insteon.markdown
@@ -191,12 +191,29 @@ automation:
 
 The following actions are available:
 
-- **insteon.add_all_link**: Puts the Insteon Modem (IM) into All-Linking mode. The IM can be set as a controller or a responder. If the IM is a controller, put the IM into linking mode then press the SET button on the device. If the IM is a responder, press the SET button on the device then put the IM into linking mode.
-- **insteon.delete_all_link**: Tells the Insteon Modem (IM) to remove an All-Link record from the All-Link Database of the IM and a device. Once the IM is set to delete the link, press the SET button on the corresponding device to complete the process.
-- **insteon.load_all_link_database**: Load the All-Link Database for a device. WARNING - Loading a device All-Link database may take a LONG time and may need to be repeated to obtain all records.
-- **insteon.print_all_link_database**: Print the All-Link Database for a device. Requires that the All-Link Database is loaded first.
-- **insteon.print_im_all_link_database**: Print the All-Link Database for the Insteon Modem (IM).
-- **insteon.add_default_links**: Add a set of default links between the modem and the device to facilitate proper communication between them.
+### Action `insteon.add_all_link`
+
+Puts the Insteon Modem (IM) into All-Linking mode. The IM can be set as a controller or a responder. If the IM is a controller, put the IM into linking mode then press the SET button on the device. If the IM is a responder, press the SET button on the device then put the IM into linking mode.
+
+### Action  `insteon.delete_all_link`
+
+Tells the Insteon Modem (IM) to remove an All-Link record from the All-Link Database of the IM and a device. Once the IM is set to delete the link, press the SET button on the corresponding device to complete the process.
+
+### Action  `insteon.load_all_link_database`
+
+Load the All-Link Database for a device. WARNING - Loading a device All-Link database may take a LONG time and may need to be repeated to obtain all records.
+
+### Action  `insteon.print_all_link_database` 
+
+Print the All-Link Database for a device. Requires that the All-Link Database is loaded first.
+
+### Action  `insteon.print_im_all_link_database`
+
+Print the All-Link Database for the Insteon Modem (IM).
+
+### Action  `insteon.add_default_links`
+
+ Add a set of default links between the modem and the device to facilitate proper communication between them.
 
 ## Device overrides
 

--- a/source/_integrations/intent_script.markdown
+++ b/source/_integrations/intent_script.markdown
@@ -127,7 +127,7 @@ intent_script:
 
 ## Actions
 
-The integration offers the following actions:
+The integration offers the following action:
 
 ### Action `intent_script.reload`
 

--- a/source/_integrations/intent_script.markdown
+++ b/source/_integrations/intent_script.markdown
@@ -127,7 +127,7 @@ intent_script:
 
 ## Actions
 
-Available actions: `reload`.
+The integration offers the following actions:
 
 ### Action `intent_script.reload`
 

--- a/source/_integrations/iperf3.markdown
+++ b/source/_integrations/iperf3.markdown
@@ -116,6 +116,8 @@ You can use the `sensor.iperf3_update` action to trigger a manual speed test for
 
 ## Action
 
+### Action `iperf3.speedtest`
+
 Once loaded, the `iperf3` integration will expose an action (`iperf3.speedtest`) that can be called to run a speed test on demand. This can be useful if you have enabled manual mode.
 
 | Data attribute | Description |

--- a/source/_integrations/izone.markdown
+++ b/source/_integrations/izone.markdown
@@ -125,6 +125,8 @@ This will help you to find network connection issues etc.
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `izone.airflow_min`
 
 Set the minimum airflow for a particular zone.

--- a/source/_integrations/jellyfin.markdown
+++ b/source/_integrations/jellyfin.markdown
@@ -68,7 +68,7 @@ Audio Codec:
 
 ## Actions
 
-### Action browse media
+### Action `media_player.browse_media`
 
 You can use the `media_player.browse_media` action to step through your Jellyfin library to find media you want to play.
 
@@ -115,7 +115,7 @@ media_player.jellyfin:
         https://jellyfin
 ```
 
-### Action search media
+### Action `media_player.search_media`
 
 You can use the `media_player.search_media` action to find media you want to play.
 
@@ -164,7 +164,7 @@ media_player.jellyfin:
       not_shown: 0
       children: []
 ```
-### Action play media
+### Action `media_player.play_media`
 
 To play media on any player you first need to find the `media_content_id` of the content you want to play, through either [browsing to the media](#action-browse-media) or [searching media](#action-search-media).
 

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -144,7 +144,7 @@ Available {% term actions %}:
 
 - `jewish_calendar.count_omer`
 
-### Action Count the Omer
+### Action `jewish_calendar.count_omer`
 
 The `jewish_calendar.count_omer` action returns the phrase for counting the Omer for a given date.
 

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -66,6 +66,8 @@ automation:
 
 ### Actions
 
+The integration offers the following actions:
+
 #### Action `kodi.add_to_playlist`
 
 Add music to the default playlist (i.e., playlistid=0).

--- a/source/_integrations/lcn.markdown
+++ b/source/_integrations/lcn.markdown
@@ -469,7 +469,7 @@ data:
 
 {% endtip %}
 
-### Action: `output_abs`
+### Action `lcn.output_abs`
 
 Set absolute brightness of output port in percent.
 
@@ -491,7 +491,7 @@ data:
   transition: 0
 ```
 
-### Action: `output_rel`
+### Action `lcn.output_rel`
 
 Set relative brightness of output port in percent.
 
@@ -512,7 +512,7 @@ data:
   brightness: 30
 ```
 
-### Action: `output_toggle`
+### Action `lcn.lcn.output_toggle`
 
 Toggle output port.
 
@@ -532,7 +532,7 @@ data:
   transition: 0
 ```
 
-### Action: `relays`
+### Action `lcn.relays`
 
 Set the relays status. The relays states are defined as a string with eight characters.
 Each character represents the state change of a relay (1=on, 0=off, t=toggle, -=nochange).
@@ -553,7 +553,7 @@ data:
   state: t---001-
 ```
 
-### Action: `led`
+### Action `lcn.led`
 
 Set the LED status.
 
@@ -572,7 +572,7 @@ data:
   state: blink
 ```
 
-### Action: `var_abs`
+### Action `lcn.var_abs`
 
 Set the absolute value of a variable or setpoint.
 If `value` is not defined, it is assumed to be 0.
@@ -601,7 +601,7 @@ Ensure that the LCN module is configured properly to provide access to the defin
 Otherwise the module might show unexpected behaviors or return error messages.
 {% endimportant %}
 
-### Action: `var_rel`
+### Action `lcn.var_rel`
 
 Set the relative value of a variable or setpoint.
 If `value` is not defined, it is assumed to be 0.
@@ -630,7 +630,7 @@ Ensure that the LCN module is configured properly to provide access to the defin
 Otherwise the module might show unexpected behavior or return error messages.
 {% endimportant %}
 
-### Action: `var_reset`
+### Action `lcn.var_reset`
 
 Reset value of variable or setpoint.
 
@@ -653,7 +653,7 @@ Ensure that the LCN module is configured properly to provide access to the defin
 Otherwise the module might show unexpected behavior or return error messages.
 {% endimportant %}
 
-### Action: `lock_regulator`
+### Action `lcn.lock_regulator`
 
 Locks a regulator setpoint.
 If `state` is not defined, it is assumed to be `False`.
@@ -674,7 +674,7 @@ data:
   state: true
 ```
 
-### Action: `send_keys`
+### Action `lcn.send_keys`
 
 Send keys (which executes bound commands).
 The keys attribute is a string with one or more key identifiers. Example: `a1a5d8`
@@ -711,7 +711,7 @@ data:
   time_unit: s
 ```
 
-### Action: `lock_keys`
+### Action `lcn.lock_keys`
 
 Locks keys.
 If the table is not defined, it is assumed to be table `a`.
@@ -748,7 +748,7 @@ data:
   time_unit: s
 ```
 
-### Action: `dyn_text`
+### Action `lcn.dyn_text`
 
 Send dynamic text to LCN-GTxD displays.
 The displays support four rows for text messages.
@@ -770,7 +770,7 @@ data:
   text: "text in row 1"
 ```
 
-### Action: `pck`
+### Action `lcn.pck`
 
 Send arbitrary PCK command. Only the command part of the PCK command has to be specified in the `pck` string.
 

--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -139,6 +139,8 @@ logger:
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `logger.set_default_level`
 
 You can alter the default log level (for integrations without a specified log

--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -139,7 +139,7 @@ logger:
 
 ## Actions
 
-### Action `set_default_level`
+### Action `logger.set_default_level`
 
 You can alter the default log level (for integrations without a specified log
 level) using the `logger.set_default_level` action.
@@ -152,7 +152,7 @@ data:
   level: info
 ```
 
-### Action `set_level`
+### Action `logger.set_level`
 
 You can alter log level for one or several integrations using the `logger.set_level` action.
 It accepts the same format as `logs` in the configuration.

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -293,7 +293,7 @@ data:
 
 The integration also provides the following actions:
 
-### Sending a message
+### `matrix.send_message`
 
 As an alternative to using the notify integration as described above, you may use `matrix.send_message` to send a
 message to a Matrix room.
@@ -339,7 +339,7 @@ data:
       - **Optional**: Yes
       - **Type**: String
 
-### Reacting to messages
+### Action `matrix.react`
 
 To react to a message with an emoji reaction, use the `matrix.react` action:
 

--- a/source/_integrations/miele.markdown
+++ b/source/_integrations/miele.markdown
@@ -179,6 +179,8 @@ Climate entities are used to control target temperatures in refrigerators, freez
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `miele.set_program`
 
 Set and start a program for applicable appliances. Note that the device must be in a state where it will accept a new program, for example, most washing machines must be in state `on` and many appliances must be set manually to 'MobileStart' or 'MobileControl' in advance. An error message is displayed if the device did not accept the action command.

--- a/source/_integrations/modern_forms.markdown
+++ b/source/_integrations/modern_forms.markdown
@@ -63,6 +63,8 @@ The Modern Forms integration provides support for the following toggleable attri
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `modern_forms.clear_fan_sleep_timer`
 
 This action will clear the sleep timer for the fan if it has been set. It will not turn off the fan when the timer is cleared.

--- a/source/_integrations/monoprice.markdown
+++ b/source/_integrations/monoprice.markdown
@@ -33,6 +33,8 @@ By default, the first 6 zones (11..16) are enabled, and there's an attempt to au
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `monoprice.snapshot`
 
 Take a snapshot of one or more zones' states. This action, and the following one are useful if you want to play a doorbell or notification sound and resume playback afterward. If `entity_id` is `all`, all zones are snapshotted.

--- a/source/_integrations/music_assistant.markdown
+++ b/source/_integrations/music_assistant.markdown
@@ -62,6 +62,8 @@ The Music Assistant integration creates a button entity for each player to favor
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `music_assistant.play_media`
 
 Play media on a Music Assistant player with more fine-grained control options. This action is more powerful than the [`media_player.play_media`](https://www.home-assistant.io/integrations/media_player/#action-media_playerplay_media) action because it allows multiple items to be added to the queue at once, it allows more specific control of the media item to be played (e.g. a track from a specific album can be specified) and Music Assistant's radio mode (where the queue is filled with similar tracks to that enqueued) can be enabled.

--- a/source/_integrations/ness_alarm.markdown
+++ b/source/_integrations/ness_alarm.markdown
@@ -118,6 +118,8 @@ Incorrect configuration of these settings will prevent the integration from func
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `ness_alarm.aux`
 
 Trigger an aux output.  This requires PCB version 7.8 or higher.

--- a/source/_integrations/ness_alarm.markdown
+++ b/source/_integrations/ness_alarm.markdown
@@ -118,7 +118,7 @@ Incorrect configuration of these settings will prevent the integration from func
 
 ## Actions
 
-### Action `aux`
+### Action `ness_alarm.aux`
 
 Trigger an aux output.  This requires PCB version 7.8 or higher.
 
@@ -127,7 +127,7 @@ Trigger an aux output.  This requires PCB version 7.8 or higher.
 | `output_id`            | No       | The aux output you wish to change.  A number from 1-8.                                                                                                              |
 | `state`                | Yes      | The On/Off State, represented as true/false. Default is true.  If P14xE 8E is enabled then a value of true will pulse output x for the time specified in P14(x+4)E. |
 
-### Action `panic`
+### Action `ness_alarm.panic`
 
 Trigger a panic
 

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -50,22 +50,7 @@ There is currently support for the following device types within Home Assistant:
 - [Light](#light)
 - [Sensor](#sensor)
 - [Switch](#switch)
-- [Actions](#actions)
-  - [Action `set_camera_light_mode`](#action-set_camera_light_mode)
-  - [Action `netatmo.set_schedule`](#action-netatmoset_schedule)
-  - [Action `netatmo.set_preset_mode_with_end_datetime`](#action-netatmoset_preset_mode_with_end_datetime)
-  - [Action `netatmo.set_temperature_with_end_datetime`](#action-netatmoset_temperature_with_end_datetime)
-  - [Action `netatmo.set_temperature_with_time_period`](#action-netatmoset_temperature_with_time_period)
-  - [Action `netatmo.clear_temperature_setting`](#action-netatmoclear_temperature_setting)
-  - [Action `netatmo.set_persons_home`](#action-netatmoset_persons_home)
-  - [Action `netatmo.set_person_away`](#action-netatmoset_person_away)
-  - [Action `netatmo.register_webhook`](#action-netatmoregister_webhook)
-  - [Action `netatmo.unregister_webhook`](#action-netatmounregister_webhook)
 - [Webhook Events](#webhook-events)
-- [Development / Testing with your own client ID](#development--testing-with-your-own-client-id)
-- [Troubleshooting](#troubleshooting)
-  - [Receiving events](#receiving-events)
-  - [Light](#light-1)
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -50,7 +50,22 @@ There is currently support for the following device types within Home Assistant:
 - [Light](#light)
 - [Sensor](#sensor)
 - [Switch](#switch)
+- [Actions](#actions)
+  - [Action `set_camera_light_mode`](#action-set_camera_light_mode)
+  - [Action `netatmo.set_schedule`](#action-netatmoset_schedule)
+  - [Action `netatmo.set_preset_mode_with_end_datetime`](#action-netatmoset_preset_mode_with_end_datetime)
+  - [Action `netatmo.set_temperature_with_end_datetime`](#action-netatmoset_temperature_with_end_datetime)
+  - [Action `netatmo.set_temperature_with_time_period`](#action-netatmoset_temperature_with_time_period)
+  - [Action `netatmo.clear_temperature_setting`](#action-netatmoclear_temperature_setting)
+  - [Action `netatmo.set_persons_home`](#action-netatmoset_persons_home)
+  - [Action `netatmo.set_person_away`](#action-netatmoset_person_away)
+  - [Action `netatmo.register_webhook`](#action-netatmoregister_webhook)
+  - [Action `netatmo.unregister_webhook`](#action-netatmounregister_webhook)
 - [Webhook Events](#webhook-events)
+- [Development / Testing with your own client ID](#development--testing-with-your-own-client-id)
+- [Troubleshooting](#troubleshooting)
+  - [Receiving events](#receiving-events)
+  - [Light](#light-1)
 
 {% include integrations/config_flow.md %}
 
@@ -105,9 +120,7 @@ The `netatmo` switch platform provides support for Legrand/BTicino switches and 
 
 ## Actions
 
-### Set Outdoor Camera Light Mode
-
-`set_camera_light_mode`
+### Action `set_camera_light_mode`
 
 Set the outdoor camera light mode.
 
@@ -115,9 +128,8 @@ Set the outdoor camera light mode.
 | ---------------------- | -------- | -------------------------- |
 | `camera_light_mode`    | Yes      | Outdoor camera light mode. |
 
-### Set Schedule
+### Action `netatmo.set_schedule`
 
-`set_schedule`
 
 Set the heating schedule.
 
@@ -125,9 +137,7 @@ Set the heating schedule.
 | ---------------------- | -------- | ------------------------------------- |
 | `schedule_name`        | Yes      | The name of the schedule to activate. |
 
-### Set preset mode with end date & time
-
-`set_preset_mode_with_end_datetime`
+### Action `netatmo.set_preset_mode_with_end_datetime`
 
 Set the preset mode for a Netatmo climate device. The preset mode must match a preset mode configured at Netatmo.
 
@@ -136,9 +146,7 @@ Set the preset mode for a Netatmo climate device. The preset mode must match a p
 | `preset_mode`          | Yes      | Climate preset mode such as Schedule, Away, or Frost Guard. |
 | `end_datetime`         | Yes      | Date & time until which the preset will be active.          |
 
-### Set temperature with end date & time
-
-`set_temperature_with_end_datetime`
+### Action `netatmo.set_temperature_with_end_datetime`
 
 Sets the target temperature for a Netatmo climate device with an end date & time.
 
@@ -147,9 +155,7 @@ Sets the target temperature for a Netatmo climate device with an end date & time
 | `target_temperature`   | Yes      | The target temperature for the device.                   |
 | `end_datetime`         | Yes      | Date & time the target temperature will be active until. |
 
-### Set temperature with time period
-
-`set_temperature_with_time_period`
+### Action `netatmo.set_temperature_with_time_period`
 
 Sets the target temperature for a Netatmo climate device as well as the time period during which this target temperature applies.
 
@@ -158,15 +164,11 @@ Sets the target temperature for a Netatmo climate device as well as the time per
 | `target_temperature`   | Yes      | The target temperature for the device.                      |
 | `time_period`          | Yes      | Time period during which the target temperature is applied. |
 
-### Clear temperature setting
-
-`clear_temperature_setting`
+### Action `netatmo.clear_temperature_setting`
 
 Clears any temperature setting for a Netatmo climate device reverting it to the current preset or schedule.
 
-### Set Person Home
-
-`set_persons_home`
+### Action `netatmo.set_persons_home`
 
 Set a list of persons as at home. Person's name must match a name known by the Netatmo Smart Indoor Camera.
 
@@ -174,9 +176,7 @@ Set a list of persons as at home. Person's name must match a name known by the N
 | ---------------------- | -------- | -------------- |
 | `persons`              | Yes      | List of names. |
 
-### Set Person Away
-
-`set_person_away`
+### Action `netatmo.set_person_away`
 
 Set a person away. If no person is set the home will be marked as empty. Person's name must match a name known by the Netatmo Smart Indoor Camera.
 
@@ -184,11 +184,13 @@ Set a person away. If no person is set the home will be marked as empty. Person'
 | ---------------------- | -------- | -------------- |
 | `person`               | Yes      | Person's name. |
 
-### (Un-)Register Webhooks
+### Action `netatmo.register_webhook`
 
-`register_webhook` and `unregister_webhook`
+Action to manually register the webhook.
 
-Actions to manually register and unregister the webhook.
+### Action `netatmo.unregister_webhook`
+
+Action to manually unregister the webhook.
 
 ## Webhook Events
 

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -120,6 +120,8 @@ The `netatmo` switch platform provides support for Legrand/BTicino switches and 
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `set_camera_light_mode`
 
 Set the outdoor camera light mode.

--- a/source/_integrations/nintendo_parental_controls.markdown
+++ b/source/_integrations/nintendo_parental_controls.markdown
@@ -92,7 +92,7 @@ The **Nintendo Switch Parental Controls** integration provides the following ent
 
 The integration provides the following actions.
 
-### Action: Add bonus time
+### Action `nintendo_parental_controls.add_bonus_time`
 
 The `nintendo_parental_controls.add_bonus_time` action adds additional bonus screen time to a specified device, which is granted outside of the maximum allowed screentime.
 

--- a/source/_integrations/nordpool.markdown
+++ b/source/_integrations/nordpool.markdown
@@ -114,7 +114,7 @@ The block price sensors are not enabled by default.
 
 ## Actions
 
-### Get price for date
+### Action `nordpool.get_prices_for_date`
 
 The integration entities provide price information only for the current date. Use the "Get price for date" action to retrieve pricing information for any date within the last two months or for tomorrow.
 
@@ -164,7 +164,7 @@ data:
 
 {% endraw %}
 
-### Get price indices for date
+### Action `nordpool.get_prices_for_date`
 
 The integration can also provide price indices for any date with published prices. Use the "Get price indices for date" action to retrieve pricing information with a custom resolution time.
 

--- a/source/_integrations/nordpool.markdown
+++ b/source/_integrations/nordpool.markdown
@@ -114,6 +114,8 @@ The block price sensors are not enabled by default.
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `nordpool.get_prices_for_date`
 
 The integration entities provide price information only for the current date. Use the "Get price for date" action to retrieve pricing information for any date within the last two months or for tomorrow.

--- a/source/_integrations/ntfy.markdown
+++ b/source/_integrations/ntfy.markdown
@@ -133,7 +133,7 @@ actions:
 
 ## Actions
 
-### Publish notification
+### Action `ntfy.publish`
 
 For more customizable notifications, use the `ntfy.publish` action instead of `notify.send_message`. With `ntfy.publish`, you can take full advantage of the **ntfy** service's capabilities. These include setting a priority, adding links, attachments, tags, and emojis.
 

--- a/source/_integrations/ntfy.markdown
+++ b/source/_integrations/ntfy.markdown
@@ -133,6 +133,8 @@ actions:
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `ntfy.publish`
 
 For more customizable notifications, use the `ntfy.publish` action instead of `notify.send_message`. With `ntfy.publish`, you can take full advantage of the **ntfy** service's capabilities. These include setting a priority, adding links, attachments, tags, and emojis.

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -42,6 +42,8 @@ Use an encrypted token for authentication:
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `nuki.lock_n_go`
 
 This will first unlock, wait a few seconds (20 by default) then re-lock. The wait period can be customized through the app.

--- a/source/_integrations/nws.markdown
+++ b/source/_integrations/nws.markdown
@@ -27,7 +27,9 @@ Providing a METAR station code is optional, and if not supplied, the closest sta
 
 One weather entity is created for each entry in the configuration. Hourly and day/night forecasts are provided through the [`weather.get_forecasts` action](/integrations/weather#action-weatherget_forecasts). The time supplied for each forecast is the start time for the forecast. Sensors are also created as disabled entities after configuration and can be enabled by the user.
 
-## Action `nws.get_forecasts_extra` 
+## Actions
+
+### Action `nws.get_forecasts_extra`
 
 `nws.get_forecasts_extra` provides extra data in a form similar to `weather.get_forecasts`. See [`weather.get_forecasts` documentation](/integrations/weather#action-weatherget_forecasts).
 

--- a/source/_integrations/nws.markdown
+++ b/source/_integrations/nws.markdown
@@ -29,6 +29,8 @@ One weather entity is created for each entry in the configuration. Hourly and da
 
 ## Actions
 
+The integration offers the following action:
+
 ### Action `nws.get_forecasts_extra`
 
 `nws.get_forecasts_extra` provides extra data in a form similar to `weather.get_forecasts`. See [`weather.get_forecasts` documentation](/integrations/weather#action-weatherget_forecasts).

--- a/source/_integrations/nx584.markdown
+++ b/source/_integrations/nx584.markdown
@@ -21,12 +21,8 @@ The `nx584` {% term integration %} provides integration with GE, Caddx, Interlog
 
 There is currently support for the following device types within Home Assistant:
 
-- [Alarm control panel](#alarm-control-panel)
+- [Alarm](#alarm-control-panel)
 - [Binary sensor](#binary-sensor)
-- [Full example](#full-example)
-- [Actions](#actions)
-  - [Action `nx584.bypass_zone`](#action-nx584bypass_zone)
-  - [Action `nx584.unbypass_zone`](#action-nx584unbypass_zone)
 
 ## Alarm control panel
 

--- a/source/_integrations/nx584.markdown
+++ b/source/_integrations/nx584.markdown
@@ -21,8 +21,12 @@ The `nx584` {% term integration %} provides integration with GE, Caddx, Interlog
 
 There is currently support for the following device types within Home Assistant:
 
-- [Alarm](#alarm-control-panel)
+- [Alarm control panel](#alarm-control-panel)
 - [Binary sensor](#binary-sensor)
+- [Full example](#full-example)
+- [Actions](#actions)
+  - [Action `nx584.bypass_zone`](#action-nx584bypass_zone)
+  - [Action `nx584.unbypass_zone`](#action-nx584unbypass_zone)
 
 ## Alarm control panel
 
@@ -121,7 +125,7 @@ binary_sensor:
 
 ## Actions
 
-### Action `bypass_zone`
+### Action `nx584.bypass_zone`
 
 This action will bypass a given zone.
 
@@ -130,7 +134,7 @@ This action will bypass a given zone.
 | `entity_id`            | yes      | entity_id of the NX584 Alarm.   |
 | `zone`                 | no       | Zone number you want to bypass. |
 
-### Action `unbypass_zone`
+### Action `nx584.unbypass_zone`
 
 This action will unbypass a given zone.
 

--- a/source/_integrations/ohme.markdown
+++ b/source/_integrations/ohme.markdown
@@ -124,7 +124,7 @@ The Ohme integration provides the following entities.
 
 The integration provides the following actions.
 
-### Action: List charge slots
+### Action `ohme.list_charge_slots`
 
 The `ohme.list_charge_slots` action is used to fetch a list of charge slots from your charger. Charge slots will only be returned if a charge is in progress.
 
@@ -132,7 +132,7 @@ The `ohme.list_charge_slots` action is used to fetch a list of charge slots from
 |------------------------|----------|--------------------------------------------------------------|
 | `config_entry`         | No       | The config entry of the account to get the charge list from. |
 
-### Action: Set price cap
+### Action `ohme.set_price_cap`
 
 The `ohme.set_price_cap` action is used to set the price cap threshold. This can be toggled by the switch **Price cap**.
 

--- a/source/_integrations/ombi.markdown
+++ b/source/_integrations/ombi.markdown
@@ -90,9 +90,9 @@ ombi:
 
 ### Submit request actions
 
-Available actions: `submit_movie_request`, `submit_music_request`, `submit_tv_request`
+Available actions: `ombi.submit_movie_request`, `ombi.submit_music_request`, `ombi.submit_tv_request`
 
-#### Action `submit_movie_request`
+#### Action `ombi.submit_movie_request`
 
 Searches and requests the closest matching movie.
 
@@ -100,7 +100,7 @@ Searches and requests the closest matching movie.
 | ---------------------- | -------- | ----------------- |
 | `name`                 | no       | Search parameter. |
 
-#### Action `submit_music_request`
+#### Action `ombi.submit_music_request`
 
 Searches and requests the closest matching music album.
 
@@ -108,7 +108,7 @@ Searches and requests the closest matching music album.
 | ---------------------- | -------- | ----------------- |
 | `name`                 | no       | Search parameter. |
 
-#### Action `submit_tv_request`
+#### Action `ombi.submit_tv_request`
 
 Searches and requests the closest matching TV show.
 

--- a/source/_integrations/openhome.markdown
+++ b/source/_integrations/openhome.markdown
@@ -46,7 +46,9 @@ actions:
 
 ## Actions
 
-### Media control actions
+### Action `openhome.invoke_pin`
+
+Starts playing content pinned on the specified device.
 
 Available actions: `invoke_pin`
 

--- a/source/_integrations/opentherm_gw.markdown
+++ b/source/_integrations/opentherm_gw.markdown
@@ -97,7 +97,7 @@ Reset the OpenTherm Gateway.
 | ---------------------- | -------- | --------------------------------------------------- |
 | `gateway_id`           | no       | The `gateway_id` as specified during configuration. |
 
-### Action `set_central_heating_ovrd`
+### Action `opentherm_gw.set_central_heating_ovrd`
 
 Set the central heating override option on the gateway.
 When overriding the control setpoint (via the [set_control_setpoint](#action-opentherm_gwset_control_setpoint) action with a temperature value other than `0`), the gateway automatically enables the central heating override to start heating. This action can then be used to control the central heating override status.

--- a/source/_integrations/overseerr.markdown
+++ b/source/_integrations/overseerr.markdown
@@ -74,9 +74,9 @@ The Overseerr integration has the following actions:
 
 - Get requests
 
-### Action get requests
+### Action `overseerr.get_requests`
 
-Get a list of media requests using `overseerr.get_requests`.
+Get a list of media requests.
 
 | Data attribute    | Optional | Description                                                 |
 |-------------------|----------|-------------------------------------------------------------|

--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -16,7 +16,7 @@ The Profiler integration provides a profile which is a set of statistics that id
 
 {% include integrations/config_flow.md %}
 
-### Action profiler.start
+### Action `profiler.start`
 
 {% my developer_call_service badge service="profiler.start" %}
 
@@ -53,7 +53,7 @@ dot callgrind.dot -Tpng -o callgrind.png
 gprof2dot -f pstats profile.1234567890123456.cprof | dot -Tsvg -o profile.svg
 ```
 
-### Action profiler.memory
+### Action `profiler.memory`
 
 {% my developer_call_service badge service="profiler.memory" %}
 
@@ -73,7 +73,7 @@ from guppy import hpy
 hpy().pb()
 ```
 
-### Action profiler.start_log_objects
+### Action `profiler.start_log_objects`
 
 {% my developer_call_service badge service="profiler.start_log_objects" %}
 
@@ -87,13 +87,13 @@ Periodically log the growth of new objects in memory. This action's primary use 
 
 See the [corresponding documentation for `growth()`](https://mg.pov.lt/objgraph/objgraph.html#objgraph.growth) regarding the format in which this data is logged.
 
-### Action profiler.stop_log_objects
+### Action `profiler.stop_log_objects`
 
 {% my developer_call_service badge service="profiler.stop_log_objects" %}
 
 Stop logging the growth of objects in memory.
 
-### Action profiler.start_log_object_sources
+### Action `profiler.start_log_object_sources`
 
 {% my developer_call_service badge service="profiler.start_log_object_sources" %}
 
@@ -108,13 +108,13 @@ Periodically log the growth of new objects in memory. This actions's primary use
 
 This action is similar to `start_log_objects` except that it is much more CPU intensive since it will attempt to locate the source of each new object up to `max_objects` each time it logs.
 
-### Action profiler.stop_log_object_sources
+### Action `profiler.stop_log_object_sources`
 
 {% my developer_call_service badge service="profiler.stop_log_object_sources" %}
 
 Stop logging the growth of objects with sources in memory.
 
-### Action profiler.dump_log_objects
+### Action `profiler.dump_log_objects`
 
 {% my developer_call_service badge service="profiler.dump_log_objects" %}
 
@@ -137,7 +137,7 @@ data:
   type: Template
 ```
 
-### Action profiler.log_thread_frames
+### Action `profiler.log_thread_frames`
 
 {% my developer_call_service badge service="profiler.log_thread_frames" %}
 
@@ -174,7 +174,7 @@ An example is below:
     sock.connect(address)
 ```
 
-### Action profiler.log_event_loop_scheduled
+### Action `profiler.log_event_loop_scheduled`
 
 {% my developer_call_service badge service="profiler.log_event_loop_scheduled" %}
 
@@ -186,13 +186,13 @@ Each upcoming scheduled item is logged similar to the below example:
 [homeassistant.components.profiler] Scheduled: <TimerHandle when=1528307.1818668307 async_track_point_in_utc_time.<locals>.run_action(<Job HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.screenlogic.ScreenlogicDataUpdateCoordinator object at 0x7f985d896d30>>>) at /usr/src/homeassistant/homeassistant/helpers/event.py:1175>`
 ```
 
-### Action profiler.lru_stats
+### Action `profiler.lru_stats`
 
 {% my developer_call_service badge service="profiler.lru_stats" %}
 
 Logs statistics from [lru_cache](https://docs.python.org/3/library/functools.html#functools.lru_cache) and [lru-dict](https://pypi.org/project/lru-dict/) to help tune Home Assistant and locate memory leaks.
 
-### Action profiler.set_asyncio_debug
+### Action `profiler.set_asyncio_debug`
 
 {% my developer_call_service badge service="profiler.set_asyncio_debug" %}
 
@@ -202,7 +202,7 @@ Logs statistics from [lru_cache](https://docs.python.org/3/library/functools.htm
 
 When `set_asyncio_debug` is enabled, `asyncio` will run in [debug mode](https://docs.python.org/3/library/asyncio-dev.html#debug-mode). Use this service to help identify an integration that is blocking the event loop.
 
-### Action profiler.log_current_tasks
+### Action `profiler.log_current_tasks`
 
 {% my developer_call_service badge service="profiler.log_current_tasks" %}
 
@@ -214,7 +214,7 @@ An example is below:
 [homeassistant.components.profiler] Task: <Task pending name='Task-1133' coro=<HubConnector._listener() running at /usr/local/lib/python3.12/site-packages/aioharmony/hubconnector_websocket.py:362> wait_for=<Future pending cb=[Task.task_wakeup()]>>
 ```
 
-### Action profiler.dump_sockets
+### Action `profiler.dump_sockets`
 
 {% my developer_call_service badge service="profiler.dump_sockets" %}
 

--- a/source/_integrations/ps4.markdown
+++ b/source/_integrations/ps4.markdown
@@ -119,7 +119,7 @@ To edit, simply open the file in a text editor, find the game or app you would l
 
 ## Actions
 
-### Action `select_source`
+### Action `media_player.select_source`
 
 Opens new application/game and closes currently running application/game. The game/app must be in the entity's source list. Games will be added automatically when you open them normally.
 
@@ -128,7 +128,7 @@ Opens new application/game and closes currently running application/game. The ga
 | `entity_id`            | No       | `media_player.ps4`         | The entity id for your PlayStation 4.                                                                       |
 | `source`               | No       | `Some Game` or `CUSA00123` | The game/app you want to open. You can use the title or SKU ID. Using the SKU ID will be the most reliable. |
 
-### Action `send_command`
+### Action `ps4.send_command`
 
 Emulate button press on PlayStation 4. This emulates the commands available for the PS4 Second Screen App. This is not to be confused with DualShock 4 controller buttons.
 

--- a/source/_integrations/rainbird.markdown
+++ b/source/_integrations/rainbird.markdown
@@ -107,7 +107,7 @@ The Rain Bird integration provides the following entities.
 
 The integration exposes actions to give additional control over a Rain Bird device.
 
-### `rainbird.start_irrigation`
+### Action `rainbird.start_irrigation`
 
 Start a Rain Bird zone for a set number of minutes. This action accepts a Rain Bird sprinkler
 zone switch entity and allows a custom duration unlike the switch.

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -207,7 +207,7 @@ recorder:
 
 ## Actions
 
-### Action `purge`
+### Action `recorder.purge`
 
 Perform the action `recorder.purge` to start a purge task which deletes events and states older than x days, according to `keep_days` action data.
 Note that purging will not immediately decrease disk space usage but it will significantly slow down further growth.
@@ -218,7 +218,7 @@ Note that purging will not immediately decrease disk space usage but it will sig
 | `repack`               | yes      | When using SQLite or PostgreSQL this will rewrite the entire database. When using MySQL or MariaDB it will optimize or recreate the events and states tables. This is a heavy operation that can cause slowdowns and increased disk space usage while it runs. Only supported by SQLite, PostgreSQL, MySQL and MariaDB. |
 | `apply_filter`         | yes      | Apply entity_id and event_type filter in addition to time based purge. Useful in combination with `include` / `exclude` filter to remove falsely added states and events. Combine with `repack: true` to reduce database size.                                                                                          |
 
-### Action `purge_entities`
+### Action `recorder.purge_entities`
 
 Perform the action `recorder.purge_entities` to start a task that purges events and states from the recorder database that match any of the specified `entity_id`, `domains`, and `entity_globs` fields. At least one of the three selection criteria fields must be provided.
 
@@ -245,15 +245,15 @@ actions:
       entity_id: sensor.power_sensor_0
 ```
 
-### Action `disable`
+### Action `recorder.disable`
 
 Perform the action `recorder.disable` to stop saving events and states to the database.
 
-### Action `enable`
+### Action `recorder.enable`
 
 Perform the action `recorder.enable` to start again saving events and states to the database. This is the opposite of `recorder.disable`.
 
-### Action `get_statistics`
+### Action `recorder.get_statistics`
 
 Perform the action `recorder.get_statistics` to retrieve statistics for one or more entities from the recorder database. This action is useful for automations or scripts that need to access historical statistics, such as mean, min, max, or sum values, for supported entities like sensors.
 

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -226,7 +226,7 @@ Depending on the supported features of the camera ([see specifications of the ca
 
 **Guard set current position** will set the current position as the new guard position.
 
-#### Action reolink.ptz_move
+#### Action `reolink.ptz_move`
 
 Some Reolink <abbr title="pan, tilt, and zoom">PTZ</abbr> cameras can move at different speeds. For those cameras, the `reolink.ptz_move` action can be used in combination with the **PTZ left**, **right**, **up**, **down**, **zoom in**, or **zoom out** entity which allows specifying the speed attribute. If the <abbr title="pan, tilt, and zoom">PTZ</abbr> button entities for a specific camera are not shown under **Choose entity** under **targets** of the `reolink.ptz_move` action, it means that this camera does not support custom <abbr title="pan, tilt, and zoom">PTZ</abbr> speeds.
 
@@ -272,7 +272,7 @@ Depending on the supported features of the camera ([see specifications of the ca
 
 **Hub scene modes** can be set in the Reolink app/client. The scene names are loaded into Home Assistant at the start of the integration. After adding new custom scenes, restart the Reolink integration.
 
-#### Action reolink.play_chime
+#### Action `reolink.play_chime`
 
 To play a ringtone on a Reolink chime, the `reolink.play_chime` action can be used.
 

--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -339,7 +339,7 @@ automation:
 
 - `rfxtrx.send`: Send a custom event using the RFXtrx device.
 
-### Action: Send
+### Action `rfxtrx.send`
 
 Simulate a button being pressed:
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -266,7 +266,7 @@ In addition, some vacuums allow routines to be set up in the app. For each of th
 
 #### Actions
 
-##### Action Set Vacuum Goto Position
+##### Action `roborock.set_vacuum_goto_position`
 
 The `roborock.set_vacuum_goto_position` action will set the vacuum to go to
 the specified coordinates.
@@ -281,7 +281,7 @@ the specified coordinates.
   - **Description**: Y-coordinate, integer value. The dock is located at y-coordinate 25500.
   - **Optional**: No.
 
-##### Action Get Vacuum Current Position
+##### Action `roborock.get_vacuum_current_position`
 
 The `roborock.get_vacuum_current_position` action will get the current position of the vacuum. This
 is a cloud call and should only be used for diagnostics. This is not meant to be used for
@@ -308,7 +308,7 @@ data: {}
     y: 25168
   ```
 
-##### Action Get Maps
+##### Action `roborock.get_maps`
 
 The `roborock.get_maps` action will return the maps available on the device and
 details about any named rooms on each map.

--- a/source/_integrations/screenlogic.markdown
+++ b/source/_integrations/screenlogic.markdown
@@ -38,7 +38,7 @@ ScreenLogic options are set via **Settings** > **Devices & services** > **Pentai
 
 ## Actions
 
-### `screenlogic.set_color_mode`
+### Action `screenlogic.set_color_mode`
 
 Sets the operation of any connected color-capable lights.
 
@@ -47,7 +47,7 @@ Sets the operation of any connected color-capable lights.
 | `config_entry`         | no       | Integration entry_id of the ScreenLogic instance you wish to set the color mode on. |
 | `color_mode`           | no       | The color mode to set. Valid values are listed below.                               |
 
-### `screenlogic.start_super_chlorination`
+### Action `screenlogic.start_super_chlorination`
 
 Begins super chlorination, running for the specified period or 24 hours if none is specified.
 
@@ -56,7 +56,7 @@ Begins super chlorination, running for the specified period or 24 hours if none 
 | `config_entry`         | no       | Integration entry_id of the ScreenLogic instance you wish to start super chlorination on. |
 | `runtime`              | yes      | Number of hours to run super chlorination for. Defaults to 24 hours.                      |
 
-### `screenlogic.stop_super_chlorination`
+### Action `screenlogic.stop_super_chlorination`
 
 Stops super chlorination.
 

--- a/source/_integrations/sql.markdown
+++ b/source/_integrations/sql.markdown
@@ -133,7 +133,7 @@ For more detailed steps on how to define a custom interval, follow the procedure
 
 ## Actions
 
-### Action SQL query
+### Action `sql.query`
 
 The `sql.query` action allows you to execute an arbitrary read-only `SELECT` query against a database and get the results back.
 

--- a/source/_integrations/squeezebox.markdown
+++ b/source/_integrations/squeezebox.markdown
@@ -236,7 +236,7 @@ This integration will notify you when updates are available on the LMS for the L
 
 The integration provides the following actions.
 
-#### Action `call_method`
+#### Action `squeezebox.call_method`
 
 Call a custom Squeezebox JSON-RPC API.
 
@@ -302,7 +302,7 @@ data:
     - '+5'
 ```
 
-#### Action `call_query`
+#### Action `squeezebox.call_query`
 
 Call a custom Squeezebox JSON-RPC API. The result of the query will be stored in the 'query_result' attribute of the player.
 

--- a/source/_integrations/streamlabswater.markdown
+++ b/source/_integrations/streamlabswater.markdown
@@ -29,7 +29,7 @@ In preparation for using this integration you will need to request an API key fo
 
 {% include integrations/config_flow.md %}
 
-## Action `set_away_mode`
+## Action `streamlabswater.set_away_mode`
 
 You can use the `streamlabswater.set_away_mode` action to set the mode to `home` or `away`. The away mode will only be changed for the configured location.
 

--- a/source/_integrations/system_bridge.markdown
+++ b/source/_integrations/system_bridge.markdown
@@ -265,7 +265,7 @@ data:
 message: URL opened
 ```
 
-### Action`system_bridge.send_keypress`
+### Action `system_bridge.send_keypress`
 
 Send a keypress to the server.
 

--- a/source/_integrations/system_log.markdown
+++ b/source/_integrations/system_log.markdown
@@ -35,11 +35,11 @@ fire_event:
 
 ## Actions
 
-### Action `clear`
+### Action `system_log.clear`
 
 To manually clear the system log, use this action.
 
-### Action `write`
+### Action `system_log.write`
 
 Write a log entry
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -308,9 +308,9 @@ Entities in the device tracker platform specifically require the `Vehicle locati
 
 Teslemetry provides various custom actions to interact with the Tesla Fleet API directly.
 
-### Navigate to coordinates
+### Action `teslemetry.navigation_gps_request`
 
-`teslemetry.navigation_gps_request`
+Navigate to coordinates.
 
 | Field         | Description                | Example                          |
 |---------------|----------------------------|----------------------------------|
@@ -320,9 +320,9 @@ Teslemetry provides various custom actions to interact with the Tesla Fleet API 
 | gps.longitude | Longitude in degrees       | 153.4081865                      |
 | order         | Order for this destination | 1                                |
 
-### Set scheduled charging
+### Action `teslemetry.set_scheduled_charging`
 
-`teslemetry.set_scheduled_charging`
+Set scheduled charging
 
 | Field     | Description                           | Example                          |
 |-----------|---------------------------------------|----------------------------------|
@@ -330,9 +330,9 @@ Teslemetry provides various custom actions to interact with the Tesla Fleet API 
 | enable    | Enable or disable scheduled charging | true                             |
 | time      | Time to start charging in HH:MM       | 6:00                             |
 
-### Set scheduled departure
+### Action `teslemetry.set_scheduled_departure`
 
-`teslemetry.set_scheduled_departure`
+Set scheduled departure
 
 | Field                           | Description                               | Example                          |
 |---------------------------------|-------------------------------------------|----------------------------------|
@@ -345,9 +345,9 @@ Teslemetry provides various custom actions to interact with the Tesla Fleet API 
 | off_peak_charging_weekdays_only | Enable off-peak charging on weekdays only | false                            |
 | end_off_peak_time               | Time to complete charging by (HH:MM)      | 5:00                             |
 
-### Valet Mode
+### Action `teslemetry.valet_mode`
 
-`teslemetry.valet_mode`
+Valet Mode
 
 | Field         | Description                  | Example                          |
 |---------------|------------------------------|----------------------------------|
@@ -355,9 +355,9 @@ Teslemetry provides various custom actions to interact with the Tesla Fleet API 
 | enable        | Enable or disable valet mode | true                             |
 | pin           | 4-digit pin                  | 1234                             |
 
-### Speed Limit
+### Action `teslemetry.speed_limit`
 
-`teslemetry.speed_limit`
+Speed Limit
 
 | Field         | Description                   | Example                          |
 |---------------|-------------------------------|----------------------------------|
@@ -365,9 +365,9 @@ Teslemetry provides various custom actions to interact with the Tesla Fleet API 
 | enable        | Enable or disable speed limit | true                             |
 | pin           | 4-digit pin                   | 1234                             |
 
-### Time of use
+### Action `teslemetry.time_of_use`
 
-`teslemetry.time_of_use`
+Time of use
 
 | Field         | Description                  | Example                                                                                                          |
 |---------------|------------------------------|------------------------------------------------------------------------------------------------------------------|

--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -156,6 +156,8 @@ the Todoist UI.
 You may use the actions from the [todo](/integrations/todo/) integration for
 creating, updating, or deleting to-do items on the to-do list.
 
+### Action `todoist.new_task`
+
 Todoist also comes with an additional action, `todoist.new_task` that offers
 more advanced attributes when creating a Todoist task. You can specify labels
 and a project, or you can leave them blank, and the task will go to your

--- a/source/_integrations/totalconnect.markdown
+++ b/source/_integrations/totalconnect.markdown
@@ -76,7 +76,7 @@ The integration provides a bypass button for each zone that can be bypassed. The
 
 The alarm control panel supports the following basic actions: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`.
 
-### Action: Arm home instant
+### Action `totalconnect.arm_home_instant`
 
 The `totalconnect.arm_home_instant` action puts the alarm panel in "arm home" with zero entry delay, triggering the alarm instantly if an entry/exit zone is faulted. This is equivalent to "arm stay instant" in most alarm panels.
 
@@ -84,7 +84,7 @@ The `totalconnect.arm_home_instant` action puts the alarm panel in "arm home" wi
 |------------------------|----------|------------------------------------------------------|
 | `entity_id`            | No       | The ID of the alarm panel to arm.                    |
 
-### Action: Arm away instant
+### Action `totalconnect.arm_away_instant`
 
 The `totalconnect.arm_away_instant` action puts the alarm panel in "arm away" with zero entry delay, triggering the alarm instantly if an entry/exit zone is faulted. This is equivalent to "arm away instant" in most alarm panels.
 

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -104,7 +104,7 @@ Example of an automation that notifies on successful download and removes the to
 
 All Transmission actions require integration `entry_id`. To find it, go to **Developer tools** > **Actions**. Choose the desired action and select your integration from dropdown. Then switch to YAML mode to see `entry_id`.
 
-### Action `add_torrent`
+### Action `transmission.add_torrent`
 
 Adds a new torrent to download. It can either be a URL (HTTP, HTTPS or FTP), magnet link or a local file (make sure that the path is [white listed](/integrations/homeassistant/#allowlist_external_dirs)).
 
@@ -114,7 +114,7 @@ Adds a new torrent to download. It can either be a URL (HTTP, HTTPS or FTP), mag
 | `torrent`              | no       | Torrent to download      |
 | `download_path`        | yes      | Absolute path to the download directory. If not specified, the Transmission's default directory will be used. |
 
-### Action `remove_torrent`
+### Action `transmission.remove_torrent`
 
 Removes a torrent from the client.
 
@@ -124,7 +124,7 @@ Removes a torrent from the client.
 | `id`                   | no       | ID of the torrent, can be found in the `torrent_info` attribute of the `*_torrents` sensors |
 | `delete_data`          | yes      | Delete torrent data (Default: false)                                                        |
 
-### Action `start_torrent`
+### Action `transmission.start_torrent`
 
 Starts a torrent.
 
@@ -133,7 +133,7 @@ Starts a torrent.
 | `entry_id`             | no       | The integration entry_id                                                                    |
 | `id`                   | no       | ID of the torrent, can be found in the `torrent_info` attribute of the `*_torrents` sensors |
 
-### Action `stop_torrent`
+### Action `transmission.stop_torrent`
 
 Stops a torrent.
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -121,7 +121,7 @@ If Home Assistant and the UniFi Network application are running on separate mach
 
 ## Actions
 
-### Action unifi.reconnect_client
+### Action `unifi.reconnect_client`
 
 Try to get a wireless client to reconnect to the network.
 
@@ -129,7 +129,7 @@ Try to get a wireless client to reconnect to the network.
 | ---------------------- | -------- | --------------------------------------------------------------------------- |
 | `device_id`            | No       | String representing a device ID related to a UniFi Network {% term integration %} .     |
 
-### Action unifi.remove_clients
+### Action `unifi.remove_clients`
 
 Clean up clients on the UniFi Network application that has only been associated with the Network application for a short period of time. The difference between first seen and last seen needs to be less than 15 minutes and the client can not have a fixed IP, hostname or name associated with it.
 

--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -231,6 +231,8 @@ Below are the accepted identifiers to resolve media. Since events do not necessa
 
 ## Actions
 
+The integration offers the following actions:
+
 ### Action `unifiprotect.add_doorbell_text`
 
 Adds a new custom message for Doorbells.

--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -231,7 +231,7 @@ Below are the accepted identifiers to resolve media. Since events do not necessa
 
 ## Actions
 
-### Action unifiprotect.add_doorbell_text
+### Action `unifiprotect.add_doorbell_text`
 
 Adds a new custom message for Doorbells.
 
@@ -240,7 +240,7 @@ Adds a new custom message for Doorbells.
 | `device_id`            | No       | Any device from the UniFi Protect instance you want to change. In case you have multiple Protect instances. |
 | `message`              | No       | New custom message to add for Doorbells. Must be less than 30 characters.                                   |
 
-### Action unifiprotect.remove_doorbell_text
+### Action `unifiprotect.remove_doorbell_text`
 
 Removes an existing message for Doorbells.
 
@@ -249,7 +249,7 @@ Removes an existing message for Doorbells.
 | `device_id`            | No       | Any device from the UniFi Protect instance you want to change. In case you have multiple Protect instances. |
 | `message`              | No       | Existing custom message to remove for Doorbells.                                                            |
 
-### Action unifiprotect.set_chime_paired_doorbells
+### Action `unifiprotect.set_chime_paired_doorbells`
 
 Use to set the paired doorbell(s) with a smart chime.
 
@@ -258,7 +258,7 @@ Use to set the paired doorbell(s) with a smart chime.
 | `device_id`            | No       | The device ID of the Chime you want to pair or unpair doorbells to.                                     |
 | `doorbells`            | Yes      | A target selector for any number of doorbells you want to pair to the chime. No value means unpair all. |
 
-### Action unifiprotect.remove_privacy_zone
+### Action `unifiprotect.remove_privacy_zone`
 
 Use to remove a privacy zone from a camera.
 
@@ -267,7 +267,7 @@ Use to remove a privacy zone from a camera.
 | `device_id`            | No       | Camera you want to remove privacy zone from.                                                            |
 | `name`                 | No       | The name of the zone to remove.                                                                         |
 
-### Action unifiprotect.get_user_keyring_info
+### Action `unifiprotect.get_user_keyring_info`
 
 | Data attribute | Optional | Description                                                                                                 |
 | -------------- | -------- | ----------------------------------------------------------------------------------------------------------- |

--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -94,6 +94,8 @@ the configuration section below.
 
 ## Actions
 
+The integration offers the following action:
+
 ### Action `vesync.update_devices`
 
 Poll Vesync server to find and add any new devices

--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -94,9 +94,9 @@ the configuration section below.
 
 ## Actions
 
-| Action | Description |
-|---------|-------------|
-| `update_devices` | Poll Vesync server to find and add any new devices |
+### Action `vesync.update_devices`
+
+Poll Vesync server to find and add any new devices
 
 ## Power & energy sensors
 

--- a/source/_integrations/vivotek.markdown
+++ b/source/_integrations/vivotek.markdown
@@ -103,13 +103,13 @@ camera:
     stream_path: live2.sdp
 ```
 
-### Actions
+## Actions
 
 Once loaded, the `camera` platform will expose actions that can be called to perform various actions.
 
 Available actions: `enable_motion_detection`, `disable_motion_detection`, `snapshot`, and `play_stream`.
 
-#### Action `play_stream`
+### Action `camera.play_stream`
 
 Play a live stream from a camera to selected media player(s). Requires [`stream`](/integrations/stream) {% term integration %} to be set up.
 
@@ -130,7 +130,7 @@ actions:
       media_player: media_player.chromecast
 ```
 
-#### Action `enable_motion_detection`
+### Action `camera.enable_motion_detection`
 
 Enable motion detection in a camera. Currently, this will enable the first event configured on the camera.
 
@@ -138,7 +138,7 @@ Enable motion detection in a camera. Currently, this will enable the first event
 | ---------------------- | -------- | --------------------------------------------------------------------------------- |
 | `entity_id`            | yes      | Name(s) of entities to enable motion detection, e.g., `camera.front_door_camera`. |
 
-#### Action `disable_motion_detection`
+### Action `camera.disable_motion_detection`
 
 Disable the motion detection in a camera. Currently, this will disable the first event configured on the camera.
 
@@ -146,7 +146,7 @@ Disable the motion detection in a camera. Currently, this will disable the first
 | ---------------------- | -------- | ---------------------------------------------------------------------------------- |
 | `entity_id`            | yes      | Name(s) of entities to disable motion detection, e.g., `camera.front_door_camera`. |
 
-#### Action `snapshot`
+### Action `camera.snapshot`
 
 Take a snapshot from a camera.
 

--- a/source/_integrations/weather.markdown
+++ b/source/_integrations/weather.markdown
@@ -70,6 +70,8 @@ wind_speed_unit: km/h
 
 ## Actions
 
+The integration offers the following action:
+
 ### Action `weather.get_forecasts`
 
 This action populates [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data)

--- a/source/_integrations/weather.markdown
+++ b/source/_integrations/weather.markdown
@@ -68,7 +68,9 @@ wind_speed: 35.17
 wind_speed_unit: km/h
 ```
 
-## Action `weather.get_forecasts`
+## Actions
+
+### Action `weather.get_forecasts`
 
 This action populates [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data)
 with a mapping of weather services and their associated forecasts.

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -89,7 +89,7 @@ Any other [actions](/docs/automation/action/) to power on the device can be conf
 
 The integration provides the following actions.
 
-### Action: Select sound output
+### Action `webostv.select_sound_output`
 
 The `webostv.select_sound_output` action is used to select the active sound output.
 The current sound output of the TV can be found under the state attributes.
@@ -99,7 +99,7 @@ The current sound output of the TV can be found under the state attributes.
 | `entity_id`            | no       | Target a specific webostv media player. |
 | `sound_output`         | no       | Name of the sound output to switch to.  |
 
-### Action: Button press
+### Action `webostv.button`
 
 The `webostv.button` action is used to simulate a button press.
 
@@ -108,7 +108,7 @@ The `webostv.button` action is used to simulate a button press.
 | `entity_id`            | no       | Target a specific webostv media player.                                                                                                                                                                                                                                                |
 | `button`               | no       | Name of the button. Known possible values are `LEFT`, `RIGHT`, `DOWN`, `UP`, `HOME`, `MENU`, `BACK`, `ENTER`, `DASH`, `INFO`, `ASTERISK`, `CC`, `EXIT`, `MUTE`, `RED`, `GREEN`, `BLUE`, `YELLOW`, `VOLUMEUP`, `VOLUMEDOWN`, `CHANNELUP`, `CHANNELDOWN`, `PLAY`, `PAUSE`, `NETFLIX`, `GUIDE`, `AMAZON`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9` |
 
-### Action: Generic command
+### Action `webostv.command`
 
 The `webostv.command` action is used to send a generic command to the TV.
 

--- a/source/_integrations/xbox.markdown
+++ b/source/_integrations/xbox.markdown
@@ -50,7 +50,7 @@ The Home Assistant Xbox {% term integration %} lets you monitor and control Xbox
 
 The Xbox media player platform will create media player entities for each console linked to your Microsoft account. These entities will display the active app and playback controls as well as a media browser implementation, allowing you to launch any installed application.
 
-### Action `play_media`
+### Action `media_player.play_media`
 
 Launches an application on the Xbox console using the application's product ID. Also supports "Home" and "TV" to navigate to the dashboard or Live TV respectively.
 
@@ -80,7 +80,7 @@ media_content_id: "9WZDNCRFJ3TJ" # Netflix
 
 The Xbox remote platform will create Remote entities for each console linked to your Microsoft Account. These entities will allow you to turn on/off and send controller or text input to your console.
 
-### Action `send_command`
+### Action `remote.send_command`
 
 | Data attribute | Optional | Description                                                       |
 | ---------------------- | -------- | --------------------------------------------------------- |

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1429,11 +1429,11 @@ For now, pronto hex codes only work on the first version (`chuangmi.ir.v2`).
 
 The Xiaomi IR Remote Platform registers four actions.
 
-### `remote.send_command`
+### Action `remote.send_command`
 
 Allows sending either named commands using an identifier or sending commands as one of the two types defined in [Command Types](/integrations/xiaomi_miio/#command-types).
 
-### `xiaomi_miio.remote_learn_command`
+### Action `xiaomi_miio.remote_learn_command`
 
 Used to learn new commands.
 
@@ -1443,11 +1443,11 @@ Use the entity_id of the Xiaomi IR Remote to start a learning process.
 
 After learning the command the base64 string can be found as a notification in Overview, the string can be copied by left clicking on the string and choose the copy option.
 
-### `xiaomi_miio.remote_set_led_on`
+### Action `xiaomi_miio.remote_set_led_on`
 
 Used to turn remote's blue LED on.
 
-### `xiaomi_miio.remote_set_led_off`
+### Action `xiaomi_miio.remote_set_led_off`
 
 Used to turn remote's blue LED off.
 

--- a/source/_integrations/yamaha.markdown
+++ b/source/_integrations/yamaha.markdown
@@ -128,7 +128,9 @@ script:
 
 ```
 
-### Action `enable_output`
+## Actions
+
+### Action `yamaha.enable_output`
 
 Enable or disable an output port (HDMI) on the receiver.
 
@@ -138,7 +140,7 @@ Enable or disable an output port (HDMI) on the receiver.
 | `port`                 | no       | Port to enable or disable, e.g., `hdmi1`.                                 |
 | `enabled`              | no       | To enable set true, otherwise set to false.                               |
 
-### Action `menu_cursor`
+### Action `yamaha.menu_cursor`
 
 Control the menu cursor.
 
@@ -147,7 +149,7 @@ Control the menu cursor.
 | `entity_id`            | yes      | String or list of strings that point at `entity_id`s of Yamaha receivers.          |
 | `cursor`               | no       | Name of the cursor key to press: `up`, `down`, `left`, `right`, `select`, `return` |
 
-### Action `select_scene`
+### Action `yamaha.select_scene`
 
 Select a scene on the receiver.
 

--- a/source/_integrations/zoneminder.markdown
+++ b/source/_integrations/zoneminder.markdown
@@ -29,13 +29,8 @@ The `zoneminder` integration sets up Home Assistant with your [ZoneMinder](https
 
 There is currently support for the following device types within Home Assistant:
 
-- [Configuration](#configuration)
-  - [Full configuration](#full-configuration)
-- [Actions](#actions)
-  - [Action `zoneminder.set_run_state`](#action-zoneminderset_run_state)
 - [Binary sensor](#binary-sensor)
 - [Camera](#camera)
-  - [Configuration](#configuration-1)
 - [Sensor](#sensor)
 - [Switch](#switch)
 
@@ -100,6 +95,8 @@ zoneminder:
 ```
 
 ## Actions
+
+The integration offers the following action:
 
 ### Action `zoneminder.set_run_state`
 

--- a/source/_integrations/zoneminder.markdown
+++ b/source/_integrations/zoneminder.markdown
@@ -29,8 +29,13 @@ The `zoneminder` integration sets up Home Assistant with your [ZoneMinder](https
 
 There is currently support for the following device types within Home Assistant:
 
+- [Configuration](#configuration)
+  - [Full configuration](#full-configuration)
+- [Actions](#actions)
+  - [Action `zoneminder.set_run_state`](#action-zoneminderset_run_state)
 - [Binary sensor](#binary-sensor)
 - [Camera](#camera)
+  - [Configuration](#configuration-1)
 - [Sensor](#sensor)
 - [Switch](#switch)
 
@@ -94,7 +99,9 @@ zoneminder:
     password: YOUR_PASSWORD
 ```
 
-### Action
+## Actions
+
+### Action `zoneminder.set_run_state`
 
 Once loaded, the `zoneminder` platform will expose an action (`set_run_state`) that can be used to change the current run state of ZoneMinder.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR cleans up the action documentation across multiple integrations to follow a consistent pattern.


**What was changed**

* Updated action headings to the ``### Action \`domain.action_name` `` format (e.g.``### Action `abode.change_setting` ``instead of `### Action: Change setting` or bare `` `blink.record` ``).
* Ensured each integration uses the full namespaced action ID in headings and “available actions” lists (for example `amcrest.enable_audio`, `aftership.add_tracking`, `guardian.upgrade_firmware`, etc.). It wasn't my main goal, but if I noticed a problem, I corrected it.
* Added or normalized `## Actions` sections where they were missing or inconsistent.
* Updated the integration docs template and Copilot instructions so new docs follow the same convention.

**Why**

* Makes it easier for users to copy-paste the correct action ID directly from the docs into automations/scripts.
* Aligns existing integration pages with the current action naming conventions used in Home Assistant.
* Reduces confusion between generic section titles and the actual action IDs exposed by integrations.
* Improved scalability and navigation: using a consistent ``Action `domain.id` `` heading format makes it easier to search for a specific action (both for users and tooling), to link directly to it, and to keep a growing set of actions maintainable.

**Future improvements**

The additional reason for standardizing these headings now is to unlock better automation later.
With a consistent `### Action \`domain.action_name `` pattern, it becomes feasible to add CI checks that verify the code and documentation stay in sync (e.g., every exposed action has a corresponding section).

Those checks are **not** part of this PR, but the unified headings make it easier in future.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
