### PR TITLE
geniushub: document hvac_action and output state attribute

### DIFF
--- a/source/_integrations/geniushub.markdown
+++ b/source/_integrations/geniushub.markdown
@@ -72,6 +72,18 @@ Climate and water heater entities will report their current temperature, setpoin
 
 **Footprint** mode is only available to **Radiator** zones that have room sensors.
 
+Climate entities also report an `hvac_action` indicating the zone's current activity:
+
+| `hvac_action` | Meaning |
+| :-----------: | ------- |
+| `heating` | Zone is actively calling for heat |
+| `idle` | Zone is on but not currently calling for heat |
+| `off` | Zone is off and not active (local API only) |
+
+{% note %}
+Distinguishing `idle` from `off` requires the local API. When using the cloud API, a satisfied zone reports `idle` regardless of whether it is scheduled or switched off.
+{% endnote %}
+
 ### Switch entities
 
 Switch entities will report back their state; other properties are available via their state attributes. Currently, HA switches do not have modes/presets, so the Home Assistant `state` will be *reported* as:
@@ -146,6 +158,7 @@ Many zone/device properties are available via the corresponding entity's state a
   "status": {
     "type": "radiator",
     "mode": "off",
+    "output": 0,
     "temperature": 19,
     "occupied": False,
     "override": {
@@ -155,6 +168,8 @@ Many zone/device properties are available via the corresponding entity's state a
   }
 }
 ```
+
+The `output` field indicates whether the zone is calling for heat (`1`) or satisfied (`0`).
 
 ... and for **Genius Valve**-derived `Sensor` entities (note 'state'):
 


### PR DESCRIPTION
Repo:   home-assistant/home-assistant.io
Branch: geniushub-fix-hvac-action-v1-api  (targeting `current`)
URL:    https://github.com/wibbit/home-assistant.io/pull/new/geniushub-fix-hvac-action-v1-api

## Proposed change

Document two changes to the GeniusHub integration that fix existing behaviour for cloud API
(v1) users:

1. Climate entities now report `hvac_action`. Previously this was gated behind a v3-only API
   field, so cloud users always saw no action. Add a table explaining the three possible states
   (`heating`, `idle`, `off`) and a note clarifying that distinguishing `idle` from `off`
   requires the local API.

2. The `output` field (heat demand signal) now appears in the `status` state attribute on
   climate, water_heater and switch entities. Update the state attributes example JSON to
   include it with an explanatory note.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167631
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards