### PR TITLE
Add LMS timeout option to Squeezebox integration

### DIFF
--- a/source/_integrations/squeezebox.markdown
+++ b/source/_integrations/squeezebox.markdown
@@ -81,12 +81,12 @@ transporter_toslink:
 {% include integrations/option_flow.md %}
 
 {% configuration_basic %}  
-Browse limit:  
+Browse limit:
  description: Maximum number of items to include when browsing media or in a playlist.
-Volume step:  
- description: Amount to adjust the volume when turning volume up or down.  
-LMS timeout:  
- description: The number of seconds to wait for a response from the LMS before timing out.  
+Volume step:
+ description: Amount to adjust the volume when turning volume up or down.
+LMS timeout:
+ description: The number of seconds to wait for a response from the LMS before timing out.
 {% endconfiguration_basic %}
 
 ## Announce

--- a/source/_integrations/squeezebox.markdown
+++ b/source/_integrations/squeezebox.markdown
@@ -85,6 +85,8 @@ Browse limit:
  description: Maximum number of items to include when browsing media or in a playlist.
 Volume step:  
  description: Amount to adjust the volume when turning volume up or down.  
+LMS timeout:  
+ description: The number of seconds to wait for a response from the LMS before timing out.  
 {% endconfiguration_basic %}
 
 ## Announce


### PR DESCRIPTION

## Proposed change
Doc update to reflect a new option in the Squeezebox integration adding a LMS timeout setting to the options config flow.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/165324
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
