### PR TITLE
Fix unifi protect doorbell example

### DIFF
--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -418,7 +418,7 @@ The UniFi Protect integration provides support for various event types triggered
 
 - **Event Name**: Doorbell
 - **Event Attributes**:
-  - **event_type**: `doorbell`
+  - **event_type**: `ring`
   - **event_id**: A unique ID that identifies the doorbell event.
 - **Description**: This event is triggered when someone rings the doorbell. It provides an `event_id`, which can be used to fetch related media, such as a thumbnail of the event. For instance, you can use `event.g4_doorbell_pro_doorbell` to get the thumbnail image when a ring occurs.
 
@@ -434,8 +434,14 @@ triggers:
     trigger: event
 conditions:
   - condition: template
-    value_template: |
-      {% raw %}{{ 'ring' in trigger.event.data.new_state.attributes.event_types }}{% endraw %}
+    value_template: >
+      {% raw %}{{
+        trigger.event.data.old_state is not none and
+        not trigger.event.data.old_state.state == 'unavailable' and
+        trigger.event.data.new_state is not none and
+        not trigger.event.data.new_state.state == 'unavailable' and
+        trigger.event.data.new_state.attributes.event_type == 'ring'
+      }}{% endraw %}
 actions:
   - data:
       message: Someone is at the door!
@@ -443,7 +449,7 @@ actions:
     action: notify.mobile_app_your_device # Replace with your notification target
 ```
 
-The condition is required to prevent the notification from being triggered by events of type 'unknown', for example, during a restart.
+The condition ensures the notification is only sent for actual doorbell rings and not during startup or power-cycle state restoration, when the entity may temporarily transition through the `unavailable` state (such as during a UniFi Protect restart).
 
 ### NFC Card Scanned Event
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This is a documentation example change.

I used the example provided, and found that a power on of the doorbell appears to fire the last doorbell event, causing the automation to trigger when I plug in the g4 pro doorbell.

I tried to make a trigger than instead of listening to the event, listens to a state change of the binary sensor. I started documenting it when I realized that you lose the event_id, so would not be able to then query unifi for the image or video.

So I went back and made the event version work.

My observations:

* 'ring' is always in event_types
* event_id on the event fired at boot up does match the last doorbell ring, but because there is a event to go to unavailable, we can't check equality between old/new state to not fire the automation
* I think timestamps can provide signal to discard the on boot event, but I didn't investigate if they can be reliably used
* attributes.event_type can't be relied upon alone. It is absent on the unavailable event, but present for the ring and the boot up

So the modification I made is close as I can get to readable and looks similar to other examples. If we come from or go to unavailable, this likely isn't a ring.

I noticed other examples guarding old/new state being none. I added those as guards as they probably don't hurt, but I don't know how to validate that myself.






## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
