### PR TITLE
Add camera documentation to Ecovacs integration

### DIFF
--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -2,6 +2,7 @@
 title: Ecovacs
 description: Instructions on how to integrate Ecovacs vacuums and mowers within Home Assistant.
 ha_category:
+  - Camera
   - Hub
   - Lawn mower
   - Vacuum
@@ -16,6 +17,7 @@ ha_domain: ecovacs
 ha_platforms:
   - binary_sensor
   - button
+  - camera
   - diagnostics
   - event
   - image
@@ -50,6 +52,8 @@ Additionally, **depending on your model**, the integration provides the followin
 
 - **Binary sensor**:
   - `Mop attached`: On if the mop is attached. Note: If you do not see the state change to `Mop attached` in Home Assistant, you may need to wake up the robot in order to push the state change. Some models report an entity state change only if the overall status of the vacuum has changed. For example, if the overall state changes from `docked` to `cleaning`.
+- **Camera**:
+  - `Camera`: Live video stream from robots that support KVS (Kinesis Video Streams) WebRTC (e.g., Deebot X5 Pro Omni). Disabled by default. See [Camera](#camera) for setup instructions.
 - **Button**:
   - `Reset lifespan`: For each supported component, a button entity to reset the lifespan will be created. All disabled by default.
   - `Relocate`: Button entity to trigger manual relocation.
@@ -94,6 +98,45 @@ Additionally, **depending on your model**, the integration provides the followin
   - `Continuous cleaning`: Enable continuous cleaning, which means the bot resumes the cleaning job if he needs to charge in between. Disabled by default.
   - `Safe protect`: Enable "Safe protect" feature. Disabled by default.
   - `True detect`: Enable "True detect" feature. Disabled by default.
+
+## Camera
+
+{% note %}
+The camera entity is only available for robots that support KVS (Kinesis Video Streams) WebRTC streaming, such as the **Deebot X5 Pro Omni**. Check your robot's app to see if it supports live video.
+{% endnote %}
+
+### Prerequisites
+
+To use the camera stream you need the **camera PIN** that was set during the initial setup of your robot in the Ecovacs app. This PIN is required by the robot firmware to authorize the WebRTC session.
+
+### Configuration
+
+1. In Home Assistant, go to **Settings** > **Devices & Services** > **Ecovacs**.
+2. Click **Configure** on your Ecovacs integration entry.
+3. In the **Camera** section, enter the camera PIN for each robot that supports it.
+4. Click **Submit**.
+
+After saving, a `camera` entity will be created for each configured robot (disabled by default). Enable it from the entity page to start receiving the live stream.
+
+### Enabling the camera entity
+
+The camera entity is **disabled by default** because it requires additional configuration (the PIN). Once you have set the PIN via the options flow:
+
+1. Go to **Settings** > **Devices & Services** > **Ecovacs** > your robot device.
+2. Find the `Camera` entity and click **Enable**.
+3. Open the camera entity to view the live stream.
+
+### Camera stream switch
+
+Each robot with a configured camera PIN also gets a **Camera stream** switch entity (in the **Switch** platform). This switch allows you to start or stop the WebRTC session independently of the camera entity itself. When the stream is inactive, the camera entity displays a black placeholder image instead of becoming unavailable.
+
+### Supported models
+
+| Model | Notes |
+|---|---|
+| Deebot X5 Pro Omni | Tested and confirmed working |
+
+Other models that use KVS WebRTC in the Ecovacs app may also work. If your model is not listed but supports camera streaming in the app, please open an issue and report your findings.
 
 ## Vacuum
 

--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -53,7 +53,7 @@ Additionally, **depending on your model**, the integration provides the followin
 - **Binary sensor**:
   - `Mop attached`: On if the mop is attached. Note: If you do not see the state change to `Mop attached` in Home Assistant, you may need to wake up the robot in order to push the state change. Some models report an entity state change only if the overall status of the vacuum has changed. For example, if the overall state changes from `docked` to `cleaning`.
 - **Camera**:
-  - `Camera`: Live video stream from robots that support KVS (Kinesis Video Streams) WebRTC (e.g., Deebot X5 Pro Omni). Disabled by default. See [Camera](#camera) for setup instructions.
+  - `Camera`: Live video stream from robots that support KVS (Kinesis Video Streams) WebRTC, for example the Deebot X5 Pro Omni. Disabled by default. See [Camera](#camera) for setup instructions.
 - **Button**:
   - `Reset lifespan`: For each supported component, a button entity to reset the lifespan will be created. All disabled by default.
   - `Relocate`: Button entity to trigger manual relocation.
@@ -111,10 +111,10 @@ To use the camera stream you need the **camera PIN** that was set during the ini
 
 ### Configuration
 
-1. In Home Assistant, go to **Settings** > **Devices & Services** > **Ecovacs**.
-2. Click **Configure** on your Ecovacs integration entry.
+1. In Home Assistant, go to **Settings** > **Devices & services** > **Ecovacs**.
+2. Select **Configure** on your Ecovacs integration entry.
 3. In the **Camera** section, enter the camera PIN for each robot that supports it.
-4. Click **Submit**.
+4. Select **Submit**.
 
 After saving, a `camera` entity will be created for each configured robot (disabled by default). Enable it from the entity page to start receiving the live stream.
 
@@ -122,8 +122,8 @@ After saving, a `camera` entity will be created for each configured robot (disab
 
 The camera entity is **disabled by default** because it requires additional configuration (the PIN). Once you have set the PIN via the options flow:
 
-1. Go to **Settings** > **Devices & Services** > **Ecovacs** > your robot device.
-2. Find the `Camera` entity and click **Enable**.
+1. Go to **Settings** > **Devices & services** > **Ecovacs** > your robot device.
+2. Find the `Camera` entity and select **Enable**.
 3. Open the camera entity to view the live stream.
 
 ### Camera stream switch
@@ -132,9 +132,7 @@ Each robot with a configured camera PIN also gets a **Camera stream** switch ent
 
 ### Supported models
 
-| Model | Notes |
-|---|---|
-| Deebot X5 Pro Omni | Tested and confirmed working |
+- Deebot X5 Pro Omni: Tested and confirmed working
 
 Other models that use KVS WebRTC in the Ecovacs app may also work. If your model is not listed but supports camera streaming in the app, please open an issue and report your findings.
 


### PR DESCRIPTION
## Proposed change

Documents the new KVS WebRTC camera support added to the Ecovacs integration.

Changes to `source/_integrations/ecovacs.markdown`:
- Add `Camera` to `ha_category` and `ha_platforms` in the front matter
- Add `Camera` entry in the **Provided entities** list (disabled by default)
- Add new **## Camera** section covering: supported robots (KVS WebRTC, for example the Deebot X5 Pro Omni), prerequisites (camera PIN from the Ecovacs app), options flow configuration steps, how to enable the camera entity, and the **Camera stream** switch entity

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167564
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards