### PR TITLE
Update madvr docs for rewritten core integration

### DIFF
--- a/source/_integrations/madvr.markdown
+++ b/source/_integrations/madvr.markdown
@@ -104,7 +104,9 @@ Sensors include:
 - Power state
 - GPU / HDMI input / CPU / mainboard temperatures
 - Active profile
-- Additional advanced sensors (`version`, `current_menu`, `aspect_ratio_mode`) can be enabled via options.
+- Incoming/outgoing signal resolution, frame rate, and HDR mode
+- Incoming signal aspect ratio plus aspect/masking ratio telemetry
+- Additional advanced sensors (`version`, `current_menu`) can be enabled via options.
 
 ### Options
 

--- a/source/_integrations/madvr.markdown
+++ b/source/_integrations/madvr.markdown
@@ -8,7 +8,7 @@ ha_category:
   - Select
   - Sensor
   - Switch
-ha_release: '2026.4'
+ha_release: '2024.8'
 ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:
@@ -64,11 +64,17 @@ target:
 
 ### Services
 
-The integration provides these domain services:
+The integration provides these domain services.
 
-- `madvr.press_key`
-- `madvr.activate_profile`
-- `madvr.run_action`
+- `madvr.press_key`: Send one remote key press.
+  Fields:
+  `key` (required), `entry_id` (optional; required when multiple madVR entries are loaded).
+- `madvr.activate_profile`: Activate a profile by group/index.
+  Fields:
+  `group_id` (required), `profile_index` (required), `entry_id` (optional; required when multiple entries are loaded).
+- `madvr.run_action`: Run one predefined action.
+  Fields:
+  `action` (required), `entry_id` (optional; required when multiple entries are loaded).
 
 ### Select and switch entities
 
@@ -80,6 +86,7 @@ The integration provides these domain services:
 ### Buttons
 
 The integration exposes button entities for common one-shot actions, including:
+
 - Power on / standby / power off
 - Hotplug
 - Restart
@@ -93,6 +100,7 @@ The integration creates a `signal_present` binary sensor.
 ### Sensor
 
 Sensors include:
+
 - Power state
 - GPU / HDMI input / CPU / mainboard temperatures
 - Active profile
@@ -101,6 +109,7 @@ Sensors include:
 ### Options
 
 The options flow allows tuning:
+
 - Sync/connect/command/read timeouts
 - Reconnect backoff and jitter
 - Advanced entity enable/disable

--- a/source/_integrations/madvr.markdown
+++ b/source/_integrations/madvr.markdown
@@ -2,20 +2,26 @@
 title: madVR Envy
 description: Instructions on how to integrate a madVR Envy into Home Assistant.
 ha_category:
+  - Button
   - Binary Sensor
   - Remote
+  - Select
   - Sensor
-ha_release: '2024.8'
+  - Switch
+ha_release: '2026.4'
 ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:
-  - '@iloveicedgreentea'
+  - '@binarylogic'
 ha_domain: madvr
 ha_platforms:
   - binary_sensor
+  - button
   - diagnostics
   - remote
+  - select
   - sensor
+  - switch
 ha_integration_type: device
 ---
 
@@ -29,103 +35,72 @@ This integration supports all current madVR Envy models.
 
 ## Remote
 
-The madVR Envy remote platform will create a [remote](/integrations/remote/) entity for the device. This entity allows you to send the following commands via the [remote.send_command](/integrations/remote/) action.
+The madVR Envy remote platform creates a [remote](/integrations/remote/) entity for the device.
 
-The command structure uses the same keywords as the [official documentation](https://madvrenvy.com/wp-content/uploads/EnvyIpControl.pdf?r=113a) and simply sends the corresponding command to the device. Please refer to the official documentation for more details and usage.
+`remote.send_command` supports:
 
-Using these commands, you can create a digital remote in the UI.
-
-Example:
+- Remote key names directly (for example: `MENU`, `INFO`, `OK`, `BACK`, `LEFT`, `RIGHT`, `UP`, `DOWN`, `POWER`).
+- Action aliases using `action:<name>` (for example: `action:restart`, `action:standby`, `action:power_off`, `action:hotplug`, `action:reload_software`, `action:tone_map_on`, `action:tone_map_off`).
 
 ```yaml
-# Command with parameters
+# Send keys
 action: remote.send_command
 data:
-  command: KeyPress, SETTINGS
+  command:
+    - MENU
+    - INFO
 target:
   entity_id: remote.madvr_envy
 ```
 
 ```yaml
-# Single command
+# Run predefined action
 action: remote.send_command
 data:
-  command: Restart
+  command: action:restart
 target:
   entity_id: remote.madvr_envy
 ```
 
-### Single Commands
+### Services
 
-These are commands that can be sent standalone, no parameters.
+The integration provides these domain services:
 
-- `PowerOff`
-- `Standby`
-- `Restart`
-- `ReloadSoftware`
-- `Bye`
-- `ResetTemporary`
-- `CloseMenu`
-- `GetMaskingRatio`
-- `GetMacAddress`
-- `ToneMapOn`
-- `ToneMapOff`
-- `Hotplug`
-- `RefreshLicenseInfo`
-- `Force1080p60Output`
+- `madvr.press_key`
+- `madvr.activate_profile`
+- `madvr.run_action`
 
-### Commands with Parameters
+### Select and switch entities
 
-These are commands that have parameters with a comma separating them.
+- `select.power_mode`: Select `on`, `standby`, or `off`.
+- `select.active_profile`: Select profile across all known profile groups.
+- Group-scoped profile selects are created when profile groups are available.
+- `switch.tone_map`: Toggle tone mapping.
 
-- `ActivateProfile (SOURCE | DISPLAY | CUSTOM)`
-- `OpenMenu (Info | Settings | Configuration | Profiles | TestPatterns)`
-- `KeyPress (MENU | UP | DOWN | LEFT | RIGHT | OK | INPUT | SETTINGS | RED | GREEN | BLUE | YELLOW | POWER)`
-- `KeyHold (MENU | UP | DOWN | LEFT | RIGHT | OK | INPUT | SETTINGS | RED | GREEN | BLUE | YELLOW | POWER)`
+### Buttons
+
+The integration exposes button entities for common one-shot actions, including:
+- Power on / standby / power off
+- Hotplug
+- Restart
+- Reload software
+- Optional remote-key buttons (menu/info/ok/back)
 
 ### Binary sensor
 
-The integration creates the following binary sensors:
-
-- `Power state` is On when the device is turned on.
-- `Signal state` is On when the device is receiving a signal from the source.
-- `HDR flag` is On when the device is receiving an HDR signal. This is useful to trigger automations based on the HDR flag, such as changing projector settings.
-- `Outgoing HDR flag` is On when the device is sending an HDR signal.
-
-These can be used for various purposes, such as triggering your masking system based on the detected aspect ratio.
+The integration creates a `signal_present` binary sensor.
 
 ### Sensor
 
-The following sensors are enabled by default:
+Sensors include:
+- Power state
+- GPU / HDMI input / CPU / mainboard temperatures
+- Active profile
+- Additional advanced sensors (`version`, `current_menu`, `aspect_ratio_mode`) can be enabled via options.
 
-- `Aspect ratio decimal`: The aspect ratio as a decimal value.
-- `Incoming bit depth`: The bit depth of the incoming video signal.
-- `Incoming black levels`: The black level setting of the incoming video signal.
-- `Incoming color space`: The color space of the incoming video signal.
-- `Incoming colorimetry`: The colorimetry of the incoming video signal.
-- `Incoming frame rate`: The frame rate of the incoming video signal.
-- `Incoming resolution`: The resolution of the incoming video signal.
-- `Masking decimal`: The masking ratio as a decimal value.
-- `Outgoing bit depth`: The bit depth of the outgoing video signal.
-- `Outgoing black levels`: The black level setting of the outgoing video signal.
-- `Outgoing color space`: The color space of the outgoing video signal.
-- `Outgoing colorimetry`: The colorimetry of the outgoing video signal.
-- `Outgoing frame rate`: The frame rate of the outgoing video signal.
-- `Outgoing resolution`: The resolution of the outgoing video signal.
+### Options
 
-The following sensors are disabled by default:
-
-- `Aspect ratio integer`: The aspect ratio as an integer ratio.
-- `Aspect ratio name`: The name of the current aspect ratio.
-- `Aspect ratio resolution`: The resolution corresponding to the current aspect ratio.
-- `CPU temperature`: The temperature of the CPU.
-- `GPU temperature`: The temperature of the GPU.
-- `HDMI temperature`: The temperature of the HDMI interface.
-- `Incoming aspect ratio`: The aspect ratio of the incoming video signal.
-- `Incoming signal type`: The type of the incoming signal (3D or 2D).
-- `Mainboard temperature`: The temperature of the mainboard.
-- `Masking integer`: The masking ratio as an integer ratio.
-- `Masking resolution`: The resolution for the current masking setting.
-- `Outgoing signal type`: The type of the outgoing signal (3D or 2D).
-
-These sensors are disabled because their values are not commonly needed but they can be enabled in the UI according to your needs.
+The options flow allows tuning:
+- Sync/connect/command/read timeouts
+- Reconnect backoff and jitter
+- Advanced entity enable/disable


### PR DESCRIPTION
## Proposed change
Update `madvr` integration documentation to match the rewritten core integration implementation.

Updates include:
- Revised platform list (`button`, `select`, `switch` added).
- Updated remote command behavior (`action:<name>` support and key handling).
- Added integration service documentation (`press_key`, `activate_profile`, `run_action`).
- Updated sensors/selects/switch/buttons and options flow descriptions.
- Updated code owner metadata in docs frontmatter.

## Related pull requests
Core PR 1 (runtime + compatibility): https://github.com/home-assistant/core/pull/164419
Core PR 2 (platforms/services): https://github.com/home-assistant/core/pull/164420

## Checklist
- [x] Documentation is updated to match current behavior.
- [x] No unrelated documentation changes included.
