### PR TITLE
Enhance lightwave configuration with unique_id

### DIFF
--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -20,7 +20,7 @@ related:
 ha_quality_scale: legacy
 ---
 
-The `Lightwave` {% term integration %} links Home Assistant with your Lightwave Connect Series WiFi link for controlling Lightwave lights, switches and TRVs.
+The `lightwave` {% term integration %} links Home Assistant with your Lightwave Connect Series WiFi link for controlling Lightwave lights, switches and TRVs.
 
 This {% term integration %} is for Connect Series WiFi links and does not support Smart Series devices, for more information see [Smart and Connect Series](https://support.lightwaverf.com/knowledge/about-smart-and-connect-series).  
 

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -20,7 +20,7 @@ related:
 ha_quality_scale: legacy
 ---
 
-The `lightwave` {% term integration %} links Home Assistant with your Lightwave Connect Series WiFi link for controlling Lightwave lights, switches and TRVs.
+The **Lightwave** {% term integration %} links Home Assistant with your Lightwave Connect Series WiFi link for controlling Lightwave lights, switches and TRVs.
 
 This {% term integration %} is for Connect Series WiFi links and does not support Smart Series devices, for more information see [Smart and Connect Series](https://support.lightwaverf.com/knowledge/about-smart-and-connect-series).  
 
@@ -34,19 +34,26 @@ lightwave:
   host: IP_ADDRESS
   lights:
     R1D3:
+      unique_id: wall_light_lwrf
       name: Wall lights
     R1D4:
+      unique_id: ceiling_light_lwrf
       name: Ceiling lights
   switches:
     R1D2:
+      unique_id: tree_socket_lwrf
       name: Tree socket
     R2D1:
+      unique_id: radio_socket_lwrf
       name: Radio socket
     R2D2:
+      unique_id: light_socket_lwrf
       name: Light socket
     R2D3:
+      unique_id: phone_socket_lwrf
       name: Phone socket
     R2D4:
+      unique_id: torch_socket_lwrf
       name: Torch socket
 ```
 
@@ -60,6 +67,10 @@ lights:
   required: false
   type: map
   keys:
+    unique_id:
+      description: Unique ID of the Light
+      required: false
+      type: string
     name:
       description: Name of the Light
       required: true
@@ -69,6 +80,10 @@ switches:
   required: false
   type: map
   keys:
+    unique_id:
+      description: Unique ID of the Switch
+      required: false
+      type: string
     name:
       description: Name of the Switch
       required: true
@@ -106,6 +121,8 @@ trv:
 
 Where IP_ADDRESS is the IP address of your Lightwave hub.
 Each `switch` or `light` requires an `id` and a `name`. The `id` takes the form `R#D#` where `R#` is the room number and `D#` is the device number.
+
+You can also use the `unique_id` parameter to set a unique ID for each device. This will allow the device to be customized in the UI, and be given aliases for voice assistants.
 
 `lights` and `switches` are optional but one of these must be present.
 

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -20,7 +20,7 @@ related:
 ha_quality_scale: legacy
 ---
 
-The **Lightwave** {% term integration %} links Home Assistant with your Lightwave Connect Series WiFi link for controlling Lightwave lights, switches and TRVs.
+The `Lightwave` {% term integration %} links Home Assistant with your Lightwave Connect Series WiFi link for controlling Lightwave lights, switches and TRVs.
 
 This {% term integration %} is for Connect Series WiFi links and does not support Smart Series devices, for more information see [Smart and Connect Series](https://support.lightwaverf.com/knowledge/about-smart-and-connect-series).  
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updates the docs to reflect the new `unique_id` attribute added to the legacy `lightwave` integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/159714
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
