### PR TITLE
Document Teslemetry charge-on-solar preview buttons

### DIFF
--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -106,6 +106,8 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Binary sensor|Trip charging|No|
 |Binary sensor|User present|Yes|
 |Binary sensor|Wiper heat|No|
+|Button|Disable charge on solar (preview feature)|Yes|
+|Button|Enable charge on solar (preview feature)|Yes|
 |Button|Flash lights|Yes|
 |Button|HomeLink|Yes|
 |Button|Honk horn|Yes|
@@ -186,6 +188,8 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Switch|Defrost|Yes|
 |Switch|Sentry mode|Yes|
 |Update|Update|Yes|
+
+The `Disable charge on solar` and `Enable charge on solar` buttons are part of the **Charge on solar buttons** preview feature. These are action-only buttons because the Tesla Fleet API does not currently expose a reliable charge-on-solar state.
 
 ### Energy sites
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -106,8 +106,8 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Binary sensor|Trip charging|No|
 |Binary sensor|User present|Yes|
 |Binary sensor|Wiper heat|No|
-|Button|Disable charge on solar (preview feature)|Yes|
-|Button|Enable charge on solar (preview feature)|Yes|
+|Button|Disable charge on solar|Yes|
+|Button|Enable charge on solar|Yes|
 |Button|Flash lights|Yes|
 |Button|HomeLink|Yes|
 |Button|Honk horn|Yes|
@@ -189,7 +189,9 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Switch|Sentry mode|Yes|
 |Update|Update|Yes|
 
-The `Disable charge on solar` and `Enable charge on solar` buttons are part of the **Charge on solar buttons** preview feature. These are action-only buttons because the Tesla Fleet API does not currently expose a reliable charge-on-solar state.
+The `Disable charge on solar` and `Enable charge on solar` buttons are available when the **Charge on solar buttons** preview feature is enabled for Teslemetry in Home Assistant Labs. Preview features are still in development and may change.
+
+These are action-only buttons because the Tesla Fleet API does not currently expose a reliable charge-on-solar state.
 
 ### Energy sites
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -189,7 +189,7 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Switch|Sentry mode|Yes|
 |Update|Update|Yes|
 
-The `Disable charge on solar` and `Enable charge on solar` buttons are available when the **Charge on solar buttons** preview feature is enabled for Teslemetry in [Home Assistant Labs](/integrations/labs). Preview features are still in development and may change.
+The **Disable charge on solar** and **Enable charge on solar** buttons are available when the **Charge on solar buttons** preview feature is enabled for Teslemetry in [Home Assistant Labs](/integrations/labs). Preview features are still in development and may change.
 
 These are action-only buttons because the Tesla Fleet API does not currently expose a reliable charge-on-solar state.
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -189,7 +189,7 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Switch|Sentry mode|Yes|
 |Update|Update|Yes|
 
-The `Disable charge on solar` and `Enable charge on solar` buttons are available when the **Charge on solar buttons** preview feature is enabled for Teslemetry in Home Assistant Labs. Preview features are still in development and may change.
+The `Disable charge on solar` and `Enable charge on solar` buttons are available when the **Charge on solar buttons** preview feature is enabled for Teslemetry in [Home Assistant Labs](/integrations/labs). Preview features are still in development and may change.
 
 These are action-only buttons because the Tesla Fleet API does not currently expose a reliable charge-on-solar state.
 


### PR DESCRIPTION
## Proposed change
Document the Teslemetry charge-on-solar preview buttons introduced in core PR https://github.com/home-assistant/core/pull/166667.

- Add `Disable charge on solar` and `Enable charge on solar` to the vehicle entities table.
- Clarify these buttons are available when the **Charge on solar buttons** preview feature is enabled in Home Assistant Labs.
- Note that preview features are still in development and may change.
- Clarify the buttons are action-only because the Tesla Fleet API does not expose a reliable charge-on-solar state.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/166667
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
