### PR TITLE
Match the Immich UI's API token scope ordering

### DIFF
--- a/source/_integrations/immich.markdown
+++ b/source/_integrations/immich.markdown
@@ -30,11 +30,11 @@ You need to [obtain the API key](https://immich.app/docs/features/command-line-i
 
 Enable the following permissions when creating your API key. Without these permissions, the integration may not work properly. The "admin-only" permissions are only available when your API key belongs to an administrative user.
 
-- `album.read`
-- `albumAsset.create`
 - `asset.download`
 - `asset.upload`
 - `asset.view`
+- `album.read`
+- `albumAsset.create`
 - `person.read`
 - `server.about`
 - `server.statistics` (_admin-only_)


### PR DESCRIPTION
## Proposed change

What the title says. This makes the scopes list non-alphabetical, but it also makes it way easier to compare the HA docs and the live Immich UI side-by-side when issuing the API token. (I did check the rest of the scopes' ordering, and they are already correct.)

<img width="1515" height="1353" alt="Screenshot of the Immich New API Key screen" src="https://github.com/user-attachments/assets/2c5bbec7-74e4-44ab-b3f0-e65dc5b7ffdf" />

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
