### PR TITLE
Add sensor showing total size of AWS S3 backups

### DIFF
--- a/source/_integrations/aws_s3.markdown
+++ b/source/_integrations/aws_s3.markdown
@@ -116,9 +116,9 @@ The integration will test the connection and confirm access to your S3 bucket.
 
 ## Sensors
 
-The integration provides the following sensor, which are updated every 6 hours:
+The integration provides the following sensor, which is updated every 6 hours:
 
-- **Total size of backups**: The sum of the size of all backups.
+- **Total size of backups**: The combined size of all Home Assistant backups stored in the configured S3 bucket for this Home Assistant installation.
 
 ## Known limitations
 

--- a/source/_integrations/aws_s3.markdown
+++ b/source/_integrations/aws_s3.markdown
@@ -114,6 +114,12 @@ Endpoint URL:
 
 The integration will test the connection and confirm access to your S3 bucket.
 
+## Sensors
+
+The integration provides the following sensor, which are updated every 6 hours:
+
+- **Total size of backups**: The sum of the size of all backups.
+
 ## Known limitations
 
 The AWS S3 integration has the following limitations:


### PR DESCRIPTION
Added section on sensors for AWS S3 integration.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/162513
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
