### PR TITLE
Fix broken release notes link in 2026.3 changelog

### DIFF
--- a/source/changelogs/core-2026.3.markdown
+++ b/source/changelogs/core-2026.3.markdown
@@ -6,7 +6,7 @@ replace_regex: \s\(\[?[a-z0-9\-\s_]+\]?\)$
 
 These are all the changes included in the Home Assistant 2026.3 release.
 For a summary in a more readable format
-[Release notes blog for this release](/blog/2026/03/04/release-202603/).
+[Release notes blog for this release](/blog/2026/03/04/release-20263/).
 
 ## All changes
 


### PR DESCRIPTION
## Proposed change

Fix the broken release notes blog link on the 2026.3 changelog page. The link pointed to `/blog/2026/03/04/release-202603/` (404) instead of the correct `/blog/2026/03/04/release-20263/`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue: fixes #44081

The URL slug `release-202603` doesn't match the blog post file `2026-03-04-release-20263.markdown`. Changed to `release-20263`.
