### PR TITLE
Added fix for Italian Iliadbox in Freebox's docs

### DIFF
--- a/source/_integrations/freebox.markdown
+++ b/source/_integrations/freebox.markdown
@@ -140,7 +140,8 @@ To do this, follow these steps:
 3. Copy the **ECC Root CA** certificate shown below.
 4. Copy the **RSA Root CA** certificate shown below.
 5. In the Additional CA integration, add both certificates as new certificate authorities, following the integration's documentation.
-6. Restart Home Assistant, then reload the Freebox integration.
+6. Restart Home Assistant to load the certificates.
+7. Manually add the Iliadbox under **Settings** > **Devices & services** by selecting **Add integration**, then **Freebox**, and create a new instance. Use `myiliadbox.iliad.it` as the host and `443` as the port.
 
 ECC Root CA
 ```text
@@ -195,5 +196,3 @@ G2Gkv4w/V/eB3eAvd5lgm6oOe8ehdr5JdpD6wnW2GOHs4SBdBo6yR+4RgEimNmgF
 Yu11tlZsB2Iw/TT1EyPVb5z6tK4wUgWLNFAvjXU=
 -----END CERTIFICATE-----
 ```
-
-After you load the certificates, you can manually add the Iliadbox under **Settings** > **Devices & services** by selecting **Add integration**, then **Freebox**, and creating a new instance. Use `myiliadbox.iliad.it` as the host and `443` as the port.

--- a/source/_integrations/freebox.markdown
+++ b/source/_integrations/freebox.markdown
@@ -69,7 +69,7 @@ To use cameras from the Freebox Delta, you will have to add "Gestion de l'alarme
 
 Only the routers with Freebox OS are supported:
 
-- Freebox V8 also known as Freebox Pop (France) and Iliadbox (Italy)
+- Freebox V8 (Freebox Pop in France, Iliadbox in Italy)
 - Freebox V7 also known as Freebox Delta
 - Freebox V6 also known as Freebox Revolution
 - Freebox mini 4k
@@ -130,10 +130,20 @@ This platform offers you a switch to toggle the Wi-Fi on or off. This will toggl
 
 ## Fix for Italian version (Iliadbox)
 
-After updating the Freebox/Iliadbox to firmware 4.8.17.2 the integration will stop working due to SSL certificate issues. This can be fixed by using the [Additional CA](https://github.com/Athozs/hass-additional-ca) custom integration to load the following new CA certificates (refer to the integration's documentation for instructions), that are taken from the API manual (HTTPS access page) accessed from the Iliadbox's web interface:
+After you update your Freebox/Iliadbox to firmware 4.8.17.2, the integration might stop working because of SSL certificate issues.
+You can work around this by loading new CA certificates into Home Assistant.
+
+To do this, follow these steps:
+
+1. Install the [Additional CA](https://github.com/Athozs/hass-additional-ca) custom integration.
+2. In your Iliadbox web interface, open the API manual and go to the HTTPS access page.
+3. Copy the **ECC Root CA** certificate shown below.
+4. Copy the **RSA Root CA** certificate shown below.
+5. In the Additional CA integration, add both certificates as new certificate authorities, following the integration's documentation.
+6. Restart Home Assistant, then reload the Freebox integration.
 
 ECC Root CA
-```
+```text
 -----BEGIN CERTIFICATE-----
 MIICOjCCAcCgAwIBAgIUI0Tu7zsrBJACQIZgLMJobtbdNn4wCgYIKoZIzj0EAwIw
 TDELMAkGA1UEBhMCSVQxDjAMBgNVBAgMBUl0YWx5MQ4wDAYDVQQKDAVJbGlhZDEd
@@ -151,7 +161,7 @@ LCiBKV2j7QQGy7N1aBmdur17ZepYzR1YV0eI+Kd978aZggsmhjXENQYVTmm/XA==
 ```
 
 RSA Root CA
-```
+```text
 -----BEGIN CERTIFICATE-----
 MIIFiTCCA3GgAwIBAgIUTXoJE/kJnSKpxk5FjcmqmGah9zcwDQYJKoZIhvcNAQEL
 BQAwTDELMAkGA1UEBhMCSVQxDjAMBgNVBAgMBUl0YWx5MQ4wDAYDVQQKDAVJbGlh
@@ -186,4 +196,4 @@ Yu11tlZsB2Iw/TT1EyPVb5z6tK4wUgWLNFAvjXU=
 -----END CERTIFICATE-----
 ```
 
-After load the certificates the Iliadbox can be manually added in 'Devices > Add integration > Freebox > New instance' and using 'myiliadbox.iliad.it' as the IP address and 443 as the port.
+After you load the certificates, you can manually add the Iliadbox under **Settings** > **Devices & services** by selecting **Add integration**, then **Freebox**, and creating a new instance. Use `myiliadbox.iliad.it` as the host and `443` as the port.

--- a/source/_integrations/freebox.markdown
+++ b/source/_integrations/freebox.markdown
@@ -69,7 +69,7 @@ To use cameras from the Freebox Delta, you will have to add "Gestion de l'alarme
 
 Only the routers with Freebox OS are supported:
 
-- Freebox V8 also known as Freebox Pop
+- Freebox V8 also known as Freebox Pop (France) and Iliadbox (Italy)
 - Freebox V7 also known as Freebox Delta
 - Freebox V6 also known as Freebox Revolution
 - Freebox mini 4k
@@ -127,3 +127,63 @@ The `freebox.reboot` action allows you to reboot your Freebox router. It does no
 ## Switch
 
 This platform offers you a switch to toggle the Wi-Fi on or off. This will toggle all Wi-Fi interfaces of the router (all SSID and all bands).
+
+## Fix for Italian version (Iliadbox)
+
+After updating the Freebox/Iliadbox to firmware 4.8.17.2 the integration will stop working due to SSL certificate issues. This can be fixed by using the [Additional CA](https://github.com/Athozs/hass-additional-ca) custom integration to load the following new CA certificates (refer to the integration's documentation for instructions), that are taken from the API manual (HTTPS access page) accessed from the Iliadbox's web interface:
+
+ECC Root CA
+```
+-----BEGIN CERTIFICATE-----
+MIICOjCCAcCgAwIBAgIUI0Tu7zsrBJACQIZgLMJobtbdNn4wCgYIKoZIzj0EAwIw
+TDELMAkGA1UEBhMCSVQxDjAMBgNVBAgMBUl0YWx5MQ4wDAYDVQQKDAVJbGlhZDEd
+MBsGA1UEAwwUSWxpYWRib3ggRUNDIFJvb3QgQ0EwHhcNMjAxMTI3MDkzODEzWhcN
+NDAxMTIyMDkzODEzWjBMMQswCQYDVQQGEwJJVDEOMAwGA1UECAwFSXRhbHkxDjAM
+BgNVBAoMBUlsaWFkMR0wGwYDVQQDDBRJbGlhZGJveCBFQ0MgUm9vdCBDQTB2MBAG
+ByqGSM49AgEGBSuBBAAiA2IABMryJyb2loHNAioY8IztN5MI3UgbVHVP/vZwcnre
+ZvJOyDvE4HJgIti5qmfswlnMzpNbwf/MkT+7HAU8jJoTorRm1wtAnQ9cWD3Ebv79
+RPwtjjy3Bza3SgdVxmd6fWPUKaNjMGEwHQYDVR0OBBYEFDUij/4lpoJ+kOXRyrcM
+jf2RPzOqMB8GA1UdIwQYMBaAFDUij/4lpoJ+kOXRyrcMjf2RPzOqMA8GA1UdEwEB
+/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgGGMAoGCCqGSM49BAMCA2gAMGUCMQC6eUV1
+pFh4UpJOTc1JToztN4ttnQR6rIzxMZ6mNCe+nhjkohWp24pr7BpUYSbEizYCMAQ6
+LCiBKV2j7QQGy7N1aBmdur17ZepYzR1YV0eI+Kd978aZggsmhjXENQYVTmm/XA==
+-----END CERTIFICATE-----
+```
+
+RSA Root CA
+```
+-----BEGIN CERTIFICATE-----
+MIIFiTCCA3GgAwIBAgIUTXoJE/kJnSKpxk5FjcmqmGah9zcwDQYJKoZIhvcNAQEL
+BQAwTDELMAkGA1UEBhMCSVQxDjAMBgNVBAgMBUl0YWx5MQ4wDAYDVQQKDAVJbGlh
+ZDEdMBsGA1UEAwwUSWxpYWRib3ggUlNBIFJvb3QgQ0EwHhcNMjAxMTI3MDkzODEy
+WhcNNDAxMTIyMDkzODEyWjBMMQswCQYDVQQGEwJJVDEOMAwGA1UECAwFSXRhbHkx
+DjAMBgNVBAoMBUlsaWFkMR0wGwYDVQQDDBRJbGlhZGJveCBSU0EgUm9vdCBDQTCC
+AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANXKZSyCmix6jt7jUmaCP4XF
+caF4azeYZuA8A4sWQmQXRWTDj8oNClE5w7zo5qUYzHIBOubKY7hhIU7RXYR5Bdny
+arNRoo5ZBplgEkv3G00IgXY2/lCywPQ8WorAn0k/uaRce239r6EkGC3fxCA3Asnc
+q9lNkUoWaf0GktJai0DuW7bNY8cq+vzZpy/36ey0LQ4OoehfiA6vlUTVWakpjecJ
+ller1RfVlgEH26wnerGge3LYBZv27XiahCft54AQLxRY3H/z8XpKsPnJJrrhEvSo
+2p64Bd+g7ZbzCdeakrypjVC/eWn14UzbcBVgh0p4F4990LuGxLVqyh6XcZOSSi01
+4fpca5xPDCiohEX7ehMLpdURbhKzPj17IpwTmonfVmxkvV8rca1PqhDPEOouwPtc
+M55eCgtwgSBeDznFKD7s+az/SZYC16GTgyXTCd2lId/J1unZ4pdzNVMAglTpnGgz
+eQkHvfcVYdJj49tOtW0OpSPBiNIC6LCVY9wtH5dRMm0k+A8QDP+9HQaOs3LIUMwu
+WGePw6r+eXUYw/2yO0z3zI/63hOpzZVixW+T7h3SY5B+sTrxR9fRD1oyk/rPV4I3
+X5mZnyzSowjcN3+hSkGIZBleMO3CHaYleIf1/9HHhCJCVeeJ4kwEWY18Z0A+ohFh
+D/dipgwmLCDH1/irDT4pAgMBAAGjYzBhMB0GA1UdDgQWBBTcW1RrTVIizaqkrkTI
+CSw86qDJkTAfBgNVHSMEGDAWgBTcW1RrTVIizaqkrkTICSw86qDJkTAPBgNVHRMB
+Af8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsFAAOCAgEAOfi6
+fCuVLJD+vttO34cdB3i5hofmNrzgLh/spnwdm4y9EvvVqDvLdVLEIbvKf0QEcW0Y
+dwP1BgmKwwHVv9YydHov8Jr4ANoGGXJnPLPcYDhRnixYEQmlTwSL/CLUcQ2hQWXx
+Oc0k1jJB7uk6TPdX2YJyW4NpIcwI2sa5Dg/L8PqM0/pMYnMyG1hBwUc2M2qg3qTJ
+zeiYT9zBHxS/JXA40yH4g9NzcFisVuYrfmINb11GmeqClm2OWehSdgdv9tEph3NW
+ntJTENRrDvuj/pGZsnbofzgHNN6/nanymmrEPxG+xUGLIAW7zFndTKityhJ9FRqF
+ultoZR2D19hh+n1277TSCPRJzUpq9rrfiqukjua3UjBzEvevnmSbLs1bXcNAxFYN
+oZZ2euHoBv+E3BHjGik4RUkEJYtf5Xh+iffk4zTMfKBERn40fB7yF1xzxyoziltL
+VxfueF9V6N7qjo5Ia7kiShXXsB+QdQdweuxWm1pPYmMbfTxNEqFUs3GhwEjzLaJc
+cJOedwCT4ntbyCcTQaRlDL8QFjdE4gNm2ZaoG+gqGTLPS55H+ZvLsgUCiR5YY44N
+G2Gkv4w/V/eB3eAvd5lgm6oOe8ehdr5JdpD6wnW2GOHs4SBdBo6yR+4RgEimNmgF
+Yu11tlZsB2Iw/TT1EyPVb5z6tK4wUgWLNFAvjXU=
+-----END CERTIFICATE-----
+```
+
+After load the certificates the Iliadbox can be manually added in 'Devices > Add integration > Freebox > New instance' and using 'myiliadbox.iliad.it' as the IP address and 443 as the port.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    The Freebox modem router is also called Iliadbox and used by the
    Italian daughter company Iliad. However the API of the italian Iliadbox
    uses different CA certificates for the HTTPS access that this integration
    is using, compared to the French Freebox.
    This pull request adds a workaround in the documentation for the Freebox
    integration to fix it for Italian users.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
