### PR TITLE
Fix 'Charger Mode' typo in ohme integration docs

### DIFF
--- a/source/_integrations/ohme.markdown
+++ b/source/_integrations/ohme.markdown
@@ -71,7 +71,7 @@ The Ohme integration provides the following entities.
 
 #### Selects
 
-- **Charger mode**
+- **Charge mode**
   - **Description**: Sets the mode of the charger. Possible options: `Smart charge`, `Max charge`, `Paused`. This is only available with a vehicle plugged in.
   - **Available for devices**: all
 - **Vehicle**
@@ -147,7 +147,7 @@ The `ohme.set_price_cap` action is used to set the price cap threshold. This can
 This integration enables several use cases to optimise efficiency of a solar and/or battery storage system.
 
 ### Solar charging
-Use the charger mode to maximize solar consumption:
+Use the charge mode to maximize solar consumption:
 - Set the charger to "Paused" when solar production is low
 - Switch to "Max charge" during peak solar hours
 


### PR DESCRIPTION
## Proposed change

Fix the entity name "Charger mode" to "Charge mode" in the ohme integration documentation. The integration entity is named "Charge Mode" but the docs reference "Charger Mode" in two places.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue: fixes #44032
