### PR TITLE
Add battery sensor documentation for Roth Touchline SL

### DIFF
--- a/source/_integrations/touchline_sl.markdown
+++ b/source/_integrations/touchline_sl.markdown
@@ -3,11 +3,13 @@ title: Roth Touchline SL
 description: Instructions on how to integrate Roth Touchline SL within Home Assistant.
 ha_category:
   - Climate
+  - Sensor
 ha_release: 2024.9
 ha_iot_class: Cloud Polling
 ha_domain: touchline_sl
 ha_platforms:
   - climate
+  - sensor
 ha_integration_type: hub
 ha_codeowners:
   - '@jnsgruk'
@@ -24,6 +26,8 @@ You must have an account registered with the [Roth Touchline SL dashboard](https
 
 ## Entities
 
+### Climate
+
 The integration will present each Roth Touchline SL zone as a climate entity, which can:
 
 - Display the current temperature
@@ -31,3 +35,11 @@ The integration will present each Roth Touchline SL zone as a climate entity, wh
 - Display when the zone is being actively heated or cooled.
 - Set a target temperature
 - Assign to a configured "Global Schedule" using Home Assistant climate entity presets.
+
+### Sensor
+
+For each zone, the integration exposes the following diagnostic sensor:
+
+| Sensor | Description |
+|--------|-------------|
+| Battery | Battery level of the wireless thermostat. Wired thermostats will report this sensor as unknown. |


### PR DESCRIPTION
## Proposed change

Documents the battery level sensor added to the Roth Touchline SL integration in home-assistant/core#166283.

Changes:
- Added `sensor` to `ha_platforms` and `ha_category`
- Restructured the Entities section with headings for Climate and Sensor
- Added a sensor table describing the battery level entity

## Additional information

The battery sensor reports the charge level of wireless Touchline SL thermostats. Wired thermostats return `null` from the API, which surfaces as unknown in Home Assistant.

## Checklist

- [x] The documentation follows the home-assistant.io [style guide](https://developers.home-assistant.io/docs/documentation_style_guide/)
- [x] Linked to the related code PR: home-assistant/core#166283