### PR TITLE
Add Trane Local integration docs

### DIFF
--- a/source/_integrations/trane.markdown
+++ b/source/_integrations/trane.markdown
@@ -27,7 +27,8 @@ This is the local counterpart to the [Nexia](/integrations/nexia/) cloud integra
 Before setting up this integration, you must:
 
 1. Assign a **static IP address** to your thermostat on your network.
-2. Put the thermostat in _pairing mode_: Go to **Menu** > **Settings** > **Network** > **Advanced Setup** > **Remote Connection** > **Pair**.
+2. Put the thermostat in _pairing mode_: 
+   - In the UI of your thermostat, go to **Menu** > **Settings** > **Network** > **Advanced Setup** > **Remote Connection** > **Pair**.
 
 ## Supported devices
 

--- a/source/_integrations/trane.markdown
+++ b/source/_integrations/trane.markdown
@@ -18,7 +18,7 @@ related:
     title: Nexia (Cloud)
 ---
 
-The **Trane Local** {% term integration %} allows you to locally control [Trane](https://www.trane.com/) and [American Standard](https://www.americanstandardair.com/) thermostats over your local network using a direct mTLS connection. No cloud connection is required.
+The **Trane Local** {% term integration %} allows you to locally control [Trane](https://www.trane.com/) and [American Standard](https://www.americanstandardair.com/) thermostats over your local network using a direct <abbr title="mutual TLS">mTLS</abbr> connection. No cloud connection is required.
 
 This is the local counterpart to the [Nexia](/integrations/nexia/) cloud integration. If your thermostat supports local control, this integration provides faster response times and does not depend on internet connectivity.
 
@@ -27,7 +27,7 @@ This is the local counterpart to the [Nexia](/integrations/nexia/) cloud integra
 Before setting up this integration, you must:
 
 1. Assign a **static IP address** to your thermostat on your network.
-2. Put the thermostat in **pairing mode**: Menu > Settings > Network > Advanced Setup > Remote Connection > Pair.
+2. Put the thermostat in _pairing mode_: Go to **Menu** > **Settings** > **Network** > **Advanced Setup** > **Remote Connection** > **Pair**.
 
 ## Supported devices
 
@@ -36,7 +36,7 @@ Before setting up this integration, you must:
 
 {% include integrations/config_flow.md %}
 
-## Switch
+## Switches
 
 The integration provides a **Hold** switch for each zone. When enabled, the thermostat maintains its current setpoints indefinitely (permanent hold). When disabled, the thermostat follows its programmed schedule.
 

--- a/source/_integrations/trane.markdown
+++ b/source/_integrations/trane.markdown
@@ -1,0 +1,51 @@
+---
+title: Trane Local
+description: Locally control Trane and American Standard thermostats over the local network.
+ha_category:
+  - Switch
+ha_iot_class: Local Push
+ha_quality_scale: bronze
+ha_release: 2026.3
+ha_codeowners:
+  - '@bdraco'
+ha_domain: trane
+ha_integration_type: hub
+ha_config_flow: true
+ha_platforms:
+  - switch
+related:
+  - docs: /integrations/nexia/
+    title: Nexia (Cloud)
+---
+
+The **Trane Local** {% term integration %} allows you to locally control [Trane](https://www.trane.com/) and [American Standard](https://www.americanstandardair.com/) thermostats over your local network using a direct mTLS connection. No cloud connection is required.
+
+This is the local counterpart to the [Nexia](/integrations/nexia/) cloud integration. If your thermostat supports local control, this integration provides faster response times and does not depend on internet connectivity.
+
+## Prerequisites
+
+Before setting up this integration, you must:
+
+1. Assign a **static IP address** to your thermostat on your network.
+2. Put the thermostat in **pairing mode**: Menu > Settings > Network > Advanced Setup > Remote Connection > Pair.
+
+## Supported devices
+
+- Trane XL1050 Smart Thermostat (firmware v5.9 or later)
+- American Standard Platinum 1050 Smart Thermostat (firmware v5.9 or later)
+
+{% include integrations/config_flow.md %}
+
+## Switch
+
+The integration provides a **Hold** switch for each zone. When enabled, the thermostat maintains its current setpoints indefinitely (permanent hold). When disabled, the thermostat follows its programmed schedule.
+
+## Data updates
+
+The integration maintains a persistent local TCP connection to the thermostat. State changes are pushed from the thermostat to Home Assistant in real time, so there is no polling interval.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Add documentation for the new Trane Local integration, which provides local control of Trane and American Standard thermostats via mTLS over TCP.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/163301
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/9685
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards