### PR TITLE
Add Transmission port forwarding binary sensor and session stats sensors documentation

### DIFF
--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -52,6 +52,8 @@ Verify SSL certificate:
 
 ## Supported functionality
 
+The **Transmission integration** provides the following sensors and switches.
+
 ### Binary sensors
 
 A binary sensor indicating whether the incoming peer port is open and reachable from the internet (port forwarding status).

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -52,7 +52,7 @@ Verify SSL certificate:
 
 ## Supported functionality
 
-The **Transmission integration** provides the following sensors and switches.
+The **Transmission** integration provides the following sensors and switches.
 
 ### Binary sensors
 

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -5,6 +5,7 @@ ha_category:
   - Downloading
   - Sensor
   - Switch
+  - Binary sensor
 ha_release: 0.87
 ha_iot_class: Local Polling
 ha_config_flow: true
@@ -14,6 +15,7 @@ ha_codeowners:
   - '@andrew-codechimp'
 ha_domain: transmission
 ha_platforms:
+  - Binary sensor
   - sensor
   - switch
 ha_integration_type: service
@@ -48,10 +50,10 @@ Verify SSL certificate:
   description: "Enable SSL certificate verification when connecting via HTTPS."
 {% endconfiguration_basic %}
 
-## Supported functionality
+### Binary sensors
 
-The Transmission integration will add the following sensors and switches.
-
+A binary sensor indicating whether the incoming peer port is open and reachable from the internet (port forwarding status).
+  
 ### Sensors
 
 - The status of your Transmission daemon.
@@ -62,6 +64,12 @@ The Transmission integration will add the following sensors and switches.
 - The total number of torrents present in the client.
 - The current number of started torrents (downloading).
 - The current number of completed torrents (seeding).
+- The current session downloaded data [GB].
+- The current session uploaded data [GB].
+- The total downloaded data [GB].
+- The total uploaded data [GB].
+- The current session upload/download ratio.
+- The total upload/download ratio.
 
 ### Switches
 

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -57,7 +57,6 @@ The **Transmission** integration provides the following sensors and switches.
 ### Binary sensors
 
 A binary sensor indicating whether the incoming peer port is open and reachable from the internet (port forwarding status).
-  
 ### Sensors
 
 - The status of your Transmission daemon.

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -15,7 +15,7 @@ ha_codeowners:
   - '@andrew-codechimp'
 ha_domain: transmission
 ha_platforms:
-  - Binary sensor
+  - binary sensor
   - sensor
   - switch
 ha_integration_type: service
@@ -49,6 +49,8 @@ Password:
 Verify SSL certificate:
   description: "Enable SSL certificate verification when connecting via HTTPS."
 {% endconfiguration_basic %}
+
+## Supported functionality
 
 ### Binary sensors
 

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -15,7 +15,7 @@ ha_codeowners:
   - '@andrew-codechimp'
 ha_domain: transmission
 ha_platforms:
-  - binary sensor
+  - binary_sensor
   - sensor
   - switch
 ha_integration_type: service


### PR DESCRIPTION
## Proposed change

Added documentation for 7 new entities in the Transmission integration:

### Binary sensors
- Port forwarding status — indicates whether the incoming peer port is open and reachable from the internet

### Sensors
- Session download — data downloaded in current session (GiB)
- Session upload — data uploaded in current session (GiB)
- Total download — cumulative data downloaded (GiB)
- Total upload — cumulative data uploaded (GiB)
- Session ratio — upload/download ratio for current session
- Total ratio — cumulative upload/download ratio

## Additional information

- Related code PR (binary sensor): home-assistant/core#166108
- Related code PR (stats sensors): home-assistant/core#166134

## Checklist

- [x] This PR is related to pull request in home-assistant/core: home-assistant/core#166108 and home-assistant/core#166134
- [x] The documentation follows the [Documentation Standards](https://www.home-assistant.io/developers/documentation/standards/)