### PR TITLE
Remove "Take control of the default dashboard" from cards related topics

### DIFF
--- a/source/dashboards/cards.markdown
+++ b/source/dashboards/cards.markdown
@@ -12,8 +12,6 @@ related:
     title: Views
   - docs: /dashboards/
     title: Introduction to dashboards
-  - docs: /dashboards/#get-started-with-your-own-dashboard/
-    title: Take control of the default dashboard
 ---
 
 Each dashboard is made up of cards.


### PR DESCRIPTION
The link to the "Get started with your own dashboard" section on the
dashboards page is no longer relevant as a related topic for cards.

https://claude.ai/code/session_01JndNoRfTShrbE1z7goPZGe