### PR TITLE
Add snapshot information for ProxmoxVE

### DIFF
--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -209,7 +209,7 @@ The created sensor will be called `binary_sensor.NODE_NAME_VMNAME_running`.
 
 If you want to use the `button` entities to perform actions on your node(s), additional privileges may be required:
 - For actions related to power, such as start, stop or reboot, the Proxmox VE user must have the power-management privilege `VM.PowerManagemt`, or role `PVEVMUser`.
-- To create snapshots, the privelege `VM.Snapshot` is required, or role `PVEVMAdmin`.
+- To create snapshots, the privilege `VM.Snapshot` is required, or role `PVEVMAdmin`.
 If monitoring works (e.g. sensors provide relevant information) but button presses fail, assign a more permissive role or create a custom role and try again.
 
 ### Diagnostic data

--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -187,7 +187,7 @@ The created sensor will be called `binary_sensor.NODE_NAME_VMNAME_running`.
 
 ### Button
 
-- **Create snapshot**: Creates a snapshot of a VM or LXC container.
+- **Create snapshot**: Creates a snapshot of a VM/LXC.
 - **Start**: Starts a node/VM/LXC.
 - **Start all**: Starts all VMs and LXCs known on a node.
 - **Stop**: Stops a node/VM/LXC.
@@ -207,7 +207,10 @@ The created sensor will be called `binary_sensor.NODE_NAME_VMNAME_running`.
 
 ### Buttons not working
 
-If you want to use the `button` entities to control power actions (start/stop/reboot and similar actions), the Proxmox VE user must have the required privileges for those actions (for example, `VM.PowerMgmt` on the relevant path for controlling VM or Container state, or `VM.Snapshot` to allow creating snapshots). If monitoring works but button presses fail, assign a more permissive role (or create a custom role) and try again.
+If you want to use the `button` entities to perform actions on your node(s), additional privileges may be required:
+- For actions related to power, such as start, stop or reboot, the Proxmox VE user must have the power-management privilege `VM.PowerManagemt`, or role `PVEVMUser`.
+- To create snapshots, the privelege `VM.Snapshot` is required, or role `PVEVMAdmin`.
+If monitoring works (e.g. sensors provide relevant information) but button presses fail, assign a more permissive role or create a custom role and try again.
 
 ### Diagnostic data
 

--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -187,6 +187,7 @@ The created sensor will be called `binary_sensor.NODE_NAME_VMNAME_running`.
 
 ### Button
 
+- **Create snapshot**: Creates a snapshot of a VM or LXC container.
 - **Start**: Starts a node/VM/LXC.
 - **Start all**: Starts all VMs and LXCs known on a node.
 - **Stop**: Stops a node/VM/LXC.
@@ -206,7 +207,7 @@ The created sensor will be called `binary_sensor.NODE_NAME_VMNAME_running`.
 
 ### Buttons not working
 
-If you want to use the `button` entities to control power actions (start/stop/reboot and similar actions), the Proxmox VE user must have the required privileges for those actions (for example, `VM.PowerMgmt` on the relevant path). If monitoring works but button presses fail, assign a more permissive role (or create a custom role) and try again.
+If you want to use the `button` entities to control power actions (start/stop/reboot and similar actions), the Proxmox VE user must have the required privileges for those actions (for example, `VM.PowerMgmt` on the relevant path for controlling VM or Container state, or `VM.Snapshot` to allow creating snapshots). If monitoring works but button presses fail, assign a more permissive role (or create a custom role) and try again.
 
 ### Diagnostic data
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Add missing snapshot button information and align permission information


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/166547
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
