### PR TITLE
KNX: add config for unit_of_measurement for yaml sensor entities

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -2004,7 +2004,7 @@ state_class:
   required: false
   type: string
 device_class:
-  description: Overrides the DPT's default [class of the device](/integrations/sensor/), changing the device state and icon that is displayed on the frontend.
+  description: Overrides the DPT's default [class of the device](/integrations/sensor#device-class), changing the device state and icon that is displayed on the frontend.
   required: false
   type: string
 unit_of_measurement:

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -2004,7 +2004,7 @@ state_class:
   required: false
   type: string
 device_class:
-  description: Overrides the DPT's default [class of the device](/integrations/sensor#device-class), changing the device state and icon that is displayed on the frontend.
+  description: Overrides the DPT's default [device class](/integrations/sensor#device-class), changing the device state and icon that is displayed on the frontend.
   required: false
   type: string
 unit_of_measurement:

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -2007,6 +2007,10 @@ device_class:
   description: Overrides the DPT's default [class of the device](/integrations/sensor/), changing the device state and icon that is displayed on the frontend.
   required: false
   type: string
+unit_of_measurement:
+  description: Override the DPT's default native unit of measurement. The unit must be valid for the selected device class.
+  required: false
+  type: string
 {% endconfiguration %}
 
 ### More examples

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -2008,7 +2008,7 @@ device_class:
   required: false
   type: string
 unit_of_measurement:
-  description: Override the DPT's default native unit of measurement. The unit must be valid for the selected device class.
+  description: Overrides the DPT's default native unit of measurement. The unit must be valid for the selected device class.
   required: false
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add config for unit_of_measurement for yaml sensor entities


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/165082
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
