### PR TITLE
Tile Card: Target Temperature & Humidity can be buttons or slider now

### DIFF
--- a/source/dashboards/features.markdown
+++ b/source/dashboards/features.markdown
@@ -746,7 +746,7 @@ style:
 
 ## Target humidity
 
-Widget that displays a slider to select the target humidity for a [humidifier](/integrations/humidifier).
+Widget that displays a slider or buttons to select the target humidity for a [humidifier](/integrations/humidifier).
 
 <p class='img'>
   <img src='/images/dashboards/features/target_humidity.png' alt='Screenshot of the tile card with the target humidity feature'>
@@ -756,6 +756,7 @@ Widget that displays a slider to select the target humidity for a [humidifier](/
 ```yaml
 features:
   - type: "target-humidity"
+    style: "slider"
 ```
 
 {% configuration features %}
@@ -763,11 +764,16 @@ type:
   required: true
   description: "`target-humidity`"
   type: string
+style:
+  required: false
+  description: "Which style of control to display. It can be either `buttons` or `slider`."
+  type: string
+  default: slider
 {% endconfiguration %}
 
 ## Target temperature
 
-Widget that displays buttons to select the target temperature for a [climate](/integrations/climate) or a [water heater](/integrations/water_heater).
+Widget that displays a slider or buttons to select the target temperature for a [climate](/integrations/climate) or a [water heater](/integrations/water_heater).
 
 <p class='img'>
   <img src='/images/dashboards/features/target_temperature.png' alt='Screenshot of the tile card with the target temperature feature'>
@@ -777,6 +783,7 @@ Widget that displays buttons to select the target temperature for a [climate](/i
 ```yaml
 features:
   - type: "target-temperature"
+    style: "buttons"
 ```
 
 {% configuration features %}
@@ -784,6 +791,11 @@ type:
   required: true
   description: "`target-temperature`"
   type: string
+style:
+  required: false
+  description: "Which style of control to display. It can be either `buttons` or `slider`."
+  type: string
+  default: slider
 {% endconfiguration %}
 
 ## Toggle


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added documentation for the enhancement of the tile card features:

Currently, the user can choose in whether the value of a numeric input should be shown as buttons or slide on the tile card. This is the only card that support this. Personally, I would like to have the option to decide for more number values. Especially since the default input type doesn't feel consistent. E.g. the target temperature are buttons, while the target humidly is a slider, which makes my dashboard look a bit messy.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/29377
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
