### PR TITLE
Add ha_config_flow to Splunk integration

### DIFF
--- a/source/_integrations/splunk.markdown
+++ b/source/_integrations/splunk.markdown
@@ -4,6 +4,7 @@ description: Record events in Splunk.
 ha_category:
   - History
 ha_iot_class: Local Push
+ha_config_flow: true
 ha_release: 0.13
 ha_domain: splunk
 ha_codeowners:

--- a/source/_integrations/splunk.markdown
+++ b/source/_integrations/splunk.markdown
@@ -19,6 +19,20 @@ ha_quality_scale: legacy
 The **Splunk** {% term integration %} makes it possible to log all state changes to an external [Splunk](https://splunk.com/) database using Splunk's HTTP Event Collector (HEC) feature. You can either use this alone, or with the Home Assistant for Splunk [app](https://github.com/miniconfig/splunk-homeassistant). Since the HEC feature is new to Splunk, you will need to use at least version 6.3.
 
 {% include integrations/config_flow.md %}
+{% configuration_basic %}
+Token:
+  description: "The HTTP Event Collector (HEC) token created in your Splunk instance."
+Host:
+  description: "The hostname or IP address of your Splunk instance."
+Port:
+  description: "The port of the HTTP Event Collector on your Splunk instance."
+Use SSL:
+  description: "Whether to use HTTPS to connect to your Splunk instance."
+Verify SSL certificate:
+  description: "Whether to verify the SSL certificate of your Splunk instance."
+Name:
+  description: "A friendly name to send to Splunk as the host, instead of the name of the HTTP Event Collector."
+{% endconfiguration_basic %}
 
 ## Filters
 


### PR DESCRIPTION
## Proposed change

Add `ha_config_flow: true` to the Splunk integration frontmatter, corresponding to the Splunk integration gaining config flow support in HA core.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted or added information to an existing page
- [ ] Added a new page

## Additional information

- This PR is related to issue:
- Link to parent core pull request: https://github.com/home-assistant/core/pull/163616

## Checklist

- [x] This PR only has changes in a single file to make reviews simple.
- [x] The content conforms to the [style guide](https://developers.home-assistant.io/docs/documenting/standards/style-guide/).