### PR TITLE
Add prerequisite note about Local Mode visibility to APsystems docs

### DIFF
--- a/source/_integrations/apsystems.markdown
+++ b/source/_integrations/apsystems.markdown
@@ -62,4 +62,8 @@ There has been a discussion about the inverter's lifetime being shortened when u
 
 Make sure the local API is activated and set to **Continuously**. For that, connect to the inverter via Bluetooth using the app and go to **Settings** > **Local Mode**, set the switch **Enable Local Mode** to on and make sure to set this to **Continuously**.
 
+{% note %}
+If the **Local Mode** option is not visible under **Settings**, the device may still be connected to the APsystems cloud. To access the setting, open the APsystems app, remove the device from the cloud or log out, and then connect to the inverter directly via Bluetooth. The **Local Mode** option should then appear under **Settings**.
+{% endnote %}
+
 {% include integrations/config_flow.md %}

--- a/source/_integrations/apsystems.markdown
+++ b/source/_integrations/apsystems.markdown
@@ -60,10 +60,19 @@ There has been a discussion about the inverter's lifetime being shortened when u
 
 ## Prerequisites
 
-Make sure the local API is activated and set to **Continuously**. For that, connect to the inverter via Bluetooth using the app and go to **Settings** > **Local Mode**, set the switch **Enable Local Mode** to on and make sure to set this to **Continuously**.
+Make sure the local API is activated and set to **Continuously**. For that, connect to the inverter via Bluetooth using the app and go to **Settings** > **Local Mode**, set the switch **Enable Local Mode** to on, and make sure to set this to **Continuously**.
 
 {% note %}
-If the **Local Mode** option is not visible under **Settings**, the device may still be connected to the APsystems cloud. To access the setting, open the APsystems app, remove the device from the cloud or log out, and then connect to the inverter directly via Bluetooth. The **Local Mode** option should then appear under **Settings**.
+If **Settings** > **Local Mode** is not visible in the APsystems app, the device is probably still connected to the APsystems cloud.
+
+To make **Settings** > **Local Mode** available:
+
+1. Open the APsystems app on your mobile device.
+2. Sign out of your APsystems cloud account in the app.
+3. If the app specifically asks you to remove the device from the cloud so that you can use it locally, follow the on-screen steps.
+4. After you are signed out, reconnect to the inverter directly via Bluetooth.
+
+When you are connected via Bluetooth only, **Settings** > **Local Mode** should be visible in the app.
 {% endnote %}
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change

Add a note to the APsystems integration Prerequisites section explaining that the **Local Mode** option may not be visible in the APsystems app when the device is connected to the cloud. The note provides steps to make the option available (disconnect from cloud, connect directly via Bluetooth).

This addresses confusion reported in home-assistant/core#121046, where users couldn't find the Local Mode setting required to set up the integration.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR addresses: home-assistant/core#121046
- The information has been personally verified on an APsystems EZ1 device.

## Checklist

- [x] This PR is against the correct branch (`current` for current docs, `next` for next).
- [x] The documentation follows the Home Assistant [documentation standards](https://developers.home-assistant.io/docs/documenting/standards).