### PR TITLE
Update UniFi Access integration docs

### DIFF
--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -12,7 +12,9 @@ ha_codeowners:
   - "@imhotep"
   - "@RaHehl"
 ha_platforms:
-  - lock
+  - binary_sensor
+  - button
+  - event
 ha_integration_type: hub
 ---
 
@@ -68,12 +70,24 @@ The integration uses a local push architecture via WebSocket. When a door's lock
 
 The **UniFi Access** integration provides the following entities.
 
-#### Locks
+#### Binary sensors
 
-Each door registered in your UniFi Access controller is represented as a **lock** entity in Home Assistant.
+Each door registered in your UniFi Access controller is represented by a **binary sensor** entity that reports the door position.
+
+- **Door**: Turns on when the door is open and off when the door is closed.
+
+#### Buttons
+
+Each door also provides an **unlock** button in Home Assistant.
 
 - **Unlock**: Triggers the configured door lock relay to open the door for its configured duration.
-- **Open**: Opens the door (same as unlock).
+
+#### Events
+
+Each door provides **event** entities for UniFi Access activity exposed by the controller.
+
+- **Access**: Fires when an access attempt is granted or denied.
+- **Doorbell**: Fires when the doorbell is rung on supported hardware.
 
 ## Known limitations
 

--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -13,8 +13,7 @@ ha_codeowners:
   - "@RaHehl"
 ha_platforms:
   - binary_sensor
-  - button
-  - event
+  - lock
 ha_integration_type: hub
 ---
 
@@ -76,18 +75,12 @@ Each door registered in your UniFi Access controller is represented by a **binar
 
 - **Door**: Turns on when the door is open and off when the door is closed.
 
-#### Buttons
+#### Locks
 
-Each door also provides an **unlock** button in Home Assistant.
+Each door registered in your UniFi Access controller is represented as a **lock** entity in Home Assistant.
 
 - **Unlock**: Triggers the configured door lock relay to open the door for its configured duration.
-
-#### Events
-
-Each door provides **event** entities for UniFi Access activity exposed by the controller.
-
-- **Access**: Fires when an access attempt is granted or denied.
-- **Doorbell**: Fires when the doorbell is rung on supported hardware.
+- **Open**: Opens the door (same as unlock).
 
 ## Known limitations
 


### PR DESCRIPTION
## Proposed change

Update the UniFi Access integration documentation to add the new door-position binary sensor.

This keeps the PR focused on documenting the new `binary_sensor` platform only, without overlapping with separate documentation PRs for other platform changes.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/165569
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - [ ] I made a change to the existing documentation and used the `current` branch.
  - [x] I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
