### PR TITLE
Add segments support to MQTT vacuum

### DIFF
--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -744,6 +744,8 @@ support_url:
     'bri_stat_t':          'brightness_state_topic',
     'bri_tpl':             'brightness_template',
     'bri_val_tpl':         'brightness_value_template',
+    'cln_segmnts_cmd_t':   'clean_segments_command_topic',
+    'cln_segmnts_cmd_tpl': 'clean_segments_command_template',
     'clr_temp_cmd_tpl':    'color_temp_command_template',
     'clr_temp_cmd_t':      'color_temp_command_topic',
     'clr_temp_k':           'color_temp_kelvin',

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -62,6 +62,14 @@ availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
+clean_segments_command_template:
+  description: Defines a [template](/docs/configuration/templating/#using-command-templates-with-mqtt) to generate the payload to send to `clean_segments_command_topic`. The `value` variable contains a list of segment ID strings. 
+  required: false
+  type: template
+clean_segments_command_topic:
+  description: The MQTT topic to publish a JSON list of segment ID strings for the segments that should be cleaned. Use the `clean_segments_command_template` option if another payload format is needed. The available segments need to be received via the `segments` attribute of a payload received at `state_topic` before the MQTT vacuum will support cleaning segments. The `clean_segments_command_topic` option needs to be configured together with the `segments` and the `unique_id` option.
+  required: false
+  type: string
 command_topic:
   description: The MQTT topic to publish commands to control the vacuum.
   required: false
@@ -208,7 +216,7 @@ set_fan_speed_topic:
   required: false
   type: string
 state_topic:
-  description: "The MQTT topic subscribed to receive state messages from the vacuum. Messages received on the `state_topic` must be a valid JSON dictionary, with a mandatory `state` key and optionally `fan_speed` keys as shown in the [example](#configuration-example)."
+  description: "The MQTT topic subscribed to receive state messages from the vacuum. Messages received on the `state_topic` must be a valid JSON dictionary, with a mandatory `state` key and optionally `fan_speed` and `segments` keys as shown in the [example](#configuration-example)."
   required: false
   type: string
 supported_features:
@@ -217,9 +225,9 @@ supported_features:
   type: [string, list]
   default: "`start`, `stop`, `return_home`, `status`, `clean_spot`"
 unique_id:
-   description: An ID that uniquely identifies this vacuum. If two vacuums have the same unique ID, Home Assistant will raise an exception. Required when used with device-based discovery.
-   required: false
-   type: string
+  description: "An ID that uniquely identifies this vacuum. If two vacuums have the same unique ID, Home Assistant will raise an exception. Required when used with device-based discovery or when segment cleaning is configured."
+  required: false
+  type: string
 {% endconfiguration %}
 
 ## Configuration example
@@ -240,6 +248,7 @@ mqtt:
         - fan_speed
         - send_command
       command_topic: "vacuum/command"
+      clean_segments_command_topic: "vacuum/clean_segments"
       set_fan_speed_topic: "vacuum/set_fan_speed"
       fan_speed_list:
         - min
@@ -247,6 +256,7 @@ mqtt:
         - high
         - max
       send_command_topic: "vacuum/send_command"
+      unique_id: "mqtt_vc_031928332"
 ```
 
 ## MQTT Protocol
@@ -312,7 +322,11 @@ MQTT payload:
 ```json
 {
     "state": "docked",
-    "fan_speed": "off"
+    "fan_speed": "off",
+    "segments": {
+      "1": "Kitchen",
+      "2": "Livingroom"
+    }
 }
 ```
 
@@ -324,6 +338,8 @@ State has to be one of vacuum states supported by Home Assistant:
 - idle,
 - returning,
 - error.
+
+The optional `segments` attribute in the MQTT payload should hold a mapping of the available cleanable segments the vacuum is able to clean. If the mapping changes, a repair flow will support to update the segment to area mapping for the vacuum.   
 
 ### Set Fan Speed
 

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -67,7 +67,7 @@ clean_segments_command_template:
   required: false
   type: template
 clean_segments_command_topic:
-  description: The MQTT topic to publish a JSON list of segment ID strings for the segments that should be cleaned. Use the `clean_segments_command_template` option if another payload format is needed. The available segments must be provided by the vacuum in the `segments` attribute of teh JSON payload published to `state_topic` before the MQTT vacuum will support cleaning segments. Using `clean_segments_command_topic` also requires that the MQTT vacuum has a `unique_id` configured.
+  description: The MQTT topic to publish a JSON list of segment ID strings for the segments that should be cleaned. Use the `clean_segments_command_template` option if another payload format is needed. The available segments must be provided by the vacuum in the `segments` attribute of the JSON payload published to `state_topic` before the MQTT vacuum will support cleaning segments. Using `clean_segments_command_topic` also requires that the MQTT vacuum has a `unique_id` configured.
   required: false
   type: string
 command_topic:

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -63,11 +63,11 @@ availability_topic:
   required: false
   type: string
 clean_segments_command_template:
-  description: Defines a [template](/docs/configuration/templating/#using-command-templates-with-mqtt) to generate the payload to send to `clean_segments_command_topic`. The `value` variable contains a list of segment ID strings. 
+  description: Defines a [template](/docs/configuration/templating/#using-command-templates-with-mqtt) to generate the payload to send to `clean_segments_command_topic`. The `value` variable contains a list of segment ID strings.
   required: false
   type: template
 clean_segments_command_topic:
-  description: The MQTT topic to publish a JSON list of segment ID strings for the segments that should be cleaned. Use the `clean_segments_command_template` option if another payload format is needed. The available segments need to be received via the `segments` attribute of a payload received at `state_topic` before the MQTT vacuum will support cleaning segments. The `clean_segments_command_topic` option needs to be configured together with the `segments` and the `unique_id` option.
+  description: The MQTT topic to publish a JSON list of segment ID strings for the segments that should be cleaned. Use the `clean_segments_command_template` option if another payload format is needed. The available segments must be provided by the vacuum in the `segments` attribute of teh JSON payload published to `state_topic` before the MQTT vacuum will support cleaning segments. Using `clean_segments_command_topic` also requires that the MQTT vacuum has a `unique_id` configured.
   required: false
   type: string
 command_topic:
@@ -325,7 +325,7 @@ MQTT payload:
     "fan_speed": "off",
     "segments": {
       "1": "Kitchen",
-      "2": "Livingroom"
+      "2": "Living room"
     }
 }
 ```
@@ -339,7 +339,7 @@ State has to be one of vacuum states supported by Home Assistant:
 - returning,
 - error.
 
-The optional `segments` attribute in the MQTT payload should hold a mapping of the available cleanable segments the vacuum is able to clean. If the mapping changes, a repair flow will support to update the segment to area mapping for the vacuum.   
+The optional `segments` attribute in the MQTT payload should contain a mapping of the available cleanable segments the MQTT vacuum can clean. When this mapping changes, Home Assistant can guide you through a repair flow will support to update the segment-to-area mapping for the vacuum.   
 
 ### Set Fan Speed
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add segments support to MQTT vacuum


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/166794
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
