### PR TITLE
Add missing energy pages to docs sidebar navigation

### DIFF
--- a/source/_includes/asides/docs_sitemap.html
+++ b/source/_includes/asides/docs_sitemap.html
@@ -179,6 +179,9 @@
   <ul>
     <li>{% active_link /docs/energy/electricity-grid/ Electricity grid %}</li>
     <li>{% active_link /docs/energy/solar-panels/ Solar panels %}</li>
+    <li>{% active_link /docs/energy/battery/ Home batteries %}</li>
+    <li>{% active_link /docs/energy/gas/ Gas usage %}</li>
+    <li>{% active_link /docs/energy/water/ Water usage %}</li>
     <li>{% active_link /docs/energy/individual-devices/ Individual devices %}</li>
     <li>{% active_link /docs/energy/faq/ FAQ %}</li>
   </ul>


### PR DESCRIPTION
## Proposed change

The gas (added Aug 2021), water (added Nov 2022), and battery (added Aug 2021) energy documentation pages were never added to the sidebar navigation. They are currently only discoverable through links on the main energy overview page.

This adds them to the sidebar alongside the existing entries for electricity grid, solar panels, individual devices, and FAQ.

## Type of change

- [x] Documentation (improvements or additions to our documentation)
