### PR TITLE
Set home dashboard as default dashboard

### DIFF
--- a/source/dashboards/dashboards.markdown
+++ b/source/dashboards/dashboards.markdown
@@ -35,7 +35,7 @@ Screenshot of the Dashboard list.
 
 Built-in dashboards that are available in the sidebar by default:
 
-- [Home dashboard](#home-dashboard). Category: built-in. If you set another dashboard as default, the Home dashboard is no longer shown in the sidebar by default.
+- [Home dashboard](#home-dashboard). Category: built-in. It is shown in the sidebar only while it is set as your default dashboard. If you set another dashboard as default, that dashboard appears in the sidebar instead.
 - [Activity dashboard](#activity-dashboard). Category: built-in.
 - Energy dashboard. Category: built-in.
 - [History dashboard](#history-dashboard). Category: built-in.

--- a/source/dashboards/dashboards.markdown
+++ b/source/dashboards/dashboards.markdown
@@ -35,11 +35,11 @@ Screenshot of the Dashboard list.
 
 Built-in dashboards that are available in the sidebar by default:
 
+- [Home dashboard](#home-dashboard). Category: built-in. If you set another dashboard as default, the Home dashboard is no longer shown in the sidebar by default.
 - [Activity dashboard](#activity-dashboard) Category: built-in.
 - Energy dashboard. Category: built-in.
 - [History dashboard](#history-dashboard). Category: built-in.
 - [Map dashboard](#map-dashboard): Category: user-created. The Map dashboard is an exception: it is available out of the box, but you can edit it freely. This is why it is categorized as **User-created** dashboard.
-- [Overview dashboard](#creating-a-new-dashboard). Category: built-in.
 - [To-do lists dashboard](#to-do-lists-dashboard). Category: built-in.
 
 <p class='img'>
@@ -51,7 +51,6 @@ Screenshot of the Dashboard list on a new installation.
 
 Some of the built-in dashboards are not shown in the sidebar by default, but are listed under {% my lovelace_dashboards title="**Settings** > **Dashboards**" %}.
 
-- [Home dashboard](#home-dashboard)
 - **Lights** dashboards: Overview of your lights, [grouped](/docs/organizing/) by [floors](/docs/organizing/floors/) and [areas](/docs/organizing/areas/).
 - **Security** dashboards: Overview of your security-related devices, [grouped](/docs/organizing/) by [floors](/docs/organizing/floors/) and [areas](/docs/organizing/areas/). The security-related devices include devices such as alarm, lock, camera, doors/covers, motion sensors, and binary sensor.
 - **Climate** dashboards: Overview of your climate devices, [grouped](/docs/organizing/) by [floors](/docs/organizing/floors/) and [areas](/docs/organizing/areas/). The climate dashboard includes devices such as heating and cooling devices, windows, and fans.
@@ -188,80 +187,38 @@ If you do not use one of the predefined dashboards, or created a dashboard you n
 3. In the dialog, select **Delete**.
    ![Deleting a dashboard](/images/dashboards/delete_dashboard.png)
 
-## Using YAML for the Overview dashboard
+## Adding YAML dashboards
 
-To change the **Overview** dashboard, create a new file `ui-lovelace.yaml` in your configuration directory and add the following section to your `configuration.yaml` and restart Home Assistant:
-
-```yaml
-lovelace:
-  mode: yaml
-```
-
-A good way to start this file is to copy and paste the "Raw configuration" from the UI so your manual configuration starts the same as your existing UI.
-
-- In your sidebar, select **Overview**.
-- In the top-right corner, select the pencil icon.
-- Select the three dots {% icon "mdi:dots-vertical" %} menu and select **Raw configuration editor**.
-- There you see the configuration for your current dashboard. Copy that into the `<config>/ui-lovelace.yaml` file.
-
-Once you take control of your UI via YAML, the Home Assistant interface for modifying it won't be available anymore, and new entities will not automatically be added to your UI.
-
-When you make changes to `ui-lovelace.yaml`, you don't have to restart Home Assistant or refresh the page. Just hit the refresh button in the menu at the top of the UI.
-
-To revert back to using the UI to edit your dashboard, remove the `lovelace` section from your `configuration.yaml` and copy the contents of your `ui-lovelace.yaml` into the raw configuration section of Home Assistant and restart.
-
-## Adding more dashboards with YAML
-
-It is also possible to use YAML to define multiple dashboards. Each dashboard will be loaded from its own YAML file.
+You can use YAML to define dashboards. Each YAML dashboard is loaded from its own YAML file. To add YAML dashboards, define them under the `lovelace: dashboards:` key in your `configuration.yaml`.
 
 ```yaml
 lovelace:
-  mode: yaml
-  # Include external resources only add when mode is yaml, otherwise manage in the resources in the dashboard configuration panel.
+  # Include external resources
   resources:
     - url: /local/my-custom-card.js
       type: module
     - url: /local/my-webfont.css
       type: css
-  # Add more dashboards
+  # Add YAML dashboards
   dashboards:
-    lovelace-generated: # Needs to contain a hyphen (-)
+    lovelace-generated:
       mode: yaml
-      filename: notexist.yaml
+      filename: generated.yaml
       title: Generated
       icon: mdi:tools
       show_in_sidebar: true
       require_admin: true
     lovelace-hidden:
       mode: yaml
-      title: hidden
+      title: Hidden
       show_in_sidebar: false
       filename: hidden.yaml
 ```
 
-You can also add YAML dashboards when your main dashboard is UI configured:
-
-```yaml
-lovelace:
-  mode: storage
-  # Add yaml dashboards
-  dashboards:
-    lovelace-yaml:
-      mode: yaml
-      title: YAML
-      icon: mdi:script
-      show_in_sidebar: true
-      filename: dashboards.yaml
-```
-
 {% configuration dashboards %}
-mode:
-  required: true
-  description: "In what mode should the main dashboard be, `yaml` or `storage` (UI managed)."
-  type: string
 resources:
   required: false
-  description: "List of resources that should be loaded. Only use this when mode is `yaml`. If you change anything here, click the three dots {% icon "mdi:dots-vertical" %} menu (top-right) and click on `Reload resources` to pick up changes without restarting Home Assistant. You can also call `lovelace.reload_resources` action directly."
+  description: "List of resources that should be loaded. If you change anything here, click the three dots {% icon "mdi:dots-vertical" %} menu (top-right) and click **Reload resources** to pick up changes without restarting Home Assistant. You can also call `lovelace.reload_resources` action directly."
   type: list
   keys:
     url:

--- a/source/dashboards/dashboards.markdown
+++ b/source/dashboards/dashboards.markdown
@@ -201,18 +201,24 @@ lovelace:
       type: css
   # Add YAML dashboards
   dashboards:
-    lovelace-generated:
+    my-home: # Needs to contain a hyphen (-)
       mode: yaml
-      filename: generated.yaml
-      title: Generated
-      icon: mdi:tools
+      filename: my-home.yaml
+      title: My home
+      icon: mdi:home-outline
       show_in_sidebar: true
-      require_admin: true
-    lovelace-hidden:
+    dashboard-hidden:
       mode: yaml
+      filename: hidden.yaml
       title: Hidden
       show_in_sidebar: false
-      filename: hidden.yaml
+    dashboard-admin:
+      mode: yaml
+      title: Admin
+      icon: mdi:tools
+      show_in_sidebar: true
+      require_admin: false
+      filename: admin.yaml
 ```
 
 {% configuration dashboards %}

--- a/source/dashboards/dashboards.markdown
+++ b/source/dashboards/dashboards.markdown
@@ -36,10 +36,10 @@ Screenshot of the Dashboard list.
 Built-in dashboards that are available in the sidebar by default:
 
 - [Home dashboard](#home-dashboard). Category: built-in. If you set another dashboard as default, the Home dashboard is no longer shown in the sidebar by default.
-- [Activity dashboard](#activity-dashboard) Category: built-in.
+- [Activity dashboard](#activity-dashboard). Category: built-in.
 - Energy dashboard. Category: built-in.
 - [History dashboard](#history-dashboard). Category: built-in.
-- [Map dashboard](#map-dashboard): Category: user-created. The Map dashboard is an exception: it is available out of the box, but you can edit it freely. This is why it is categorized as **User-created** dashboard.
+- [Map dashboard](#map-dashboard). Category: user-created. The Map dashboard is an exception: it is available out of the box, but you can edit it freely. This is why it is categorized as **User-created** dashboard.
 - [To-do lists dashboard](#to-do-lists-dashboard). Category: built-in.
 
 <p class='img'>

--- a/source/dashboards/dashboards.markdown
+++ b/source/dashboards/dashboards.markdown
@@ -189,7 +189,7 @@ If you do not use one of the predefined dashboards, or created a dashboard you n
 
 ## Adding YAML dashboards
 
-You can use YAML to define dashboards. Each YAML dashboard is loaded from its own YAML file. To add YAML dashboards, define them under the `lovelace: dashboards:` key in your `configuration.yaml`.
+You can use YAML to define dashboards. Each YAML dashboard is loaded from its own YAML file. To add YAML dashboards, in your `configuration.yaml` file create a `dashboards:` section under the top-level `lovelace:` key.
 
 ```yaml
 lovelace:


### PR DESCRIPTION
## Proposed change

Set home dashboard as default dashboard.
The overview dashboard is replaced by this dashboard and no long exist by default (user can still configure it as manual using strategy).
The yaml mode for default dashboard no longer exist and `ui-lovelace.yaml` has been removed. All dashboards must be configured under the `dashboards` key if using `yaml`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/158265
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
