### PR TITLE
Add energy history sensors to Tessie

### DIFF
--- a/source/_integrations/tessie.markdown
+++ b/source/_integrations/tessie.markdown
@@ -258,27 +258,27 @@ The integration will show vehicle software updates and their installation progre
 
 #### Energy history
 
-- Battery charged
-- Battery discharged
-- Battery exported (disabled)
-- Battery imported from generator (disabled)
-- Battery imported from grid (disabled)
-- Battery imported from solar (disabled)
-- Consumer imported from battery (disabled)
-- Consumer imported from generator (disabled)
-- Consumer imported from grid (disabled)
-- Consumer imported from solar (disabled)
+- Battery charged from generator (disabled)
+- Battery charged from grid (disabled)
+- Battery charged from solar (disabled)
+- Battery discharged (disabled)
+- Energy consumed from battery (disabled)
+- Energy consumed from generator (disabled)
+- Energy consumed from grid (disabled)
+- Energy consumed from solar (disabled)
 - Generator exported (disabled)
-- Grid exported
 - Grid exported from battery (disabled)
 - Grid exported from generator (disabled)
 - Grid exported from solar (disabled)
 - Grid imported
 - Grid services exported (disabled)
 - Grid services imported (disabled)
-- Home usage
 - Solar exported (disabled)
-- Solar generated
+- Total battery charged
+- Total battery discharged
+- Total grid exported
+- Total home usage
+- Total solar generated
 
 ### Switch
 

--- a/source/_integrations/tessie.markdown
+++ b/source/_integrations/tessie.markdown
@@ -256,6 +256,30 @@ The integration will show vehicle software updates and their installation progre
 - Power
 - State code
 
+#### Energy history
+
+- Battery charged
+- Battery discharged
+- Battery exported (disabled)
+- Battery imported from generator (disabled)
+- Battery imported from grid (disabled)
+- Battery imported from solar (disabled)
+- Consumer imported from battery (disabled)
+- Consumer imported from generator (disabled)
+- Consumer imported from grid (disabled)
+- Consumer imported from solar (disabled)
+- Generator exported (disabled)
+- Grid exported
+- Grid exported from battery (disabled)
+- Grid exported from generator (disabled)
+- Grid exported from solar (disabled)
+- Grid imported
+- Grid services exported (disabled)
+- Grid services imported (disabled)
+- Home usage
+- Solar exported (disabled)
+- Solar generated
+
 ### Switch
 
 - Allow charging from grid
@@ -263,8 +287,8 @@ The integration will show vehicle software updates and their installation progre
 
 ## Energy dashboard
 
-The Tesla Fleet API only provides power data for Powerwall and Solar products. This means they cannot be used on the energy dashboard directly.
+The energy history sensors provide cumulative energy values (kWh) that can be used directly on the [energy dashboard](/docs/energy/).
 
-Energy flows can be calculated from `Battery power` and `Grid power` sensors using a [Template Sensor](/integrations/template/) to separate the positive and negative values into positive import and export values.
+Alternatively, energy flows can be calculated from `Battery power` and `Grid power` sensors using a [Template Sensor](/integrations/template/) to separate the positive and negative values into positive import and export values.
 The `Load power`, `Solar power`, and the templated sensors can then use a [Riemann Sum](/integrations/integration/) to convert their instant power (kW) values into cumulative energy values (kWh),
 which then can be used within the energy dashboard.


### PR DESCRIPTION
## Proposed change

Document the 21 new energy history sensors added to the Tessie integration in home-assistant/core#162976. These sensors provide cumulative energy values (kWh) from the Tesla Fleet API's energy history endpoint, enabling direct use in the Home Assistant Energy Dashboard.

Also updates the Energy dashboard section to reflect that these sensors can be used directly, while retaining the Template Sensor + Riemann Sum workaround as an alternative.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/162976
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards