### PR TITLE
Add Unraid integration documentation

### DIFF
--- a/source/_integrations/unraid.markdown
+++ b/source/_integrations/unraid.markdown
@@ -1,6 +1,6 @@
 ---
-title: Unraid
-description: Instructions on how to integrate your Unraid server with Home Assistant.
+title: unRAID
+description: Instructions on how to integrate your unRAID server with Home Assistant.
 ha_category:
   - Binary sensor
   - Button
@@ -23,15 +23,15 @@ ha_integration_type: hub
 ha_quality_scale: platinum
 ---
 
-The **Unraid** {% term integration %} allows you to monitor and control your [Unraid](https://unraid.net/) server from Home Assistant. This integration connects via the Unraid GraphQL API, which is available in Unraid 7.2.0 and newer.
+The **unRAID** {% term integration %} allows you to monitor and control your [unRAID](https://unraid.net/) server from Home Assistant. This integration connects via the unRAID GraphQL API, which is available in unRAID 7.2.0 and newer.
 
 {% include integrations/config_flow.md %}
 
 ## Prerequisites
 
-Before setting up this integration, you need to generate an API key on your Unraid server:
+Before setting up this integration, you need to generate an API key on your unRAID server:
 
-1. Log in to your Unraid web interface.
+1. Log in to your unRAID web interface.
 2. Go to **Settings** > **Management Access** > **API Keys**.
 3. Select **Add API Key**.
 4. Set the **Role** to **ADMIN** (required for full functionality).
@@ -47,13 +47,13 @@ The following options are available during setup:
 
 {% configuration_basic %}
 Server IP or Hostname:
-  description: The IP address (e.g., `192.168.1.100`) or hostname of your Unraid server.
+  description: The IP address (e.g., `192.168.1.100`) or hostname of your unRAID server.
 API Key:
-  description: The API key generated from your Unraid server with ADMIN role permissions.
+  description: The API key generated from your unRAID server with ADMIN role permissions.
 HTTP Port:
-  description: The HTTP port (default 80). Only change if modified in Unraid Settings > Management Access.
+  description: The HTTP port (default 80). Only change if modified in unRAID Settings > Management Access.
 HTTPS Port:
-  description: The HTTPS port (default 443). Only change if modified in Unraid Settings > Management Access.
+  description: The HTTPS port (default 443). Only change if modified in unRAID Settings > Management Access.
 {% endconfiguration_basic %}
 
 ## Sensors
@@ -67,7 +67,7 @@ The integration creates the following system-level sensors:
 - **CPU temperature**: Processor temperature (if available)
 - **CPU power**: Processor power consumption in watts (if available)
 - **Uptime**: System uptime as a timestamp
-- **Active notifications**: Count of unread notifications on the Unraid server
+- **Active notifications**: Count of unread notifications on the unRAID server
 
 ### Array sensors
 
@@ -90,11 +90,11 @@ For each user share configured on your server:
 
 ### Flash drive sensor
 
-- **Flash usage**: USB flash drive usage for the Unraid boot device
+- **Flash usage**: USB flash drive usage for the unRAID boot device
 
 ### UPS sensors (if connected)
 
-If your Unraid server has a UPS connected:
+If your unRAID server has a UPS connected:
 
 - **Battery level**: Current UPS battery percentage
 - **Load**: UPS load percentage
@@ -157,7 +157,7 @@ For each disk:
 
 ## Data updates
 
-The integration polls your Unraid server for updates. The default polling interval is 30 seconds. You can [define a custom polling interval](/common-tasks/general/#defining-a-custom-polling-interval) if needed.
+The integration polls your unRAID server for updates. The default polling interval is 30 seconds. You can [define a custom polling interval](/common-tasks/general/#defining-a-custom-polling-interval) if needed.
 
 {% note %}
 Frequent polling will prevent disks from spinning down. Consider increasing the polling interval if disk spin-down is important to you.
@@ -165,7 +165,7 @@ Frequent polling will prevent disks from spinning down. Consider increasing the 
 
 ## Known limitations
 
-- Requires Unraid 7.2.0 or newer (GraphQL API v4.21.0+)
+- Requires unRAID 7.2.0 or newer (GraphQL API v4.21.0+)
 - The API key must have ADMIN role for full functionality
 - Some sensors may not be available depending on your hardware configuration (for example, CPU temperature requires motherboard support)
 
@@ -175,18 +175,18 @@ Frequent polling will prevent disks from spinning down. Consider increasing the 
 
 - Verify the IP address or hostname is correct and reachable from Home Assistant.
 - Ensure the correct HTTP/HTTPS ports are configured.
-- Check that your Unraid server is running and accessible on your network.
+- Check that your unRAID server is running and accessible on your network.
 
 ### Invalid authentication error
 
 - Verify the API key is correct and has not expired.
 - Ensure the API key has the ADMIN role assigned.
-- Try generating a new API key in Unraid Settings > Management Access > API Keys.
+- Try generating a new API key in unRAID Settings > Management Access > API Keys.
 
 ### Unsupported version error
 
-- This integration requires Unraid 7.2.0 or newer.
-- Update your Unraid server to the latest version.
+- This integration requires unRAID 7.2.0 or newer.
+- Update your unRAID server to the latest version.
 
 ### Missing sensors
 
@@ -194,10 +194,10 @@ Some sensors require specific hardware or configuration:
 
 - **CPU temperature**: Requires motherboard sensor support
 - **CPU power**: Requires processor power monitoring support
-- **UPS sensors**: Requires a UPS connected and configured in Unraid
+- **UPS sensors**: Requires a UPS connected and configured in unRAID
 
 ## Removing the integration
 
 {% include integrations/remove_device_service.md %}
 
-After removing the integration, you may optionally delete the API key from your Unraid server in **Settings** > **Management Access** > **API Keys**.
+After removing the integration, you may optionally delete the API key from your unRAID server in **Settings** > **Management Access** > **API Keys**.

--- a/source/_integrations/unraid.markdown
+++ b/source/_integrations/unraid.markdown
@@ -1,0 +1,203 @@
+---
+title: Unraid
+description: Instructions on how to integrate your Unraid server with Home Assistant.
+ha_category:
+  - Binary sensor
+  - Button
+  - Sensor
+  - Switch
+  - System monitor
+ha_release: "2026.2"
+ha_iot_class: Local Polling
+ha_codeowners:
+  - "@ruaan-deysel"
+ha_domain: unraid
+ha_config_flow: true
+ha_platforms:
+  - binary_sensor
+  - button
+  - diagnostics
+  - sensor
+  - switch
+ha_integration_type: hub
+ha_quality_scale: platinum
+---
+
+The **Unraid** {% term integration %} allows you to monitor and control your [Unraid](https://unraid.net/) server from Home Assistant. This integration connects via the Unraid GraphQL API, which is available in Unraid 7.2.0 and newer.
+
+{% include integrations/config_flow.md %}
+
+## Prerequisites
+
+Before setting up this integration, you need to generate an API key on your Unraid server:
+
+1. Log in to your Unraid web interface.
+2. Go to **Settings** > **Management Access** > **API Keys**.
+3. Select **Add API Key**.
+4. Set the **Role** to **ADMIN** (required for full functionality).
+5. Copy the generated API key for use during setup.
+
+{% important %}
+The API key must have the **ADMIN** role to access all features. A key with lower permissions may result in limited functionality.
+{% endimportant %}
+
+## Configuration options
+
+The following options are available during setup:
+
+{% configuration_basic %}
+Server IP or Hostname:
+  description: The IP address (e.g., `192.168.1.100`) or hostname of your Unraid server.
+API Key:
+  description: The API key generated from your Unraid server with ADMIN role permissions.
+HTTP Port:
+  description: The HTTP port (default 80). Only change if modified in Unraid Settings > Management Access.
+HTTPS Port:
+  description: The HTTPS port (default 443). Only change if modified in Unraid Settings > Management Access.
+{% endconfiguration_basic %}
+
+## Sensors
+
+### System sensors
+
+The integration creates the following system-level sensors:
+
+- **CPU usage**: Current CPU utilization percentage
+- **RAM usage**: Current memory usage with free/used/total in attributes
+- **CPU temperature**: Processor temperature (if available)
+- **CPU power**: Processor power consumption in watts (if available)
+- **Uptime**: System uptime as a timestamp
+- **Active notifications**: Count of unread notifications on the Unraid server
+
+### Array sensors
+
+- **Array state**: Current state of the disk array (for example, Started, Stopped)
+- **Array usage**: Percentage of array capacity used with detailed size attributes
+- **Parity check progress**: Progress percentage during parity operations
+
+### Disk sensors
+
+For each disk in your array (including parity, data, and cache disks):
+
+- **Temperature**: Current disk temperature
+- **Usage**: Disk usage percentage with size details in attributes
+
+### Share sensors
+
+For each user share configured on your server:
+
+- **Usage**: Share usage percentage with free/used/total size attributes
+
+### Flash drive sensor
+
+- **Flash usage**: USB flash drive usage for the Unraid boot device
+
+### UPS sensors (if connected)
+
+If your Unraid server has a UPS connected:
+
+- **Battery level**: Current UPS battery percentage
+- **Load**: UPS load percentage
+- **Runtime**: Estimated battery runtime remaining
+- **Power**: Current power draw in watts
+
+## Binary sensors
+
+### Disk health
+
+For each disk in your array:
+
+- **Disk health**: Indicates if the disk has SMART warnings or errors (problem sensor)
+
+### Array status
+
+- **Array started**: Indicates if the disk array is running
+- **Parity check running**: Indicates if a parity operation is in progress
+- **Parity valid**: Indicates if parity data is valid (problem sensor when invalid)
+
+### UPS status
+
+- **UPS connected**: Indicates if a UPS is connected and communicating
+
+## Switches
+
+### Docker containers
+
+For each Docker container on your server:
+
+- **Container switch**: Turn Docker containers on/off
+
+### Virtual machines
+
+For each virtual machine on your server:
+
+- **VM switch**: Start/stop virtual machines
+
+## Buttons
+
+### Array controls
+
+- **Start array**: Start the disk array
+- **Stop array**: Stop the disk array (requires confirmation)
+
+### Parity controls
+
+- **Start parity check**: Start a non-correcting parity check
+- **Start parity check (correcting)**: Start a correcting parity check
+- **Pause parity check**: Pause the running parity operation
+- **Resume parity check**: Resume a paused parity operation
+- **Stop parity check**: Cancel the running parity operation
+
+### Disk controls
+
+For each disk:
+
+- **Spin up**: Spin up the disk
+- **Spin down**: Spin down the disk
+
+## Data updates
+
+The integration polls your Unraid server for updates. The default polling interval is 30 seconds. You can [define a custom polling interval](/common-tasks/general/#defining-a-custom-polling-interval) if needed.
+
+{% note %}
+Frequent polling will prevent disks from spinning down. Consider increasing the polling interval if disk spin-down is important to you.
+{% endnote %}
+
+## Known limitations
+
+- Requires Unraid 7.2.0 or newer (GraphQL API v4.21.0+)
+- The API key must have ADMIN role for full functionality
+- Some sensors may not be available depending on your hardware configuration (for example, CPU temperature requires motherboard support)
+
+## Troubleshooting
+
+### Cannot connect error
+
+- Verify the IP address or hostname is correct and reachable from Home Assistant.
+- Ensure the correct HTTP/HTTPS ports are configured.
+- Check that your Unraid server is running and accessible on your network.
+
+### Invalid authentication error
+
+- Verify the API key is correct and has not expired.
+- Ensure the API key has the ADMIN role assigned.
+- Try generating a new API key in Unraid Settings > Management Access > API Keys.
+
+### Unsupported version error
+
+- This integration requires Unraid 7.2.0 or newer.
+- Update your Unraid server to the latest version.
+
+### Missing sensors
+
+Some sensors require specific hardware or configuration:
+
+- **CPU temperature**: Requires motherboard sensor support
+- **CPU power**: Requires processor power monitoring support
+- **UPS sensors**: Requires a UPS connected and configured in Unraid
+
+## Removing the integration
+
+{% include integrations/remove_device_service.md %}
+
+After removing the integration, you may optionally delete the API key from your Unraid server in **Settings** > **Management Access** > **API Keys**.

--- a/source/_integrations/unraid.markdown
+++ b/source/_integrations/unraid.markdown
@@ -47,7 +47,7 @@ The following options are available during setup:
 
 {% configuration_basic %}
 Server IP or Hostname:
-  description: The IP address (e.g., `192.168.1.100`) or hostname of your unRAID server.
+  description: The IP address (for example, `192.168.1.100`) or hostname of your unRAID server.
 API Key:
   description: The API key generated from your unRAID server with ADMIN role permissions.
 HTTP Port:


### PR DESCRIPTION
## Summary

Add documentation for the new Unraid integration.

## Related PR

This documentation corresponds to the Unraid integration PR in core: https://github.com/home-assistant/core/pull/160581

## Checklist

- [x] Documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting)
- [x] Integration header fields match `manifest.json`
- [x] Includes prerequisites section with API key setup instructions
- [x] Configuration options documented using `{% configuration_basic %}`
- [x] All entity platforms documented (sensors, binary sensors, switches, buttons)
- [x] Troubleshooting section included
- [x] Removal instructions included

## Documentation Overview

The Unraid integration documentation covers:

- **Prerequisites**: How to generate an API key on the Unraid server
- **Configuration**: UI configuration options (host, API key, ports)
- **Sensors**: System, array, disk, share, flash, and UPS sensors
- **Binary Sensors**: Disk health, array status, parity status, UPS connectivity
- **Switches**: Docker containers and virtual machines
- **Buttons**: Array controls, parity operations, disk spin up/down
- **Troubleshooting**: Common errors and solutions
- **Known limitations**: Version requirements and hardware dependencies