### PR TITLE
Remove non existing Package-level attributes of seventeentrack integration

### DIFF
--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -34,21 +34,6 @@ Although the 17track.net website states that account passwords cannot be longer 
 - Delivered
 - Returned
 
-## Package-level attributes
-
-Each package entry (for example, within a status sensor) contains the following attributes.
-
-- package.friendly_name
-- package.status
-- package.destination_country
-- package.info_text
-- package.timestamp
-- package.location
-- package.origin_country
-- package.package_type
-- package.tracking_info_language
-- package.tracking_number
-
 ## Examples
 
 ### Dashboard summary card


### PR DESCRIPTION
## Proposed change

Remove non existing Package-level attributes of seventeentrack integration (removed in https://github.com/home-assistant/core/pull/142622)


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/135598

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
