### PR TITLE
Add documentation for "filter expired warnings" option

### DIFF
--- a/source/_integrations/dwd_weather_warnings.markdown
+++ b/source/_integrations/dwd_weather_warnings.markdown
@@ -25,6 +25,8 @@ Warncell ID or name:
   description: Identifier of the region. It can be a warncell ID (integer) or a warncell name. It is heavily advised to use warncell ID because a warncell name is sometimes not unique. A list of valid warncell IDs and names can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.html). Some of the warncells are outdated but still listed. If the setup fails, search the list for a similar sounding warncell. If the warncell name is not unique, `" (not unique used ID)!"` will be added to the reported `region_name`.
 Device tracker entity:
   description: A `device_tracker` entity that will be used to identify the warncell. The entity *has* to contain the attributes `latitude` and `longitude`. Setting either this field or `Warncell ID or name` is required, but not both.
+Filter expired warnings:
+  description: Hides warnings where the end time is in the past, regardless if they are still returned from the API.
 {% endconfiguration_basic %}
 
 ### Attributes

--- a/source/_integrations/dwd_weather_warnings.markdown
+++ b/source/_integrations/dwd_weather_warnings.markdown
@@ -26,7 +26,7 @@ Warncell ID or name:
 Device tracker entity:
   description: A `device_tracker` entity that will be used to identify the warncell. The entity *has* to contain the attributes `latitude` and `longitude`. Setting either this field or `Warncell ID or name` is required, but not both.
 Filter expired warnings:
-  description: Hides warnings where the end time is in the past, regardless if they are still returned from the API.
+  description: Hides warnings where the end time is in the past, regardless of whether they are still returned by the API.
 {% endconfiguration_basic %}
 
 ### Attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Adds the "filter expired warnings" options from PR https://github.com/home-assistant/core/pull/163096

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/163096

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
