### PR TITLE
[2026.3] Add Sure Petcare entities details and pet select location blueprint

### DIFF
--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -29,40 +29,52 @@ These are the entities available in the Sure Petcare integration.
 
 ### Pets
 
-| Domain        | Name                     | Description
-| ------------- | ------------------------ | ------------------------------------------------------------
-| Binary sensor | Presence                 | Whether the pet is inside (presence).
-| Sensor        | Last seen flap device ID | Diagnostic: last flap device ID used by the pet (useful for the [pet select location blueprint](#pet-select-location-template-entity)); `unknown` if the last status is not from a flap update.
-| Sensor        | Last seen user ID        | Diagnostic: last user ID that manually changed pet location (useful for the [pet select location blueprint](#pet-select-location-template-entity)); `unknown` if the last status is not from a manual update.
+#### Binary sensors
+
+- **Presence**: Whether the pet is inside (presence).
+
+#### Sensors
+
+- **Last seen flap device ID**: Diagnostic: last flap device ID used by the pet (useful for the [pet select location blueprint](#pet-select-location-template-entity)); `unknown` if the last status is not from a flap update.
+- **Last seen user ID**: Diagnostic: last user ID that manually changed pet location (useful for the [pet select location blueprint](#pet-select-location-template-entity)); `unknown` if the last status is not from a manual update.
 
 ### Pet and cat flaps
 
-| Domain         | Name           | Description                                                                    |
-| -------------- | -------------- | ------------------------------------------------------------------------------ |
-| Binary sensor  | Connectivity   | Device connectivity (online); shows device RSSI when available.                |
-| Lock           | Locked in      | Lock state: flap locked to allow entry only.                                   |
-| Lock           | Locked out     | Lock state: flap locked to allow exit only.                                    |
-| Lock           | Locked all     | Lock state: flap locked both ways.                                             |
-| Sensor         | Battery level  | Battery level percentage (derived from battery voltage).                       |
+#### Binary sensors
+
+- **Connectivity**: Device connectivity (online); shows device RSSI when available.
+
+#### Locks
+
+- **Locked in**: Lock state: flap locked to allow entry only.
+- **Locked out**: Lock state: flap locked to allow exit only.
+- **Locked all**: Lock state: flap locked both ways.
+
+#### Sensors
+
+- **Battery level**: Battery level percentage (derived from battery voltage).
 
 ### Feeders
 
-| Domain         | Name           | Description                                                                    |
-| -------------- | -------------- | ------------------------------------------------------------------------------ |
-| Binary sensor  | Connectivity   | Feeder connectivity (online); shows device RSSI when available.                |
-| Sensor         | Battery level  | Battery level percentage (derived from battery voltage).                       |
+#### Binary sensors
+
+- **Connectivity**: Feeder connectivity (online); shows device RSSI when available.
+
+#### Sensors
+
+- **Battery level**: Battery level percentage (derived from battery voltage).            |
 
 ### Felaqua
 
-| Domain | Name    | Description                  |
-| ------ | ------- | ---------------------------- |
-| Sensor | Felaqua | Water remaining in the bowl. |
+#### Sensors
+
+- **Felaqua**: Water remaining in the bowl.
 
 ### Hub
 
-| Domain         | Name           | Description                                                                  |
-| -------------- | -------------- | ---------------------------------------------------------------------------- |
-| Binary sensor  | Connectivity   | Hub connectivity (online); attributes include `led_mode` and `pairing_mode`. |
+#### Binary sensors
+
+- **Connectivity**: Hub connectivity (online); attributes include `led_mode` and `pairing_mode`.
 
 ## Actions
 

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -23,6 +23,46 @@ The **Sure Petcare** {% term integration %} allows you to get information on you
 
 {% include integrations/config_flow.md %}
 
+## Entities
+
+These are the entities available in the Sure Petcare integration.
+
+### Pets
+
+| Domain        | Name                     | Description
+| ------------- | ------------------------ | ------------------------------------------------------------
+| Binary sensor | Presence                 | Whether the pet is inside (presence).
+| Sensor        | Last seen flap device id | Diagnostic: last flap device id used by the pet (useful for the [pet select location blueprint](#pet-select-location)); unknown if the last status is not from a flap update.
+| Sensor        | Last seen user id        | Diagnostic: last user id that manually changed pet location (useful for the [pet select location blueprint](#pet-select-location)); unknown if the last status is not from a manual update.
+
+### Cat flap
+
+| Domain         | Name           | Description                                                                    |
+| -------------- | -------------- | ------------------------------------------------------------------------------ |
+| Binary sensor  | Connectivity   | Device connectivity (online); shows device RSSI when available.                |
+| Lock           | Locked in      | Lock state: flap locked to allow entry only.                                   |
+| Lock           | Locked out     | Lock state: flap locked to allow exit only.                                    |
+| Lock           | Locked all     | Lock state: flap locked both ways.                                             |
+| Sensor         | Battery level  | Battery level percent (derived from battery voltage).                          |
+
+### Feeders
+
+| Domain         | Name           | Description                                                                    |
+| -------------- | -------------- | ------------------------------------------------------------------------------ |
+| Binary sensor  | Connectivity   | Feeder connectivity (online); shows device RSSI when available.                |
+| Sensor         | Battery level  | Battery level percent (derived from battery voltage).                          |
+
+### Felaqua
+
+| Domain | Name    | Description                  |
+| ------ | ------- | ---------------------------- |
+| Sensor | Felaqua | Water remaining in the bowl. |
+
+### Hub
+
+| Domain         | Name           | Description                                                                  |
+| -------------- | -------------- | ---------------------------------------------------------------------------- |
+| Binary sensor  | Connectivity   | Hub connectivity (online); attributes include `led_mode` and `pairing_mode`. |
 
 ## Actions
 
@@ -61,3 +101,16 @@ The `surepetcare.set_pet_location` action sets the pet location.
 
 - `Inside` - Pet is inside.
 - `Outside` - Pet is outside.
+
+## Blueprints
+
+### Pet select location
+
+**[Source](https://gist.github.com/Zhephyr54/846f369dce673a989e141e9c2555e4d2)**
+
+Create a select entity for a pet representing its current location.
+This is especially useful if you have multiple flaps that do not directly lead outside and the existing binary sensors can't accurately reflect your pets' locations.
+
+Supports up to 10 flaps.
+
+The sync is one-way only. While the pet select location is synced from the pet binary sensor, manually changing the select entity state won't impact the pet binary sensor (thus no impact in Sure Petcare).

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -23,7 +23,7 @@ The **Sure Petcare** {% term integration %} allows you to get information on you
 
 {% include integrations/config_flow.md %}
 
-## Entities
+## Supported functionality
 
 These are the entities available in the Sure Petcare integration.
 

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -32,8 +32,8 @@ These are the entities available in the Sure Petcare integration.
 | Domain        | Name                     | Description
 | ------------- | ------------------------ | ------------------------------------------------------------
 | Binary sensor | Presence                 | Whether the pet is inside (presence).
-| Sensor        | Last seen flap device ID | Diagnostic: last flap device ID used by the pet (useful for the [pet select location blueprint](#pet-select-location)); `unknown` if the last status is not from a flap update.
-| Sensor        | Last seen user ID        | Diagnostic: last user ID that manually changed pet location (useful for the [pet select location blueprint](#pet-select-location)); `unknown` if the last status is not from a manual update.
+| Sensor        | Last seen flap device ID | Diagnostic: last flap device ID used by the pet (useful for the [pet select location blueprint](#pet-select-location-template-entity)); `unknown` if the last status is not from a flap update.
+| Sensor        | Last seen user ID        | Diagnostic: last user ID that manually changed pet location (useful for the [pet select location blueprint](#pet-select-location-template-entity)); `unknown` if the last status is not from a manual update.
 
 ### Cat flap
 

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -62,13 +62,18 @@ These are the entities available in the Sure Petcare integration.
 
 #### Sensors
 
-- **Battery level**: Battery level percentage (derived from battery voltage).            |
+- **Battery level**: Battery level percentage (derived from battery voltage).
 
 ### Felaqua
+
+#### Binary sensors
+
+- **Connectivity**: Felaqua connectivity (online); shows device RSSI when available.
 
 #### Sensors
 
 - **Felaqua**: Water remaining in the bowl.
+- **Battery level**: Battery level percentage (derived from battery voltage).
 
 ### Hub
 

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -35,8 +35,8 @@ These are the entities available in the Sure Petcare integration.
 
 #### Sensors
 
-- **Last seen flap device ID**: Diagnostic: last flap device ID used by the pet (useful for the [pet select location blueprint](#pet-select-location-template-entity)); `unknown` if the last status is not from a flap update.
-- **Last seen user ID**: Diagnostic: last user ID that manually changed pet location (useful for the [pet select location blueprint](#pet-select-location-template-entity)); `unknown` if the last status is not from a manual update.
+- **Last seen flap device ID**: Last flap device ID used by the pet (useful for the [pet select location blueprint](#pet-select-location-template-entity)). `unknown` if the last status is not from a flap update.
+- **Last seen user ID**: Last user ID that manually changed the pet location (useful for the [pet select location blueprint](#pet-select-location-template-entity)). `unknown` if the last status is not from a manual update.
 
 ### Pet and cat flaps
 

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -35,8 +35,8 @@ These are the entities available in the Sure Petcare integration.
 
 #### Sensors
 
-- **Last seen flap device ID**: Last flap device ID used by the pet (useful for the [pet select location blueprint](#pet-select-location-template-entity)). `unknown` if the last status is not from a flap update.
-- **Last seen user ID**: Last user ID that manually changed the pet location (useful for the [pet select location blueprint](#pet-select-location-template-entity)). `unknown` if the last status is not from a manual update.
+- **Last seen flap device ID**: Last flap device ID used by the pet (useful for the [pet select location blueprint](#pet-select-location-template-entity)). `unknown` if the last status is not from a flap update. This sensor is disabled by default.
+- **Last seen user ID**: Last user ID that manually changed the pet location (useful for the [pet select location blueprint](#pet-select-location-template-entity)). `unknown` if the last status is not from a manual update. This sensor is disabled by default.
 
 ### Pet and cat flaps
 

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -32,8 +32,8 @@ These are the entities available in the Sure Petcare integration.
 | Domain        | Name                     | Description
 | ------------- | ------------------------ | ------------------------------------------------------------
 | Binary sensor | Presence                 | Whether the pet is inside (presence).
-| Sensor        | Last seen flap device id | Diagnostic: last flap device id used by the pet (useful for the [pet select location blueprint](#pet-select-location)); unknown if the last status is not from a flap update.
-| Sensor        | Last seen user id        | Diagnostic: last user id that manually changed pet location (useful for the [pet select location blueprint](#pet-select-location)); unknown if the last status is not from a manual update.
+| Sensor        | Last seen flap device ID | Diagnostic: last flap device ID used by the pet (useful for the [pet select location blueprint](#pet-select-location)); `unknown` if the last status is not from a flap update.
+| Sensor        | Last seen user ID        | Diagnostic: last user ID that manually changed pet location (useful for the [pet select location blueprint](#pet-select-location)); `unknown` if the last status is not from a manual update.
 
 ### Cat flap
 
@@ -43,14 +43,14 @@ These are the entities available in the Sure Petcare integration.
 | Lock           | Locked in      | Lock state: flap locked to allow entry only.                                   |
 | Lock           | Locked out     | Lock state: flap locked to allow exit only.                                    |
 | Lock           | Locked all     | Lock state: flap locked both ways.                                             |
-| Sensor         | Battery level  | Battery level percent (derived from battery voltage).                          |
+| Sensor         | Battery level  | Battery level percentage (derived from battery voltage).                       |
 
 ### Feeders
 
 | Domain         | Name           | Description                                                                    |
 | -------------- | -------------- | ------------------------------------------------------------------------------ |
 | Binary sensor  | Connectivity   | Feeder connectivity (online); shows device RSSI when available.                |
-| Sensor         | Battery level  | Battery level percent (derived from battery voltage).                          |
+| Sensor         | Battery level  | Battery level percentage (derived from battery voltage).                       |
 
 ### Felaqua
 
@@ -104,9 +104,11 @@ The `surepetcare.set_pet_location` action sets the pet location.
 
 ## Blueprints
 
-### Pet select location
+### Pet select location (template entity)
 
-**[Source](https://gist.github.com/Zhephyr54/846f369dce673a989e141e9c2555e4d2)**
+<!-- markdownlint-disable MD034 -->
+{% my blueprint_import badge blueprint_url="https://gist.github.com/Zhephyr54/846f369dce673a989e141e9c2555e4d2" %}
+<!-- markdownlint-enable MD034 -->
 
 Create a select entity for a pet representing its current location.
 This is especially useful if you have multiple flaps that do not directly lead outside and the existing binary sensors can't accurately reflect your pets' locations.

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -35,7 +35,7 @@ These are the entities available in the Sure Petcare integration.
 | Sensor        | Last seen flap device ID | Diagnostic: last flap device ID used by the pet (useful for the [pet select location blueprint](#pet-select-location-template-entity)); `unknown` if the last status is not from a flap update.
 | Sensor        | Last seen user ID        | Diagnostic: last user ID that manually changed pet location (useful for the [pet select location blueprint](#pet-select-location-template-entity)); `unknown` if the last status is not from a manual update.
 
-### Cat flap
+### Pet and cat flaps
 
 | Domain         | Name           | Description                                                                    |
 | -------------- | -------------- | ------------------------------------------------------------------------------ |


### PR DESCRIPTION
## Proposed change

Following up [this suggestion](https://github.com/home-assistant/core/pull/160215#issuecomment-3957484292) after adding new diagnostic sensors to the Sure Petcare integration in 2026.3. As there was no detail about any existing entity, I added it for all entities as well.
Also added a blueprint section to link the related blueprint (this was the main reason to add those new sensors).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/160215
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


**Note:** Not sure if I am correct basing this PR on the `next` branch because 2026.3 should be released soon?