### PR TITLE
Updated IoTaWatt Documentation to explain about outputs visibility

### DIFF
--- a/source/_integrations/iotawatt.markdown
+++ b/source/_integrations/iotawatt.markdown
@@ -43,7 +43,7 @@ For example:
 | - | - | - |
 | MainsConsumption|Watts|`(Main_In_Red + Main_In_White + Main_In_Blue) max 0` |
 | MainsExport|Watts|`((Main_In_Red + Main_In_White + Main_In_Blue) min 0) abs` |
-| Solar|Watts|`((Solar_Red max 0) + (Solar_White max 0) + (Solar_Blue max 0)` |
+| Solar|Watts|`((Solar_Red max 0) + (Solar_White max 0) + (Solar_Blue max 0))` |
 
 Replace `(Main_In_Red + Main_In_White + Main_In_Blue)` with the correct formula for your main feed.  
 

--- a/source/_integrations/iotawatt.markdown
+++ b/source/_integrations/iotawatt.markdown
@@ -25,9 +25,9 @@ and create them as sensors in Home Assistant.
 
 You can use the energy sensors directly with the Home Assistant energy dashboard.
 
-IoTaWatt **Inputs** are available as sensors and are shown on the device screen in the Visual Interface. 
+IoTaWatt **Inputs** are available as sensors and are shown on the IoTaWatt device page in Home Assistant.
 
-Any **Outputs** you create within the IoTaWatt unit are also available as sensors for use in the Energy Dashboard and templates. However, they are not listed on the Device's User Interface card because of the Home Assistant policy on unique naming. If you start typing the name of a defined IoTaWatt output when configuring the Energy Dashboard or in a Template/Helper, Home Assistant will suggest completing the sensor name. 
+Any **Outputs** you create within the IoTaWatt unit are also available as sensors for use in the energy dashboard and templates. However, they are not listed on the IoTaWatt device page because of the Home Assistant policy on unique naming. When you configure the energy dashboard or create a template or helper, start typing the name of a defined IoTaWatt output. Home Assistant suggests completing the sensor name.
 
 ## Energy production systems
 
@@ -35,15 +35,15 @@ If you have an energy production system such as solar panels, follow these instr
 
 ### Configure IoTaWatt
 
-You will need to configure IoTaWatt output sensors for Consumption, Export, and Production. 
+You will need to configure IoTaWatt output sensors for consumption, export, and production.
 
 For example:
 
-| Name | Unit | Formula
-| - | - | -
-| MainsConsumption|Watts|`(Main_In_Red + Main_In_White + Main_In_Blue) max 0`
-| MainsExport|Watts|`((Main_In_Red + Main_In_White + Main_In_Blue) min 0) abs`
-| Solar|Watts|`((Solar_Red max 0) + (Solar_White max 0) + (Solar_Blue max 0)`
+| Name | Unit | Formula |
+| - | - | - |
+| MainsConsumption|Watts|`(Main_In_Red + Main_In_White + Main_In_Blue) max 0` |
+| MainsExport|Watts|`((Main_In_Red + Main_In_White + Main_In_Blue) min 0) abs` |
+| Solar|Watts|`((Solar_Red max 0) + (Solar_White max 0) + (Solar_Blue max 0)` |
 
 Replace `(Main_In_Red + Main_In_White + Main_In_Blue)` with the correct formula for your main feed.  
 

--- a/source/_integrations/iotawatt.markdown
+++ b/source/_integrations/iotawatt.markdown
@@ -27,15 +27,15 @@ You can use the energy sensors directly with the Home Assistant energy dashboard
 
 IoTaWatt **Inputs** are available as sensors and are shown on the device screen in the Visual Interface. 
 
-Any **Outputs** that you create within the IoTaWatt unit itself are also made available as sensors for use in the Energy Dashboard, templates, etc. however they are not listed within the User Interface card for the Device because of the Home Assistant Policy on Unique Naming. If you start typing the name of a defined IoTaWatt output when configuring the Energy Dashboard or in a Template/Helper then Home Assistant will suggest the completion of the sensor name. 
+Any **Outputs** you create within the IoTaWatt unit are also available as sensors for use in the Energy Dashboard and templates. However, they are not listed on the Device's User Interface card because of the Home Assistant policy on unique naming. If you start typing the name of a defined IoTaWatt output when configuring the Energy Dashboard or in a Template/Helper, Home Assistant will suggest completing the sensor name. 
 
-## Energy Production Systems
+## Energy production systems
 
 If you have an energy production system such as solar panels, follow these instructions:
 
 ### Configure IoTaWatt
 
-You will need to configure IoTaWatt output sensors for Consumption, Export and Production. 
+You will need to configure IoTaWatt output sensors for Consumption, Export, and Production. 
 
 For example:
 

--- a/source/_integrations/iotawatt.markdown
+++ b/source/_integrations/iotawatt.markdown
@@ -21,22 +21,31 @@ and create them as sensors in Home Assistant.
 
 {% include integrations/config_flow.md %}
 
-## Energy management
+## Energy management and sensor availability
 
 You can use the energy sensors directly with the Home Assistant energy dashboard.
+
+IoTaWatt **Inputs** are available as sensors and are shown on the device screen in the Visual Interface. 
+
+Any **Outputs** that you create within the IoTaWatt unit itself are also made available as sensors for use in the Energy Dashboard, templates, etc. however they are not listed within the User Interface card for the Device because of the Home Assistant Policy on Unique Naming. If you start typing the name of a defined IoTaWatt output when configuring the Energy Dashboard or in a Template/Helper then Home Assistant will suggest the completion of the sensor name. 
+
+## Energy Production Systems
 
 If you have an energy production system such as solar panels, follow these instructions:
 
 ### Configure IoTaWatt
 
-You will need to configure two new IoTaWatt output sensors:
+You will need to configure IoTaWatt output sensors for Consumption, Export and Production. 
+
+For example:
 
 | Name | Unit | Formula
 | - | - | -
 | MainsConsumption|Watts|`(Main_In_Red + Main_In_White + Main_In_Blue) max 0`
 | MainsExport|Watts|`((Main_In_Red + Main_In_White + Main_In_Blue) min 0) abs`
+| Solar|Watts|`((Solar_Red max 0) + (Solar_White max 0) + (Solar_Blue max 0)`
 
-Replace `(Main_In_Red + Main_In_White + Main_In_Blue)` with the correct formula for your main feed.
+Replace `(Main_In_Red + Main_In_White + Main_In_Blue)` with the correct formula for your main feed.  
 
 #### Using a solar net system
 
@@ -48,6 +57,8 @@ If you have two solar sensors named `Solar1` and `Solar2` you would use:
 `(Main_In_Red + Main_In_White + Main_In_Blue - Solar1 - Solar2)`
 
 ### Configure Energy Management
+
+The IoTaWatt Outputs are available for use:
 
 In the Grid Consumption settings, select `MainsConsumption.wh`  
 In the Return to grid settings, select `MainsExport.wh`  


### PR DESCRIPTION
Have updated the IoTaWatt Documentation to explain that Outputs are available but not shown on the device card due to Unique Naming Policy

This should reduce the 'why can't I see outputs' questions from Newbies (like me)

Also included an example of a Solar Output

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
