### PR TITLE
Fix broken min/max examples in common template patterns

### DIFF
--- a/source/_docs/templating/patterns.markdown
+++ b/source/_docs/templating/patterns.markdown
@@ -65,35 +65,47 @@ When you have several sensors of the same kind, you often want to pick out the e
 A [Group helper](/integrations/group/) can pick the minimum, maximum, or mean from a group of sensors and expose it as a regular sensor. No template needed if you only need the value.
 {% endtip %}
 
-**The warmest room:**
+**The lowest battery:**
+
+{% example %}
+template: |
+  {{
+    states.sensor
+    | selectattr('attributes.device_class', 'eq', 'battery')
+    | selectattr('entity_id', 'has_value')
+    | map(attribute='state')
+    | map('float')
+    | min
+    | round(0)
+  }}%
+output: "18%"
+{% endexample %}
+
+We gather all battery sensors, use [`has_value`](/template-functions/has_value/) to remove any that are `unknown` or `unavailable`, convert their states to numbers, then [`min`](/template-functions/min/) picks the smallest. The `| float` conversion is important because sensor states are text, and comparing text alphabetically gives wrong results (`"9"` would beat `"23"` because `"9"` comes after `"2"`).
+
+**The warmest room (with the room name):**
+
+The previous example gives you the value but not which sensor it came from. When you need both, loop through the sensors and track the winner in a [`namespace`](/template-functions/namespace/):
 
 {% example %}
 template: |
   {% set temps = states.sensor
      | selectattr('attributes.device_class', 'eq', 'temperature')
+     | selectattr('entity_id', 'has_value')
      | list %}
-  {% set warmest = temps | max(attribute='state') %}
-  {{ warmest.name }}: {{ warmest.state }}°C
+  {% set ns = namespace(warmest=temps[0]) %}
+  {% for sensor in temps %}
+    {% if sensor.state | float > ns.warmest.state | float %}
+      {% set ns.warmest = sensor %}
+    {% endif %}
+  {% endfor %}
+  {{ ns.warmest.name }}: {{ ns.warmest.state }}°C
 output: "Kitchen: 23.5°C"
 {% endexample %}
 
-We gather all temperature sensors, then ask [`max`](/template-functions/max/) to find the one with the highest `state` value. The result is the whole entity, so we can show both its name and its state.
+Same filtering as before, but instead of extracting the values and losing track of which entity they belong to, we keep the full entity reference. The loop compares each sensor's state as a number and remembers the winner. At the end, we can show both the name and the value.
 
-**The lowest battery:**
-
-{% example %}
-template: |
-  {% set batteries = states.sensor
-     | selectattr('attributes.device_class', 'eq', 'battery')
-     | rejectattr('state', 'in', ['unknown', 'unavailable'])
-     | list %}
-  {{ batteries | map(attribute='state') | map('float') | min | round(0) }}%
-output: "18%"
-{% endexample %}
-
-This one adds an important step: [`rejectattr`](/template-functions/rejectattr/) removes sensors that are offline, so they don't accidentally become "the lowest". We then turn the states into numbers and ask [`min`](/template-functions/min/) to find the smallest.
-
-See also [`map`](/template-functions/map/).
+See also [`map`](/template-functions/map/) and [`namespace`](/template-functions/namespace/).
 
 ## Safe numbers from a sensor
 
@@ -220,7 +232,7 @@ A [Group helper](/integrations/group/) with a `sum` type adds up its members and
 template: |
   {{ states.sensor
      | selectattr('attributes.device_class', 'eq', 'power')
-     | rejectattr('state', 'in', ['unknown', 'unavailable'])
+     | selectattr('entity_id', 'has_value')
      | map(attribute='state') | map('float') | sum | round(1) }} W
 output: "427.3 W"
 {% endexample %}
@@ -285,7 +297,7 @@ On dashboards, a grid of [Tile cards](/dashboards/tile/) shows individual entiti
 template: |
   {% for sensor in states.sensor
      | selectattr('attributes.device_class', 'eq', 'temperature')
-     | rejectattr('state', 'in', ['unknown', 'unavailable']) %}
+     | selectattr('entity_id', 'has_value') %}
     {{ sensor.name }}: {{ sensor.state }}°C
   {% endfor %}
 output: |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Fixes two incorrect examples in the "Finding the highest or lowest value" section on the Common patterns page, reported by community member Taras on the forum.

Bugs fixed:

- Warmest room example used max(attribute='state') which compares states as strings. This means "9" would beat "23" alphabetically, and "unknown" could be selected as the "warmest". Replaced with a namespace + loop approach that converts to float for correct numeric comparison while keeping the entity reference so the room name appears in the output.
- Both examples used rejectattr('state', 'in', ['unknown', 'unavailable']). Replaced with selectattr('entity_id', 'has_value') which is shorter, reads as intent, and is correct by definition (checks both states internally).

**Swapped the two examples so they build on each other:**

- Lowest battery (first, simpler): filter chain approach (map → min). You get the value but not which sensor it came from.
- Warmest room (second, builds on it): introduces namespace + loop when you need both the value AND the entity name. Opens with "The previous example gives you the value but not which sensor it came from."

Small change in the rejectattr, I've replaced it with an simpler has_value using the selectattr

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
