### PR TITLE
Add Eurotronic Comet Blue documentation

### DIFF
--- a/source/_integrations/eurotronic_cometblue.markdown
+++ b/source/_integrations/eurotronic_cometblue.markdown
@@ -61,7 +61,9 @@ As shortcuts, the climate platform supports the following presets:
 
 - **Eco**: Temperature is set to the low schedule temperature.
 - **Comfort**: Temperature is set to the high schedule temperature.
-- **None**: Cannot be selected manually and is automatically selected if the temperature is other than the above.
+- **Boost**: Valve is fully open.
+- **Away**: Holiday mode is currently active. Display only.
+- **None**: Temperature is other than the above. Display only.
 
 Additionally, the following modes are available:
 
@@ -76,6 +78,7 @@ The integration {% term polling polls %} data from the thermostat every 5 minute
 ## Known limitations
 
 - Target high and low temperatures can only be set on the device itself.
+- Holiday mode/away preset can only be set on the device itself.
 - The devices only support temperature steps of 0.5°C and time steps of 15 minutes.
 - If you manually change the target temperature or use presets, the thermostat returns to its programmed schedule at the next schedule change.
 - If the thermostat is in holiday mode, you cannot reset it from Home Assistant. To reset it, press the `MENU` button on the thermostat until it resets.

--- a/source/_integrations/eurotronic_cometblue.markdown
+++ b/source/_integrations/eurotronic_cometblue.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate Eurotronic Comet Blue Thermostats 
 ha_category:
   - Climate
 ha_iot_class: Local Polling
-ha_release: 2026.4
+ha_release: 2026.5
 ha_config_flow: true
 ha_bluetooth: true
 ha_codeowners:

--- a/source/_integrations/eurotronic_cometblue.markdown
+++ b/source/_integrations/eurotronic_cometblue.markdown
@@ -6,10 +6,12 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: 2026.4
 ha_config_flow: true
+ha_bluetooth: true
 ha_codeowners:
   - '@rikroe'
 ha_domain: eurotronic_cometblue
 ha_integration_type: device
+ha_quality_scale: bronze
 ha_platforms:
   - climate
 ---
@@ -32,11 +34,9 @@ Before you set up this integration, make sure the following requirements are met
 1. The [Bluetooth](/integrations/bluetooth) integration is enabled and working.
 2. Bluetooth active scanning is enabled.
 
-## Configuration
 
 The Eurotronic Comet Blue {% term integration %} will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
 
-The devices require active scans to be discovered.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/eurotronic_cometblue.markdown
+++ b/source/_integrations/eurotronic_cometblue.markdown
@@ -12,13 +12,11 @@ ha_domain: eurotronic_cometblue
 ha_integration_type: device
 ha_platforms:
   - climate
-  - number
-  - sensor
 ---
 
 The **Eurotronic Comet Blue** {% term integration %} allows you to integrate Eurotronic Comet Blue (and similar) thermostats.
 
-You can use this integration to read thermostat status, adjust temperatures, and manage schedule-related settings in Home Assistant.
+You can use this integration to read thermostat status and adjust temperatures in Home Assistant.
 
 ## Supported devices
 
@@ -51,7 +49,7 @@ Device PIN:
 
 This integration provides climate control and thermostat configuration entities.
 
-Comet Blue devices can run on an internal schedule or be controlled directly. When the schedule is active, the thermostat switches between low and high target temperatures based on that schedule.
+Comet Blue devices run on an internal schedule and can be manually controlled temporarily. When the schedule is active, the thermostat switches between low and high target temperatures based on that schedule.
 
 If you manually change the target temperature or use presets, the thermostat returns to its programmed schedule on the next schedule change.
 
@@ -63,7 +61,7 @@ As shortcuts, the climate platform supports the following presets:
 
 - **Eco**: temperature is set to low schedule temperature
 - **Comfort**: temperature set to high schedule temperature
-- **Away**: cannot be selected manually, must be set via the **Set Holiday** action
+- **None**: cannot be selected manually, automatically selected if temperature is other than the above
 
 Additionally, the following modes are available:
 
@@ -71,178 +69,13 @@ Additionally, the following modes are available:
 - **Heat**: Valve is fully open
 - **Auto**: The thermostat controls the temperature automatically, based on target temperature
 
-### Numbers
-
-Number entities provide specific settings that affect automatic thermostat behavior.
-
-- **Temperature Offset**: Temperature calibration for the internal thermostat control
-- **Target Temperature High**: Temperature used for the `Comfort` preset and if schedule is on
-- **Target Temperature Low**: Temperature used for the `Eco` preset and if schedule is off
-- **Window Open Minutes**: How long should the thermostat stay `OFF` if it detects an abrupt temperature drop
-
-## Actions
-
-The integration provides the following actions.
-
-### Action: Get schedule
-
-The `eurotronic_cometblue.get_schedule` action reads the current schedule from a thermostat.
-
-- **Target**: `entity_id`
-  - **Description**: Climate entity from the Eurotronic Comet Blue integration
-  - **Required**: Yes
-- **Response**: This action returns the current weekly schedule for the targeted climate entity.
-  - **Shortened example**:
-
-    ```yaml
-    climate.cometblue_climate:
-      monday:
-        start1: "07:00"
-        end1: "22:00"
-      tuesday:
-        start1: "07:00"
-        end1: "22:00"
-      sunday:
-        start1: "09:00"
-        end1: "22:30"
-    ```
-
-### Action: Set schedule
-
-The `eurotronic_cometblue.set_schedule` action writes a weekly schedule to a thermostat.
-
-- **Target**: `entity_id`
-  - **Description**: Climate entity from the Eurotronic Comet Blue integration
-  - **Required**: Yes
-- **Data attributes**:
-  - **`monday`** to **`sunday`**
-    - **Description**: Days schedule as an object with `start` and `end` pairs
-    - **Optional**: Yes
-    - **Example**:
-
-      ```yaml
-      start1: "07:00:00"
-      end1: "09:00:00"
-      start2: "10:00:00"
-      end2: "12:00:00"
-      start3: "13:00:00"
-      end3: "17:00:00"
-      start4: "20:00:00"
-      end4: "23:00:00"
-      ```
-
-### Action: Set datetime
-
-The `eurotronic_cometblue.set_datetime` action sets the thermostat date and time to the local time of your Home Assistant instance. 
-
-- **Target**: `entity_id`
-  - **Description**: Climate entity from the Eurotronic Comet Blue integration
-  - **Required**: Yes
-- **Data attributes**:
-  - **`datetime`**
-    - **Description**: Optional datetime value if the local time of the Home Assistant instance is not applicable
-    - **Required**: No
-
-### Action: Set holiday
-
-The `eurotronic_cometblue.set_holiday` action enables holiday mode on a thermostat.
-
-{% important %}
-
-If the device is in holiday mode, you cannot reset it from Home Assistant. To reset it, press the `MENU` button on the device until it resets.
-
-{% endimportant %}
-
-- **Target**: `entity_id`
-  - **Description**: Climate entity from the Eurotronic Comet Blue integration
-  - **Required**: Yes
-- **Data attributes**:
-  - **`start`**
-    - **Description**: Start date and time for holiday mode
-    - **Required**: Yes
-    - **Example**: `2023-12-24`
-  - **`end`**
-    - **Description**: End date and time for holiday mode
-    - **Required**: Yes
-    - **Example**: `2023-12-31`
-  - **`temperature`**
-    - **Description**: Holiday temperature in °C
-    - **Required**: Yes
-    - **Example**: `20`
-    - **Range**: 8 to 28
-    - **Step**: 0.5
-
-## Examples
-
-The following examples show how to use Eurotronic Comet Blue actions in
-automations and scripts.
-
-### Read the schedule from a thermostat
-
-```yaml
-action: eurotronic_cometblue.get_schedule
-target:
-  entity_id: climate.living_room_radiator
-```
-
-This action returns the weekly schedule in the response data.
-
-### Set a weekly schedule
-
-```yaml
-action: eurotronic_cometblue.set_schedule
-target:
-  entity_id: climate.living_room_radiator
-data:
-  monday:
-    start1: "07:00:00"
-    end1: "09:00:00"
-    start2: "17:00:00"
-    end2: "22:00:00"
-  tuesday:
-    start1: "07:00:00"
-    end1: "09:00:00"
-    start2: "17:00:00"
-    end2: "22:00:00"
-  wednesday: {}
-  thursday: {}
-  friday:
-    start1: "07:00:00"
-    end1: "09:00:00"
-  saturday:
-    start1: "09:00:00"
-    end1: "12:00:00"
-  sunday:
-    start1: "09:00:00"
-    end1: "12:00:00"
-```
-
-### Set thermostat date and time
-
-```yaml
-action: eurotronic_cometblue.set_datetime
-target:
-  entity_id: climate.living_room_radiator
-```
-
-### Enable holiday mode
-
-```yaml
-action: eurotronic_cometblue.set_holiday
-target:
-  entity_id: climate.living_room_radiator
-data:
-  start: "2026-12-24 00:00:00"
-  end: "2026-12-31 23:59:00"
-  temperature: 17
-```
-
 ## Data updates
 
 The integration {% term polling polls %} data from the thermostat every 5 minutes by default.
 
 ## Known limitations
 
+- Target high and low temperatures can only be set on the device itself
 - The devices only supports temperature steps of 0.5°C and time steps of 15 minutes.
 - If you manually change the target temperature or use presets, the thermostat returns to its programmed schedule at the next schedule change.
 - If the thermostat is in holiday mode, you cannot reset it from Home Assistant. To reset it, press the `MENU` button on the thermostat until it resets.

--- a/source/_integrations/eurotronic_cometblue.markdown
+++ b/source/_integrations/eurotronic_cometblue.markdown
@@ -59,15 +59,15 @@ The climate entity lets you control the thermostat by setting a target temperatu
 
 As shortcuts, the climate platform supports the following presets:
 
-- **Eco**: temperature is set to low schedule temperature
-- **Comfort**: temperature set to high schedule temperature
-- **None**: cannot be selected manually, automatically selected if temperature is other than the above
+- **Eco**: Temperature is set to the low schedule temperature.
+- **Comfort**: Temperature is set to the high schedule temperature.
+- **None**: Cannot be selected manually and is automatically selected if the temperature is other than the above.
 
 Additionally, the following modes are available:
 
-- **Off**: Valve is fully closed
-- **Heat**: Valve is fully open
-- **Auto**: The thermostat controls the temperature automatically, based on target temperature
+- **Off**: Valve is fully closed.
+- **Heat**: Valve is fully open.
+- **Auto**: The thermostat controls the temperature automatically, based on the target temperature.
 
 ## Data updates
 
@@ -75,8 +75,8 @@ The integration {% term polling polls %} data from the thermostat every 5 minute
 
 ## Known limitations
 
-- Target high and low temperatures can only be set on the device itself
-- The devices only supports temperature steps of 0.5°C and time steps of 15 minutes.
+- Target high and low temperatures can only be set on the device itself.
+- The devices only support temperature steps of 0.5°C and time steps of 15 minutes.
 - If you manually change the target temperature or use presets, the thermostat returns to its programmed schedule at the next schedule change.
 - If the thermostat is in holiday mode, you cannot reset it from Home Assistant. To reset it, press the `MENU` button on the thermostat until it resets.
 

--- a/source/_integrations/eurotronic_cometblue.markdown
+++ b/source/_integrations/eurotronic_cometblue.markdown
@@ -34,7 +34,7 @@ Before you set up this integration, make sure the following requirements are met
 
 ## Configuration
 
-The Eurotronic Comet Blue {% term integration %} integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
+The Eurotronic Comet Blue {% term integration %} will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
 
 The devices require active scans to be discovered.
 

--- a/source/_integrations/eurotronic_cometblue.markdown
+++ b/source/_integrations/eurotronic_cometblue.markdown
@@ -1,0 +1,60 @@
+---
+title: Eurotronic Comet Blue Thermostats
+description: Instructions on how to integrate Eurotronic Comet Blue Thermostats into Home Assistant.
+ha_category:
+  - Climate
+ha_iot_class: Local Polling
+ha_release: 2026.4
+ha_config_flow: true
+ha_codeowners:
+  - '@rikroe'
+ha_domain: eurotronic_cometblue
+ha_integration_type: device
+ha_platforms:
+  - climate
+  - number
+  - sensor
+---
+
+The **Eurotronic Comet Blue** {% term integration %} allows you to integrate Eurotronic Comet Blue (and similar) thermostats.
+These Bluetooth Radiator Valves can be programmed with a schedule, as well as overwritten via Home Assistant.
+
+## Supported devices
+- Eurotronic Comet Blue
+- Sygonix HT100 BT
+- Xavax Hama
+- Lidl Silvercrest RT2000BT
+
+## Discovery
+
+The Eurotronic Comet Blue {% term integration %} integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
+
+The device require active scans to be discovered.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Device PIN:
+  description: "Device PIN with 6 digits."
+  required: true
+  type: integer
+  default: 000000
+{% endconfiguration_basic %}
+
+## Climate
+TODO: high/low, presets
+
+## Numbers
+TODO: Target temp low, high, offset, window
+
+## Actions
+### Get schedule
+### Set schedule
+### Set datetime
+### Set holiday
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/eurotronic_cometblue.markdown
+++ b/source/_integrations/eurotronic_cometblue.markdown
@@ -17,41 +17,243 @@ ha_platforms:
 ---
 
 The **Eurotronic Comet Blue** {% term integration %} allows you to integrate Eurotronic Comet Blue (and similar) thermostats.
-These Bluetooth Radiator Valves can be programmed with a schedule, as well as overwritten via Home Assistant.
+
+You can use this integration to read thermostat status, adjust temperatures, and manage schedule-related settings in Home Assistant.
 
 ## Supported devices
+
 - Eurotronic Comet Blue
 - Sygonix HT100 BT
 - Xavax Hama
 - Lidl Silvercrest RT2000BT
 
-## Discovery
+## Prerequisites
+
+Before you set up this integration, make sure the following requirements are met:
+
+1. The [Bluetooth](/integrations/bluetooth) integration is enabled and working.
+2. Bluetooth active scanning is enabled.
+
+## Configuration
 
 The Eurotronic Comet Blue {% term integration %} integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
 
-The device require active scans to be discovered.
+The devices require active scans to be discovered.
 
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}
 Device PIN:
-  description: "Device PIN with 6 digits."
-  required: true
-  type: integer
-  default: 000000
+  description: "Device PIN with 6 digits, defaults to `000000`."
 {% endconfiguration_basic %}
 
-## Climate
-TODO: high/low, presets
+## Supported functionality
 
-## Numbers
-TODO: Target temp low, high, offset, window
+This integration provides climate control and thermostat configuration entities.
+
+Comet Blue devices can run on an internal schedule or be controlled directly. When the schedule is active, the thermostat switches between low and high target temperatures based on that schedule.
+
+If you manually change the target temperature or use presets, the thermostat returns to its programmed schedule on the next schedule change.
+
+### Climate
+
+The climate entity lets you control the thermostat by setting a target temperature which the device will try to reach on its own.
+
+As shortcuts, the climate platform supports the following presets:
+
+- **Eco**: temperature is set to low schedule temperature
+- **Comfort**: temperature set to high schedule temperature
+- **Away**: cannot be selected manually, must be set via the **Set Holiday** action
+
+Additionally, the following modes are available:
+
+- **Off**: Valve is fully closed
+- **Heat**: Valve is fully open
+- **Auto**: The thermostat controls the temperature automatically, based on target temperature
+
+### Numbers
+
+Number entities provide specific settings that affect automatic thermostat behavior.
+
+- **Temperature Offset**: Temperature calibration for the internal thermostat control
+- **Target Temperature High**: Temperature used for the `Comfort` preset and if schedule is on
+- **Target Temperature Low**: Temperature used for the `Eco` preset and if schedule is off
+- **Window Open Minutes**: How long should the thermostat stay `OFF` if it detects an abrupt temperature drop
 
 ## Actions
-### Get schedule
-### Set schedule
-### Set datetime
-### Set holiday
+
+The integration provides the following actions.
+
+### Action: Get schedule
+
+The `eurotronic_cometblue.get_schedule` action reads the current schedule from a thermostat.
+
+- **Target**: `entity_id`
+  - **Description**: Climate entity from the Eurotronic Comet Blue integration
+  - **Required**: Yes
+- **Response**: This action returns the current weekly schedule for the targeted climate entity.
+  - **Shortened example**:
+
+    ```yaml
+    climate.cometblue_climate:
+      monday:
+        start1: "07:00"
+        end1: "22:00"
+      tuesday:
+        start1: "07:00"
+        end1: "22:00"
+      sunday:
+        start1: "09:00"
+        end1: "22:30"
+    ```
+
+### Action: Set schedule
+
+The `eurotronic_cometblue.set_schedule` action writes a weekly schedule to a thermostat.
+
+- **Target**: `entity_id`
+  - **Description**: Climate entity from the Eurotronic Comet Blue integration
+  - **Required**: Yes
+- **Data attributes**:
+  - **`monday`** to **`sunday`**
+    - **Description**: Days schedule as an object with `start` and `end` pairs
+    - **Optional**: Yes
+    - **Example**:
+
+      ```yaml
+      start1: "07:00:00"
+      end1: "09:00:00"
+      start2: "10:00:00"
+      end2: "12:00:00"
+      start3: "13:00:00"
+      end3: "17:00:00"
+      start4: "20:00:00"
+      end4: "23:00:00"
+      ```
+
+### Action: Set datetime
+
+The `eurotronic_cometblue.set_datetime` action sets the thermostat date and time to the local time of your Home Assistant instance. 
+
+- **Target**: `entity_id`
+  - **Description**: Climate entity from the Eurotronic Comet Blue integration
+  - **Required**: Yes
+- **Data attributes**:
+  - **`datetime`**
+    - **Description**: Optional datetime value if the local time of the Home Assistant instance is not applicable
+    - **Required**: No
+
+### Action: Set holiday
+
+The `eurotronic_cometblue.set_holiday` action enables holiday mode on a thermostat.
+
+{% important %}
+
+If the device is in holiday mode, you cannot reset it from Home Assistant. To reset it, press the `MENU` button on the device until it resets.
+
+{% endimportant %}
+
+- **Target**: `entity_id`
+  - **Description**: Climate entity from the Eurotronic Comet Blue integration
+  - **Required**: Yes
+- **Data attributes**:
+  - **`start`**
+    - **Description**: Start date and time for holiday mode
+    - **Required**: Yes
+    - **Example**: `2023-12-24`
+  - **`end`**
+    - **Description**: End date and time for holiday mode
+    - **Required**: Yes
+    - **Example**: `2023-12-31`
+  - **`temperature`**
+    - **Description**: Holiday temperature in °C
+    - **Required**: Yes
+    - **Example**: `20`
+    - **Range**: 8 to 28
+    - **Step**: 0.5
+
+## Examples
+
+The following examples show how to use Eurotronic Comet Blue actions in
+automations and scripts.
+
+### Read the schedule from a thermostat
+
+```yaml
+action: eurotronic_cometblue.get_schedule
+target:
+  entity_id: climate.living_room_radiator
+```
+
+This action returns the weekly schedule in the response data.
+
+### Set a weekly schedule
+
+```yaml
+action: eurotronic_cometblue.set_schedule
+target:
+  entity_id: climate.living_room_radiator
+data:
+  monday:
+    start1: "07:00:00"
+    end1: "09:00:00"
+    start2: "17:00:00"
+    end2: "22:00:00"
+  tuesday:
+    start1: "07:00:00"
+    end1: "09:00:00"
+    start2: "17:00:00"
+    end2: "22:00:00"
+  wednesday: {}
+  thursday: {}
+  friday:
+    start1: "07:00:00"
+    end1: "09:00:00"
+  saturday:
+    start1: "09:00:00"
+    end1: "12:00:00"
+  sunday:
+    start1: "09:00:00"
+    end1: "12:00:00"
+```
+
+### Set thermostat date and time
+
+```yaml
+action: eurotronic_cometblue.set_datetime
+target:
+  entity_id: climate.living_room_radiator
+```
+
+### Enable holiday mode
+
+```yaml
+action: eurotronic_cometblue.set_holiday
+target:
+  entity_id: climate.living_room_radiator
+data:
+  start: "2026-12-24 00:00:00"
+  end: "2026-12-31 23:59:00"
+  temperature: 17
+```
+
+## Data updates
+
+The integration {% term polling polls %} data from the thermostat every 5 minutes by default.
+
+## Known limitations
+
+- If you manually change the target temperature or use presets, the thermostat returns to its programmed schedule at the next schedule change.
+- If the thermostat is in holiday mode, you cannot reset it from Home Assistant. To reset it, press the `MENU` button on the thermostat until it resets.
+
+## Troubleshooting
+
+As the data is refreshed using an active Bluetooth connection, {% term polling %} can fail due to connection issues.
+
+If you see repeated connection issues, try the following:
+
+1. Move your Home Assistant host closer to the thermostat.
+2. Add [ESPHome Bluetooth proxies](/integrations/bluetooth/#remote-adapters-bluetooth-proxies) closer to the thermostat.
 
 ## Removing the integration
 

--- a/source/_integrations/eurotronic_cometblue.markdown
+++ b/source/_integrations/eurotronic_cometblue.markdown
@@ -243,6 +243,7 @@ The integration {% term polling polls %} data from the thermostat every 5 minute
 
 ## Known limitations
 
+- The devices only supports temperature steps of 0.5°C and time steps of 15 minutes.
 - If you manually change the target temperature or use presets, the thermostat returns to its programmed schedule at the next schedule change.
 - If the thermostat is in holiday mode, you cannot reset it from Home Assistant. To reset it, press the `MENU` button on the thermostat until it resets.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the new Eurotronic Comet Blue integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/165626
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/9990
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
