### PR TITLE
Add state_attr_translated template filter and function

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -377,7 +377,7 @@ The `state_translated` function returns a translated state of an entity using a 
 
 Not supported in [limited templates](#limited-templates).
 
-The `state_attr_translated` function returns a translated attribute value of an entity using the language that is currently configured in the [general settings](https://my.home-assistant.io/redirect/general/). This is useful for attributes like `fan_mode`, `hvac_action`, `preset_mode`, or `color_mode`, which have translations defined but are stored as untranslated values in the state.
+The `state_attr_translated` function returns a translated attribute value of an entity using the language that is currently configured in {% my general title="**Settings** > **System** > **General**" %}. This is useful for attributes like `fan_mode`, `hvac_action`, `preset_mode`, or `color_mode`, which have translations defined but are stored as untranslated values in the state.
 
 #### State attribute translated examples
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -384,15 +384,15 @@ The `state_attr_translated` function returns a translated attribute value of an 
 {% raw %}
 
 ```text
-{{ state_attr("climate.living_room", "fan_mode") }}                     # low
-{{ state_attr_translated("climate.living_room", "fan_mode") }}          # Low
-{{ "climate.living_room" | state_attr_translated("fan_mode") }}         # Low
+{{ state_attr("climate.living_room", "fan_mode") }} # low
+{{ state_attr_translated("climate.living_room", "fan_mode") }} # Low
+{{ "climate.living_room" | state_attr_translated("fan_mode") }} # Low
 ```
 
 ```text
-{{ state_attr("climate.living_room", "hvac_action") }}                  # heating
-{{ state_attr_translated("climate.living_room", "hvac_action") }}       # Heating
-{{ "climate.living_room" | state_attr_translated("hvac_action") }}      # Heating
+{{ state_attr("climate.living_room", "hvac_action") }} # heating
+{{ state_attr_translated("climate.living_room", "hvac_action") }} # Heating
+{{ "climate.living_room" | state_attr_translated("hvac_action") }} # Heating
 ```
 
 {% endraw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -373,6 +373,31 @@ The `state_translated` function returns a translated state of an entity using a 
 {% endraw %}
 
 
+### State attribute translated
+
+Not supported in [limited templates](#limited-templates).
+
+The `state_attr_translated` function returns a translated attribute value of an entity using the language that is currently configured in the [general settings](https://my.home-assistant.io/redirect/general/). This is useful for attributes like `fan_mode`, `hvac_action`, `preset_mode`, or `color_mode`, which have translations defined but are stored as untranslated values in the state.
+
+#### State attribute translated examples
+
+{% raw %}
+
+```text
+{{ state_attr("climate.living_room", "fan_mode") }}                     # low
+{{ state_attr_translated("climate.living_room", "fan_mode") }}          # Low
+{{ "climate.living_room" | state_attr_translated("fan_mode") }}         # Low
+```
+
+```text
+{{ state_attr("climate.living_room", "hvac_action") }}                  # heating
+{{ state_attr_translated("climate.living_room", "hvac_action") }}       # Heating
+{{ "climate.living_room" | state_attr_translated("hvac_action") }}      # Heating
+```
+
+{% endraw %}
+
+
 ### Working with groups
 
 Not supported in [limited templates](#limited-templates).


### PR DESCRIPTION
## Proposed change

Add state_attr_translated template filter and function

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/165317
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
