### PR TITLE
Revert "Update _redirects for Template Blueprint link"

### DIFF
--- a/source/_redirects
+++ b/source/_redirects
@@ -13,7 +13,7 @@ layout: null
 /bluesky https://bsky.app/profile/home-assistant.io
 /newsletter https://newsletter.openhomefoundation.org/
 /suggest-community-highlight https://docs.google.com/forms/d/e/1FAIpQLSd9VWPeVM0xg0swWL6kT3wkQUKt8vWsTL5WtPO95LAy-0cYZw/viewform
-/get-blueprints https://community.home-assistant.io/tags/c/blueprints-exchange/53/template-entity
+/get-blueprints https://community.home-assistant.io/c/blueprints-exchange/53
 /merch https://home-assistant-store.creator-spring.com
 /feature-requests https://github.com/orgs/home-assistant/discussions
 /issues https://github.com/home-assistant/core/issues


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#42878

I failed to diligently check for other places using the redirect link.

Addresses Issue: https://github.com/home-assistant/supervisor/issues/6479