### PR TITLE
Add Trinnov Altitude docs (initial media_player scope)

### DIFF
--- a/source/_integrations/trinnov_altitude.markdown
+++ b/source/_integrations/trinnov_altitude.markdown
@@ -1,0 +1,59 @@
+---
+title: Trinnov Altitude
+description: Instructions for setting up the Trinnov Altitude integration in Home Assistant.
+ha_category:
+  - Media player
+  - Remote
+  - Sensor
+ha_iot_class: Local Push
+ha_release: '2026.4'
+ha_domain: trinnov_altitude
+ha_codeowners:
+  - '@binarylogic'
+ha_config_flow: true
+ha_platforms:
+  - media_player
+  - remote
+  - sensor
+  - switch
+  - select
+  - number
+  - button
+ha_integration_type: device
+---
+
+The **Trinnov Altitude** integration lets Home Assistant control and monitor Trinnov Altitude processors over your local network.
+
+The integration supports power control (including Wake-on-LAN when a MAC address is configured), source and preset selection, volume and mute controls, and device status sensors.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+host:
+  description: Hostname or IP address of your Trinnov Altitude processor.
+mac:
+  description: Optional MAC address used for Wake-on-LAN power on.
+{% endconfiguration_basic %}
+
+## Supported functionality
+
+- Power on/off
+- Source and preset selection
+- Upmixer mode selection
+- Volume and mute control
+- Device state and status sensors
+- Remote command passthrough for advanced control
+
+## Known behavior
+
+- To power on from Home Assistant, configure the device MAC address during setup.
+- After power-on, wait until the remote entity becomes `on` before sending additional commands.
+- The integration requires the Trinnov device to be reachable on your local network.
+
+## Troubleshooting
+
+If setup fails:
+
+- Confirm the Trinnov Altitude is powered and reachable from Home Assistant.
+- Verify the host/IP is correct.
+- If Wake-on-LAN is used, verify the MAC address format (`00:11:22:33:44:55`).

--- a/source/_integrations/trinnov_altitude.markdown
+++ b/source/_integrations/trinnov_altitude.markdown
@@ -18,7 +18,6 @@ ha_platforms:
   - switch
   - select
   - number
-  - button
 ha_integration_type: device
 ---
 

--- a/source/_integrations/trinnov_altitude.markdown
+++ b/source/_integrations/trinnov_altitude.markdown
@@ -46,7 +46,7 @@ mac:
 ## Known behavior
 
 - To power on from Home Assistant, configure the device MAC address during setup.
-- After power-on, wait until the remote entity becomes `on` before sending additional commands.
+- After power-on, wait until the remote entity shows as **On** in Home Assistant before sending additional commands.
 - The integration requires the Trinnov device to be reachable on your local network.
 
 ## Troubleshooting


### PR DESCRIPTION
## Proposed change
Add initial documentation for the Trinnov Altitude integration matching the first core submission scope.

This docs PR is scoped to the initial `media_player` platform and setup flow.

## Related pull request
Core PR: https://github.com/home-assistant/core/pull/164422

## Checklist
- [x] Documentation is updated to match the current implementation scope.
- [x] No unrelated documentation changes included.
