### PR TITLE
Add WLED presets-as-effects template light example and known limitations

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -1271,11 +1271,7 @@ template:
           target:
             entity_id: light.wled_bedroom
           data:
-            rgbw_color:
-              - "{{ r }}"
-              - "{{ g }}"
-              - "{{ b }}"
-              - "{{ w }}"
+            rgbw_color: "{{ rgbw }}"
             effect: "Solid"
         set_effect:
           action: select.select_option

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -1233,6 +1233,60 @@ template:
 
 {% endraw %}
 
+### Wrapping WLED presets as light effects
+
+This example creates a template light that wraps an RGBW WLED device and exposes its saved presets — predefined combinations of effects, colors, and brightness stored on the device — as selectable effects directly in the light entity. This is useful if you prefer to pick presets from the effects list in a light card on your dashboard, without having to use a separate select entity.
+
+The template light mirrors the state, brightness, and RGBW color of the underlying WLED light entity. Selecting an effect sends the matching preset name to the WLED preset select entity.
+
+{% raw %}
+
+```yaml
+template:
+  - light:
+      - name: "WLED bedroom with presets"
+        unique_id: wled_preset_light
+        state: "{{ states('light.wled_bedroom') }}"
+        level: "{{ state_attr('light.wled_bedroom', 'brightness') | default(0, true) | int }}"
+        rgbw: "{{ state_attr('light.wled_bedroom', 'rgbw_color') }}"
+        effect_list: "{{ state_attr('select.wled_bedroom_preset', 'options') }}"
+        effect: "{{ states('select.wled_bedroom_preset') }}"
+        availability: "{{ not is_state('light.wled_bedroom', 'unavailable') }}"
+        turn_on:
+          action: light.turn_on
+          target:
+            entity_id: light.wled_bedroom
+        turn_off:
+          action: light.turn_off
+          target:
+            entity_id: light.wled_bedroom
+        set_level:
+          action: light.turn_on
+          target:
+            entity_id: light.wled_bedroom
+          data:
+            brightness: "{{ brightness }}"
+        set_rgbw:
+          action: light.turn_on
+          target:
+            entity_id: light.wled_bedroom
+          data:
+            rgbw_color:
+              - "{{ r }}"
+              - "{{ g }}"
+              - "{{ b }}"
+              - "{{ w }}"
+            effect: "Solid"
+        set_effect:
+          action: select.select_option
+          target:
+            entity_id: select.wled_bedroom_preset
+          data:
+            option: "{{ effect }}"
+```
+
+{% endraw %}
+
 {% configuration light %}
 light:
   description: List of your lights.

--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -196,6 +196,8 @@ Information about new WLED releases is checked independently, once every 3 hours
 
 - There is no segment master control to apply changes (color, effect, brightness) to all segments in a single action. To control multiple segments at once, you can group them using a [light group](/integrations/group#light-group), though this sends separate requests per segment and may result in less smooth transitions compared to WLED's native multi-segment control.
 
+- Only the primary color of a segment can be set through the integration. The secondary and tertiary colors that many WLED effects use cannot be controlled from Home Assistant. To change them, use the WLED web interface or the WLED API directly.
+
 ## Supported devices
 
 The integration requires **WLED version 0.14.0 or newer**.
@@ -277,10 +279,12 @@ to a preset called My Preset:
     option: "My Preset"
 ```
 
-When a preset is activated and the light state is modified afterward 
-(e.g. with a `light.turn_on` action), the preset may be reset to an empty value. 
-This can affect services such as `select.select_next`, which will start again 
+When a preset is activated and the light state is modified afterward
+(for example, with a `light.turn_on` action), the preset may be reset to an empty value.
+This can affect services such as `select.select_next`, which will start again
 from the first option instead of continuing the cycle.
+
+If you want to pick presets directly from the effects list in a light card, you can use a [template light](/integrations/template/#wrapping-wled-presets-as-light-effects) to wrap the WLED device and expose its presets as effects.
 
 ### Automation using specific palette name
 

--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -196,7 +196,7 @@ Information about new WLED releases is checked independently, once every 3 hours
 
 - There is no segment master control to apply changes (color, effect, brightness) to all segments in a single action. To control multiple segments at once, you can group them using a [light group](/integrations/group#light-group), though this sends separate requests per segment and may result in less smooth transitions compared to WLED's native multi-segment control.
 
-- Only the primary color of a segment can be set through the integration. The secondary and tertiary colors that many WLED effects use cannot be controlled from Home Assistant. To change them, use the WLED web interface or the WLED API directly.
+- Only the primary color of a segment can be set through the integration. The secondary and tertiary colors that many WLED effects use cannot be controlled directly from Home Assistant. The workaround is to configure those colors in the WLED app or web interface, save the configuration as a preset, and then activate that preset from Home Assistant — the preset restores all colors, including secondary and tertiary.
 
 ## Supported devices
 


### PR DESCRIPTION
- Add example to template light docs showing how to wrap an RGBW WLED device and expose its presets as selectable effects in a light entity
- Document in WLED known limitations that only the primary segment color can be set; secondary and tertiary colors are not supported
- Add cross-reference from WLED preset section to the template example

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

WLED effects are powerful but awkward to use directly from Home Assistant. To get a good result, you typically need to combine multiple actions — selecting the effect, setting speed, intensity, and a color palette — and some of those options (like secondary and tertiary segment colors) are not exposed in Home Assistant at all. On top of that, WLED ships with hundreds of effects, and Home Assistant offers no way to filter or search them, making the list hard to navigate in practice.

A much more practical workflow is to fine-tune your scenes in the official WLED app, save them as presets, and then simply activate those presets from Home Assistant. Until now there was no documented way to surface presets natively in a light card — users had to rely on a separate select entity alongside the light.

This PR documents that workflow:

- Template light example — adds a new example to the template integration docs showing how to wrap an RGBW WLED device with a template light that exposes its saved presets as selectable effects. This lets you pick a preset directly from the effects list in a light card, with no extra entities on the dashboard.
- WLED known limitation — documents that only the primary segment color can be set through the integration; secondary and tertiary colors must be configured in the WLED web interface or API.
- WLED cross-reference — adds a link from the "Activating a preset" section of the WLED docs to the new template light example, so users discover the pattern naturally.


Related discussion: https://github.com/orgs/home-assistant/discussions/3236

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
