### PR TITLE
Document additional configuration options for Ness Alarm

### DIFF
--- a/source/_integrations/ness_alarm.markdown
+++ b/source/_integrations/ness_alarm.markdown
@@ -69,6 +69,21 @@ After setting up the integration, you can add zones through the UI:
 
 You can reconfigure a zone's device class at any time by selecting the zone's configure button.
 
+### Options
+
+After setting up the integration, you can configure additional options:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
+2. Find the **Ness Alarm** integration and select **Configure**.
+3. Adjust the available options:
+
+{% configuration_basic %}
+Scan interval:
+  description: "Time in seconds between polling the alarm panel for updates. Default is 60 seconds."
+Show arm home mode:
+  description: "Enable this to show the arm home option on the alarm panel."
+{% endconfiguration_basic %}
+
 ## Actions
 
 ### Action `aux`


### PR DESCRIPTION
# Proposed change

Adds documentation for the new options flow in the Ness Alarm integration, which allows users to configure the scan interval (polling frequency) and the arm home mode toggle via the UI. This was added as part of a bugfix where `scan_interval` was being dropped during YAML-to-config-entry migration.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/164780
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards