### PR TITLE
Add documentation to configurable sauna types to Saunum integration #42050

### DIFF
--- a/source/_integrations/saunum.markdown
+++ b/source/_integrations/saunum.markdown
@@ -64,6 +64,27 @@ The Saunum Leil control unit natively operates in Celsius, even if Fahrenheit is
 
 Once started, the sauna begins heating to the target temperature and automatically turns off after the configured duration. During an active session, you cannot change the sauna type, sauna duration, or fan duration settings.
 
+### Sauna type preset modes
+
+The Saunum Leil control unit supports three sauna type presets that can store different configurations for temperature, sauna duration, and fan duration. These presets allow you start your sauna session with different settings quickly.
+
+You can select the active preset using the climate entity's preset mode control. The preset determines the default values for temperature, duration, and fan settings when starting a sauna session.
+
+{% note %}
+The preset mode (sauna type) can only be changed when the sauna session is not active.
+{% endnote %}
+
+#### Customizing preset names
+
+Preset names can be configured on the Saunum Leil control unit itself. You can also customize the preset names in Home Assistant to match the names configured on your device:
+
+1. Go to the Saunum integration in {% my integrations title="**Settings** > **Devices & Services**" %}.
+2. Click on **Configure** for your Saunum Leil device.
+3. Enter custom names for each of the three sauna type presets to match those configured on your Leil touch panel (for example, "Finnish Sauna", "Quick Session", "Deep Heat").
+4. Click **Submit** to save your changes.
+
+The custom preset names will immediately appear in the climate entity's preset mode selector, making it easier to identify and select your preferred sauna configuration.
+
 ### Fan mode settings
 
 The sauna heater has a built-in ventilation fan that helps circulate air and maintain even temperature distribution. You can adjust the fan speed during an active sauna session using the climate entity's fan mode control:
@@ -96,7 +117,7 @@ The **Saunum** integration provides the following entities for controlling and m
 
 - **Sauna**
   - **Description**: Main climate control for your sauna, allowing you to set target temperature and control heating.
-  - **Features**: Temperature control, HVAC modes (off, heat), fan mode (off, low, medium, high).
+  - **Features**: Temperature control, HVAC modes (off, heat), fan mode (off, low, medium, high), preset mode (sauna type selection).
 
 ### Light
 

--- a/source/_integrations/saunum.markdown
+++ b/source/_integrations/saunum.markdown
@@ -79,9 +79,9 @@ The preset mode (sauna type) can only be changed when the sauna session is not a
 Preset names can be configured on the Saunum Leil control unit itself. You can also customize the preset names in Home Assistant to match the names configured on your device:
 
 1. Go to the Saunum integration in {% my integrations title="**Settings** > **Devices & Services**" %}.
-2. Click on **Configure** for your Saunum Leil device.
-3. Enter custom names for each of the three sauna type presets to match those configured on your Leil touch panel (for example, "Finnish Sauna", "Quick Session", "Deep Heat").
-4. Click **Submit** to save your changes.
+2. Select **Configure** for your Saunum Leil device.
+3. Enter custom names for each of the three sauna type presets to match those configured on your Leil touch panel (for example, **Finnish Sauna**, **Quick Session**, **Deep Heat**).
+4. Select **Submit** to save your changes.
 
 The custom preset names will immediately appear in the climate entity's preset mode selector, making it easier to identify and select your preferred sauna configuration.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->


The Saunum Leil control unit supports three sauna type presets that can store different configurations for temperature, sauna duration, and fan duration. These presets allow you start your sauna session with different settings quickly.
Preset settings and names can only be configured on the device, but preset names are not exposed via ModBus. This feature adds sauna preset types to climate entity and makes names configurable from integration settings so users can keep names in sync with the device.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/157741
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
