### PR TITLE
Add Lytiva integration documentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
       nokogiri (~> 1.12)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.17.0)
+    json (2.17.1)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)

--- a/source/_docs/energy/water.markdown
+++ b/source/_docs/energy/water.markdown
@@ -31,6 +31,7 @@ We have the following integrations available for existing products that can prov
 - [HomeWizard Energy](/integrations/homewizard)
 - [StreamLabs](/integrations/streamlabswater)
 - [Suez Water](/integrations/suez_water)
+- [Watergate](/integrations/watergate)
 
 There are also products for water usage monitoring that are based on existing common IoT protocol standards:
 

--- a/source/_integrations/essent.markdown
+++ b/source/_integrations/essent.markdown
@@ -97,7 +97,6 @@ If your sensors are showing unavailable or unknown states, check the following:
 
 2. **API service status**: Essent's API may be temporarily unavailable
    - Check {% my logs title="Settings → System → Logs" %} for error messages
-   - Open `https://www.essent.nl/api/public/tariffmanagement/dynamic-prices/v1/` in a browser or via `curl`; a JSON response confirms the service is reachable, while HTTP errors mean the API is down or blocked by your network
    - Wait and check if data returns within an hour
 
 ### Prices don't match my Essent account

--- a/source/_integrations/labs.markdown
+++ b/source/_integrations/labs.markdown
@@ -20,11 +20,9 @@ The **Labs** {% term integration %} provides a dedicated panel where you can pre
 Labs preview features are different from beta testing:
 
 - *Beta testing* evaluates the stability of upcoming Home Assistant releases.
-- *Labs preview features* are preview features being refined through real-world usage and feedback.
-
-{% include integrations/config_flow.md %}
-
-## About Labs preview features
+- *Labs preview features* are in the process of being refined through real-world usage and feedback.
+  
+## About Labs
 
 Labs allows you to:
 
@@ -34,38 +32,42 @@ Labs allows you to:
 
 All preview features in Labs are:
 
-- Optional: Disabled by default, you must explicitly enable them.
+- Optional: Disabled by default, you need to explicitly enable them.
 - Free of critical bugs: Fully functional and free of critical bugs.
 - Subject to change: Feature set may be extended, and design and behavior may be refined based on feedback.
 - Reversible: Can be disabled at any time.
 
-## Accessing Labs
 
-To access the Labs panel:
 
-1. Go to {% my labs title="**Settings** > **System** > **Labs**" %}.
-2. Only admin users can access this panel.
 
-## Using preview features
+## About preview features
 
-Each preview feature in Labs includes:
+Each preview feature section in Labs includes:
 
 - **Name** and **Description**: What the feature does.
 - **Enable/Disable** button: Turn the feature on or off.
 
 Optionally they include:
 
-- Feedback link: Share your experience with the community.
-- Documentation link: Learn more about the feature.
-- Report issue link: Report bugs or problems.
+- **Feedback** link: Share your experience with the community.
+- **Documentation** link: Learn more about the feature.
+- **Report issue** link: Report bugs or problems.
 
-### Enabling a feature
+## Enabling a preview feature
 
-1. Navigate to {% my labs title="the Labs panel" %}.
+### Prerequisites
+
+- You need administrator rights to access this panel.
+- Some preview features require specific integrations to be installed and configured.
+  - If a feature is unavailable with a message indicating a required integration, set up that integration and try again.
+
+### To enable a preview feature
+
+1. Go to {% my labs title="**Settings** > **System** > **Labs**" %}.
 2. Find the feature you want to try.
-3. Select the **Enable** button.
+3. Select **Enable**.
 
-You can also use My Home Assistant links to navigate directly to a specific feature in Labs. For example:
+You can also use My Home Assistant links to directly go to a specific feature in Labs. For example:
 
 ```text
 https://my.home-assistant.io/redirect/labs/?domain=kitchen_sink&preview_feature=special_repair
@@ -73,22 +75,25 @@ https://my.home-assistant.io/redirect/labs/?domain=kitchen_sink&preview_feature=
 
 These links are useful in release notes, documentation, or when sharing specific features with others.
 
-### Disabling a feature
+## Disabling a preview feature
 
-1. Return to {% my labs title="the Labs panel" %}.
+### Prerequisites
+
+- You need administrator rights to access this panel.
+- You have enabled a preview feature.
+
+### To disable a preview feature
+
+1. Go to {% my labs title="**Settings** > **System** > **Labs**" %}.
 2. Find the enabled feature.
-3. Select the **Disable** button.
-
-## Feature requirements
-
-Some preview features require specific integrations to be installed and configured. If a feature is unavailable with a message indicating a required integration, you must first set up that integration before you can enable the feature.
+3. Select **Disable**.
 
 ## Providing feedback
 
 Your feedback helps improve these features! When you enable a preview feature:
 
-1. Use the **Give Feedback** link to share your experience in the community forum.
-2. Use the **Report Issue** link to report bugs on GitHub.
+1. Use the **Give feedback** link to share your experience in the community forum.
+2. Use the **Report issue** link to report bugs on GitHub.
 3. Be specific about what works well and what could be improved.
 4. Include relevant details like your Home Assistant version and setup.
 

--- a/source/_integrations/lytiva.markdown
+++ b/source/_integrations/lytiva.markdown
@@ -1,0 +1,201 @@
+---
+title: Lytiva
+description: Instructions on how to integrate Lytiva devices with Home Assistant.
+ha_category:
+  - Light
+  - Switch
+  - Cover
+  - Climate
+  - Fan
+  - Sensor
+  - Binary Sensor
+  - Scene
+ha_release: 2025.2
+ha_iot_class: Local Push
+ha_config_flow: true
+ha_codeowners:
+  - '@lytiva'
+ha_domain: lytiva
+ha_platforms:
+  - binary_sensor
+  - climate
+  - cover
+  - fan
+  - light
+  - scene
+  - sensor
+  - switch
+---
+
+The **Lytiva** integration allows you to control Lytiva smart home devices through Home Assistant via MQTT.
+
+## Prerequisites
+
+- A running MQTT broker (e.g., Mosquitto)
+- Lytiva devices configured and connected to your network
+- Network connectivity between Home Assistant and your MQTT broker
+
+## Configuration
+
+The Lytiva integration is configured via the Home Assistant user interface.
+
+### Adding Lytiva to Home Assistant
+
+1. Go to **Settings** → **Devices & Services**
+2. Click the **+ Add Integration** button
+3. Search for and select **Lytiva**
+4. Enter your MQTT broker details:
+   - **MQTT Broker**: IP address or hostname of your MQTT broker
+   - **Port**: MQTT broker port (default: 1883)
+   - **Username**: MQTT username (if you have !)
+   - **Password**: MQTT password (if you have !)
+5. Click **Submit**
+
+Home Assistant will automatically discover your Lytiva devices via MQTT discovery.
+
+## Supported Devices
+
+The Lytiva integration supports the following device types:
+
+### Lights
+- On/Off control
+- Brightness adjustment
+- Color temperature control (if supported by device)
+- RGB color control (if supported by device)
+- State monitoring
+
+### Switches
+- On/Off control
+- State monitoring
+
+### Covers
+- Open/Close/Stop control
+- Position control
+- State monitoring
+
+### Climate
+- Temperature control
+- HVAC mode selection
+- On/Off control
+- State monitoring
+
+### Fans
+- On/Off control
+- Speed control
+- State monitoring
+
+### Sensors
+- Temperature & humidity sensors
+- CO2 sensors
+- lux sensors
+
+### Binary Sensors
+- Human presence sensors
+- In-Out sensors
+- Parking sensors
+
+### Scenes
+- Scene activation
+
+## MQTT Topics
+
+Lytiva uses the following MQTT topic structure:
+
+- **Discovery**: `homeassistant/{platform}/{device_id}/config`
+- **Status**: `LYT/{address}/NODE/E/STATUS` or `LYT/{address}/GROUP/E/STATUS` or `LYT/{address}/SCENE/E/STATUS`
+- **Command**: `LYT/{address}/NODE/CONTROL` or `LYT/{address}/GROUP/CONTROL` or `LYT/{address}/SCENE/CONTROL`
+
+## Options
+
+After adding the integration, you can configure additional options:
+
+1. Go to **Settings** → **Devices & Services**
+2. Find the **Lytiva** integration
+3. Click **Configure**
+4. Adjust the **Discovery Prefix** if needed (default: `homeassistant`)
+
+## Automation Examples
+
+### Turn on a Lytiva light at sunset
+
+{% raw %}
+```yaml
+automation:
+  - alias: "Turn on Lytiva light at sunset"
+    trigger:
+      - platform: sun
+        event: sunset
+    action:
+      - service: light.turn_on
+        target:
+          entity_id: light.lytiva_living_room
+        data:
+          brightness: 200
+```
+{% endraw %}
+
+### Control Lytiva cover based on temperature
+
+{% raw %}
+```yaml
+automation:
+  - alias: "Close covers when hot"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.lytiva_temperature
+        above: 30
+    action:
+      - service: cover.close_cover
+        target:
+          entity_id: cover.lytiva_bedroom_curtain
+```
+{% endraw %}
+
+### Activate a Lytiva scene
+
+{% raw %}
+```yaml
+automation:
+  - alias: "Movie time scene"
+    trigger:
+      - platform: state
+        entity_id: media_player.living_room_tv
+        to: "playing"
+    action:
+      - service: scene.turn_on
+        target:
+          entity_id: scene.lytiva_movie_mode
+```
+{% endraw %}
+
+## Troubleshooting
+
+### Devices not discovered
+
+1. Verify your MQTT broker is running and accessible
+2. Check that Lytiva devices are publishing discovery messages
+3. Verify the discovery prefix matches (default: `homeassistant`)
+
+### Devices not responding to commands
+
+1. Verify MQTT broker connectivity
+2. Check that devices are subscribed to command topics
+3. Verify username/password if authentication is enabled
+4. Check device-specific logs for errors
+
+## Removing the integration
+
+1. Go to **Settings** → **Devices & Services**
+2. Find the **Lytiva** integration
+3. Click the three dots menu
+4. Select **Delete**
+5. Confirm deletion
+
+All Lytiva devices and entities will be removed from Home Assistant.
+
+## Support
+
+For issues, feature requests, or questions:
+
+- [GitHub Issues](https://github.com/home-assistant/core/issues)
+- [Home Assistant Community Forum](https://community.home-assistant.io/)

--- a/source/_integrations/lytiva.markdown
+++ b/source/_integrations/lytiva.markdown
@@ -35,8 +35,8 @@ The Lytiva integration is configured via the Home Assistant user interface.
 4. Enter your MQTT broker details:
    - **MQTT Broker**: IP address or hostname of your MQTT broker
    - **Port**: MQTT broker port (default: 1883)
-   - **Username**: MQTT username (optional)
-   - **Password**: MQTT password (optional)
+   - **Username**: MQTT username
+   - **Password**: MQTT password
 5. Click **Submit**
 
 Home Assistant will automatically discover your Lytiva light devices via MQTT discovery.
@@ -58,9 +58,15 @@ The Lytiva integration currently supports light devices with the following featu
 
 Lytiva uses the following MQTT topic structure:
 
-- **Discovery**: `homeassistant/light/{device_id}/config`
-- **Status**: `LYT/{address}/NODE/E/STATUS` or `LYT/{address}/GROUP/E/STATUS`
-- **Command**: `LYT/{address}/NODE/E/COMMAND` or `LYT/{address}/GROUP/E/COMMAND`
+- **Discovery**: `LYT/homeassistant/{device_type}/{unique_id}/config`
+- **Integration Status**: `LYT/homeassistant/status`
+
+## Protocol Details
+
+The integration uses the [lytiva-connect](https://pypi.org/project/lytiva-connect/) library. 
+
+- **Commands**: Payloads are sent as JSON with this fields : `dimming` (0-100), `r`, `g`, `b`, or `color_temperature`.
+- **Status**: Devices return status in a nested JSON format, for example: `{"type": "cct", "cct": {"dimming": 40, "color_temperature": 50}}`.
 
 ## Options
 
@@ -69,7 +75,6 @@ After adding the integration, you can configure additional options:
 1. Go to **Settings** → **Devices & Services**
 2. Find the **Lytiva** integration
 3. Click **Configure**
-4. Adjust the **Discovery Prefix** if needed (default: `homeassistant`)
 
 ## Automation Examples
 
@@ -133,8 +138,7 @@ automation:
 ### Devices not discovered
 
 1. Verify your MQTT broker is running and accessible
-2. Check that Lytiva devices are publishing discovery messages to the correct topics
-3. Verify the discovery prefix matches (default: `homeassistant`)
+2. Check that Lytiva devices are publishing
 
 ### Devices not responding to commands
 

--- a/source/_integrations/lytiva.markdown
+++ b/source/_integrations/lytiva.markdown
@@ -3,31 +3,19 @@ title: Lytiva
 description: Instructions on how to integrate Lytiva devices with Home Assistant.
 ha_category:
   - Light
-  - Switch
-  - Cover
-  - Climate
-  - Fan
-  - Sensor
-  - Binary Sensor
-  - Scene
 ha_release: 2025.2
 ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:
-  - '@lytiva'
+  - '@convasys'
 ha_domain: lytiva
 ha_platforms:
-  - binary_sensor
-  - climate
-  - cover
-  - fan
   - light
-  - scene
-  - sensor
-  - switch
 ---
 
 The **Lytiva** integration allows you to control Lytiva smart home devices through Home Assistant via MQTT.
+
+- Currently, this integration supports **light** devices. Additional platforms (switch, cover, climate, fan, sensor, binary sensor, and scene) will be added in future updates.
 
 ## Prerequisites
 
@@ -47,63 +35,32 @@ The Lytiva integration is configured via the Home Assistant user interface.
 4. Enter your MQTT broker details:
    - **MQTT Broker**: IP address or hostname of your MQTT broker
    - **Port**: MQTT broker port (default: 1883)
-   - **Username**: MQTT username (if you have !)
-   - **Password**: MQTT password (if you have !)
+   - **Username**: MQTT username (optional)
+   - **Password**: MQTT password (optional)
 5. Click **Submit**
 
-Home Assistant will automatically discover your Lytiva devices via MQTT discovery.
+Home Assistant will automatically discover your Lytiva light devices via MQTT discovery.
 
 ## Supported Devices
 
-The Lytiva integration supports the following device types:
-
 ### Lights
+
+The Lytiva integration currently supports light devices with the following features:
+
 - On/Off control
 - Brightness adjustment
-- Color temperature control (if supported by device)
 - RGB color control (if supported by device)
-- State monitoring
+- Color temperature control (if supported by device)
 
-### Switches
-- On/Off control
-- State monitoring
-
-### Covers
-- Open/Close/Stop control
-- Position control
-- State monitoring
-
-### Climate
-- Temperature control
-- HVAC mode selection
-- On/Off control
-- State monitoring
-
-### Fans
-- On/Off control
-- Speed control
-- State monitoring
-
-### Sensors
-- Temperature & humidity sensors
-- CO2 sensors
-- lux sensors
-
-### Binary Sensors
-- Human presence sensors
-- In-Out sensors
-- Parking sensors
-
-### Scenes
-- Scene activation
+- Additional device types (switches, covers, climate controls, fans, sensors, and scenes) will be added in future releases.
 
 ## MQTT Topics
 
 Lytiva uses the following MQTT topic structure:
 
-- **Discovery**: `homeassistant/{platform}/{device_id}/config`
-- **Status**: `LYT/{address}/NODE/E/STATUS` or `LYT/{address}/GROUP/E/STATUS` or `LYT/{address}/SCENE/E/STATUS`
-- **Command**: `LYT/{address}/NODE/CONTROL` or `LYT/{address}/GROUP/CONTROL` or `LYT/{address}/SCENE/CONTROL`
+- **Discovery**: `homeassistant/light/{device_id}/config`
+- **Status**: `LYT/{address}/NODE/E/STATUS` or `LYT/{address}/GROUP/E/STATUS`
+- **Command**: `LYT/{address}/NODE/E/COMMAND` or `LYT/{address}/GROUP/E/COMMAND`
 
 ## Options
 
@@ -134,37 +91,40 @@ automation:
 ```
 {% endraw %}
 
-### Control Lytiva cover based on temperature
+### Set light color based on time of day
 
 {% raw %}
 ```yaml
 automation:
-  - alias: "Close covers when hot"
+  - alias: "Warm light in evening"
     trigger:
-      - platform: numeric_state
-        entity_id: sensor.lytiva_temperature
-        above: 30
+      - platform: time
+        at: "18:00:00"
     action:
-      - service: cover.close_cover
+      - service: light.turn_on
         target:
-          entity_id: cover.lytiva_bedroom_curtain
+          entity_id: light.lytiva_bedroom
+        data:
+          brightness: 180
+          color_temp: 370
 ```
 {% endraw %}
 
-### Activate a Lytiva scene
+### Turn off all Lytiva lights at bedtime
 
 {% raw %}
 ```yaml
 automation:
-  - alias: "Movie time scene"
+  - alias: "Bedtime - turn off all lights"
     trigger:
-      - platform: state
-        entity_id: media_player.living_room_tv
-        to: "playing"
+      - platform: time
+        at: "23:00:00"
     action:
-      - service: scene.turn_on
+      - service: light.turn_off
         target:
-          entity_id: scene.lytiva_movie_mode
+          entity_id: all
+        data:
+          entity_id: "light.lytiva_*"
 ```
 {% endraw %}
 
@@ -173,15 +133,14 @@ automation:
 ### Devices not discovered
 
 1. Verify your MQTT broker is running and accessible
-2. Check that Lytiva devices are publishing discovery messages
+2. Check that Lytiva devices are publishing discovery messages to the correct topics
 3. Verify the discovery prefix matches (default: `homeassistant`)
 
 ### Devices not responding to commands
 
 1. Verify MQTT broker connectivity
 2. Check that devices are subscribed to command topics
-3. Verify username/password if authentication is enabled
-4. Check device-specific logs for errors
+3. Verify username/password if authentication is enabled on your MQTT broker
 
 ## Removing the integration
 
@@ -192,6 +151,18 @@ automation:
 5. Confirm deletion
 
 All Lytiva devices and entities will be removed from Home Assistant.
+
+## Future Updates
+
+The following platforms are planned for future releases:
+
+- Switch
+- Cover
+- Climate
+- Fan
+- Sensor
+- Binary Sensor
+- Scene
 
 ## Support
 

--- a/source/_posts/2025-12-03-release-202512.markdown
+++ b/source/_posts/2025-12-03-release-202512.markdown
@@ -276,6 +276,8 @@ We welcome the following new integrations in this release:
   Integrate your Anglian Water smart water meter to track water usage and consumption costs.
 - **[Backblaze B2]**, added by [@ElCruncharino]  
   Use a Backblaze B2 cloud storage bucket as a backup location for your Home Assistant backups.
+- **[EnergyID]**, added by [@Molier]  
+  Sync anything from your home directly to EnergyID for advanced analytics, performance tracking and benchmarking.
 - **[Essent]**, added by [@jaapp]  
   Monitor dynamic electricity and gas prices for Essent customers in the Netherlands with variable pricing contracts.
 - **[Google Air Quality]**, added by [@Thomas55555]  
@@ -296,6 +298,7 @@ We welcome the following new integrations in this release:
 [@bestycame]: https://github.com/bestycame
 [@ElCruncharino]: https://github.com/ElCruncharino
 [@flip-dots]: https://github.com/flip-dots
+[@molier]: https://github.com/Molier
 [@jaapp]: https://github.com/jaapp
 [@mettolen]: https://github.com/mettolen
 [@pantherale0]: https://github.com/pantherale0
@@ -305,6 +308,7 @@ We welcome the following new integrations in this release:
 [Airobot]: /integrations/airobot
 [Anglian Water]: /integrations/anglian_water
 [Backblaze B2]: /integrations/backblaze_b2
+[EnergyID]: /integrations/energyid
 [Essent]: /integrations/essent
 [Google Air Quality]: /integrations/google_air_quality
 [Google Weather]: /integrations/google_weather


### PR DESCRIPTION
## Summary

Documentation for the new Lytiva integration that adds support for Lytiva smart home devices via MQTT.

## Link to integration PR

home-assistant/core#158026

## Link to brands PR

home-assistant/brands#8645

## Proposed change

This PR adds comprehensive documentation for the Lytiva integration, including:
- Installation and configuration instructions
- MQTT topic structure
- Supported devices
- Automation examples
- Troubleshooting guide

## Type of change

- [x] Documentation for a new integration

## Additional information

- The integration uses MQTT for local push communication
- Includes config flow for easy setup via UI

## Checklist

- [x] Documentation follows the [style guidelines](https://developers.home-assistant.io/docs/documenting/)
- [x] All links are valid and working
- [x] Examples have been tested
- [x] YAML front matter is complete and correct
- [x] Screenshots included (if applicable)