### PR TITLE
Add climate platform to Trane Local docs

### DIFF
--- a/source/_integrations/trane.markdown
+++ b/source/_integrations/trane.markdown
@@ -2,6 +2,7 @@
 title: Trane Local
 description: Locally control Trane and American Standard thermostats over the local network.
 ha_category:
+  - Climate
   - Switch
 ha_iot_class: Local Push
 ha_quality_scale: bronze
@@ -12,6 +13,7 @@ ha_domain: trane
 ha_integration_type: hub
 ha_config_flow: true
 ha_platforms:
+  - climate
   - switch
 related:
   - docs: /integrations/nexia/
@@ -27,7 +29,7 @@ This is the local counterpart to the [Nexia](/integrations/nexia/) cloud integra
 Before setting up this integration, you must:
 
 1. Assign a **static IP address** to your thermostat on your network.
-2. Put the thermostat in _pairing mode_: 
+2. Put the thermostat in _pairing mode_:
    - In the UI of your thermostat, go to **Menu** > **Settings** > **Network** > **Advanced Setup** > **Remote Connection** > **Pair**.
 
 ## Supported devices
@@ -37,7 +39,29 @@ Before setting up this integration, you must:
 
 {% include integrations/config_flow.md %}
 
-## Switches
+## Supported functionality
+
+### Climate
+
+The integration creates a climate entity for each zone on your thermostat. You can control the HVAC mode, target temperature, and fan mode.
+
+#### HVAC modes
+
+- **Off**: The zone is turned off.
+- **Heat**: The zone heats to the target temperature using a manual hold.
+- **Cool**: The zone cools to the target temperature using a manual hold.
+- **Heat/Cool**: The zone maintains both a heating and cooling setpoint using a manual hold. The thermostat automatically heats or cools to keep the temperature within the range you set.
+- **Auto**: The zone follows the programmed schedule on the thermostat.
+
+The difference between **Heat/Cool** and **Auto** is that **Heat/Cool** uses a manual hold with dual setpoints, while **Auto** follows the thermostat's built-in schedule.
+
+#### Fan modes
+
+- **Auto**: The fan runs only when heating or cooling is active.
+- **On**: The fan runs continuously.
+- **Circulate**: The fan runs periodically to circulate air, even when heating or cooling is not active.
+
+### Switches
 
 The integration provides a **Hold** switch for each zone. When enabled, the thermostat maintains its current setpoints indefinitely (permanent hold). When disabled, the thermostat follows its programmed schedule.
 


### PR DESCRIPTION
## Proposed change

Add documentation for the climate platform being added to the Trane Local integration. Documents HVAC modes (off, heat, cool, heat/cool, auto), fan modes (auto, on, circulate), and restructures the supported functionality section.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/163571
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards