### PR TITLE
Add Hetzner Cloud integration documentation

### DIFF
--- a/source/_integrations/hetzner.markdown
+++ b/source/_integrations/hetzner.markdown
@@ -1,0 +1,52 @@
+---
+title: Hetzner Cloud
+description: Instructions on how to integrate Hetzner Cloud with Home Assistant.
+ha_category:
+  - Binary sensor
+ha_iot_class: Cloud Polling
+ha_release: 2025.4
+ha_config_flow: true
+ha_codeowners:
+  - '@Bre77'
+ha_domain: hetzner
+ha_platforms:
+  - binary_sensor
+ha_integration_type: hub
+ha_quality_scale: bronze
+---
+
+The **Hetzner Cloud** {% term integration %} allows you to monitor your [Hetzner Cloud](https://www.hetzner.com/cloud) infrastructure from Home Assistant. It connects to the Hetzner Cloud API to track the health status of your load balancer targets.
+
+## Prerequisites
+
+To use the Hetzner Cloud integration, you need an API token for your Hetzner Cloud project.
+
+1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud/).
+2. Select the project you want to monitor.
+3. Go to **Security** > **API tokens**.
+4. Select **Generate API token** and create a token with **Read** permissions.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+API Token:
+  description: "The API token for your Hetzner Cloud project."
+{% endconfiguration_basic %}
+
+## Supported functionality
+
+### Binary sensors
+
+The integration creates a binary sensor for each target attached to your load balancers. Each sensor shows whether the target is healthy based on the load balancer's health checks.
+
+- **Target health**: Shows the health status of a load balancer target (server or IP). The sensor is **on** when all health checks for the target report healthy, and **off** when any health check reports unhealthy.
+
+## Data updates
+
+The integration polls the Hetzner Cloud API every 60 seconds to update load balancer and target health data.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/hetzner.markdown
+++ b/source/_integrations/hetzner.markdown
@@ -37,9 +37,13 @@ API Token:
 
 ### Binary sensors
 
-The integration creates a binary sensor for each target attached to your load balancers. Each sensor shows whether the target is healthy based on the load balancer's health checks.
+The integration creates a binary sensor for each **server** or **IP** target attached to your load balancers. Each sensor shows whether the target is healthy based on the load balancer's health checks.
 
-- **Target health**: Shows the health status of a load balancer target (server or IP). The sensor is **on** when all health checks for the target report healthy, and **off** when any health check reports unhealthy.
+- **Target health**: Shows the health status of a load balancer target. The sensor is **on** when all health checks for the target report healthy, and **off** when any health check reports unhealthy.
+
+## Known limitations
+
+- **label_selector targets are not supported.** Load balancers using `label_selector` type targets will not produce any entities due to a limitation in the underlying `hcloud` Python library, which does not parse the resolved targets within `label_selector` entries. If you need health monitoring for these targets, switch to direct **server** targets on your load balancer.
 
 ## Data updates
 


### PR DESCRIPTION
## Proposed change

Adds documentation for the new Hetzner Cloud integration. This integration monitors load balancer target health via the Hetzner Cloud API. The documentation includes prerequisites for obtaining an API token, configuration instructions via config flow, and details about the binary sensor entities created for each load balancer target (supporting server and IP type targets only).

## Type of change

- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/164782
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - [x] I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards