### PR TITLE
Document MCP Server Assist context-snapshot resource support

### DIFF
--- a/source/_integrations/mcp_server.markdown
+++ b/source/_integrations/mcp_server.markdown
@@ -16,7 +16,7 @@ related:
 ha_quality_scale: silver
 ---
 
-The [Model Context Protocol](https://modelcontextprotocol.io) is an open protocol that standardizes how applications provide context to <abbr title="Large Language Models">LLMs</abbr>. The **Model Context Protocol Server** (MCP) integration enables using Home Assistant to provide context for <abbr title="Model Context Protocol">MCP</abbr> LLM Client Applications. For example, you can control your lights from Claude Desktop, or expose your Google Tasks to-do list as a tool.
+The [Model Context Protocol](https://modelcontextprotocol.io) is an open protocol that standardizes how applications provide context to <abbr title="Large Language Models">LLMs</abbr>. The **Model Context Protocol Server** (MCP) integration enables using Home Assistant to provide context for <abbr title="Model Context Protocol">MCP</abbr> LLM Client Applications. For example, you can control your lights from Claude Desktop, or let an MCP client read the entities you have exposed to Assist.
 
 Controlling Home Assistant is done by providing <abbr title="Model Context Protocol">MCP</abbr> clients access to the Assist API of Home Assistant. You can control what devices and entities it can access from the {% my voice_assistants title="exposed entities page" %}.
 
@@ -182,7 +182,20 @@ The [MCP Prompts](https://modelcontextprotocol.io/docs/concepts/prompts) provide
 inform LLMs how to call the tools. The tools used by the configured LLM API
 are exposed.
 
-## Known Limitations
+### Resources
+
+When the selected LLM API includes Assist, Home Assistant also exposes a
+read-only [MCP Resource](https://modelcontextprotocol.io/docs/concepts/resources)
+named `homeassistant://assist/exposed-entities`.
+
+This resource returns a YAML snapshot of the entities you have exposed to
+Assist, including the entity ID, friendly name, domain, current state, area
+name, and a curated set of attributes. MCP clients can use this resource to
+understand what is available in your Home Assistant instance before they call
+tools. If you select an LLM API that does not include Assist, this resource is
+not available.
+
+## Known limitations
 
 The Home Assistant Model Context Protocol integration currently only supports a
 subset of MCP features:
@@ -191,7 +204,7 @@ subset of MCP features:
 | ------- | --------- |
 | Prompts | ✅ |
 | Tools | ✅ |
-| Resources | ❌ |
+| Resources | ✅ (Assist only) |
 | Sampling | ❌ |
 | Notifications | ❌ |
 

--- a/source/_integrations/mcp_server.markdown
+++ b/source/_integrations/mcp_server.markdown
@@ -18,7 +18,7 @@ ha_quality_scale: silver
 
 The [Model Context Protocol](https://modelcontextprotocol.io) is an open protocol that standardizes how applications provide context to <abbr title="Large Language Models">LLMs</abbr>. The **Model Context Protocol Server** (MCP) integration enables using Home Assistant to provide context for <abbr title="Model Context Protocol">MCP</abbr> LLM Client Applications. For example, you can control your lights from Claude Desktop, or expose your Google Tasks to-do list as a tool.
 
-Controlling Home Assistant is done by providing <abbr title="Model Context Protocol">MCP</abbr> clients access to the Assist API of Home Assistant. You can control what devices and entities it can access from the {% my voice_assistants title="exposed entities page" %}.
+Controlling Home Assistant is done by providing <abbr title="Model Context Protocol">MCP</abbr> clients with access to Home Assistant's Assist API. You can control what devices and entities it can access from the {% my voice_assistants title="exposed entities page" %}, and your <abbr title="Model Context Protocol">MCP</abbr> client can also read a real-time snapshot of that context. This gives your AI assistant a clear picture of your home's current state.
 
 ## Prerequisites
 

--- a/source/_integrations/mcp_server.markdown
+++ b/source/_integrations/mcp_server.markdown
@@ -192,8 +192,8 @@ This resource returns a YAML snapshot of the entities you have exposed to
 Assist, including the entity ID, friendly name, domain, current state, area
 name, and a curated set of attributes. MCP clients can use this resource to
 understand what is available in your Home Assistant instance before they call
-tools. If you select an LLM API that does not include Assist, this resource is
-not available.
+tools. If the configured LLM API does not include Assist, this resource is not
+available.
 
 ## Known limitations
 

--- a/source/_integrations/mcp_server.markdown
+++ b/source/_integrations/mcp_server.markdown
@@ -16,7 +16,7 @@ related:
 ha_quality_scale: silver
 ---
 
-The [Model Context Protocol](https://modelcontextprotocol.io) is an open protocol that standardizes how applications provide context to <abbr title="Large Language Models">LLMs</abbr>. The **Model Context Protocol Server** (MCP) integration enables using Home Assistant to provide context for <abbr title="Model Context Protocol">MCP</abbr> LLM Client Applications. For example, you can control your lights from Claude Desktop, or let an MCP client read the entities you have exposed to Assist.
+The [Model Context Protocol](https://modelcontextprotocol.io) is an open protocol that standardizes how applications provide context to <abbr title="Large Language Models">LLMs</abbr>. The **Model Context Protocol Server** (MCP) integration enables using Home Assistant to provide context for <abbr title="Model Context Protocol">MCP</abbr> LLM Client Applications. For example, you can control your lights from Claude Desktop, or let an MCP client read a snapshot of your current Assist context.
 
 Controlling Home Assistant is done by providing <abbr title="Model Context Protocol">MCP</abbr> clients access to the Assist API of Home Assistant. You can control what devices and entities it can access from the {% my voice_assistants title="exposed entities page" %}.
 
@@ -184,16 +184,14 @@ are exposed.
 
 ### Resources
 
-When the selected LLM API includes Assist, Home Assistant also exposes a
-read-only [MCP Resource](https://modelcontextprotocol.io/docs/concepts/resources)
-named `homeassistant://assist/exposed-entities`.
+When the configured LLM API includes the `GetLiveContext` tool, Home Assistant
+also exposes a read-only [MCP Resource](https://modelcontextprotocol.io/docs/concepts/resources)
+named `homeassistant://assist/context-snapshot`.
 
-This resource returns a YAML snapshot of the entities you have exposed to
-Assist, including the entity ID, friendly name, domain, current state, area
-name, and a curated set of attributes. MCP clients can use this resource to
-understand what is available in your Home Assistant instance before they call
-tools. If the configured LLM API does not include Assist, this resource is not
-available.
+This resource returns a plain-text snapshot that matches the existing
+`GetLiveContext` tool output. It is intended for inspection, debugging, and
+explanation workflows where a static snapshot is useful. If the configured LLM
+API does not expose `GetLiveContext`, this resource is not available.
 
 ## Known limitations
 

--- a/source/_integrations/mcp_server.markdown
+++ b/source/_integrations/mcp_server.markdown
@@ -16,7 +16,7 @@ related:
 ha_quality_scale: silver
 ---
 
-The [Model Context Protocol](https://modelcontextprotocol.io) is an open protocol that standardizes how applications provide context to <abbr title="Large Language Models">LLMs</abbr>. The **Model Context Protocol Server** (MCP) integration enables using Home Assistant to provide context for <abbr title="Model Context Protocol">MCP</abbr> LLM Client Applications. For example, you can control your lights from Claude Desktop, or let an MCP client read a snapshot of your current Assist context.
+The [Model Context Protocol](https://modelcontextprotocol.io) is an open protocol that standardizes how applications provide context to <abbr title="Large Language Models">LLMs</abbr>. The **Model Context Protocol Server** (MCP) integration enables using Home Assistant to provide context for <abbr title="Model Context Protocol">MCP</abbr> LLM Client Applications. For example, you can control your lights from Claude Desktop, or expose your Google Tasks to-do list as a tool.
 
 Controlling Home Assistant is done by providing <abbr title="Model Context Protocol">MCP</abbr> clients access to the Assist API of Home Assistant. You can control what devices and entities it can access from the {% my voice_assistants title="exposed entities page" %}.
 


### PR DESCRIPTION
## Proposed change

Update the Model Context Protocol Server docs to match the new Core support for a read-only MCP resource.

This updates the `mcp_server` integration page to:
- mention that MCP clients can read entities exposed to Assist
- document the `homeassistant://assist/context-snapshot` resource
- mark MCP Resources as supported in the feature table

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167396
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards