### PR TITLE
Remove broken yarn repository from devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,10 @@ ARG VARIANT=2
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 ARG NODE_VERSION="lts/*"
+
+# Fix: Remove the broken Yarn repository from the apt sources.
+# This prevents 'apt-get update' from failing due to the missing GPG key.
+RUN rm -f /etc/apt/sources.list.d/yarn.list
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 RUN su vscode -c "/usr/local/rvm/bin/rvm fix-permissions"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,9 +27,13 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
+    ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
+    google-protobuf (4.33.5-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.33.5-arm64-darwin)
       bigdecimal
       rake (>= 13)
@@ -87,6 +91,8 @@ GEM
     multi_json (1.19.1)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
+    nokogiri (1.18.10-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
@@ -98,7 +104,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     prism (1.9.0)
-    public_suffix (7.0.2)
+    public_suffix (6.0.2)
     racc (1.8.1)
     rack (3.2.4)
     rack-protection (4.2.1)
@@ -143,10 +149,9 @@ GEM
     ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
     sass (3.4.25)
-    sass-embedded (1.97.3-arm64-darwin)
+    sass-embedded (1.97.3)
       google-protobuf (~> 4.31)
-    sass-embedded (1.97.3-x86_64-linux-gnu)
-      google-protobuf (~> 4.31)
+      rake (>= 13)
     sass-globbing (1.1.5)
       sass (>= 3.1)
     sassc (2.1.0)
@@ -173,6 +178,7 @@ GEM
     webrick (1.9.2)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-23
   x86_64-linux
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The current image for our dev container is broken because it contains a broken repository that we actually don't need. This PR removes the yarn repository from apt so that the build of the image succeed.

```logs
 > [dev_container_auto_added_stage_label 4/4] RUN   apt update   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends       ack   && echo "en_US UTF-8" > /etc/locale.gen   && locale-gen en_US.UTF-8:
0.108 
0.108 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
0.108 
0.151 Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
0.163 Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]
[2026-02-10T12:50:50.479Z] 
0.167 Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
0.195 Get:4 http://deb.debian.org/debian bookworm/main arm64 Packages [8,691 kB]
0.205 Get:5 https://dl.yarnpkg.com/debian stable InRelease
0.255 Err:5 https://dl.yarnpkg.com/debian stable InRelease
0.255   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
0.292 Get:6 http://deb.debian.org/debian bookworm-updates/main arm64 Packages [6,936 B]
0.293 Get:7 http://deb.debian.org/debian-security bookworm-security/main arm64 Packages [290 kB]
0.824 Reading package lists...
1.095 W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
1.095 E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
------
```

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
