### PR TITLE
fix: Linux Battery file can be a string

### DIFF
--- a/source/_integrations/linux_battery.markdown
+++ b/source/_integrations/linux_battery.markdown
@@ -37,7 +37,7 @@ name:
 battery:
   description: Name or number of the battery in `/sys/class/power_supply/`.
   required: false
-  default: "BAT1"
+  default: BAT1
   type: [string, integer]
 system:
   description: "The local system type. Support `linux` and `android`."

--- a/source/_integrations/linux_battery.markdown
+++ b/source/_integrations/linux_battery.markdown
@@ -35,10 +35,10 @@ name:
   default: Battery
   type: string
 battery:
-  description: Number of the battery.
+  description: Name or number of the battery in `/sys/class/power_supply/`.
   required: false
-  default: 1
-  type: integer
+  default: "BAT1"
+  type: [string, integer]
 system:
   description: "The local system type. Support `linux` and `android`."
   required: false

--- a/source/_integrations/linux_battery.markdown
+++ b/source/_integrations/linux_battery.markdown
@@ -35,7 +35,7 @@ name:
   default: Battery
   type: string
 battery:
-  description: Name or number of the battery in `/sys/class/power_supply/`.
+  description: Name or number of the battery directory in `/sys/class/power_supply/` (for example, `BAT0`, `BAT1`, or a custom string).
   required: false
   default: BAT1
   type: [string, integer]


### PR DESCRIPTION
This is the documentation PR to a `home-assistant/core` bug fix.
PR: https://github.com/home-assistant/core/pull/159034

The assumption that the battery file name is always of the type BAT0 is incorrect. It could be an arbitrary string. This change allows specifying the battery id as a string but retains backwards compatibility with the legacy int option.

Related to: https://github.com/home-assistant/core/issues/125911

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/159034
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
