### PR TITLE
Update ESPHome entity ID documentation to reflect standard generation

### DIFF
--- a/source/_integrations/esphome.markdown
+++ b/source/_integrations/esphome.markdown
@@ -150,7 +150,7 @@ The [Native API Component](https://esphome.io/components/api.html) also supports
 ## Entity naming and IDs
 
 - Entity name is a combination of the friendly name (or name if unset) and component name
-- Entity ID is derived from the entity name with the device name prepended
+- Entity ID is derived from the entity name
 - Unicode characters in names are transliterated to their closest ASCII equivalents for compatibility
 
 Example with `friendly_name` set:
@@ -164,7 +164,7 @@ sensor:
    name: "Temperature"
 ```
 
-The entity will be named `Living room desk Temperature` and will default to having an entity ID of `sensor.livingroomdesk_temperature`.
+The entity will be named `Living room desk Temperature` and will default to having an entity ID of `sensor.living_room_desk_temperature`.
 
 Example without `friendly_name` set:
 


### PR DESCRIPTION
## Proposed change

Update the ESPHome integration documentation to reflect that entity IDs are now generated using Home Assistant's standard entity ID generation rules, which derive the entity ID from the entity name (using the friendly name when set) rather than the ESPHome YAML `name` field.

This aligns ESPHome with how other integrations handle entity ID generation.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/154097
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
