### PR TITLE
Fix tag trigger device_id variable in automation templating docs

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -167,7 +167,7 @@ These are the properties available for a [Tag trigger](/docs/automation/trigger/
 | ---- | ---- |
 | `trigger.platform` | Hardcoded: `tag`
 | `trigger.tag_id` | The tag ID captured.
-| `trigger.device_id` | Optional device ID that captured the tag.
+| `trigger.event.data.device_id` | Optional device ID that captured the tag.
 
 ### Template
 


### PR DESCRIPTION
## Proposed change

Fix the Tag trigger variable documentation in the automation templating page. The docs list `trigger.device_id` but the correct variable path is `trigger.event.data.device_id`.

Verified against [`homeassistant/components/tag/trigger.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/tag/trigger.py) in home-assistant/core - the tag trigger passes the full event object in the trigger dict, so device_id is accessed via `trigger.event.data.device_id`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue: fixes #43916

This contribution was developed with AI assistance (Claude Code).