### PR TITLE
Add documentation for setting the password of the hass user on openwrt

### DIFF
--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -34,7 +34,7 @@ Edit the `/etc/config/rpcd` and add the following lines:
 ```yaml
 config login
         option username 'hass'
-        option password '$p$hass'
+        option password '$p$hass' # This is just a placeholder, don't specify an actual password here, do it with passwd as described below.
         list read hass
         list read unauthenticated
         list write hass
@@ -69,6 +69,17 @@ Check if the `file` namespaces is registered with the RPC server.
 # ubus list | grep file
 file
 ```
+
+Specify the password for the new hass user by running
+```bash
+# passwd hass
+Changing password for hass
+New password: 
+Retype password: 
+passwd: password for hass changed by root
+/etc/init.d/rpcd restart
+```
+
 
 After this is done, add the following to your {% term "`configuration.yaml`" %} file.
 {% include integrations/restart_ha_after_config_inclusion.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The hass user is created without a password, so it is unclear from the documentation, which password needs to be passed when making actual rpc calls. I updated the documentation to include the steps which describe how to set up the password for the hass user properly.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
