### PR TITLE
Add invert cover feature

### DIFF
--- a/source/dashboards/features.markdown
+++ b/source/dashboards/features.markdown
@@ -321,7 +321,7 @@ type:
   type: string
 invert:
   required: false
-  description: The slider direction is inverted by default. If you don't want it in this way set this to `false`.
+  description: The slider direction is inverted by default. Set to `false` to disable the default inversion.
   type: boolean
   default: true
 {% endconfiguration %}

--- a/source/dashboards/features.markdown
+++ b/source/dashboards/features.markdown
@@ -311,6 +311,7 @@ Widget that displays a slider to control the position for a [cover](/integration
 ```yaml
 features:
   - type: "cover-position"
+    invert: false    
 ```
 
 {% configuration features %}
@@ -318,6 +319,11 @@ type:
   required: true
   description: "`cover-position`"
   type: string
+invert:
+  required: false
+  description: The slider direction is inverted by default. If you don't want it in this way set this to `false`.
+  type: boolean
+  default: true
 {% endconfiguration %}
 
 ## Cover tilt


### PR DESCRIPTION
## Proposed change

The feature for cover position has the slider "inverted". I understand the reason of this decision, but this is driving me crazy since the beginning and I'm not the only one: https://community.home-assistant.io/t/reverse-slider-display/746748 so I decided to add an "optional" parameter to disable the inversion.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/28389
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
