### PR TITLE
Clarify OTBR manual setup URL format

### DIFF
--- a/source/_integrations/otbr.markdown
+++ b/source/_integrations/otbr.markdown
@@ -23,4 +23,6 @@ Installing this integration manually is an advanced use case, for example if you
 
 {% include integrations/config_flow.md %}
 
+When asked to provide a URL, enter the address of your border router's REST API. The URL uses plain HTTP, not HTTPS, and includes the host and port of your border router. A standard OpenThread border router exposes its REST API on port `8081`, so your URL typically looks like `http://192.168.1.42:8081`. Replace the IP address with the one of your own border router.
+
 To view the app documentation, go to {% my supervisor_addon title="**Settings** > **Apps** > **OpenThread Border Router**" addon="core_openthread_border_router" %} and select the **Documentation** tab.

--- a/source/_integrations/otbr.markdown
+++ b/source/_integrations/otbr.markdown
@@ -23,6 +23,6 @@ Installing this integration manually is an advanced use case, for example if you
 
 {% include integrations/config_flow.md %}
 
-When asked to provide a URL, enter the address of your border router's REST API. The URL uses plain HTTP, not HTTPS, and includes the host and port of your border router. A standard OpenThread border router exposes its REST API on port `8081`, so your URL typically looks like `http://192.168.1.42:8081`. Replace the IP address with the one of your own border router.
+When asked to provide a URL, enter the address of your border router's REST API. The URL uses plain HTTP, not HTTPS, and includes the host and port of your border router. A standard OpenThread border router exposes its REST API on port `8081`, so your URL typically looks like `http://192.168.1.42:8081`. Replace the IP address with your border router's IP address.
 
 To view the app documentation, go to {% my supervisor_addon title="**Settings** > **Apps** > **OpenThread Border Router**" addon="core_openthread_border_router" %} and select the **Documentation** tab.


### PR DESCRIPTION
## Proposed change

When the OpenThread Border Router integration is set up manually (for users running their own border router), the only instruction was the generic "follow the config flow" text. Users had no way to know what to type in the **URL** field: HTTP or HTTPS? Host only? With port? Which port?

Add a short explanation right after the config flow include that spells out the URL format, scheme, default port (`8081`, as defined in `openthread/ot-br-posix`), and a concrete example.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #44572

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
