### PR TITLE
Add port configuration for Fujitsu anywAiR

### DIFF
--- a/source/_integrations/fujitsu_anywair.markdown
+++ b/source/_integrations/fujitsu_anywair.markdown
@@ -32,3 +32,7 @@ ha_iot_class: Local Polling
 ---
 
 {% include integrations/supported_brand.md %}
+
+## Port Configuration
+
+Fujitsu anywAiR uses port *10211* for API communication. You will need to change the default port provided by the Advantage Air integration to *10211* to use it with Fujitsu anywAiR.

--- a/source/_integrations/fujitsu_anywair.markdown
+++ b/source/_integrations/fujitsu_anywair.markdown
@@ -35,4 +35,4 @@ ha_iot_class: Local Polling
 
 ## Port Configuration
 
-Fujitsu anywAiR uses port *10211* for API communication. You will need to change the default port provided by the Advantage Air integration to *10211* to use it with Fujitsu anywAiR.
+Fujitsu anywAiR uses port **10211** for API communication. You will need to change the default port provided by the Advantage Air integration to **10211** to use it with Fujitsu anywAiR.

--- a/source/_integrations/fujitsu_anywair.markdown
+++ b/source/_integrations/fujitsu_anywair.markdown
@@ -33,6 +33,6 @@ ha_iot_class: Local Polling
 
 {% include integrations/supported_brand.md %}
 
-## Port Configuration
+## Port configuration
 
 Fujitsu anywAiR uses port **10211** for API communication. You will need to change the default port provided by the Advantage Air integration to **10211** to use it with Fujitsu anywAiR.


### PR DESCRIPTION
Fujitsu anywAiR uses a different default port than the Advantage Air integration its based on.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
