### PR TITLE
Update Nest integration documentation with AP warnings and workaround

### DIFF
--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -22,7 +22,7 @@ ha_platforms:
   - diagnostics
   - event
   - sensor
-ha_integration_type: hub
+ha_integration_type: integration
 ---
 
 The **Google Nest** {% term integration %} allows you to integrate a few [supported](https://developers.google.com/nest/device-access/supported-devices) Google [Nest](https://store.google.com/us/category/connected_home?) devices in Home Assistant. This integration uses the [Smart Device Management](https://developers.google.com/nest/device-access/api) API and Google's Cloud Pubsub to efficiently listen for changes in device state or other events. See [Supported Devices](https://developers.google.com/nest/device-access/supported-devices) for all devices supported by the SDM API.
@@ -43,6 +43,24 @@ You are in control of the information and capabilities exposed to Home Assistant
 - The Nest Device Access Console Pub/Sub setup process has changed as of January 23rd 2025. **Please make sure you are using the latest version of Home Assistant.**
 
 - The Nest Smart Device Management (SDM) API **requires a US$5 fee**. Before buying, make sure your device is [supported](https://developers.google.com/nest/device-access/supported-devices).
+
+{% important %}
+This integration is incompatible with the [Google Advanced Protection Program](https://landing.google.com/intl/en_in/advancedprotection/). The "Restricted" API scopes required for device control are automatically blocked for Advanced Protection users.
+
+Workaround: If you have enabled AP, create and use a secondary, standard Google Account (non-AP) to host the devices:
+
+1. Create a new Google Account *without* Advanced Protection (if you don't have one already).
+
+2. Create a new **Home** in the Google Home app using this new account.
+
+3. Remove your Nest devices from your main account and re-add them to this new **Home**. Note that this may delete saved video history or settings for some devices.
+
+4. Invite your main account (the one with AP) as a **Family Member** to the new **Home**. This allows you to retain control in the Google Home app on your phone.
+
+5. Connect Home Assistant using the new standard account credentials.
+{% endimportant %}
+
+*[AP]: Advanced Protection Program
 
 ## Configuration
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -43,24 +43,7 @@ You are in control of the information and capabilities exposed to Home Assistant
 - The Nest Device Access Console Pub/Sub setup process has changed as of January 23rd 2025. **Please make sure you are using the latest version of Home Assistant.**
 
 - The Nest Smart Device Management (SDM) API **requires a US$5 fee**. Before buying, make sure your device is [supported](https://developers.google.com/nest/device-access/supported-devices).
-
-{% important %}
-This integration is incompatible with the [Google Advanced Protection Program](https://landing.google.com/intl/en_in/advancedprotection/). The "Restricted" API scopes required for device control are automatically blocked for Advanced Protection users.
-
-Workaround: If you have enabled AP, create and use a secondary, standard Google Account (non-AP) to host the devices:
-
-1. Create a new Google Account *without* Advanced Protection (if you don't have one already).
-
-2. Create a new **Home** in the Google Home app using this new account.
-
-3. Remove your Nest devices from your main account and re-add them to this new **Home**. Note that this may delete saved video history or settings for some devices.
-
-4. Invite your main account (the one with AP) as a **Family Member** to the new **Home**. This allows you to retain control in the Google Home app on your phone.
-
-5. Connect Home Assistant using the new standard account credentials.
-{% endimportant %}
-
-*[AP]: Advanced Protection Program
+- This integration is incompatible with the [Google Advanced Protection Program](https://landing.google.com/intl/en_in/advancedprotection/). See [Known limitations](#google-advanced-protection-program) below for workarounds.
 
 ## Configuration
 
@@ -552,6 +535,26 @@ This feature is enabled by the following permissions:
 {% endnote %}
 
 ## Known limitations
+
+### Google Advanced Protection Program
+
+The "Restricted" API scopes required for device control are automatically blocked for [Google Advanced Protection Program](https://landing.google.com/intl/en_in/advancedprotection/) users.
+
+{% important %}
+Workaround: If you have enabled AP, create and use a secondary, standard Google Account (non-AP) to host the devices:
+
+1. Create a new Google Account *without* Advanced Protection (if you don't have one already).
+
+2. Create a new **Home** in the Google Home app using this new account.
+
+3. Remove your Nest devices from your main account and re-add them to this new **Home**. Note that this may delete saved video history or settings for some devices.
+
+4. Invite your main account (the one with AP) as a **Family Member** to the new **Home**. This allows you to retain control in the Google Home app on your phone.
+
+5. Connect Home Assistant using the new standard account credentials.
+{% endimportant %}
+
+*[AP]: Advanced Protection Program
 
 ### Google account types
 

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -43,7 +43,7 @@ You are in control of the information and capabilities exposed to Home Assistant
 - The Nest Device Access Console Pub/Sub setup process has changed as of January 23rd 2025. **Please make sure you are using the latest version of Home Assistant.**
 
 - The Nest Smart Device Management (SDM) API **requires a US$5 fee**. Before buying, make sure your device is [supported](https://developers.google.com/nest/device-access/supported-devices).
-- This integration is incompatible with the [Google Advanced Protection Program](https://landing.google.com/intl/en_in/advancedprotection/). See [Known limitations](#google-advanced-protection-program) below for workarounds.
+- The SDM API is also incompatible with some Google Account types or Security settings, including Google Workspace and the Advanced Protection Program. See [Known limitations](#known-limitations) below.
 
 ## Configuration
 
@@ -536,6 +536,17 @@ This feature is enabled by the following permissions:
 
 ## Known limitations
 
+### Google account types
+
+There are limitations to which Google accounts can use the SDM API. See the [Device Access Registration](https://developers.google.com/nest/device-access/registration) documentation for details.
+
+The primary limitations are the following:
+
+- Google Workspace accounts are not supported. Only consumer accounts (for example, gmail.com) can be used.
+- Once a Google Account is associated with your Device Access Project, it cannot be changed. Be sure you are signed in to the correct Google Account before continuing.
+
+Keep in mind, the US$5 registration fee is non-refundable.
+
 ### Google Advanced Protection Program
 
 The "Restricted" API scopes required for device control are automatically blocked for [Google Advanced Protection Program](https://landing.google.com/intl/en_in/advancedprotection/) users.
@@ -555,17 +566,6 @@ Workaround: If you have enabled AP, create and use a secondary, standard Google 
 {% endimportant %}
 
 *[AP]: Advanced Protection Program
-
-### Google account types
-
-There are limitations to which Google accounts can use the SDM API. See the [Device Access Registration](https://developers.google.com/nest/device-access/registration) documentation for details.
-
-The primary limitations are the following:
-
-- Google Workspace accounts are not supported. Only consumer accounts (for example, gmail.com) can be used.
-- Once a Google Account is associated with your Device Access Project, it cannot be changed. Be sure you are signed in to the correct Google Account before continuing.
-
-Keep in mind, the US$5 registration fee is non-refundable.
 
 ### Google Home App migration and cameras
 


### PR DESCRIPTION
## Proposed change

Added a documentation warning about incompatibility with the Google Advanced Protection Program and provided workaround steps.

Workaround for home-assistant/home-assistant.io#41562

## Type of change

* [ ] Spelling, grammar or other readability improvements (`current` branch).
* [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
* [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
* [ ] I've opened up a PR to add logos and icons in [[Brands repository](https://github.com/home-assistant/brands)](https://github.com/home-assistant/brands).
* [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
* [ ] Removed stale or deprecated documentation.

## Additional information

* Link to parent pull request in the codebase:
* Link to parent pull request in the Brands repository:
* This PR is a workaround for issue: home-assistant/home-assistant.io#41562

## Checklist

* [x] This PR uses the correct branch, based on one of the following:
* I made a change to the existing documentation and used the `current` branch.
* I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.


* [x] The documentation follows the Home Assistant documentation [[standards](https://www.google.com/search?q=%5Bhttps://developers.home-assistant.io/docs/documenting/standards%5D(https://developers.home-assistant.io/docs/documenting/standards))](https://www.google.com/search?q=%5Bhttps://developers.home-assistant.io/docs/documenting/standards%5D(https://developers.home-assistant.io/docs/documenting/standards)).