### PR TITLE
Document Overseerr issue management services

### DIFF
--- a/source/_integrations/overseerr.markdown
+++ b/source/_integrations/overseerr.markdown
@@ -96,7 +96,7 @@ The Overseerr integration has the following actions:
 - `overseerr.update_issue` - Update an existing issue
 - `overseerr.delete_issue` - Delete an issue
 
-### Get requests
+### Action get requests
 
 Get a list of media requests using the `overseerr.get_requests` action.
 
@@ -105,14 +105,14 @@ Get a list of media requests using the `overseerr.get_requests` action.
 - **sort_order** (*Optional*): Sort the requests by `added` or `modified` date.
 - **requested_by** (*Optional*): Filter the requests by the user ID that requested them.
 
-### Get issues
+### Action get issues
 
 Retrieves a list of issues from Overseerr using the `overseerr.get_issues` action.
 
 - **config_entry_id** (*Required*): The Overseerr instance to get issues from.
 - **status** (*Optional*): Filter the issues by status (`all`, `open`, `resolved`).
 
-### Create issue
+### Action create issue
 
 Creates a new issue for media in Overseerr using the `overseerr.create_issue` action.
 
@@ -121,7 +121,7 @@ Creates a new issue for media in Overseerr using the `overseerr.create_issue` ac
 - **message** (*Required*): A description of the issue.
 - **media_id** (*Required*): The media ID to report the issue for.
 
-### Update issue
+### Action update issue
 
 Updates an existing issue in Overseerr using the `overseerr.update_issue` action.
 
@@ -130,7 +130,7 @@ Updates an existing issue in Overseerr using the `overseerr.update_issue` action
 - **status** (*Optional*): Update the status of the issue (`open`, `resolved`).
 - **message** (*Optional*): Add a comment to the issue.
 
-### Delete issue
+### Action delete issue
 
 Deletes an issue from Overseerr using the `overseerr.delete_issue` action.
 

--- a/source/_integrations/overseerr.markdown
+++ b/source/_integrations/overseerr.markdown
@@ -105,12 +105,27 @@ Get a list of media requests.
 - **sort_order** (*Optional*): Sort requests by when they were added or last modified.
 - **requested_by** (*Optional*): Show only requests from a specific user.
 
+```yaml
+action: overseerr.get_requests
+data:
+  config_entry_id: "abc123"
+  status: pending
+  sort_order: added
+```
+
 ### Action get issues
 
 Get a list of reported issues.
 
 - **config_entry_id** (*Required*): The Overseerr instance to get issues from.
 - **status** (*Optional*): Show all issues, only open issues, or only resolved issues.
+
+```yaml
+action: overseerr.get_issues
+data:
+  config_entry_id: "abc123"
+  status: open
+```
 
 ### Action create issue
 
@@ -121,6 +136,15 @@ Report a problem with media.
 - **message** (*Required*): A description of the problem.
 - **media_id** (*Required*): The media ID to report the issue for.
 
+```yaml
+action: overseerr.create_issue
+data:
+  config_entry_id: "abc123"
+  issue_type: video
+  message: "Video stuttering in episode 3"
+  media_id: 12345
+```
+
 ### Action update issue
 
 Update an existing issue or add a comment.
@@ -130,12 +154,28 @@ Update an existing issue or add a comment.
 - **status** (*Optional*): Mark the issue as open or resolved.
 - **message** (*Optional*): A comment with additional information.
 
+```yaml
+action: overseerr.update_issue
+data:
+  config_entry_id: "abc123"
+  issue_id: 42
+  status: resolved
+  message: "Fixed in latest version"
+```
+
 ### Action delete issue
 
 Delete an issue.
 
 - **config_entry_id** (*Required*): The Overseerr instance to delete the issue from.
 - **issue_id** (*Required*): The issue ID to delete.
+
+```yaml
+action: overseerr.delete_issue
+data:
+  config_entry_id: "abc123"
+  issue_id: 42
+```
 
 
 ## Use cases

--- a/source/_integrations/overseerr.markdown
+++ b/source/_integrations/overseerr.markdown
@@ -89,19 +89,59 @@ The Overseerr integration has the following actions:
 
 - `overseerr.get_requests` - Get a list of media requests
 
+### Issue actions
+
+- `overseerr.get_issues` - Get a list of issues
+- `overseerr.create_issue` - Create a new issue
+- `overseerr.update_issue` - Update an existing issue
+- `overseerr.delete_issue` - Delete an issue
+
 ### Get requests
 
 Get a list of media requests using the `overseerr.get_requests` action.
 
-- **config_entry_id** (*Required*): The ID of the Overseerr config entry to get data from.
-- **status** (*Optional*): The status to filter the results on.
-- **sort_order** (*Optional*): The sort order to sort the results in (`added`/`modified`).
-- **requested_by** (*Optional*): Filter the requests based on the user ID of the requester.
+- **config_entry_id** (*Required*): The Overseerr instance to get requests from.
+- **status** (*Optional*): Filter the requests by status (`approved`, `pending`, `available`, `processing`, `unavailable`, `failed`).
+- **sort_order** (*Optional*): Sort the requests by `added` or `modified` date.
+- **requested_by** (*Optional*): Filter the requests by the user ID that requested them.
+
+### Get issues
+
+Retrieves a list of issues from Overseerr using the `overseerr.get_issues` action.
+
+- **config_entry_id** (*Required*): The Overseerr instance to get issues from.
+- **status** (*Optional*): Filter the issues by status (`all`, `open`, `resolved`).
+
+### Create issue
+
+Creates a new issue for media in Overseerr using the `overseerr.create_issue` action.
+
+- **config_entry_id** (*Required*): The Overseerr instance to create the issue in.
+- **issue_type** (*Required*): The type of issue being reported (`video`, `audio`, `subtitle`, `other`).
+- **message** (*Required*): A description of the issue.
+- **media_id** (*Required*): The media ID to report the issue for.
+
+### Update issue
+
+Updates an existing issue in Overseerr using the `overseerr.update_issue` action.
+
+- **config_entry_id** (*Required*): The Overseerr instance to update the issue in.
+- **issue_id** (*Required*): The ID of the issue to update.
+- **status** (*Optional*): Update the status of the issue (`open`, `resolved`).
+- **message** (*Optional*): Add a comment to the issue.
+
+### Delete issue
+
+Deletes an issue from Overseerr using the `overseerr.delete_issue` action.
+
+- **config_entry_id** (*Required*): The Overseerr instance to delete the issue from.
+- **issue_id** (*Required*): The ID of the issue to delete.
 
 
 ## Use cases
 
 The integration can be used to build automations to help and notify you of new media requests and issues.
+The provided actions can be used to provide extra context to voice assistants or to manage and track issues with your media content.
 
 ## Example automations
 

--- a/source/_integrations/overseerr.markdown
+++ b/source/_integrations/overseerr.markdown
@@ -107,35 +107,35 @@ Get a list of media requests.
 
 ### Action get issues
 
-Get a list of reported issues with your media.
+Get a list of reported issues.
 
 - **config_entry_id** (*Required*): The Overseerr instance to get issues from.
 - **status** (*Optional*): Show all issues, only open issues, or only resolved issues.
 
 ### Action create issue
 
-Report a problem with a movie or TV show.
+Report a problem with media.
 
 - **config_entry_id** (*Required*): The Overseerr instance to create the issue in.
-- **issue_type** (*Required*): What type of problem you're reporting (video quality, audio, subtitles, or other).
-- **message** (*Required*): Describe the problem.
-- **media_id** (*Required*): The ID number of the movie or TV show with the problem.
+- **issue_type** (*Required*): The type of problem (video quality, audio, subtitles, or other).
+- **message** (*Required*): A description of the problem.
+- **media_id** (*Required*): The media ID to report the issue for.
 
 ### Action update issue
 
-Update an existing issue or add a comment to it.
+Update an existing issue or add a comment.
 
 - **config_entry_id** (*Required*): The Overseerr instance to update the issue in.
-- **issue_id** (*Required*): The issue number you want to update.
+- **issue_id** (*Required*): The issue ID to update.
 - **status** (*Optional*): Mark the issue as open or resolved.
-- **message** (*Optional*): Add a comment with additional information.
+- **message** (*Optional*): A comment with additional information.
 
 ### Action delete issue
 
-Delete an issue that was reported by mistake or is no longer needed.
+Delete an issue.
 
 - **config_entry_id** (*Required*): The Overseerr instance to delete the issue from.
-- **issue_id** (*Required*): The issue number you want to delete.
+- **issue_id** (*Required*): The issue ID to delete.
 
 
 ## Use cases

--- a/source/_integrations/overseerr.markdown
+++ b/source/_integrations/overseerr.markdown
@@ -98,44 +98,44 @@ The Overseerr integration has the following actions:
 
 ### Action get requests
 
-Get a list of media requests using the `overseerr.get_requests` action.
+Get a list of media requests.
 
 - **config_entry_id** (*Required*): The Overseerr instance to get requests from.
-- **status** (*Optional*): Filter the requests by status (`approved`, `pending`, `available`, `processing`, `unavailable`, `failed`).
-- **sort_order** (*Optional*): Sort the requests by `added` or `modified` date.
-- **requested_by** (*Optional*): Filter the requests by the user ID that requested them.
+- **status** (*Optional*): Filter requests by their status.
+- **sort_order** (*Optional*): Sort requests by when they were added or last modified.
+- **requested_by** (*Optional*): Show only requests from a specific user.
 
 ### Action get issues
 
-Retrieves a list of issues from Overseerr using the `overseerr.get_issues` action.
+Get a list of reported issues with your media.
 
 - **config_entry_id** (*Required*): The Overseerr instance to get issues from.
-- **status** (*Optional*): Filter the issues by status (`all`, `open`, `resolved`).
+- **status** (*Optional*): Show all issues, only open issues, or only resolved issues.
 
 ### Action create issue
 
-Creates a new issue for media in Overseerr using the `overseerr.create_issue` action.
+Report a problem with a movie or TV show.
 
 - **config_entry_id** (*Required*): The Overseerr instance to create the issue in.
-- **issue_type** (*Required*): The type of issue being reported (`video`, `audio`, `subtitle`, `other`).
-- **message** (*Required*): A description of the issue.
-- **media_id** (*Required*): The media ID to report the issue for.
+- **issue_type** (*Required*): What type of problem you're reporting (video quality, audio, subtitles, or other).
+- **message** (*Required*): Describe the problem.
+- **media_id** (*Required*): The ID number of the movie or TV show with the problem.
 
 ### Action update issue
 
-Updates an existing issue in Overseerr using the `overseerr.update_issue` action.
+Update an existing issue or add a comment to it.
 
 - **config_entry_id** (*Required*): The Overseerr instance to update the issue in.
-- **issue_id** (*Required*): The ID of the issue to update.
-- **status** (*Optional*): Update the status of the issue (`open`, `resolved`).
-- **message** (*Optional*): Add a comment to the issue.
+- **issue_id** (*Required*): The issue number you want to update.
+- **status** (*Optional*): Mark the issue as open or resolved.
+- **message** (*Optional*): Add a comment with additional information.
 
 ### Action delete issue
 
-Deletes an issue from Overseerr using the `overseerr.delete_issue` action.
+Delete an issue that was reported by mistake or is no longer needed.
 
 - **config_entry_id** (*Required*): The Overseerr instance to delete the issue from.
-- **issue_id** (*Required*): The ID of the issue to delete.
+- **issue_id** (*Required*): The issue number you want to delete.
 
 
 ## Use cases


### PR DESCRIPTION
## Description

This PR documents the new issue management services for the Overseerr integration introduced in home-assistant/core#159370.

### Services documented:
- `overseerr.get_issues` - Retrieve issues with status filtering
- `overseerr.create_issue` - Create new issues for media
- `overseerr.update_issue` - Update existing issues
- `overseerr.delete_issue` - Delete issues

Also updated the existing `overseerr.get_requests` service documentation to include all available status options.

## Related PRs

- Core implementation: https://github.com/home-assistant/core/pull/159370