### PR TITLE
Fix 404 on link to release post

### DIFF
--- a/source/changelogs/core-2026.1.markdown
+++ b/source/changelogs/core-2026.1.markdown
@@ -6,7 +6,7 @@ replace_regex: \s\(\[?[a-z0-9\-\s_]+\]?\)$
 
 These are all the changes included in the Home Assistant 2026.1 release.
 For a summary in a more readable format
-[Release notes blog for this release](/blog/2026/01/07/release-202601/).
+[Release notes blog for this release](/blog/2026/01/07/release-20261/).
 
 ## Beta Fixes
 


### PR DESCRIPTION
There was a slight mistake in the slug for the release post

## Proposed change
Bugfix a 404 from [this page](https://www.home-assistant.io/changelogs/core-2026.1) back to the 2026.1 release notes.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
