### PR TITLE
Add notify_on_use param to Schlage add_code service docs

### DIFF
--- a/source/_integrations/schlage.markdown
+++ b/source/_integrations/schlage.markdown
@@ -118,6 +118,7 @@ You can use the `schlage.add_code` action to add a new code to your lock. The co
 | `entity_id` | no | Lock entity to use (one or more) | `lock.front_door` |
 | `name` | no | Name for the code | `Example Person` |
 | `code` | no | Code to add (4-8 digits) | `3333` |
+| `notify_on_use` | yes | Whether the native Schlage notification should be sent when this PIN is used | `true` |
 
 {% raw %}
 
@@ -129,6 +130,7 @@ data:
     - lock.front_door
   name: Example Person
   code: "3333"
+  notify_on_use: true
 ```
 
 {% endraw %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updates doc entry for schlage integration `add_code` service.

Adds optional `notify_on_use` parameter to the `add_code` action details and example.

<img src="https://github.com/user-attachments/assets/da5d2e2a-64a0-4fb2-b02a-3a1e771716ea" width="400">

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167402 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
