### PR TITLE
Add binary sensor documentation for Qube heat pump

### DIFF
--- a/source/_integrations/hr_energy_qube.markdown
+++ b/source/_integrations/hr_energy_qube.markdown
@@ -3,6 +3,7 @@ title: HR-Energy Qube heat pump
 description: Instructions on how to integrate your Qube heat pump with Home Assistant.
 ha_release: 2026.4
 ha_category:
+  - Binary sensor
   - Sensor
 ha_iot_class: Local Polling
 ha_config_flow: true
@@ -10,6 +11,7 @@ ha_codeowners:
   - '@MattieGit'
 ha_domain: hr_energy_qube
 ha_platforms:
+  - binary_sensor
   - sensor
 ha_integration_type: hub
 ha_quality_scale: bronze
@@ -37,6 +39,14 @@ Host:
 {% endconfiguration_basic %}
 
 ## Supported functionality
+
+### Binary sensors
+
+- **Outputs**: source pump, user pump, buffer pump, four-way valve, three-way valve, cooling output, and heater steps 1-3
+- **Alarms**: global alarm, plus specific alarms for anti-legionella timeout, domestic hot water (DHW) timeout, dewpoint, supply too hot, flow, central heating, cooling, heating, source, compressor, and working hours
+- **Demand signals**: heat demand, thermostat demand, plant demand, and external demand
+- **System status**: keypad, day mode, summer mode, anti-legionella, dewpoint, booster, source flow, and photovoltaic (PV) surplus
+- **Sensor status** (disabled by default): room sensor enabled, plant sensor enabled, buffer sensor enabled, and DHW controller enabled
 
 ### Sensors
 

--- a/source/_integrations/hr_energy_qube.markdown
+++ b/source/_integrations/hr_energy_qube.markdown
@@ -44,8 +44,8 @@ Host:
 
 - **Outputs**: source pump, user pump, buffer pump, four-way valve, three-way valve, cooling output, and heater steps 1-3
 - **Alarms**: global alarm, plus specific alarms for anti-legionella timeout, domestic hot water (DHW) timeout, dewpoint, supply too hot, flow, central heating, cooling, heating, source, compressor, and working hours
-- **Demand signals**: heat demand, thermostat demand, plant demand, and external demand
-- **System status**: keypad, day mode, summer mode, anti-legionella, dewpoint, booster, source flow, and photovoltaic (PV) surplus
+- **Demand signals**: thermostat demand, plant demand, and external demand
+- **System status**: keypad, day mode, summer mode, anti-legionella, dewpoint, booster security, source flow, and photovoltaic (PV) surplus
 - **Sensor status** (disabled by default): room sensor enabled, plant sensor enabled, buffer sensor enabled, and DHW controller enabled
 
 ### Sensors


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add binary sensor platform documentation to the `hr_energy_qube` integration. Documents 36 binary sensors across five categories: outputs, alarms, demand signals, system status, and sensor status indicators. Adds `binary_sensor` to `ha_platforms` and `ha_category` frontmatter.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/166611
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards