### PR TITLE
Allow to disable seconds in DurationSelector

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -618,8 +618,8 @@ device:
 
 ## Duration selector
 
-The duration select allow the user to select a time duration. This can be
-helpful for, e.g., delays or offsets.
+The duration selector lets you select a time duration.
+This can be helpful for, e.g., delays or offsets.
 
 ![Screenshot of the Duration selector](/images/blueprints/selector-duration.png)
 
@@ -632,6 +632,11 @@ enable_day:
   description: When `true`, the duration selector will allow selecting days.
   type: boolean
   default: false
+  required: false
+enable_second:
+  description: When `true`, the duration selector will allow selecting seconds.
+  type: boolean
+  default: true
   required: false
 enable_millisecond:
   description: When `true`, the duration selector will allow selecting milliseconds.
@@ -652,7 +657,7 @@ For example:
 days: 1 # Only when enable_day was set to true
 hours: 12
 minutes: 30
-seconds: 15
+seconds: 15 # Only when enable_second is true (default)
 milliseconds: 500 # Only when enable_millisecond was set to true
 ```
 

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -619,7 +619,7 @@ device:
 ## Duration selector
 
 The duration selector lets you select a time duration.
-This can be helpful for, e.g., delays or offsets.
+This can be helpful, for example, for delays or offsets.
 
 ![Screenshot of the Duration selector](/images/blueprints/selector-duration.png)
 
@@ -654,10 +654,10 @@ The output of this selector is a mapping of the time values the user selected.
 For example:
 
 ```yaml
-days: 1 # Only when enable_day was set to true
+days: 1 # Only when enable_day is set to true
 hours: 12
 minutes: 30
-seconds: 15 # Only when enable_second is true (default)
+seconds: 15 # Only when enable_second is set to true (default)
 milliseconds: 500 # Only when enable_millisecond was set to true
 ```
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
As discussed in https://github.com/home-assistant/core/pull/161803#discussion_r2742928281 this extends the DurationSelector configuration to also disable seconds like already possible for days and milliseconds.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/163803
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
