### PR TITLE
Add warm mist and timer for VeSync devices

### DIFF
--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -52,6 +52,7 @@ The following platforms are supported:
 This {% term integration %} supports devices controllable by the VeSync App. The following devices are supported by this {% term integration %}. This list may not be exhaustive as devices have multiple model numbers within this.
 
 ### Bulbs
+
 - Etekcity WiFi Dimmable LED Bulb (ESL100)
 - Etekcity WiFi Dimmable and Tunable White LED Bulb (ESL100CW)
 
@@ -76,7 +77,7 @@ This {% term integration %} supports devices controllable by the VeSync App. The
 - Core 400S: Smart True HEPA Air Purifier
 - Core 600S: Smart True HEPA Air Purifier
 - EverestAir: Smart Air Purifier
-- Vital 100S Smart True HEPA Air Purifier (LAP-V102S-WUS) 
+- Vital 100S Smart True HEPA Air Purifier (LAP-V102S-WUS)
 - Vital 200S Smart True HEPA Air Purifier (LAP-V201S-WUS)
 - LEVOIT Smart Wifi Air Purifier (LV-PUR131S)
 - LEVOIT Smart Tower Fan (LTF-F422S-WUS)
@@ -107,8 +108,8 @@ This integration follows standard integration removal. No extra steps are requir
 
 ## Actions
 
-| Action | Description |
-|---------|-------------|
+| Action           | Description                                        |
+|------------------|----------------------------------------------------|
 | `update_devices` | Poll Vesync server to find and add any new devices |
 
 ## Power & energy sensors
@@ -126,6 +127,7 @@ itself. Note that prior versions of the {% term integration %} exposed these as 
 | `sensor.<outlet name>_energy_use_yearly`  | Total energy usage for year start from 12:01AM on Jan 1 in kWh          | 105.25  |
 
 ## Fan & air quality sensors
+
 All VeSync air purifiers expose the remaining filter lifetime, and some also expose air quality measurements.
 
 | Sensor                  | Description                                                                            | Example   |
@@ -176,8 +178,7 @@ Sensors and settings exposed by VeSync humidifiers.
 | Switch                  | Description                                                                        | Example   |
 | ----------------------- | ---------------------------------------------------------------------------------- | --------- |
 | `display`               | Display On or Off                                                                  | On        |
-| 'auto_off_config'       | Auto turn off when humidity target exceeded,  resume when below target             | On        |
-
+| `auto_off_config`       | Auto turn off when humidity target exceeded,  resume when below target             | On        |
 
 ## Binary Sensors
 
@@ -198,7 +199,6 @@ Sensors and settings exposed by VeSync Air Fryers.
 | `cook_set_time`         | The number of minutes for cooking                                                      | 15        |
 | `remaining_time`        | The numbers of minutes left in cooking or preheating                                   | 8         |
 | `preheat_set_time`      | The number of minutes for pre heating                                                  | 10        |
-
 
 ## Extracting attribute data
 

--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -86,6 +86,7 @@ This {% term integration %} supports devices controllable by the VeSync App. The
 
 - Classic200S: Classic 200S Smart Ultrasonic Cool Mist Humidifier
 - Classic300S: Classic 300S Ultrasonic Smart Humidifier
+- LV600S: Smart Hybrid Ultrasonic humidifier
 - Superior6000S: Superior 6000S Smart Evaporative Humidifier
 
 ### Air Fryers
@@ -167,10 +168,10 @@ Sensors and settings exposed by VeSync humidifiers.
 | ----------------------- | ---------------------------------------------------------------------------------- | --------- |
 | `humidity`              | Current humidity (in %)                                                            | 35        |
 
-| Number                  | Description                                                                        | Example   |
-| ----------------------- | ---------------------------------------------------------------------------------- | --------- |
-| `mist_level`            | Mist level intensity (Range: 1-9, Step: 1). Only available in manual mode.         | 1         |
-| `warm_mist_level`       | Warm mist level intensity (Range: 0-3, Step: 1)                                    | 3         |
+| Number                  | Description                                                                                          | Example   |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- | --------- |
+| `mist_level`            | Mist level intensity (Range: 1-9, Step: 1). Only available in manual mode.                           | 1         |
+| `warm_mist_level`       | Warm mist level intensity (Range: 0-3, Step: 1). Only available for supported models such as LV600S. | 3         |
 
 | Select                  | Description                                                                        | Example   |
 | ----------------------- | ---------------------------------------------------------------------------------- | --------- |
@@ -200,6 +201,20 @@ Sensors and settings exposed by VeSync Air Fryers.
 | `cook_set_time`         | The number of minutes for cooking                                                      | 15        |
 | `remaining_time`        | The numbers of minutes left in cooking or preheating                                   | 8         |
 | `preheat_set_time`      | The number of minutes for pre heating                                                  | 10        |
+
+## Entities that are supported for all devices
+
+| Sensor            | Description                      | Example |
+| ----------------- | -------------------------------- | ------- |
+| `timer_remaining` | Remaining timer time in minutes. | 60      |
+
+| Number           | Description                                      | Example |
+| ---------------- | ------------------------------------------------ | ------- |
+| `timer_duration` | Duration for the timer. (Range: 0-720, Step: 1). | 60      |
+
+| Button        | Description                      |
+| ------------- | -------------------------------- |
+| `clear_timer` | Clear and remove existing timer. |
 
 ## Extracting attribute data
 

--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -86,7 +86,7 @@ This {% term integration %} supports devices controllable by the VeSync App. The
 
 - Classic200S: Classic 200S Smart Ultrasonic Cool Mist Humidifier
 - Classic300S: Classic 300S Ultrasonic Smart Humidifier
-- LV600S: Smart Hybrid Ultrasonic humidifier
+- LV600S: Smart Hybrid Ultrasonic Humidifier
 - Superior6000S: Superior 6000S Smart Evaporative Humidifier
 
 ### Air Fryers
@@ -110,7 +110,7 @@ This integration follows standard integration removal. No extra steps are requir
 ## Actions
 
 | Action           | Description                                        |
-|------------------|----------------------------------------------------|
+| ---------------- | -------------------------------------------------- |
 | `update_devices` | Poll Vesync server to find and add any new devices |
 
 ## Power & energy sensors
@@ -180,7 +180,7 @@ Sensors and settings exposed by VeSync humidifiers.
 | Switch                  | Description                                                                        | Example   |
 | ----------------------- | ---------------------------------------------------------------------------------- | --------- |
 | `display`               | Display On or Off                                                                  | On        |
-| `auto_off_config`       | Auto turn off when humidity target exceeded,  resume when below target             | On        |
+| `auto_off_config`       | Auto turn off when humidity target exceeded, resume when below target              | On        |
 
 ## Binary Sensors
 
@@ -202,15 +202,15 @@ Sensors and settings exposed by VeSync Air Fryers.
 | `remaining_time`        | The numbers of minutes left in cooking or preheating                                   | 8         |
 | `preheat_set_time`      | The number of minutes for pre heating                                                  | 10        |
 
-## Entities that are supported for all devices
+## Timer Entities
 
 | Sensor            | Description                      | Example |
 | ----------------- | -------------------------------- | ------- |
 | `timer_remaining` | Remaining timer time in minutes. | 60      |
 
-| Number           | Description                                      | Example |
-| ---------------- | ------------------------------------------------ | ------- |
-| `timer_duration` | Duration for the timer. (Range: 0-720, Step: 1). | 60      |
+| Number           | Description                                        | Example |
+| ---------------- | -------------------------------------------------- | ------- |
+| `timer_duration` | Timer duration in minutes (Range: 0-720, Step: 1). | 60      |
 
 | Button        | Description                      |
 | ------------- | -------------------------------- |

--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -170,6 +170,7 @@ Sensors and settings exposed by VeSync humidifiers.
 | Number                  | Description                                                                        | Example   |
 | ----------------------- | ---------------------------------------------------------------------------------- | --------- |
 | `mist_level`            | Mist level intensity (Range: 1-9, Step: 1). Only available in manual mode.         | 1         |
+| `warm_mist_level`       | Warm mist level intensity (Range: 0-3, Step: 1)                                    | 3         |
 
 | Select                  | Description                                                                        | Example   |
 | ----------------------- | ---------------------------------------------------------------------------------- | --------- |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Some devices in the VeSync ecosystem have a "Warm Mist" feature, and all devices support a timer setting (as per pyvesync documentation). Neither of these features is exposed to the Home Assistant instance.
I am adding this because I recently got the humidifier, and I really miss the ability to change the Warm Mist level or set the Timer from Home Assistant without opening the VeSync app.

- Add warm_mist setting in the Humidifiers section.
- Create a new section with timer entities.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/163353
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
