### PR TITLE
Update 17TRACK dashboard example to use get_packages action

### DIFF
--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -53,7 +53,31 @@ Each package entry (for example, within a status sensor) contains the following 
 
 ### Dashboard summary card
 
-Use the following templated Markdown card to list all packages in transit along with their status:
+To display package information on your dashboard, first create a trigger-based template sensor that calls the `seventeentrack.get_packages` action:
+
+```yaml
+template:
+  - trigger:
+      - trigger: time_pattern
+        hours: /1
+      - trigger: homeassistant
+        event: start
+    action:
+      - action: seventeentrack.get_packages
+        data:
+          config_entry_id: YOUR_CONFIG_ENTRY_ID
+          package_state:
+            - in_transit
+        response_variable: result
+    sensor:
+      - name: "Packages in transit"
+        unique_id: packages_in_transit
+        state: "{{ result.packages | count }}"
+        attributes:
+          packages: "{{ result.packages }}"
+```
+
+Then use a templated Markdown card to list all packages in transit along with their status:
 
 {% raw %}
 
@@ -61,17 +85,19 @@ Use the following templated Markdown card to list all packages in transit along 
 type: markdown
 title: Packages in transit
 content: >
-  {% for package in
-  states.sensor['17track_in_transit'].attributes.packages %}
+  {% for package in state_attr('sensor.packages_in_transit', 'packages') %}
 
-  >- **{{ package.friendly_name }} ({{ package.tracking_number }}):** {{
+  - **{{ package.friendly_name }} ({{ package.tracking_number }}):** {{
   package.info_text }}
 
   {% endfor %}
-
 ```
 
 {% endraw %}
+
+{% tip %}
+To find your `config_entry_id`, go to {% my integrations title="**Settings** > **Devices & services**" %}, select the 17Track integration, click the three-dot menu, and select **Copy entry ID**.
+{% endtip %}
 
 ## Actions
 


### PR DESCRIPTION
## Proposed change
The previous example used attributes.packages which no longer exists. Updated to use a trigger-based template sensor with the seventeentrack.get_packages action instead.


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue: fixes #36814
- fixes https://github.com/home-assistant/core/issues/156341#issuecomment-3694740086
- fixes https://github.com/home-assistant/core/issues/144499#issuecomment-3694297699

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
