### PR TITLE
Add zeroconf discovery documentation for air-Q

### DIFF
--- a/source/_integrations/airq.markdown
+++ b/source/_integrations/airq.markdown
@@ -15,6 +15,7 @@ ha_config_flow: true
 ha_platforms:
   - number
   - sensor
+ha_zeroconf: true
 ha_integration_type: hub
 ---
 
@@ -22,8 +23,9 @@ The **air-Q** {% term integration %} allows integrating the sensors, provided by
 
 {% include integrations/config_flow.md %}
 
-During the initial configuration, the user is prompted for the IP address of the {% term device %} or the first 5 characters of the serial number, as well as the device password.
+Your air-Q device can be automatically discovered on your network. When Home Assistant discovers a new air-Q device, it appears as a notification in the UI. Select the notification and enter your device password to complete the setup.
 
+If your device is not discovered automatically, you can set it up manually. During the manual configuration, you are prompted for the IP address of the {% term device %} or the first 5 characters of the serial number, as well as the device password.
 
 For this integration to communicate with the device, both must be connected to the same Wi-Fi network.
 


### PR DESCRIPTION
Document automatic network discovery of air-Q devices via zeroconf and add ha_zeroconf front matter flag.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
SSIA


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/164727
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
