### PR TITLE
Add controller info in Matter lock user and credential responses

### DIFF
--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -477,7 +477,7 @@ response_variable: lock_info
 
 #### Action: Get lock users
 
-The `matter.get_lock_users` action returns all users configured on the lock. For each user, the response includes their name, status, type, credential rule, a list of credential references (type and slot index), which controller (such as Home Assistant, Apple Home, or Google Home) created the user, and which controller last modified the user. For security reasons, the lock does not expose the actual credential secrets (such as PIN codes or RFID tag data). This action returns a response and does not require any additional data attributes.
+The `matter.get_lock_users` action lists all users on the lock. For each user, the response shows their name, status, and type. It also shows their credential rule. The response lists credential references, including type and slot index. It shows which controller created the user. It also shows which controller last changed the user. For security, the lock does not show real credential secrets like PIN codes or RFID tags. This action returns a response. No extra data is required.
 
 ```yaml
 action: matter.get_lock_users

--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -477,7 +477,7 @@ response_variable: lock_info
 
 #### Action: Get lock users
 
-The `matter.get_lock_users` action returns all users configured on the lock. For each user, the response includes their name, status, type, credential rule, and a list of credential references (type and slot index). For security reasons, the lock does not expose the actual credential secrets (such as PIN codes or RFID tag data). This action returns a response and does not require any additional data attributes.
+The `matter.get_lock_users` action returns all users configured on the lock. For each user, the response includes their name, status, type, credential rule, a list of credential references (type and slot index), and which controller (such as Home Assistant, Apple Home, or Google Home) created and last modified the user. For security reasons, the lock does not expose the actual credential secrets (such as PIN codes or RFID tag data). This action returns a response and does not require any additional data attributes.
 
 ```yaml
 action: matter.get_lock_users
@@ -569,7 +569,7 @@ data:
 
 #### Action: Get lock credential status
 
-The `matter.get_lock_credential_status` action returns the status of a specific credential slot on the lock, including whether the slot is occupied and which user it belongs to. This action returns a response.
+The `matter.get_lock_credential_status` action returns the status of a specific credential slot on the lock, including whether the slot is occupied, which user it belongs to, and which controller (such as Home Assistant, Apple Home, or Google Home) created and last modified the credential. This action returns a response.
 
 - **Data attribute**: `credential_type`
   - **Description**: The type of credential to query.

--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -477,7 +477,7 @@ response_variable: lock_info
 
 #### Action: Get lock users
 
-The `matter.get_lock_users` action returns all users configured on the lock. For each user, the response includes their name, status, type, credential rule, a list of credential references (type and slot index), and which controller (such as Home Assistant, Apple Home, or Google Home) created and last modified the user. For security reasons, the lock does not expose the actual credential secrets (such as PIN codes or RFID tag data). This action returns a response and does not require any additional data attributes.
+The `matter.get_lock_users` action returns all users configured on the lock. For each user, the response includes their name, status, type, credential rule, a list of credential references (type and slot index), which controller (such as Home Assistant, Apple Home, or Google Home) created the user, and which controller last modified the user. For security reasons, the lock does not expose the actual credential secrets (such as PIN codes or RFID tag data). This action returns a response and does not require any additional data attributes.
 
 ```yaml
 action: matter.get_lock_users
@@ -569,7 +569,7 @@ data:
 
 #### Action: Get lock credential status
 
-The `matter.get_lock_credential_status` action returns the status of a specific credential slot on the lock, including whether the slot is occupied, which user it belongs to, and which controller (such as Home Assistant, Apple Home, or Google Home) created and last modified the credential. This action returns a response.
+The `matter.get_lock_credential_status` action returns the status of a specific credential slot on the lock, including whether the slot is occupied, which user it belongs to, which controller (such as Home Assistant, Apple Home, or Google Home) created the credential, and which controller last modified it. This action returns a response.
 
 - **Data attribute**: `credential_type`
   - **Description**: The type of credential to query.


### PR DESCRIPTION
## Proposed change

Update the Matter lock documentation to mention that the `get_lock_users` and `get_lock_credential_status` actions now also return which controller created and last modified a user or credential.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167875
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
