### PR TITLE
Pylutron 0.4.0 - Multi-state LED Support

### DIFF
--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -30,7 +30,7 @@ ha_integration_type: hub
 ha_config_flow: true
 ---
 
-[Lutron](https://www.lutron.com/) is an American lighting control company. They have several lines of home automation devices that manage light switches/dimmers, occupancy sensors, HVAC controls, etc. The **Lutron** integration in Home Assistant is responsible for communicating with the main hub for these systems.
+[Lutron](https://www.lutron.com/) is an American lighting control company. They have several lines of home automation devices that manage light switches, dimmers, occupancy sensors, and HVAC controls. The **Lutron** integration in Home Assistant is responsible for communicating with the main hub for these systems.
 
 Presently, the integration supports communicating with the RadioRA 2 Main Repeater and handles various devices like light switches, dimmers, keypad scenes, fans, and shades.
 
@@ -52,17 +52,19 @@ If you are using RadioRA2 software version 12 or later, the default `lutron` use
 
 ## Keypad buttons
 
-Keypad buttons actions are provided in event entities.
+Keypad button actions are provided in event entities.
 
 The buttons fire a `lutron_event` on the event bus. This event includes the following data attributes:
+
 - `id`: The slugified name of the button (for example, `office_pico_on`).
 - `action`: The action performed (`single`, `pressed`, or `released`).
 
 ## Keypad LEDs
 
-Each full-width button on a Lutron SeeTouch, Hybrid SeeTouch, and Tabletop SeeTouch Keypad has an LED that can be controlled by Home Assistant. 
+Each full-width button on a Lutron seeTouch, Hybrid seeTouch, and Tabletop seeTouch Keypad has an LED that can be controlled by Home Assistant. 
 
 Indicator LEDs for scenes (keypad buttons) are available as **Select** entities. They support the following states:
+
 - **Off**
 - **On**
 - **Slow Flash**

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -52,18 +52,7 @@ If you are using RadioRA2 software version 12 or later, the default `lutron` use
 
 ## Keypad buttons
 
-Keypad button actions are provided in event entities.
-
-The following event types are available:
-- `single_press`: Fired when a button is pressed on most keypads.
-- `press`: Fired when a button is pressed on keypads that support release events (like Raise/Lower buttons).
-- `release`: Fired when a button is released on keypads that support release events.
-
-Buttons also fire a `lutron_event` on the event bus for backward compatibility. This event includes the following data attributes:
-- `id`: The slugified name of the button (for example, `office_pico_on`).
-- `action`: The action performed (`single`, `pressed`, or `released`).
-- `full_id`: The slugified name of the area and button.
-- `uuid`: The Lutron unique identifier for the button.
+Keypad buttons actions are provided in event entities.
 
 ## Keypad LEDs
 
@@ -95,15 +84,14 @@ Any configured Powr Savr occupancy sensors will be added as occupancy binary sen
 
 ## Example automations
 
-### Keypad button notification
-
-This example shows how to use the `event` entity for a notification.
-
 ```yaml
 - alias: "Keypad button pressed notification"
   triggers:
-    - trigger: state
-      entity_id: event.office_pico_on
+    - trigger: event
+      event_type: lutron_event
+      event_data:
+        id: office_pico_on
+        action: single
   actions:
     - action: notify.telegram
       data:

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -36,7 +36,7 @@ Presently, the integration supports communicating with the RadioRA 2 Main Repeat
 
 ## Configuration
 
-When configured, the `lutron` integration will automatically discover the rooms and their associated switches/dimmers as configured by the RadioRA 2 software from Lutron. Each room will be treated as a separate group.
+When configured, the **Lutron** integration will automatically discover the rooms and their associated switches/dimmers as configured by the RadioRA 2 software from Lutron. Each room will be treated as a separate group.
 
 To use Lutron RadioRA 2 devices in your installation, you'll need to first create a username/password in your Lutron programming software. Once a telnet username/password has been programmed, you can follow the instructions from the next chapter.
 
@@ -53,6 +53,10 @@ If you are using RadioRA2 software version 12 or later, the default `lutron` use
 ## Keypad buttons
 
 Keypad buttons actions are provided in event entities.
+
+The buttons fire a `lutron_event` on the event bus. This event includes the following data attributes:
+- `id`: The slugified name of the button (for example, `office_pico_on`).
+- `action`: The action performed (`single`, `pressed`, or `released`).
 
 ## Keypad LEDs
 

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -2,14 +2,16 @@
 title: Lutron
 description: Instructions on how to use Lutron devices with Home Assistant.
 ha_category:
+  - Binary sensor
   - Cover
   - Event
   - Fan
   - Hub
   - Light
   - Scene
+  - Select
   - Switch
-ha_release: 0.37
+ha_release: 2026.3
 ha_iot_class: Local Polling
 ha_codeowners:
   - '@cdheiser'
@@ -22,14 +24,15 @@ ha_platforms:
   - fan
   - light
   - scene
+  - select
   - switch
 ha_integration_type: hub
 ha_config_flow: true
 ---
 
-[Lutron](https://www.lutron.com/) is an American lighting control company. They have several lines of home automation devices that manage light switches/dimmers, occupancy sensors, HVAC controls, etc. The `lutron` integration in Home Assistant is responsible for communicating with the main hub for these systems.
+[Lutron](https://www.lutron.com/) is an American lighting control company. They have several lines of home automation devices that manage light switches/dimmers, occupancy sensors, HVAC controls, etc. The **Lutron** integration in Home Assistant is responsible for communicating with the main hub for these systems.
 
-Presently, there's only support for communicating with the RadioRA 2 Main Repeater and only handle light switches, dimmers, and seeTouch keypad scenes.
+Presently, the integration supports communicating with the RadioRA 2 Main Repeater and handles various devices like light switches, dimmers, keypad scenes, fans, and shades.
 
 ## Configuration
 
@@ -49,22 +52,42 @@ If you are using RadioRA2 software version 12 or later, the default `lutron` use
 
 ## Keypad buttons
 
-Keypad buttons actions are provided in event entities.
+Keypad button actions are provided in event entities.
+
+The following event types are available:
+- `single_press`: Fired when a button is pressed on most keypads.
+- `press`: Fired when a button is pressed on keypads that support release events (like Raise/Lower buttons).
+- `release`: Fired when a button is released on keypads that support release events.
+
+Buttons also fire a `lutron_event` on the event bus for backward compatibility. This event includes the following data attributes:
+- `id`: The slugified name of the button (for example, `office_pico_on`).
+- `action`: The action performed (`single`, `pressed`, or `released`).
+- `full_id`: The slugified name of the area and button.
+- `uuid`: The Lutron unique identifier for the button.
 
 ## Keypad LEDs
 
-Each full-width button on a Lutron SeeTouch, Hybrid SeeTouch, and Tabletop SeeTouch Keypad has an LED that can be controlled by Home Assistant. Performing an action of `switch.turn_off` or `switch.turn_on` against the appropriate LED entity will control the keypad LED.
+Each full-width button on a Lutron SeeTouch, Hybrid SeeTouch, and Tabletop SeeTouch Keypad has an LED that can be controlled by Home Assistant. 
 
-Keep in mind that the Lutron system will also control the LED state independent of Home Assistant, according to the programming of the RadioRA2 system. This also means you can query LED states to determine if a certain scene is active, since the LED will have been illuminated by the RadioRA2 repeaters. This includes the "phantom" LEDs of Main Repeater Keypad buttons; even though there is no physical button or LED, the RadioRA2 system tracks the scenes and will "light" the LED that can be queried.
+Indicator LEDs for scenes (keypad buttons) are available as **Select** entities. They support the following states:
+- **Off**
+- **On**
+- **Slow Flash**
+- **Fast Flash**
 
-If a button is not programmed to control any lights or other devices in the RadioRA2 system but is given a name in the programming software, it will be available to fire events in Home Assistant. However, since there is no way to have a scene "active" on a button with no devices associated, the Main Repeater will automatically extinguish the keypad LED a few seconds after the button press. If you wish to have Home Assistant light the keypad LED after a button press, you will need to delay your action to light the LED for several seconds, so it arrives after the Main Repeater has sent the command to turn it off.
+{% note %}
+Previous versions of this integration used **Switch** entities to control Keypad LEDs. These switch entities are now deprecated and will be removed in a future release. You should update your automations to use the new **Select** entities instead.
+{% endnote %}
+
+The Lutron system also controls the LED state independent of Home Assistant, according to the programming of the RadioRA 2 system. This means you can query LED states to determine if a certain scene is active, since the LED will have been illuminated by the RadioRA 2 repeaters. This includes the "phantom" LEDs of Main Repeater Keypad buttons; even though there is no physical button or LED, the RadioRA 2 system tracks the scenes and will "light" the LED that can be queried.
+
+If a button is not programmed to control any lights or other devices in the RadioRA 2 system but is given a name in the programming software, it will be available to fire events in Home Assistant. However, since there is no way to have a scene "active" on a button with no devices associated, the Main Repeater will automatically extinguish the keypad LED a few seconds after the button press. If you wish to have Home Assistant light the keypad LED after a button press, you will need to delay your action to light the LED for several seconds, so it arrives after the Main Repeater has sent the command to turn it off.
 
 ## Scene
 
-This integration uses keypad programming to identify scenes.  Currently, it works with seeTouch, hybrid seeTouch, main repeater, homeowner, Pico, and seeTouch RF tabletop keypads.
-The Lutron scene platform allows you to control scenes programmed into your SeeTouch keypads.
+This integration uses keypad programming to identify scenes. Currently, it works with seeTouch, hybrid seeTouch, main repeater, homeowner, Pico, and seeTouch RF tabletop keypads.
 
-After setup, scenes will appear in Home Assistant using the area, keypad and button name.
+The Lutron scene platform allows you to control scenes programmed into your seeTouch keypads. After setup, scenes will appear in Home Assistant using the area, keypad, and button name.
 
 ## Occupancy sensors
 
@@ -72,16 +95,35 @@ Any configured Powr Savr occupancy sensors will be added as occupancy binary sen
 
 ## Example automations
 
-``` yaml
-- alias: "keypad button pressed notification"
+### Keypad button notification
+
+This example shows how to use the `event` entity for a notification.
+
+```yaml
+- alias: "Keypad button pressed notification"
   triggers:
-    - trigger: event
-      event_type: lutron_event
-      event_data:
-        id: office_pico_on
-        action: single
+    - trigger: state
+      entity_id: event.office_pico_on
   actions:
     - action: notify.telegram
       data:
-        message: "pico just turned on!"
+        message: "The Pico button was just pressed!"
+```
+
+### Flash keypad LED
+
+This example shows how to set a keypad LED to slow flash.
+
+```yaml
+- alias: "Flash keypad LED when garage door is open"
+  triggers:
+    - trigger: state
+      entity_id: cover.garage_door
+      to: "open"
+  actions:
+    - action: select.select_option
+      target:
+        entity_id: select.office_keypad_garage_led
+      data:
+        option: "Slow Flash"
 ```


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updating to pylutron 0.4.0 changed the behavior of Keypad LEDs to support multiple states.  The old swtich entity style for Keypad LEDs is now deprecated and a new select entity is used.

Also included some minor fixes to stale documentation around device support

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/165568
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
