### PR TITLE
Explain device tracker entity status in asuswrt

### DIFF
--- a/source/_integrations/asuswrt.markdown
+++ b/source/_integrations/asuswrt.markdown
@@ -54,7 +54,7 @@ If the integration is configured to use the http(s) protocol, also the following
 - Last boot sensor (Timestamp)
 - Uptime sensor (HH:MM:SS)
 
-By default, the integration will create **enabled** Device Tracker entities for devices that HA already knows about via some other integration. The ASUSWRT integration will create **disabled** device_tracker entities for other devices on the network, and the user can enable them manually in the Home Assistant GUI: go to Settings > Devices & Services > Entities. Filter on Integrations = ASUSWRT. Filter on Status = Dsiabled. Now you should see the disabled device_tracker entities and you can enable them one at a time as desired.
+By default, the integration will create **enabled** Device Tracker entities for devices that HA already knows about via some other integration. The ASUSWRT integration will create **disabled** device_tracker entities for other devices on the network, and the user can enable them manually in the Home Assistant GUI: go to Settings > Devices & Services > Entities. Filter on Integrations = ASUSWRT. Filter on Status = Disabled. Now you should see the disabled device_tracker entities and you can enable them one at a time as desired.
 
 {% include integrations/option_flow.md %}
 {% configuration_basic %}

--- a/source/_integrations/asuswrt.markdown
+++ b/source/_integrations/asuswrt.markdown
@@ -54,7 +54,7 @@ If the integration is configured to use the http(s) protocol, also the following
 - Last boot sensor (Timestamp)
 - Uptime sensor (HH:MM:SS)
 
-Only `Connected devices sensor` and `Last boot sensor` are created in status **enabled**, all other sensors are created in status **disabled**. To use them, simply **enable** on the devices page.
+By default, the integration will create **enabled** Device Tracker entities for devices that HA already knows about via some other integration. The ASUSWRT integration will create **disabled** device_tracker entities for other devices on the network, and the user can enable them manually in the Home Assistant GUI: go to Settings > Devices & Services > Entities. Filter on Integrations = ASUSWRT. Filter on Status = Dsiabled. Now you should see the disabled device_tracker entities and you can enable them one at a time as desired.
 
 {% include integrations/option_flow.md %}
 {% configuration_basic %}


### PR DESCRIPTION
…er creation

Gave more detailed explanation of when the integration creates enabled vs disabled device_tracker entities, and how to enable them if desired.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Rewrote/expanded the explanation of device_tracker entities created in the readme file.
-->



## Type of change
<!--
    Documentation change only.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
