### PR TITLE
Adds doc for timer trigger

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -22,6 +22,7 @@ An {% term automation %} can be triggered by an {% term event %}, a certain {% t
 - [Template trigger](#template-trigger)
 - [Time trigger](#time-trigger)
 - [Time pattern trigger](#time-pattern-trigger)
+- [Timer trigger](#timer-trigger)
 - [Persistent notification trigger](#persistent-notification-trigger)
 - [Webhook trigger](#webhook-trigger)
 - [Zone trigger](#zone-trigger)
@@ -948,6 +949,21 @@ automation 3:
 {% note %}
 Do not prefix numbers with a zero - using `'01'` instead of `'1'` for example will result in errors.
 {% endnote %}
+
+## Timer trigger
+
+Timer trigger fires when any of the selected timer events fire for the selected entity. You can select more than one event per trigger.
+
+```yaml
+automation:
+  triggers:
+    - trigger: timer
+      entity_id: timer.test
+      # Possible values: start, finish, pause, cancel
+      events:
+        - pause
+        - cancel
+```
 
 ## Persistent notification trigger
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Add new trigger for timers



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
   - Core: home-assistant/core#162537
   - Frontend: home-assistant/frontend#29482
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/core#158350

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
