### PR TITLE
Document Xbox recently played games sensor and service

### DIFF
--- a/source/_integrations/xbox.markdown
+++ b/source/_integrations/xbox.markdown
@@ -286,6 +286,7 @@ Just like the binary sensors, the Xbox sensor platform automatically keeps track
 | **Now playing**  | Shows the title of the game currently being played. Additional details such as a short description, genre, developer, age rating, and achievement progress are available in the entity's attributes. |
 | **Total space: *{name}*** | Reports the total storage capacity of the device. A separate sensor is created for each Xbox console and connected internal and external storage device. |
 | **Free space: *{name}*** | Reports the available (unused) storage space on the device. A separate sensor is created for each Xbox console and connected internal and external storage device. |
+| **Recently played games** | Shows the count of recently played games (up to 10 games). This sensor tracks your gaming activity and restores its state after Home Assistant restarts. Use the `get_recently_played_games` service to access detailed information about each game. |
 
 ## Image
 
@@ -300,6 +301,57 @@ For your account and each of your favorite friends, several image entities are a
 ## Media source
 
 The Xbox media source platform lets your browse your own and community gameclips or screenshots, as well as promotional images for games you've played, through the Media Browser panel. As with any other media source {% term integration %}, you can also send these clips to supported media players like Chromecast.
+
+## Services
+
+The Xbox {% term integration %} provides the following service to access detailed gaming information.
+
+### Service `xbox.get_recently_played_games`
+
+Retrieves detailed information about your recently played games from Xbox Network. This service returns comprehensive data about up to 10 recently played games, including achievement progress, gamerscore, timestamps, and game metadata. You can use this service to create custom template sensors or automations based on your gaming activity.
+
+The service returns the following information:
+
+- **xuid**: The Xbox User ID of the account
+- **account_name**: The display name of your Xbox account
+- **games**: A list of recently played games, where each game includes:
+  - **title**: The name of the game
+  - **title_id**: The unique game identifier
+  - **last_played**: ISO timestamp of when you last played the game
+  - **achievements_earned**: Number of achievements you've unlocked
+  - **achievements_total**: Total number of achievements available in the game
+  - **gamerscore_earned**: Gamerscore points you've earned
+  - **gamerscore_total**: Total gamerscore points available in the game
+  - **achievement_progress**: Achievement completion percentage (0-100)
+  - **image_url**: Game cover art URL (poster or logo)
+
+| Data attribute   | Optional | Description                                              |
+| ---------------- | -------- | -------------------------------------------------------- |
+| `config_entry_id` | no       | The Xbox configuration entry ID to get data from. You can find this in {% my integrations title="**Settings** > **Devices & services**" %} by selecting the Xbox integration, then selecting the three dots menu {% icon "mdi:dots-vertical" %} and selecting **Download diagnostics**. |
+
+#### Example template sensor using the service
+
+You can create template sensors that call this service to track specific gaming metrics. Here's an example that creates a sensor showing your total gamerscore from recently played games:
+
+```yaml
+template:
+  - trigger:
+      - trigger: time_pattern
+        minutes: "/30"
+    action:
+      - action: xbox.get_recently_played_games
+        data:
+          config_entry_id: "your_config_entry_id_here"
+        response_variable: xbox_data
+    sensor:
+      - name: "Total recent gamerscore"
+        unique_id: total_recent_gamerscore
+        state: >
+          {% raw %}{{ xbox_data.games | sum(attribute='gamerscore_earned') }}{% endraw %}
+        attributes:
+          games_played: >
+            {% raw %}{{ xbox_data.games | length }}{% endraw %}
+```
 
 ## Manual OAuth2 configuration
 

--- a/source/_integrations/xbox.markdown
+++ b/source/_integrations/xbox.markdown
@@ -306,9 +306,9 @@ The Xbox media source platform lets your browse your own and community gameclips
 
 The Xbox {% term integration %} provides the following service to access detailed gaming information.
 
-### Service `xbox.get_recently_played_games`
+### Service: Get recently played games
 
-Retrieves detailed information about your recently played games from Xbox Network. This service returns comprehensive data about up to 10 recently played games, including achievement progress, gamerscore, timestamps, and game metadata. You can use this service to create custom template sensors or automations based on your gaming activity.
+Retrieves detailed information about your recently played games from Xbox Network using the `xbox.get_recently_played_games` service. This service returns comprehensive data about up to 10 recently played games, including achievement progress, gamerscore, timestamps, and game metadata. You can use this service to create custom template sensors or automations based on your gaming activity.
 
 The service returns the following information:
 

--- a/source/_integrations/xbox.markdown
+++ b/source/_integrations/xbox.markdown
@@ -286,7 +286,7 @@ Just like the binary sensors, the Xbox sensor platform automatically keeps track
 | **Now playing**  | Shows the title of the game currently being played. Additional details such as a short description, genre, developer, age rating, and achievement progress are available in the entity's attributes. |
 | **Total space: *{name}*** | Reports the total storage capacity of the device. A separate sensor is created for each Xbox console and connected internal and external storage device. |
 | **Free space: *{name}*** | Reports the available (unused) storage space on the device. A separate sensor is created for each Xbox console and connected internal and external storage device. |
-| **Recently played games** | Shows the count of recently played games (up to 10 games). This sensor tracks your gaming activity and restores its state after Home Assistant restarts. Use the `get_recently_played_games` service to access detailed information about each game. |
+| **Recently played games** | Shows the count of recently played games (up to 10 games). This sensor tracks your gaming activity and restores its state after Home Assistant restarts. Use the `get_recently_played_games` action to access detailed information about each game. |
 
 ## Image
 
@@ -302,15 +302,15 @@ For your account and each of your favorite friends, several image entities are a
 
 The Xbox media source platform lets your browse your own and community gameclips or screenshots, as well as promotional images for games you've played, through the Media Browser panel. As with any other media source {% term integration %}, you can also send these clips to supported media players like Chromecast.
 
-## Services
+## Actions
 
-The Xbox {% term integration %} provides the following service to access detailed gaming information.
+The Xbox {% term integration %} provides the following actions to access detailed gaming information:
 
-### Service: Get recently played games
+### Action: Get recently played games
 
-Retrieves detailed information about your recently played games from Xbox Network using the `xbox.get_recently_played_games` service. This service returns comprehensive data about up to 10 recently played games, including achievement progress, gamerscore, timestamps, and game metadata. You can use this service to create custom template sensors or automations based on your gaming activity.
+Retrieves detailed information about your recently played games from Xbox Network using the `xbox.get_recently_played_games` action. This action returns comprehensive data about up to 10 recently played games, including achievement progress, gamerscore, timestamps, and game metadata. You can use this action to create custom template sensors or automations based on your gaming activity.
 
-The service returns the following information:
+The action returns the following information:
 
 - **xuid**: The Xbox User ID of the account
 - **account_name**: The display name of your Xbox account
@@ -325,13 +325,17 @@ The service returns the following information:
   - **achievement_progress**: Achievement completion percentage (0-100)
   - **image_url**: Game cover art URL (poster or logo)
 
-| Data attribute   | Optional | Description                                              |
-| ---------------- | -------- | -------------------------------------------------------- |
-| `config_entry_id` | no       | The Xbox configuration entry ID to get data from. You can find this in {% my integrations title="**Settings** > **Devices & services**" %} by selecting the Xbox integration, then selecting the three dots menu {% icon "mdi:dots-vertical" %} and selecting **Download diagnostics**. |
+{% configuration_basic %}
 
-#### Example template sensor using the service
+config_entry_id:
+  description: The Xbox configuration entry ID to get data from. You can find this in {% my integrations title="**Settings** > **Devices & services**" %} by selecting the Xbox integration, then selecting the three dots menu {% icon "mdi:dots-vertical" %} and selecting **Download diagnostics**.
+  required: true
 
-You can create template sensors that call this service to track specific gaming metrics. Here's an example that creates a sensor showing your total gamerscore from recently played games:
+{% endconfiguration_basic %}
+
+#### Example template sensor using the action
+
+You can create template sensors that call this action to track specific gaming metrics. Here's an example that creates a sensor showing your total gamerscore from recently played games:
 
 ```yaml
 template:


### PR DESCRIPTION
## Proposed change

This PR adds documentation for new Xbox integration features introduced in home-assistant/core#158186, which adds a recently played games sensor and a service to retrieve detailed gaming information.

The documentation includes:
- Description of the new **Recently played games** sensor that tracks up to 10 recently played games
- Comprehensive documentation for the `xbox.get_recently_played_games` service with detailed parameter descriptions
- A practical template sensor example showing how to use the service response data to create custom sensors

The documentation follows all Home Assistant documentation standards including proper formatting, glossary term usage, My links, and YAML style guidelines.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/158186
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards