### PR TITLE
Replace e.g., i.e., and etc. in non-integration docs

### DIFF
--- a/source/_dashboards/entities.markdown
+++ b/source/_dashboards/entities.markdown
@@ -14,7 +14,7 @@ related:
     title: Card naming
 ---
 
-The entities card is the most common type of card. It groups items together into lists. It can be used to display an entity's state or attribute, but also contain buttons, web links, etc.
+The entities card is the most common type of card. It groups items together into lists. It can be used to display an entity's state or attribute, but also contain buttons, web links, and more.
 
 {% include dashboard/edit_dashboard.md %}
 
@@ -125,7 +125,7 @@ confirmation:
 
 ## Special row elements
 
-Rather than only displaying an entity's state as a text output, the entities card supports multiple special rows for buttons, attributes, web links, dividers and sections, etc.
+Rather than only displaying an entity's state as a text output, the entities card supports multiple special rows for buttons, attributes, web links, dividers, sections, and more.
 
 ### Attribute
 
@@ -349,7 +349,7 @@ type:
   type: string
 url:
   required: true
-  description: "Website URL (or internal URL e.g., `/hassio/dashboard` or `/panel_custom_name`)."
+  description: "Website URL, or internal URL such as `/hassio/dashboard` or `/panel_custom_name`."
   type: string
 name:
   required: false
@@ -358,7 +358,7 @@ name:
   default: URL path
 icon:
   required: false
-  description: "Icon to display (e.g., `mdi:home`)."
+  description: "Icon to display, for example `mdi:home`."
   type: string
   default: "`mdi:link`"
 new_tab:

--- a/source/_dashboards/iframe.markdown
+++ b/source/_dashboards/iframe.markdown
@@ -68,7 +68,7 @@ allow:
   default: "fullscreen"
 disable_sandbox:
   required: false
-  description: Disables the [sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) attribute of the iframe, e.g. required for Chrome when viewing PDFs. This is less secure and should only be used if you trust the content of the iframe.
+  description: Disables the [sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) attribute of the iframe, for example when viewing PDFs in Chrome. This is less secure and should only be used if you trust the content of the iframe.
   type: boolean
   default: false
 {% endconfiguration %}

--- a/source/_dashboards/markdown.markdown
+++ b/source/_dashboards/markdown.markdown
@@ -43,7 +43,7 @@ card_size:
   required: false
   type: integer
   default: none
-  description: The algorithm for placing cards aesthetically may have problems with the Markdown card if it contains templates. You can use this value to help it estimate the height of the card in units of 50 pixels (approximately 3 lines of text in default size). (e.g., `4`)
+  description: The algorithm for placing cards aesthetically may have problems with the Markdown card if it contains templates. You can use this value to help it estimate the height of the card in units of 50 pixels (approximately 3 lines of text in default size), for example `4`.
 entity_id:
   required: false
   type: [string, list]

--- a/source/_dashboards/picture-elements.markdown
+++ b/source/_dashboards/picture-elements.markdown
@@ -77,7 +77,7 @@ dark_mode_filter:
 
 ## Elements
 
-Elements are the active components (icons, badges, buttons, text, etc.) that overlay the image.
+Elements are the active components (icons, badges, buttons, text, and more) that overlay the image.
 
 There are several different element types that can be added to a Picture Elements card:
 
@@ -266,7 +266,7 @@ type:
   type: string
 icon:
   required: true
-  description: "Icon to display (e.g., `mdi:home`)."
+  description: "Icon to display, for example `mdi:home`."
   type: string
 title:
   required: false
@@ -402,7 +402,7 @@ for more information.
 {% configuration %}
 type:
   required: true
-  description: 'Card name with `custom:` prefix (e.g., `custom:my-custom-card`).'
+  description: 'Card name with `custom:` prefix, for example `custom:my-custom-card`.'
   type: string
 style:
   required: true

--- a/source/_includes/common-tasks/data_disk.md
+++ b/source/_includes/common-tasks/data_disk.md
@@ -1,6 +1,6 @@
 ## Using external data disk
 
-{% term "Home Assistant Operating System" %} supports storing data on a secondary storage medium. For example, this can be a second internal SSD or HDD or a USB attached SSD or HDD. This data disk contains not only user data but also most of the Home Assistant software as well (Core, Supervisor, etc.). This means a fast data disk will make the system overall much faster.
+{% term "Home Assistant Operating System" %} supports storing data on a secondary storage medium. For example, this can be a second internal SSD or HDD or a USB attached SSD or HDD. This data disk contains not only user data but also most of the Home Assistant software as well, including Core and Supervisor. This means a fast data disk will make the system overall much faster.
 
 ![Graphics showing the architecture of the data disk feature](/images/haos/usb-data-disk.png)
 
@@ -78,7 +78,7 @@ To migrate an external data disk from one system to another, follow these steps:
 
 1. [Create a backup](/common-tasks/general/#backups) of both systems and store these backups on another system (not strictly necessary, but recommended just in case, at least for the important data).
 2. Shut down system 1 and remove the data disk.
-3. Make sure system 2 has Home Assistant OS installed, and Home Assistant is up and running. Home Assistant is using the data disk (partition) on the boot drive (e.g. SD card) at this point.
+3. Make sure system 2 has Home Assistant OS installed, and Home Assistant is up and running. Home Assistant is using the data disk (partition) on the boot drive, such as the SD card, at this point.
 4. Make sure system 2 has completed the basic [onboarding](/getting-started/onboarding/) steps, including the last steps where devices are discovered automatically.
 5. Plug the external disk into system 2 and go to the **Settings** > **System**. Select the three dots {% icon "mdi:dots-vertical" %} menu, and **Restart Home Assistant** > **Reboot system**.
    Result: A repair issue is displayed **Multiple data disks detected**.

--- a/source/_includes/common-tasks/data_disk.md
+++ b/source/_includes/common-tasks/data_disk.md
@@ -1,6 +1,6 @@
 ## Using external data disk
 
-{% term "Home Assistant Operating System" %} supports storing data on a secondary storage medium. For example, this can be a second internal SSD or HDD or a USB attached SSD or HDD. This data disk contains not only user data but also most of the Home Assistant software as well, including Core and Supervisor. This means a fast data disk will make the system overall much faster.
+{% term "Home Assistant Operating System" %} supports storing data on a secondary storage medium. For example, this can be a second internal SSD or HDD, or a USB-attached SSD or HDD. This data disk contains not only user data but also most of the Home Assistant software, including {% term "Home Assistant Core" %} and Apps. This means a fast data disk will make the system much faster overall.
 
 ![Graphics showing the architecture of the data disk feature](/images/haos/usb-data-disk.png)
 

--- a/source/_includes/common-tasks/enable_i2c.md
+++ b/source/_includes/common-tasks/enable_i2c.md
@@ -2,7 +2,7 @@
 
 Home Assistant using the {% term "Home Assistant Operating System" %} which is a managed environment, which means you can't use existing methods to enable the I2C bus on a Raspberry Pi. In order to use I2C devices you will have to 
 - Enable I2C for the Home Assistant Operating System 
-- Setup I2C devices e.g. sensors
+- Setup I2C devices, such as sensors
 
 ### Enable I2C with an SD card reader
 
@@ -60,7 +60,7 @@ You can enable I2C via this terminal:
   ```
 ### Troubleshooting
 
-After rebooting the host there should be `i2c-0` and similar device files in `/dev`. If such device files are missing, enabling I2C failed for some reason. You can check the status of I2C kernel modules by using `lsmod | grep i2c` in the terminal. If they are loaded, you should find at least the entry `i2c_dev`. Active usage of the modules is indicated by a number, e.g. `i2c_dev 20480 2` would indicate two active I2C device files.
+After rebooting the host there should be `i2c-0` and similar device files in `/dev`. If such device files are missing, enabling I2C failed for some reason. You can check the status of I2C kernel modules by using `lsmod | grep i2c` in the terminal. If they are loaded, you should find at least the entry `i2c_dev`. Active usage of the modules is indicated by a number. For example, `i2c_dev 20480 2` would indicate two active I2C device files.
 
 An active I2C can also be checked with a multi meter showing 3.3 V on the I2C pins GPIO2 and GPIO3. 
   

--- a/source/_includes/common-tasks/enable_i2c.md
+++ b/source/_includes/common-tasks/enable_i2c.md
@@ -2,7 +2,7 @@
 
 Home Assistant using the {% term "Home Assistant Operating System" %} which is a managed environment, which means you can't use existing methods to enable the I2C bus on a Raspberry Pi. In order to use I2C devices you will have to 
 - Enable I2C for the Home Assistant Operating System 
-- Setup I2C devices, such as sensors
+- Set up I2C devices, such as sensors
 
 ### Enable I2C with an SD card reader
 

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -391,7 +391,7 @@ Minimum recommended assignments:
     3. Choose **Generic Default** for the operating system.
     4. Check the box for **Customize configuration before install**.
     5. Under **Network Selection**, select your bridge.
-    6. Under customization select **Overview** > **Firmware** > **UEFI x86_64: ...**. Make sure to select a non-secureboot version of OVMF (does not contain the word `secure`, `secboot`, etc.), for example `/usr/share/edk2/ovmf/OVMF_CODE.fd`.
+    6. Under customization select **Overview** > **Firmware** > **UEFI x86_64: ...**. Make sure to select a non-secureboot version of OVMF (does not contain words such as `secure` or `secboot`), for example `/usr/share/edk2/ovmf/OVMF_CODE.fd`.
     7. Select **Add Hardware** (bottom left), and select **Channel**.
     8. Select device type: **unix**.
     9. Select name: **org.qemu.guest_agent.0**.

--- a/source/getting-started/concepts-terminology.markdown
+++ b/source/getting-started/concepts-terminology.markdown
@@ -43,7 +43,7 @@ Entities are the basic building blocks to hold data in Home Assistant. An {% ter
 ## Areas
 
 An area in Home Assistant is a logical grouping of {% term devices %} and {% term entities %} that are meant to match areas (or rooms) in the physical world: your home. For example, the `living room` area groups devices and entities in your living room. Areas allow you to target service calls at an entire group of devices. For example, turning off all the lights in the living room.
-Locations within your home such as living room, dance floor, etc. Areas can be assigned to {% term floors %}.
+These are locations within your home, such as the living room or the dance floor. Areas can be assigned to {% term floors %}.
 Areas can also be used for automatically generated cards, such as the [Area card](/dashboards/area/).
 
 ## Automations

--- a/source/installation/generic-x86-64.markdown
+++ b/source/installation/generic-x86-64.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Generic x86-64"
-description: "Install Home Assistant on Generic x86-64 systems (e.g. Intel NUC)"
+description: "Install Home Assistant on Generic x86-64 systems such as the Intel NUC"
 installation_type: generic-x86-64
 ---
 {% comment %}

--- a/source/voice_control/best_practices.markdown
+++ b/source/voice_control/best_practices.markdown
@@ -62,9 +62,9 @@ Assist leverages domains to define the proper verbs for the action being taken (
 
 It might not bother anyone to have a `switch.main_valve` in the UI instead of a valve, but you can’t ask Assist to open the main valve if the main valve is a switch. If it was a `valve.main_valve`, then the former sentence would have worked without a hitch.
 
-To prevent this, you can use either the [Change device type of a switch integration](/integrations/switch_as_x/) or create virtual entities using [template](/integrations/template/) entities or Generic X (e.g. [generic thermostat](/integrations/generic_thermostat/)).
+To prevent this, you can use either the [Change device type of a switch integration](/integrations/switch_as_x/) or create virtual entities using [template](/integrations/template/) entities or Generic X, such as the [generic thermostat](/integrations/generic_thermostat/).
 
-The same thing applies to some device classes. For example, if you have a `binary_sensor.bedroom_window` with no `device_class` set, you can only ask whether the bedroom window is on, which doesn’t even make sense. To be able to ask if it’s open, you need to set a proper `device_class` to that `binary_sensor`, i.e. window.
+The same thing applies to some device classes. For example, if you have a `binary_sensor.bedroom_window` with no `device_class` set, you can only ask whether the bedroom window is on, which doesn’t even make sense. To be able to ask if it’s open, you need to set a proper `device_class` to that `binary_sensor`, such as `window`.
 
 
 ## Ready?


### PR DESCRIPTION
## Proposed change

Our style guide bans `e.g.`, `i.e.`, `etc.`, and `etcetera` in favor of clearer phrasings like "for example", "that is", "such as", and "and more". Replace all occurrences in the non-integration documentation areas with context-appropriate phrasings.

Scope of this PR:

- `source/_dashboards/`
- `source/installation/`
- `source/getting-started/`
- `source/voice_control/`
- `source/_includes/`

The remaining occurrences (in `source/_integrations/`) will follow in subsequent small PRs, batched alphabetically.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
