### PR TITLE
Add known limitations and examples to victron_gx docs

### DIFF
--- a/source/_integrations/victron_gx.markdown
+++ b/source/_integrations/victron_gx.markdown
@@ -97,7 +97,7 @@ Read-only sensors for monitoring system metrics, such as:
 
 ## Known limitations
 
-- The integration does not support real-time data push. Entities are updated at a fixed interval (every 30 seconds) even though the underlying connection is push-based via MQTT.
+- The integration receives updates through MQTT push, but limits entity updates to at most once every 30 seconds. This means rapidly changing values may appear with a short delay.
 
 ## Examples
 
@@ -117,7 +117,7 @@ automation:
     actions:
       - action: notify.notify
         data:
-          title: "Low Battery Warning"
+          title: "Low battery warning"
           message: >
             Your Victron battery charge is at
             {{ states('sensor.battery_monitor_charge') }}%.

--- a/source/_integrations/victron_gx.markdown
+++ b/source/_integrations/victron_gx.markdown
@@ -103,7 +103,7 @@ Read-only sensors for monitoring system metrics, such as:
 
 ### Send a notification when the battery is low
 
-You can use this automation to receive a notification when your battery state of charge drops below a certain threshold:
+You can use this automation to receive a notification when your battery state of charge drops below a certain threshold. Replace `sensor.battery_monitor_charge` with your actual battery charge entity.
 
 {% raw %}
 
@@ -112,15 +112,15 @@ automation:
   - alias: "Notify when battery is low"
     triggers:
       - trigger: numeric_state
-        entity_id: sensor.battery_state_of_charge
+        entity_id: sensor.battery_monitor_charge
         below: 20
     actions:
       - action: notify.notify
         data:
           title: "Low Battery Warning"
           message: >
-            Your Victron battery state of charge is at
-            {{ states('sensor.battery_state_of_charge') }}%.
+            Your Victron battery charge is at
+            {{ states('sensor.battery_monitor_charge') }}%.
 ```
 
 {% endraw %}

--- a/source/_integrations/victron_gx.markdown
+++ b/source/_integrations/victron_gx.markdown
@@ -95,6 +95,36 @@ Read-only sensors for monitoring system metrics, such as:
 - Inverter input and output power, frequency, and state
 - <abbr title="electric vehicle">EV</abbr> charger status, power, and session energy
 
+## Known limitations
+
+- The integration does not support real-time data push. Entities are updated at a fixed interval (every 30 seconds) even though the underlying connection is push-based via MQTT.
+
+## Examples
+
+### Send a notification when the battery is low
+
+You can use this automation to receive a notification when your battery state of charge drops below a certain threshold:
+
+{% raw %}
+
+```yaml
+automation:
+  - alias: "Notify when battery is low"
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.battery_state_of_charge
+        below: 20
+    actions:
+      - action: notify.notify
+        data:
+          title: "Low Battery Warning"
+          message: >
+            Your Victron battery state of charge is at
+            {{ states('sensor.battery_state_of_charge') }}%.
+```
+
+{% endraw %}
+
 ## Troubleshooting
 
 ### Cannot connect

--- a/source/_integrations/victron_gx.markdown
+++ b/source/_integrations/victron_gx.markdown
@@ -127,7 +127,7 @@ Configurable options for controlling device behavior, such as:
 
 ### Send a notification when the battery is low
 
-You can use this automation to receive a notification when your battery state of charge drops below a certain threshold. Replace `sensor.battery_monitor_charge` with your actual battery charge entity.
+You can use this automation to receive a notification when your battery state of charge drops below a certain threshold. Replace `sensor.battery_soc` with your actual battery charge entity.
 
 {% raw %}
 

--- a/source/_integrations/victron_gx.markdown
+++ b/source/_integrations/victron_gx.markdown
@@ -112,7 +112,7 @@ automation:
   - alias: "Notify when battery is low"
     triggers:
       - trigger: numeric_state
-        entity_id: sensor.battery_monitor_charge
+        entity_id: sensor.battery_soc
         below: 20
     actions:
       - action: notify.notify
@@ -120,7 +120,7 @@ automation:
           title: "Low battery warning"
           message: >
             Your Victron battery charge is at
-            {{ states('sensor.battery_monitor_charge') }}%.
+            {{ states('sensor.battery_soc') }}%.
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change

Add known limitations and examples sections to the victron_gx documentation for gold quality scale compliance.

- **Known limitations**: Documents the 30-second update throttle behavior
- **Examples**: Adds a battery low notification automation example

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167866
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
