### PR TITLE
Update level integration documentation

### DIFF
--- a/source/_integrations/level.markdown
+++ b/source/_integrations/level.markdown
@@ -1,23 +1,44 @@
 ---
-title: Level
-description: Connect and control your Level Matter devices using the Matter integration
+title: Level Lock
+description: Connect your Level account to control Level smart locks in Home Assistant.
 ha_release: '2025.10'
-ha_iot_class: Local Push
+ha_iot_class: Cloud Push
 ha_category:
   - Lock
-ha_domain: level
-ha_integration_type: brand
+ha_domain: levelhome
+ha_integration_type: hub
 ha_platforms:
   - lock
-ha_iot_standard: matter
 ha_brand: true
 ---
 
-[Level](https://level.co/) is committed to making sure their products are up-to-date and ready to use in Home Assistant.
+[Level](https://level.co/) smart locks connect to Home Assistant through your Level account. This integration uses the Level Home mobile app to authorize access and provides cloud push updates for near-instant state changes.
 
-Level Matter devices work locally and integrate seamlessly with the Matter integration in Home Assistant. As all connectivity is happening locally, status updates and controlling your devices happen instantly in Home Assistant.
+Some Level locks also support Matter and can be added locally through the Matter integration.
 
-{% my add_matter_device badge domain=page.ha_domain %}
+{% my add_matter_device badge domain="matter" %}
 
 [Learn more about Matter in Home Assistant.](/integrations/matter/)
 
+## Prerequisites
+
+- A Level smart lock already set up in the Level Home mobile app.
+- A Level account that can access the lock.
+
+## Installation
+
+1. In Home Assistant, go to **Settings** > **Devices & services**.
+2. Select **Add integration** and search for `Level Lock`.
+3. Enter your email address or phone number.
+4. Open the Level Home mobile app and enter the verification code shown in Home Assistant.
+5. Return to Home Assistant and select **Submit** to finish setup.
+
+## Removal
+
+1. In Home Assistant, go to **Settings** > **Devices & services**.
+2. Select the **Level Lock** integration.
+3. Select **Remove** and confirm.
+
+## Service actions
+
+This integration does not register custom service actions. Use the standard [`lock.lock`](/integrations/lock/#action-locklock) and [`lock.unlock`](/integrations/lock/#action-lockunlock) service actions for Level lock entities.


### PR DESCRIPTION
## Proposed change

Add Level Home integration documentation for bronze quality. New integration allows for controlling a Level Lock device through the Level Connect using websocket connections.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Parent PR: https://github.com/home-assistant/core/pull/160799

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
