### PR TITLE
Proofread and style cleanup for the MQTT integration page

### DIFF
--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -51,7 +51,7 @@ MQTT (aka MQ Telemetry Transport) is a machine-to-machine or "Internet of Things
 
 {% include integrations/config_flow.md %}
 
-MQTT Devices and entities can be set up through [MQTT -discovery](#mqtt-discovery) or [added manually](#manual-configured-mqtt-items) via YAML or subentries.
+MQTT devices and entities can be set up through [MQTT discovery](#mqtt-discovery) or [added manually](#manual-configured-mqtt-items) via YAML or subentries.
 
 <a name="configuration-via-mqtt-discovery"></a>
 {% details "Configuration of MQTT components via MQTT discovery" %}
@@ -145,7 +145,7 @@ To add an MQTT device via a Subentry, follow these steps:
 
 1. Go to **{% my integrations title="Settings > Devices & services" %}**.
 2. Select the MQTT integration.
-3. Add a subentry via {% my integrations title="**Settings** > **Devices & services**" %}, click {% icon "mdi:dots-vertical" %} and select **Add MQTT device**.
+3. Add a subentry via {% my integrations title="**Settings** > **Devices & services**" %}, select {% icon "mdi:dots-vertical" %}, and select **Add MQTT device**.
 
 A device context and one or more entities can be added to the subentry.
 
@@ -181,7 +181,7 @@ Add the MQTT integration, then provide your broker's hostname (or IP address) an
 
 1. Go to **{% my integrations title="Settings > Devices & services" %}**.
 2. Select the MQTT integration.
-3. Reconfigure the MQTT broker settings via {% my integrations title="**Settings** > **Devices & services**" %}, click {% icon "mdi:dots-vertical" %} and select **Reconfigure**.
+3. Reconfigure the MQTT broker settings via {% my integrations title="**Settings** > **Devices & services**" %}, select {% icon "mdi:dots-vertical" %}, and select **Reconfigure**.
 
 MQTT subentries can also be reconfigured. Additional entities can be added, or an entity can be removed from the sub entry. Each MQTT subentry holds one MQTT device. The MQTT device must have at least one entity.
 
@@ -191,7 +191,7 @@ If you experience an error message like `Failed to connect due to exception: [SS
 
 ### Advanced broker configuration
 
-Advanced broker configuration options include setting a custom client ID, setting a client certificate and key for authentication, and enabling TLS validation of the broker's certificate for secure connection. To access the advanced settings, open the MQTT broker settings, switch on `Advanced options` and click `Next`. The advanced options will be shown by default if there are advanced settings active already.
+Advanced broker configuration options include setting a custom client ID, setting a client certificate and key for authentication, and enabling TLS validation of the broker's certificate for secure connection. To access the advanced settings, open the MQTT broker settings, switch on **Advanced options**, and select **Next**. The advanced options will be shown by default if there are advanced settings active already.
 
 {% tip %}
 Advanced broker options are accessible only when advanced mode is enabled (see user settings), or when advanced broker settings are configured already.
@@ -203,12 +203,12 @@ You can set a custom MQTT client ID, this can help when debugging. Mind that the
 
 #### Keep alive
 
-The time in seconds between sending keep alive messages for this client. The default is 60 seconds. The keep alive setting should be minimal 15 seconds.
+The time in seconds between sending keep alive messages for this client. The default is 60 seconds. The keep alive setting should be at least 15 seconds.
 
 #### Broker certificate validation
 
-To enable a secure connection to the broker, the broker certificate should be validated. If your broker uses a trusted certificate, then choose `Auto`. This will allow validation against certificate CAs bundled certificates. If a self-signed certificate is used, select `Custom`. A custom PEM- or DER-encoded CA certificate can be uploaded. Click `NEXT` to show the control to upload the CA certificate.
-If the server certificate does not match the hostname then validation will fail. To allow a connection without the verification of the hostname, turn the `Ignore broker certificate validation` switch on.
+To enable a secure connection to the broker, the broker certificate should be validated. If your broker uses a trusted certificate, then choose **Auto**. This will allow validation against certificate CAs bundled certificates. If a self-signed certificate is used, select **Custom**. A custom PEM- or DER-encoded CA certificate can be uploaded. Select **Next** to show the control to upload the CA certificate.
+If the server certificate does not match the hostname then validation will fail. To allow a connection without the verification of the hostname, turn the **Ignore broker certificate validation** switch on.
 
 #### MQTT Protocol
 
@@ -216,12 +216,12 @@ The MQTT protocol setting defaults to version `3.1.1`. If your MQTT broker suppo
 
 #### Securing the connection
 
-With a secure broker connection, it is possible to use a client certificate for authentication. To set the client certificate and private key turn on the option `Use a client certificate` and click "Next" to reveal file upload controls. A client certificate and the corresponding private key must be uploaded together. Both client certificate and private key must be either PEM- or DER-encoded. If the private key is encrypted with a password, ensure you supply the correct password when uploading the client certificate and key files.
+With a secure broker connection, it is possible to use a client certificate for authentication. To set the client certificate and private key, turn on the option **Use a client certificate** and select **Next** to reveal file upload controls. A client certificate and the corresponding private key must be uploaded together. Both client certificate and private key must be either PEM- or DER-encoded. If the private key is encrypted with a password, ensure you supply the correct password when uploading the client certificate and key files.
 
 #### Using WebSockets as transport
 
-You can select `websockets` as transport method if your MQTT broker supports it. When you select `websockets` and click `NEXT`, you will be able to add a WebSockets path (default = `/`) and WebSockets headers (optional). The target WebSockets URI: `ws://{broker}:{port}{WebSockets path}` is built with `broker`, `port` and `ws_path` (WebSocket path) settings.
-To configure the WebSocket's headers supply a valid JSON dictionary string. E.g. `{ "Authorization": "token" , "x-header": "some header"}`. The default transport method is `tcp`. The WebSockets transport can be secured using TLS and optionally using user credentials or a client certificate.
+You can select `websockets` as the transport method if your MQTT broker supports it. When you select `websockets` and select **Next**, you will be able to add a WebSockets path (default is `/`) and WebSockets headers (optional). The target WebSockets URI `ws://{broker}:{port}{WebSockets path}` is built with the `broker`, `port`, and `ws_path` (WebSocket path) settings.
+To configure the WebSocket's headers, supply a valid JSON dictionary string. For example, `{ "Authorization": "token" , "x-header": "some header"}`. The default transport method is `tcp`. The WebSockets transport can be secured using TLS and optionally using user credentials or a client certificate.
 
 {% note %}
 A configured client certificate will only be active if broker certificate validation is enabled.
@@ -251,7 +251,7 @@ See also [MQTT Discovery section](#mqtt-discovery)
 
 ### Birth and last will messages
 
-Home Assistant's MQTT integration supports so-called Birth and Last Will and Testament (LWT) messages. The former is used to send a message after the service has started, and the latter is used to notify other clients about a disconnected client. Please note that the LWT message will be sent both in case of a clean (e.g. Home Assistant shutting down) and in case of an unclean (e.g. Home Assistant crashing or losing its network connection) disconnect.
+Home Assistant's MQTT integration supports so-called Birth and Last Will and Testament (LWT) messages. The former is used to send a message after the service has started, and the latter is used to notify other clients about a disconnected client. Note that the LWT message will be sent both in case of a clean disconnect (for example, Home Assistant shutting down) and in case of an unclean disconnect (for example, Home Assistant crashing or losing its network connection).
 
 If a disabled entity is enabled and added after 30 seconds, the MQTT integration will be reloaded and will cause all discovered MQTT entities to be unloaded.
 When MQTT starts up, all existing MQTT devices, entities, tags, and device triggers, will be unavailable until a discovery message is received and processed. A device or service that exposes the MQTT discovery should subscribe to the Birth message and use this as a trigger to send the [discovery payload](#discovery-payload). To avoid high IO loads on the MQTT broker, adding some random delay in sending the discovery payload is recommended.
@@ -263,7 +263,7 @@ Alternative approaches:
 
 By default, Home Assistant sends `online` and `offline` to `homeassistant/status`.
 
-MQTT Birth and Last Will messages can be customized or disabled from the UI. To do this, click on "Configure" in the integration page in the UI, then "Re-configure MQTT" and then "Next".
+MQTT Birth and Last Will messages can be customized or disabled from the UI. To do this, select **Configure** on the integration page in the UI, then **Re-configure MQTT**, and then **Next**.
 
 ## Testing your setup
 
@@ -273,7 +273,7 @@ The `mosquitto` broker package ships command line tools (often as `*-clients` pa
 mosquitto_pub -h 127.0.0.1 -t homeassistant/switch/1/on -m "Switch is ON"
 ```
 
-Another way to send MQTT messages manually is to use the **MQTT** integration in the frontend. Choose "Settings" on the left menu, click "Devices & services", and choose "Configure" in the "Mosquitto broker" tile. Enter something similar to the example below into the "topic" field under "Publish a packet" and press "PUBLISH" .
+Another way to send MQTT messages manually is to use the **MQTT** integration in the frontend. Select **Settings** on the left menu, select **Devices & services**, and select **Configure** in the **Mosquitto broker** tile. Enter something similar to the example below into the **topic** field under **Publish a packet** and select **Publish**.
 
 1. Go to **{% my integrations title="Settings > Devices & services" %}**.
 2. Select the Mosquitto broker integration, then select **Configure**.
@@ -289,7 +289,7 @@ and in the Payload field
    ON
 ```
 
-In the "Listen to a topic" field, type `#` to see everything, or "homeassistant/switch/#" to just follow a published topic, then press "START LISTENING". The messages should appear similar to the text below:
+In the **Listen to a topic** field, type `#` to see everything, or `homeassistant/switch/#` to just follow a published topic, then select **Start listening**. The messages should appear similar to the text below:
 
 ```bash
 Message 23 received on homeassistant/switch/1/power/stat/POWER at 12:16 PM:
@@ -317,7 +317,7 @@ If, for example, we have configured a `sensor`, and we have set `default_entity_
 
 This means any MQTT entity which is part of a device will [automatically have its `friendly_name` attribute prefixed with the device name](https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations)
 
-Unnamed `binary_sensor`, `button`, `number` and `sensor` entities will now be named by their device class instead of being named "MQTT binary sensor" etc.
+Unnamed `binary_sensor`, `button`, `number`, and `sensor` entities will now be named by their device class instead of being named "MQTT binary sensor" and similar.
 It's allowed to set an MQTT entity's name to `None` (use `null` in YAML) to mark it as the main feature of a device.
 
 Note that on each MQTT entity, the `has_entity_name` attribute will be set to `True`. More details [can be found here](https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations).
@@ -360,7 +360,7 @@ The discovery topic needs to follow a specific format:
 ```
 
 - `<discovery_prefix>`: The Discovery Prefix defaults to `homeassistant` and this prefix can be [changed](#discovery-options).
-- `<component>`: One of the supported MQTT integrations, e.g., `binary_sensor`, or `device` in case of device discovery.
+- `<component>`: One of the supported MQTT integrations, for example, `binary_sensor`, or `device` in case of device discovery.
 - `<node_id>`: (*Optional*):  ID of the node providing the topic, this is not used by Home Assistant but may be used to structure the MQTT topic. The ID of the node must only consist of characters from the character class `[a-zA-Z0-9_-]` (alphanumerics, underscore and hyphen).
 - `<object_id>`: The ID of the device. This allows for separate topics for each device. The ID of the device must only consist of characters from the character class `[a-zA-Z0-9_-]` (alphanumerics, underscore and hyphen).
 
@@ -1020,7 +1020,7 @@ an MQTT entity, tag, or device automation will be set up directly after receivin
 When Home Assistant is restarting, discovered MQTT items with a unique ID will be unavailable until a new
 discovery message is received. MQTT items without a unique ID will not be added at startup.
 So a device or service using MQTT discovery must make sure a configuration message is offered
-after the **MQTT** integration has been (re)started. There are 2 common approaches to make sure the
+after the **MQTT** integration has been (re)started. There are two common approaches to make sure the
 discovered items are set up at startup:
 
 1. Using Birth and Will messages to trigger setup
@@ -1183,7 +1183,7 @@ Delete the sensor by sending an empty message.
 mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/binary_sensor/garden/config" -m ''
 ```
 
-For more details please refer to the [MQTT testing section](/integrations/mqtt/#testing-your-setup).
+For more details, refer to the [MQTT testing section](/integrations/mqtt/#testing-your-setup).
 
 #### Sensors
 
@@ -1251,7 +1251,7 @@ A common state payload that can be parsed with the `value_template` in the senso
 
 #### Entities with command topics
 
-Setting up a light, switch etc. is similar but requires a `command_topic` as mentioned in the [MQTT switch documentation](/integrations/switch.mqtt/).
+Setting up a light or switch is similar but requires a `command_topic` as mentioned in the [MQTT switch documentation](/integrations/switch.mqtt/).
 
 - Configuration topic: `homeassistant/switch/irrigation/config`
 - State topic: `homeassistant/switch/irrigation/state`
@@ -1499,7 +1499,7 @@ script:
       - action: mqtt.publish
         data:
           payload: "{{ message }}"
-          topic: home/"{{ target }}"
+          topic: "home/{{ target }}"
           retain: true
 ```
 
@@ -1525,7 +1525,7 @@ When `payload` is rendered from [template](/docs/templating/where-to-use/#mqtt) 
 
 ```yaml
 topic: homeassistant/light/1/command
-payload: on
+payload: "ON"
 ```
 
 ```yaml
@@ -1544,7 +1544,7 @@ it properly. Like:
 
 ```yaml
 topic: homeassistant/light/1/state
-payload: "{\"Status\":\"off\", \"Data\":\"something\"}"`
+payload: "{\"Status\":\"off\", \"Data\":\"something\"}"
 ```
 
 The example below shows how to publish a temperature sensor 'Bathroom Temperature'.
@@ -1559,7 +1559,7 @@ data:
   payload: >-
     {"device_class": "temperature",
     "unit_of_measurement": "\u00b0C",
-    "value_template": "{{ value|float }}",
+    "value_template": "{{ value | float }}",
     "state_topic": "rtl_433/rtl433/devices/Acurite-986/1R/51778/temperature_C",
     "unique_id": "Acurite-986-1R-51778-T",
     "device": {
@@ -1575,7 +1575,7 @@ Example of how to use `qos` and `retain`:
 
 ```yaml
 topic: homeassistant/light/1/command
-payload: on
+payload: "ON"
 qos: 2
 retain: true
 ```

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -207,7 +207,7 @@ The time in seconds between sending keep alive messages for this client. The def
 
 #### Broker certificate validation
 
-To enable a secure connection to the broker, the broker certificate should be validated. If your broker uses a trusted certificate, then choose **Auto**. This will allow validation against certificate CAs bundled certificates. If a self-signed certificate is used, select **Custom**. A custom PEM- or DER-encoded CA certificate can be uploaded. Select **Next** to show the control to upload the CA certificate.
+To enable a secure connection to the broker, the broker certificate should be validated. If your broker uses a trusted certificate, then choose **Auto**. This validates the broker certificate against the bundled certificate authority (CA) certificates. If a self-signed certificate is used, select **Custom**. A custom PEM- or DER-encoded CA certificate can be uploaded. Select **Next** to show the control to upload the CA certificate.
 If the server certificate does not match the hostname then validation will fail. To allow a connection without the verification of the hostname, turn the **Ignore broker certificate validation** switch on.
 
 #### MQTT Protocol
@@ -220,7 +220,7 @@ With a secure broker connection, it is possible to use a client certificate for 
 
 #### Using WebSockets as transport
 
-You can select `websockets` as the transport method if your MQTT broker supports it. When you select `websockets` and select **Next**, you will be able to add a WebSockets path (default is `/`) and WebSockets headers (optional). The target WebSockets URI `ws://{broker}:{port}{WebSockets path}` is built with the `broker`, `port`, and `ws_path` (WebSocket path) settings.
+You can select `websockets` as the transport method if your MQTT broker supports it. When you select `websockets` and select **Next**, you will be able to add a WebSockets path (default is `/`) and WebSockets headers (optional). The target WebSockets URI `ws://{broker}:{port}{ws_path}` is built with the `broker`, `port`, and `ws_path` (WebSocket path) settings.
 To configure the WebSocket's headers, supply a valid JSON dictionary string. For example, `{ "Authorization": "token" , "x-header": "some header"}`. The default transport method is `tcp`. The WebSockets transport can be secured using TLS and optionally using user credentials or a client certificate.
 
 {% note %}


### PR DESCRIPTION
## Proposed change

Full-page grammar and style pass on the MQTT integration page, including YAML example cleanup per the [YAML style guide](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/). In-place fixes only. No section reordering.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
