### PR TITLE
Document Neato cloud service phase-out

### DIFF
--- a/source/_integrations/neato.markdown
+++ b/source/_integrations/neato.markdown
@@ -26,7 +26,7 @@ The **Neato** {% term integration %} allows you to control your [Neato Botvac Co
 
 Vorwerk is phasing out Neato cloud services. On 6 October 2025, they [announced](https://support.neatorobotics.com/support/solutions/articles/204000073686) that the cloud platform can no longer be maintained in a reliable and future-proof way.
 
-Because the Neato Developer Network is no longer available, **new setups of this integration are no longer possible**. Existing setups may continue to work until the cloud is fully shut down.
+Because the Neato Developer Network is no longer available, you can no longer set up this integration as a new installation. Existing setups may continue to work until the cloud is fully shut down.
 
 {% endimportant %}
 

--- a/source/_integrations/neato.markdown
+++ b/source/_integrations/neato.markdown
@@ -22,6 +22,14 @@ ha_integration_type: hub
 
 The **Neato** {% term integration %} allows you to control your [Neato Botvac Connected Robots][botvac-connected].
 
+{% important %}
+
+Vorwerk is phasing out Neato cloud services. On 6 October 2025, they [announced](https://support.neatorobotics.com/support/solutions/articles/204000073686) that the cloud platform can no longer be maintained in a reliable and future-proof way.
+
+Because the Neato Developer Network is no longer available, **new setups of this integration are no longer possible**. Existing setups may continue to work until the cloud is fully shut down.
+
+{% endimportant %}
+
 There is support for the following platform types within Home Assistant:
 
 - **Camera** - allows you to view the latest cleaning map.
@@ -32,7 +40,7 @@ There is support for the following platform types within Home Assistant:
 
 ## Prerequisites
 
-Visit [the Neato Developer Network](https://developers.neatorobotics.com/applications) and create a new app.
+Previously, you would visit the Neato Developer Network to create a new app and obtain credentials. The Neato Developer Network is no longer available, so new credentials can no longer be created. The steps below are kept for reference for users who already have existing credentials.
 
 {% important %}
 


### PR DESCRIPTION
## Proposed change

Vorwerk [announced](https://support.neatorobotics.com/support/solutions/articles/204000073686) on 6 October 2025 that Neato cloud services are being phased out. The Neato Developer Network is already unavailable, so users can no longer create the app credentials needed to set up the integration.

This PR:

- Adds a prominent notice at the top of the Neato integration page explaining the phase-out and linking to Vorwerk's official announcement.
- Rewrites the prerequisites so users are no longer sent to the dead `developers.neatorobotics.com` URL, while keeping the existing steps as reference for users who still have working credentials.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #44602

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
