### PR TITLE
Add clarifying note about REST integration vs sensor platform examples

### DIFF
--- a/source/_integrations/sensor.rest.markdown
+++ b/source/_integrations/sensor.rest.markdown
@@ -304,6 +304,10 @@ sensor:
 
 ### Fetch multiple JSON attributes and present them as values
 
+{% note %}
+Most examples below use the `rest:` configuration format, which belongs to the [RESTful integration](/integrations/rest). The RESTful integration allows defining multiple sensors from a single HTTP endpoint, reducing the number of requests to the same service. If you only need a single sensor from an endpoint, use the `sensor` platform configuration shown in the examples above.
+{% endnote %}
+
 [JSON Test](https://www.jsontest.com/) returns the current time, date and milliseconds since epoch from [http://date.jsontest.com/](http://date.jsontest.com/).
 
 {% raw %}


### PR DESCRIPTION
The "Fetch multiple JSON attributes" section on the REST sensor page contains examples that use the `rest:` configuration format (RESTful integration) rather than the `sensor: platform: rest` format. This can confuse users looking for single-sensor examples.

Added a note at the top of the section explaining the distinction and linking to the [RESTful integration](/integrations/rest) page, so users understand when to use each format.

Fixes #44298

This contribution was developed with AI assistance (Claude Code).