### PR TITLE
docs(transmission): document port forwarding binary sensor and unknow…

### DIFF
--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -56,7 +56,18 @@ The **Transmission** integration provides the following sensors and switches.
 
 ### Binary sensors
 
-A binary sensor indicating whether the incoming peer port is open and reachable from the internet (port forwarding status).
+* **Port forwarding**: Indicates whether the port configured in Transmission
+  is reachable from the internet. This sensor is disabled by default and can
+  be enabled in the entity settings.
+
+{% note %}
+The port forwarding check relies on an external service
+(`portcheck.transmissionbt.com`). If this service is unavailable or
+unreachable (for example when using a VPN such as ProtonVPN with NAT-PMP),
+the sensor state will show as **unknown** while all other Transmission sensors
+continue to update normally.
+{% endnote %}
+
 ### Sensors
 
 - The status of your Transmission daemon.


### PR DESCRIPTION
…n state behavior

## Description

Add documentation for the new port forwarding binary sensor introduced in #166108.

Clarify that the sensor may show `unknown` when the external port check service (`portcheck.transmissionbt.com`) is unavailable or unreachable (e.g. when using a VPN with NAT-PMP port forwarding), while all other sensors continue to update normally.

## Related

- Core PR: home-assistant/core#166108