### PR TITLE
Update Transmission integration documentation with new sensors and binary sensor

### DIFF
--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -62,7 +62,17 @@ The Transmission integration will add the following sensors and switches.
 - The total number of torrents present in the client.
 - The current number of started torrents (downloading).
 - The current number of completed torrents (seeding).
+- The current session downloaded data [GB].
+- The current session uploaded data [GB].
+- The total downloaded data [GB].
+- The total uploaded data [GB].
+- The current session upload/download ratio.
+- The total upload/download ratio.
 
+### Binary sensors
+
+- A binary sensor indicating whether the incoming peer port is open (port forwarding status).
+  
 ### Switches
 
 - A switch to start/stop all torrents.


### PR DESCRIPTION
## Proposed change

Added documentation for 7 new entities in the Transmission integration:

- `binary_sensor.transmission_port_forwarding` — monitors whether the incoming peer port is open (port forwarding status)
- `sensor.transmission_session_download` — data downloaded in current session (GB)
- `sensor.transmission_session_upload` — data uploaded in current session (GB)
- `sensor.transmission_total_download` — cumulative data downloaded (GB)
- `sensor.transmission_total_upload` — cumulative data uploaded (GB)
- `sensor.transmission_session_ratio` — upload/download ratio for current session
- `sensor.transmission_total_ratio` — cumulative upload/download ratio

## Additional information

Related code PR: home-assistant/core#166108

## Checklist

- [x] This PR is related to pull request in home-assistant/core: home-assistant/core#166108
- [x] The documentation follows the [Documentation Standards](https://www.home-assistant.io/developers/documentation/standards/)
- [x] The documentation is added/updated for www.home-assistant.io