### PR TITLE
Add rebuild command to duplicate-log-file docs

### DIFF
--- a/source/common-tasks/os.markdown
+++ b/source/common-tasks/os.markdown
@@ -151,8 +151,5 @@ ha core rebuild
 ha core restart
 ```
 
-
-**Important**: rebuilding the Home Assistant Core (`ha core rebuild`) is required for the changes to take effect.
-
 <!-- Enabling i2c-->
 {% include common-tasks/enable_i2c.md %}

--- a/source/common-tasks/os.markdown
+++ b/source/common-tasks/os.markdown
@@ -139,6 +139,7 @@ By default, Home Assistant Core logs are sent to the Systemd Journal, which can 
 
 ```bash
 ha core options --duplicate-log-file=true
+ha core rebuild
 ha core restart
 ```
 
@@ -146,8 +147,12 @@ To disable it:
 
 ```bash
 ha core options --duplicate-log-file=false
+ha core rebuild
 ha core restart
 ```
+
+
+**Important**: rebuilding the Home Assistant Core (`ha core rebuild`) is required for the changes to take effect.
 
 <!-- Enabling i2c-->
 {% include common-tasks/enable_i2c.md %}


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Rebuilding is required otherwise the changes won't take effect.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/160338

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
