### PR TITLE
Add blueprints for UniFi Access

### DIFF
--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -135,73 +135,15 @@ The integration uses a local push architecture via WebSocket. When a door's lock
 
 ### Send a notification when the doorbell rings
 
-{% raw %}
+Get notified on your phone or trigger any action when someone rings a UniFi Access doorbell.
 
-```yaml
-alias: "Doorbell notification"
-triggers:
-  - trigger: state
-    entity_id: event.front_door_doorbell
-actions:
-  - action: notify.mobile_app_my_phone
-    data:
-      title: "Doorbell"
-      message: "Someone is at the front door!"
-```
+{% my blueprint_import badge blueprint_url="https://www.home-assistant.io/blueprints/integrations/unifi_access_doorbell_notification.yaml" %}
 
-{% endraw %}
+### React to door access events
 
-### Log who unlocked a door
+Send a notification or trigger an action when someone unlocks a door or when an access attempt is denied.
 
-{% raw %}
-
-```yaml
-alias: "Access granted notification"
-triggers:
-  - trigger: state
-    entity_id: event.front_door_access
-conditions:
-  - condition: state
-    entity_id: event.front_door_access
-    attribute: event_type
-    state: "access_granted"
-actions:
-  - action: notify.mobile_app_my_phone
-    data:
-      title: "Door unlocked"
-      message: >
-        {{ trigger.to_state.attributes.actor }}
-        unlocked the front door
-        via {{ trigger.to_state.attributes.authentication }}.
-```
-
-{% endraw %}
-
-### Alert on denied access attempts
-
-{% raw %}
-
-```yaml
-alias: "Access denied alert"
-triggers:
-  - trigger: state
-    entity_id: event.front_door_access
-conditions:
-  - condition: state
-    entity_id: event.front_door_access
-    attribute: event_type
-    state: "access_denied"
-actions:
-  - action: notify.mobile_app_my_phone
-    data:
-      title: "Access denied!"
-      message: >
-        Access denied at front door
-        for {{ trigger.to_state.attributes.actor }}
-        ({{ trigger.to_state.attributes.authentication }}).
-```
-
-{% endraw %}
+{% my blueprint_import badge blueprint_url="https://www.home-assistant.io/blueprints/integrations/unifi_access_door_access_notification.yaml" %}
 
 ## Known limitations
 

--- a/source/blueprints/integrations/unifi_access_door_access_notification.yaml
+++ b/source/blueprints/integrations/unifi_access_door_access_notification.yaml
@@ -43,14 +43,15 @@ blueprint:
       selector:
         action:
 
-trigger_variables:
-  selected_event_type: !input event_type
-
 triggers:
   - trigger: state
     entity_id: !input access_entity
 
-conditions: "{{ trigger.to_state.attributes.event_type == selected_event_type }}"
+conditions:
+  - condition: state
+    entity_id: !input access_entity
+    attribute: event_type
+    state: !input event_type
 
 actions: !input actions
 

--- a/source/blueprints/integrations/unifi_access_door_access_notification.yaml
+++ b/source/blueprints/integrations/unifi_access_door_access_notification.yaml
@@ -1,0 +1,57 @@
+blueprint:
+  name: UniFi Access door access notification
+  description: >
+    Send a notification when someone unlocks a door or
+    when an access attempt is denied at a UniFi Access
+    door.
+  domain: automation
+  author: RaHehl
+  homeassistant:
+    min_version: 2026.4.0
+
+  input:
+    access_entity:
+      name: Access event
+      description: >
+        The UniFi Access door access event entity to
+        monitor.
+      selector:
+        entity:
+          filter:
+            - integration: unifi_access
+              domain: event
+
+    event_type:
+      name: Event type
+      description: >
+        The type of access event to react to.
+      selector:
+        select:
+          options:
+            - label: "Access granted"
+              value: "access_granted"
+            - label: "Access denied"
+              value: "access_denied"
+
+    actions:
+      name: Actions
+      description: >
+        The actions to run when the selected access event
+        occurs (for example, send a notification or log
+        the event).
+      default: []
+      selector:
+        action:
+
+trigger_variables:
+  selected_event_type: !input event_type
+
+triggers:
+  - trigger: state
+    entity_id: !input access_entity
+
+conditions: "{{ trigger.to_state.attributes.event_type == selected_event_type }}"
+
+actions: !input actions
+
+mode: single

--- a/source/blueprints/integrations/unifi_access_doorbell_notification.yaml
+++ b/source/blueprints/integrations/unifi_access_doorbell_notification.yaml
@@ -1,0 +1,38 @@
+blueprint:
+  name: UniFi Access doorbell notification
+  description: >
+    Send a notification to your phone when someone rings
+    a UniFi Access doorbell.
+  domain: automation
+  author: RaHehl
+  homeassistant:
+    min_version: 2026.4.0
+
+  input:
+    doorbell_entity:
+      name: Doorbell
+      description: >
+        The UniFi Access doorbell event entity to monitor.
+      selector:
+        entity:
+          filter:
+            - integration: unifi_access
+              domain: event
+              device_class: doorbell
+
+    actions:
+      name: Actions
+      description: >
+        The actions to run when the doorbell rings (for
+        example, send a notification or turn on a light).
+      default: []
+      selector:
+        action:
+
+triggers:
+  - trigger: state
+    entity_id: !input doorbell_entity
+
+actions: !input actions
+
+mode: single


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add blueprints for UniFi Access


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
