### PR TITLE
Escape  `(` & `}` within the example for the fritz call monitor

### DIFF
--- a/source/_integrations/fritzbox_callmonitor.markdown
+++ b/source/_integrations/fritzbox_callmonitor.markdown
@@ -61,7 +61,7 @@ automation:
             {% elif is_state("sensor.phone", "dialing") %}
               Calling {{ state_attr('sensor.phone', 'to_name') }} \({{ state_attr('sensor.phone', 'to') }}\)
             {% elif is_state("sensor.phone", "ringing") %}
-              Incoming call from {{ state_attr('sensor.phone', 'from_name') }} \(({{ state_attr('sensor.phone', 'from') }}\)
+              Incoming call from {{ state_attr('sensor.phone', 'from_name') }} \({{ state_attr('sensor.phone', 'from') }}\)
             {% else %}
               Talking to {{ state_attr('sensor.phone', 'with_name') }} \({{ state_attr('sensor.phone', 'with') }}\)
             {% endif %}

--- a/source/_integrations/fritzbox_callmonitor.markdown
+++ b/source/_integrations/fritzbox_callmonitor.markdown
@@ -59,10 +59,10 @@ automation:
             {% if is_state("sensor.phone", "idle") %}
               Phone is idle
             {% elif is_state("sensor.phone", "dialing") %}
-              Calling {{ state_attr('sensor.phone', 'to_name') }} ({{ state_attr('sensor.phone', 'to') }})
+              Calling {{ state_attr('sensor.phone', 'to_name') }} \({{ state_attr('sensor.phone', 'to') }}\)
             {% elif is_state("sensor.phone", "ringing") %}
-              Incoming call from {{ state_attr('sensor.phone', 'from_name') }} ({{ state_attr('sensor.phone', 'from') }})
+              Incoming call from {{ state_attr('sensor.phone', 'from_name') }} \(({{ state_attr('sensor.phone', 'from') }}\)
             {% else %}
-              Talking to {{ state_attr('sensor.phone', 'with_name') }} ({{ state_attr('sensor.phone', 'with') }})
+              Talking to {{ state_attr('sensor.phone', 'with_name') }} \({{ state_attr('sensor.phone', 'with') }}\)
             {% endif %}
 ```


### PR DESCRIPTION
Since some releases we do get the following error message when triggering this or similiar scripts.

>Can't parse entities: character '(' is reserved and must be escaped with the preceding '\'

`(` & `}` needs to be escaped now.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Since some releases we do get the following error message when triggering this or similiar scripts.

>Can't parse entities: character '(' is reserved and must be escaped with the preceding '\'

`(` & `}` needs to be escaped now.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

n.a.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
