### PR TITLE
Document missing rounded and with_unit parameters for states()

### DIFF
--- a/source/_template_functions/states.markdown
+++ b/source/_template_functions/states.markdown
@@ -42,6 +42,8 @@ output: "21.5"
 ```signature
 states(
     entity_id: str,
+    rounded: bool = False,
+    with_unit: bool = False,
 ) -> str
 ```
 
@@ -55,6 +57,18 @@ entity_id:
     The entity ID to get the state from. Returns the state as a string, or `unknown` if the entity does not exist.
   required: true
   type: string
+rounded:
+  description: >
+    When `true`, numeric states are rounded according to the entity's display precision (the same rounding shown in the UI). When omitted, it follows `with_unit`.
+  required: false
+  default: "false"
+  type: boolean
+with_unit:
+  description: >
+    When `true`, appends the entity's unit of measurement to the state. Implies `rounded` unless `rounded` is set explicitly.
+  required: false
+  default: "false"
+  type: boolean
 {% endfunction_parameters %}
 
 ## Iterating over states
@@ -96,7 +110,7 @@ output: "22.5"
 
 ### Use a sensor value in a notification
 
-Include the current temperature reading in a notification message.
+Include the current temperature reading in a notification message. Use `with_unit=true` to automatically append the entity's unit of measurement, so the output uses whatever unit the sensor reports (°C, °F, K) without hardcoding it.
 
 {% example %}
 action: |
@@ -104,7 +118,7 @@ action: |
     - action: notify.mobile
       data:
         message: >
-          The temperature is {{ states("sensor.outside_temperature") }}°C
+          The temperature is {{ states("sensor.outside_temperature", with_unit=true) }}
 {% endexample %}
 
 ### Check a value before acting


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Fixes a community-reported issue where the states() function reference page documented only 1 of its 3 parameters


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
