### PR TITLE
Update UniFi Access docs: add sensor platform

### DIFF
--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -117,6 +117,13 @@ These switches affect *all* doors managed by the controller at once and have dir
 - **Lockdown**
   - **Description**: Activates or deactivates the lockdown mode on your UniFi Access controller. When turned on, the controller triggers a facility-wide lockdown, locking all doors to restrict access.
 
+#### Sensors
+
+For controllers that support temporary lock rules, each door also exposes the following diagnostic sensor entities:
+
+- **Door Lock Rule**: Reports the currently active temporary lock rule for the door. Possible states are `custom`, `keep_lock`, `keep_unlock`, `lock_early`, `lock_now`, `reset`, and `schedule`. Returns `unknown` when no temporary rule is active.
+- **Rule End Time**: Reports the date and time when the active temporary lock rule expires. Returns `unknown` when no temporary rule is active or when the rule has no expiry.
+
 ## Data updates
 
 The integration uses a local push architecture via WebSocket. When a door's lock or position status changes, or when the emergency mode (evacuation or lockdown) is updated, the UniFi Access controller pushes updates to Home Assistant in real time. No {% term polling %} is performed.
@@ -186,13 +193,6 @@ actions:
 ```
 
 {% endraw %}
-
-#### Sensors
-
-For controllers that support temporary lock rules, each door also exposes the following diagnostic sensor entities:
-
-- **Door Lock Rule**: Reports the currently active temporary lock rule for the door. Possible states are `custom`, `keep_lock`, `keep_unlock`, `lock_early`, `lock_now`, `reset`, and `schedule`. Returns `unknown` when no temporary rule is active.
-- **Rule End Time**: Reports the date and time when the active temporary lock rule expires. Returns `unknown` when no temporary rule is active or when the rule has no expiry.
 
 ## Known limitations
 

--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to integrate UniFi Access with Home Assistant.
 ha_category:
   - Doorbell
   - Lock
+  - Sensor
 ha_release: 2026.4
 ha_domain: unifi_access
 ha_iot_class: Local Push
@@ -17,6 +18,7 @@ ha_platforms:
   - button
   - event
   - lock
+  - sensor
   - switch
 ha_integration_type: hub
 ---
@@ -184,6 +186,13 @@ actions:
 ```
 
 {% endraw %}
+
+#### Sensors
+
+For controllers that support temporary lock rules, each door also exposes the following **diagnostic** sensor entities:
+
+- **Door Lock Rule**: Reports the currently active temporary lock rule for the door. Possible states are `custom`, `keep_lock`, `keep_unlock`, `lock_early`, `lock_now`, `reset`, and `schedule`. Returns `unknown` when no temporary rule is active.
+- **Rule End Time**: Reports the date and time when the active temporary lock rule expires. Returns `unknown` when no temporary rule is active or when the rule has no expiry.
 
 ## Known limitations
 

--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -189,7 +189,7 @@ actions:
 
 #### Sensors
 
-For controllers that support temporary lock rules, each door also exposes the following **diagnostic** sensor entities:
+For controllers that support temporary lock rules, each door also exposes the following diagnostic sensor entities:
 
 - **Door Lock Rule**: Reports the currently active temporary lock rule for the door. Possible states are `custom`, `keep_lock`, `keep_unlock`, `lock_early`, `lock_now`, `reset`, and `schedule`. Returns `unknown` when no temporary rule is active.
 - **Rule End Time**: Reports the date and time when the active temporary lock rule expires. Returns `unknown` when no temporary rule is active or when the rule has no expiry.


### PR DESCRIPTION
## Proposed change

Documents the two new diagnostic sensor entities introduced by the UniFi Access sensor platform (home-assistant/core#166094):

- **Door Lock Rule**: active temporary lock rule type per door
- **Rule End Time**: expiry timestamp of the active lock rule

Also adds `sensor` to `ha_platforms` and `Sensor` to `ha_category` in the frontmatter.

## Type of change

- Document existing feature (new platform in existing integration)
