### PR TITLE
Add select platform documentation for ViCare integration

### DIFF
--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -4,6 +4,7 @@ description: Instructions how to integrate Viessmann heating devices with Home A
 ha_category:
   - Climate
   - Fan
+  - Select
   - Water heater
 ha_release: 0.99
 ha_iot_class: Cloud Polling
@@ -16,6 +17,7 @@ ha_platforms:
   - diagnostics
   - fan
   - number
+  - select
   - sensor
   - water_heater
 ha_dhcp: true
@@ -102,6 +104,10 @@ Button entities are available for triggering like a one-time charge of the water
 ### Number
 
 Number entities are available to adjust values like the predefined temperature for different heating programs or the heating curve shift and slope.
+
+### Select
+
+Select entities allow configuring the domestic hot water (DHW) operating mode of your Viessmann device. Available options depend on the specific device model and may include modes such as balanced, economical, or off.
 
 ## Actions
 

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -107,7 +107,7 @@ Number entities are available to adjust values like the predefined temperature f
 
 ### Select
 
-Select entities allow configuring the domestic hot water (<abbr title="domestic hot water">DHW</abbr>) operating mode of your Viessmann device. Available options depend on the specific device model and may include modes such as balanced, economical, or off.
+Select entities allow configuring the domestic hot water (<abbr title="domestic hot water">DHW</abbr>) operating mode of your Viessmann device. Available options depend on the specific device model and may include `balanced`, `economical`, or `off` modes.
 
 ## Actions
 

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -107,7 +107,7 @@ Number entities are available to adjust values like the predefined temperature f
 
 ### Select
 
-Select entities allow configuring the domestic hot water (DHW) operating mode of your Viessmann device. Available options depend on the specific device model and may include modes such as balanced, economical, or off.
+Select entities allow configuring the domestic hot water (<abbr title="domestic hot water">DHW</abbr>) operating mode of your Viessmann device. Available options depend on the specific device model and may include modes such as balanced, economical, or off.
 
 ## Actions
 


### PR DESCRIPTION
## Proposed change

Add documentation for the new select platform in the ViCare integration, which provides a select entity for configuring the domestic hot water (DHW) operating mode.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/163832
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards