### PR TITLE
Add missing miele level sensors

### DIFF
--- a/source/_integrations/miele.markdown
+++ b/source/_integrations/miele.markdown
@@ -172,7 +172,7 @@ Climate entities are used to control target temperatures in refrigerators, freez
   - **Plate**: Four to six sensors that show the current state of hob heating plates. The status mimics the display on the actual hob. For example, 0 is off, 5 is approximately 50% power, and "B" is power boost. Plates can only be monitored from Home Assistant, not controlled.
   - **TwinDos level**: Two sensors displaying the remaining level in the detergent containers in applicable washing machines. If the device does not support this sensor, the value is shown as `Unknown`.
   - **PowerDisk level**: A sensor displaying the remaining level in the detergent container in applicable dishwashers. If the device does not support this sensor, the value is shown as `Unknown`.
-  - **Rinse aid level**: A sensor displaying the remaining level in the detergent container in dishwashers.
+  - **Rinse aid level**: A sensor displaying the remaining level in the rinse aid container in dishwashers.
   - **Salt level**: A sensor displaying the remaining level in the salt container in dishwashers.
 {% enddetails %}
 

--- a/source/_integrations/miele.markdown
+++ b/source/_integrations/miele.markdown
@@ -173,7 +173,7 @@ Climate entities are used to control target temperatures in refrigerators, freez
   - **TwinDos level**: Two sensors displaying the remaining level in the detergent containers in applicable washing machines. If the device does not support this sensor, the value is shown as `Unknown`.
   - **PowerDisk level**: A sensor displaying the remaining level in the detergent container in applicable dishwashers. If the device does not support this sensor, the value is shown as `Unknown`.
   - **Rinse aid level**: A sensor displaying the remaining level in the detergent container in dishwashers.
-  - **Salt level**: A sensor displaying the remaining level in the detergent container in dishwashers.
+  - **Salt level**: A sensor displaying the remaining level in the salt container in dishwashers.
 {% enddetails %}
 
 ### Switch

--- a/source/_integrations/miele.markdown
+++ b/source/_integrations/miele.markdown
@@ -171,6 +171,9 @@ Climate entities are used to control target temperatures in refrigerators, freez
   - **Finish**: Shows the estimated date and time when the program will finish. If you've set a delayed start, it shows when the appliance is expected to complete the cycle, including the delay time.
   - **Plate**: Four to six sensors that show the current state of hob heating plates. The status mimics the display on the actual hob. For example, 0 is off, 5 is approximately 50% power, and "B" is power boost. Plates can only be monitored from Home Assistant, not controlled.
   - **TwinDos level**: Two sensors displaying the remaining level in the detergent containers in applicable washing machines. If the device does not support this sensor, the value is shown as `Unknown`.
+  - **PowerDisk level**: A sensor displaying the remaining level in the detergent container in applicable dishwashers. If the device does not support this sensor, the value is shown as `Unknown`.
+  - **Rinse aid level**: A sensor displaying the remaining level in the detergent container in dishwashers.
+  - **Salt level**: A sensor displaying the remaining level in the detergent container in dishwashers.
 {% enddetails %}
 
 ### Switch


### PR DESCRIPTION
## Proposed change
Feature added in https://github.com/home-assistant/core/pull/157858 (marked for release in 2025.02) introduced some sensors that were not documented.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/157858
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
