### PR TITLE
Add troubleshooting text for "2FA code was invalid" error in OPower ConEd

### DIFF
--- a/source/_integrations/opower.markdown
+++ b/source/_integrations/opower.markdown
@@ -85,6 +85,10 @@ Alternatively, you can create a new TOTP secret for your account and use the "no
 
 **NOTE: At this time, ConEd only has a single TOTP set up per account. Therefore, it is important that you configure the same TOTP secret for ConEd access in both Opower and your authenticator app.**
 
+**Troubleshooting: "2FA code was invalid" error**
+
+If authentication fails despite correct credentials and TOTP secret, this might be due to your Home Assistant server's clock and the ConEd server's clock being out of sync. TOTP codes are only valid within 30-second windows. Try updating and restarting Home Assistant Core, which may resolve the issue. Some users have reported needing to restart multiple times before the issue gets resolved.
+
 ### Exelon subsidiaries (ACE, BGE, ComEd, Delmarva, PECO, Pepco)
 
 The integration properly supports Multi-Factor Authentication (MFA) for Exelon subsidiaries via code sent to either email or phone SMS. These subsidiaries turned on MFA automatically for customers,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Add troubleshooting guidance for ConEd users experiencing "2FA code was invalid" errors (https://github.com/home-assistant/core/issues/160801) with the Opower integration. Multiple users have reported this issue, which appears to be resolved by updating and restarting Home Assistant Core to resync the system clock.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
