### PR TITLE
Fix template example in low batteries tutorial

### DIFF
--- a/source/_docs/templating/tutorial-battery-alerts.markdown
+++ b/source/_docs/templating/tutorial-battery-alerts.markdown
@@ -56,15 +56,15 @@ Open {% my developer_template title="**Developer tools** > **Template**" %} and 
 
 {% example %}
 template: |
-  {% set low = [] %}
+  {% set low = namespace(batteries=[]) %}
   {% for sensor in states.sensor
-     | selectattr('attributes.device_class', 'eq', 'battery')
-     | rejectattr('state', 'in', ['unknown', 'unavailable']) %}
-    {% if sensor.state | float(100) < 20 %}
-      {% set low = low + [device_name(sensor.entity_id)] %}
+    | selectattr('attributes.device_class', 'eq', 'battery')
+    | rejectattr('state', 'in', ['unknown', 'unavailable']) %}
+    {% if sensor.state | float(100) < 100 %}
+      {% set low.batteries = low.batteries + [device_name(sensor.entity_id)] %}
     {% endif %}
   {% endfor %}
-  {{ low }}
+  {{ low.batteries }}
 output: "['Front door lock', 'Motion sensor', 'Bedroom sensor']"
 {% endexample %}
 

--- a/source/_docs/templating/tutorial-battery-alerts.markdown
+++ b/source/_docs/templating/tutorial-battery-alerts.markdown
@@ -70,17 +70,17 @@ output: "['Front door lock', 'Motion sensor', 'Bedroom sensor']"
 
 Read it left to right:
 
-1. Start with an empty list called `low`.
+1. Create a namespace called `low` with an empty `batteries` list inside.
 2. For each sensor whose `device_class` is `battery`, skipping any that are `unknown` or `unavailable`...
 3. If its state (converted to a number) is below `20`...
-4. Add the name of the **device** that sensor belongs to.
+4. Add the name of the **device** that sensor belongs to to `low.batteries`.
 
 Why the device name? With modern Home Assistant naming, a battery sensor's own name is often only "Battery", which is not very helpful in a notification. The [`device_name`](/template-functions/device_name/) function gives you back the friendly name of the device the sensor is attached to (like "Front door lock" or "Motion sensor").
 
 You should see a list of device names with low batteries. If the list is empty, you can temporarily raise the threshold (change `20` to `100`) to confirm the template is working.
 
 {% note %}
-You might remember from [Loops and conditions](/docs/templating/loops-and-conditions/) that variables changed inside a loop do not survive the loop. This example gets away with rebuilding `low` each time, which works for straightforward counting. For more complex counting, use a [`namespace`](/template-functions/namespace/).
+Variables set inside a `for` loop do not survive outside the loop, so `low` is created with a [`namespace`](/template-functions/namespace/). That is the object whose attribute (`low.batteries`) can be updated inside the loop and still hold the full list afterwards. See [Loops and conditions](/docs/templating/loops-and-conditions/) for more on this quirk.
 {% endnote %}
 
 ## Step 3: Format the message
@@ -89,7 +89,7 @@ A bare list is not what you want to send to your phone. Add the area the device 
 
 {% example %}
 template: |
-  {% set low = [] %}
+  {% set low = namespace(batteries=[]) %}
   {% for sensor in states.sensor
      | selectattr('attributes.device_class', 'eq', 'battery')
      | rejectattr('state', 'in', ['unknown', 'unavailable']) %}
@@ -98,15 +98,15 @@ template: |
       {% set area = area_name(sensor.entity_id) %}
       {% set label = device ~ (' in ' ~ area if area else '')
          ~ ' (' ~ sensor.state ~ '%)' %}
-      {% set low = low + [label] %}
+      {% set low.batteries = low.batteries + [label] %}
     {% endif %}
   {% endfor %}
-  {% if low | count == 0 %}
+  {% if low.batteries | count == 0 %}
     All batteries are healthy.
-  {% elif low | count == 1 %}
-    1 device needs a new battery: {{ low[0] }}.
+  {% elif low.batteries | count == 1 %}
+    1 device needs a new battery: {{ low.batteries[0] }}.
   {% else %}
-    {{ low | count }} devices need new batteries: {{ low | join(', ') }}.
+    {{ low.batteries | count }} devices need new batteries: {{ low.batteries | join(', ') }}.
   {% endif %}
 output: |-
   3 devices need new batteries: Front door lock in Hallway (15%),
@@ -151,7 +151,7 @@ action: |
     data:
       title: "Battery check"
       message: >
-        {% set low = [] %}
+        {% set low = namespace(batteries=[]) %}
         {% for sensor in states.sensor
            | selectattr('attributes.device_class', 'eq', 'battery')
            | rejectattr('state', 'in', ['unknown', 'unavailable']) %}
@@ -160,15 +160,15 @@ action: |
             {% set area = area_name(sensor.entity_id) %}
             {% set label = device ~ (' in ' ~ area if area else '')
                ~ ' (' ~ sensor.state ~ '%)' %}
-            {% set low = low + [label] %}
+            {% set low.batteries = low.batteries + [label] %}
           {% endif %}
         {% endfor %}
-        {% if low | count == 0 %}
+        {% if low.batteries | count == 0 %}
           All batteries are healthy.
-        {% elif low | count == 1 %}
-          1 device needs a new battery: {{ low[0] }}.
+        {% elif low.batteries | count == 1 %}
+          1 device needs a new battery: {{ low.batteries[0] }}.
         {% else %}
-          {{ low | count }} devices need new batteries: {{ low | join(', ') }}.
+          {{ low.batteries | count }} devices need new batteries: {{ low.batteries | join(', ') }}.
         {% endif %}
 {% endexample %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This was noted in the community forums 
The battery template in the tutorial is broken (probably caused by an AI cleanup).

https://community.home-assistant.io/t/reworked-templating-documentation-is-now-live-feedback-welcome/1001962/3?u=frenck

This PR fixes it again.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
