### PR TITLE
Add config_flow for Orvibo integration

### DIFF
--- a/source/_integrations/orvibo.markdown
+++ b/source/_integrations/orvibo.markdown
@@ -26,7 +26,7 @@ When the switches cannot be discovered, they can be manually configured.
 Host:
 description: "The host name or IP address (e.g., \"192.168.1.2\") of your switch."
 Mac address:
-description: "The Mac address of the switch. This field is optional. If it is ommitted, the {% term integration %} will attempt to discover and connect to the switch using the Host field alone. If this discovery fails, you must enter both the host and Mac address information.
+description: "The Mac address of the switch. This field is optional. If it is omitted, the {% term integration %} will attempt to discover and connect to the switch using the Host field alone. If this discovery fails, you must enter both the host and Mac address information.
 
 ## Troubleshooting
 

--- a/source/_integrations/orvibo.markdown
+++ b/source/_integrations/orvibo.markdown
@@ -18,49 +18,16 @@ Please be aware that the product ORVIBO WIFI SMART SOCKET S20 (LGS-20) has been 
 
 The **Orvibo** {% term integration %} allows you to toggle your Orvibo S20 Wifi Smart Sockets.
 
-To automatically discover Orvibo sockets on your network:
+{% include integrations/config_flow.md %}
 
-```yaml
-# Example configuration.yaml entry
-switch:
-  - platform: orvibo
-```
+When the switches cannot be discovered, they can be manually configured.
 
-To specify Orvibo sockets and skip discovery:
+{% configuration_basic %}
+Host:
+description: "The host name or IP address (e.g., \"192.168.1.2\") of your switch."
+Mac address:
+description: "The Mac address of the switch. This field is optional. If it is ommitted, the {% term integration %} will attempt to discover and connect to the switch using the Host field alone. If this discovery fails, you must enter both the host and Mac address information.
 
-```yaml
-# Example configuration.yaml entry
-switch:
-  - platform: orvibo
-    discovery: false
-    switches:
-      - host: IP_ADDRESS
-        mac: MA:CA:DD:RE:SS:00
-        name: "My Socket"
-```
+## Troubleshooting
 
-{% configuration %}
-discovery:
-  description: Whether to discover sockets.
-  required: false
-  default: true
-  type: boolean
-switches:
-  description: A list of Orvibo switches.
-  required: false
-  type: list
-  keys:
-    host:
-      description: "IP address of your socket, e.g., 192.168.1.10."
-      required: true
-      type: string
-    mac:
-      description: "MAC address of the socket, e.g., `AA:BB:CC:DD:EE:FF`. This is required if the socket is connected to a different subnet to the machine running Home Assistant."
-      required: false
-      type: string
-    name:
-      description: Your name for the socket.
-      required: false
-      default: Orvibo S20 Switch
-      type: string
-{% endconfiguration %}
+Discovery requires that Home Assistant and the Orvibo switches are on the same network subnet. In addition, discovery may fail if the switches are asleep. In this case, try toggling the state of the switch or power cycling the switch. If discovery still fails, you can configure the switches manually.


### PR DESCRIPTION

## Proposed change
The Orvibo integration now supports config_flow configuration rather than yaml.  This PR updates the doc for config_flow.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/155115
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
