### PR TITLE
Clarify auth_providers order for skip login

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -158,8 +158,8 @@ homeassistant:
 Assuming you have only the owner created though onboarding process, no other users ever created. The above example configuration will allow you directly access Home Assistant main page if you access from your internal network (192.168.0.0/24) or from localhost (127.0.0.1). If you get a login abort error, then you can change to use Home Assistant Authentication Provider to login, if you access your Home Assistant instance from outside network.
 
 {% note %}
-When configuring skip login in Home Assistant, the order of `auth_providers` is critical. Authentication providers are evaluated top to bottom, and the first matching provider is used.
-To enable skip login as intended, the trusted_networks provider must be listed before the homeassistant provider. If `type: homeassistant` is configured first, Home Assistant will immediately present the login page and the skip login logic will never be reached, even if the client is on a trusted network.
+The order of `auth_providers` is critical as providers are evaluated top to bottom.
+To enable skip login as intended, the `trusted_networks` provider must be listed before the `homeassistant` provider. If `type: homeassistant` is configured first, Home Assistant will immediately present the login page and the skip login logic will never be reached, even if the client is on a trusted network.
 {% endnote %}
 
 ### Command line

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -157,6 +157,11 @@ homeassistant:
 
 Assuming you have only the owner created though onboarding process, no other users ever created. The above example configuration will allow you directly access Home Assistant main page if you access from your internal network (192.168.0.0/24) or from localhost (127.0.0.1). If you get a login abort error, then you can change to use Home Assistant Authentication Provider to login, if you access your Home Assistant instance from outside network.
 
+{% note %}
+When configuring skip login in Home Assistant, the order of `auth_providers` is critical. Authentication providers are evaluated top to bottom, and the first matching provider is used.
+To enable skip login as intended, the trusted_networks provider must be listed before the homeassistant provider. If `type: homeassistant` is configured first, Home Assistant will immediately present the login page and the skip login logic will never be reached, even if the client is on a trusted network.
+{% endnote %}
+
 ### Command line
 
 The command line auth provider executes a configurable shell command to perform user authentication. Two environment variables, `username` and `password`, are passed to the command. Access is granted when the command exits successfully (with exit code 0).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Adds documentation clarifying that the order of `auth_providers` types in Home Assistant configuration is critical for the skip login functionality to work as intended.

While `trusted_networks` supports skipping the login page, this behavior only applies if it is evaluated before the homeassistant authentication provider. If `type: homeassistant` is listed first, the login page is always shown and the bypass logic is never reached (even when the client is on a trusted network)

Creating a PR to add this note to the documentation was suggested in [this github issue](https://github.com/home-assistant/core/issues/131710#issuecomment-2506407372)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
