### PR TITLE
Proofread and style cleanup for the Template integration page

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -203,7 +203,7 @@ template:
     type: template
     default: true
   default_entity_id:
-    description: Use `default_entity_id` instead of name for automatic generation of the entity id. E.g. `sensor.my_awesome_sensor`. When used without a `unique_id`, the entity id updates during restart or reload if the entity id is available.  If the entity id already exists, the entity id is created with a number at the end. When used with a `unique_id`, the `default_entity_id` is only used when the entity is added for the first time.
+    description: Use `default_entity_id` instead of name for automatic generation of the entity id. For example, `sensor.my_awesome_sensor`. When used without a `unique_id`, the entity id updates during restart or reload if the entity id is available. If the entity id already exists, the entity id is created with a number at the end. When used with a `unique_id`, the `default_entity_id` is only used when the entity is added for the first time.
     required: false
     type: string
   icon:
@@ -377,7 +377,7 @@ binary_sensor:
       required: false
       type: time
     delay_on:
-      description: The amount of time (e.g. `0:00:05`) the template state must be ***met*** before this sensor switches to `on`. This can also be a template.
+      description: The amount of time (for example, `0:00:05`) the template state must be ***met*** before this sensor switches to `on`. This can also be a template.
       required: false
       type: time
     device_class:
@@ -386,7 +386,7 @@ binary_sensor:
       type: device_class
       default: None
     state:
-      description: The sensor is `on` if the template evaluates as `True`, `yes`, `on`, `enable` or a positive number. The sensor is `unknown` if the template evaluates as `None`. Any other value renders it as `off`. The actual appearance in the frontend (`Open`/`Closed`, `Detected`/`Clear` etc) depends on the sensor's device_class value
+      description: The sensor is `on` if the template evaluates as `True`, `yes`, `on`, `enable`, or a positive number. The sensor is `unknown` if the template evaluates as `None`. Any other value renders it as `off`. The actual appearance in the frontend (such as `Open`/`Closed` or `Detected`/`Clear`) depends on the sensor's device_class value.
       required: true
       type: template
 
@@ -406,7 +406,7 @@ template:
         delay_off:
           minutes: 5
         state: >
-          {{ states('sensor.washing_machine_power')|float > 0 }}
+          {{ states('sensor.washing_machine_power') | float > 0 }}
 ```
 
 ### State based binary sensor - Is Anyone Home
@@ -430,7 +430,7 @@ template:
 
 ### State based binary sensor - device tracker sensor with latitude and longitude attributes
 
-This example shows how to combine a non-GPS (e.g., NMAP) and GPS device tracker while still including latitude and longitude attributes
+This example shows how to combine a non-GPS (for example, NMAP) and GPS device tracker while still including latitude and longitude attributes
 
 ```yaml
 # Example configuration.yaml entry
@@ -537,7 +537,7 @@ The template cover platform allows you to create covers with templates to define
 template:
   - cover:
       - name: Garage Door
-        state: "{{ states('sensor.garage_door')|float > 0 }}"
+        state: "{{ states('sensor.garage_door') | float > 0 }}"
         device_class: garage
         open_cover:
           action: script.open_garage_door
@@ -555,7 +555,7 @@ template:
         entity_id: sensor.garage_door
     cover:
       - name: Garage Door
-        state: "{{ trigger.to_state.state|float(0) > 0 }}"
+        state: "{{ trigger.to_state.state | float(0) > 0 }}"
         device_class: garage
         open_cover:
           action: script.open_garage_door
@@ -666,7 +666,7 @@ template:
           target:
             entity_id: switch.garage_door
         icon: >-
-          {% if states('sensor.garage_door')|float > 0 %}
+          {% if states('sensor.garage_door') | float > 0 %}
             mdi:garage-open
           {% else %}
             mdi:garage
@@ -1060,8 +1060,8 @@ Light entities can be created from the frontend in the Helpers section or via YA
 template:
   - light:
       - name: "Theater Lights"
-        level: "{{ state_attr('sensor.theater_brightness', 'lux')|int }}"
-        state: "{{ state_attr('sensor.theater_brightness', 'lux')|int > 0 }}"
+        level: "{{ state_attr('sensor.theater_brightness', 'lux') | int }}"
+        state: "{{ state_attr('sensor.theater_brightness', 'lux') | int > 0 }}"
         temperature: "{{states('input_number.temperature_input') | int}}"
         hs: "({{states('input_number.h_input') | int}}, {{states('input_number.s_input') | int}})"
         effect_list: "{{ state_attr('light.led_strip', 'effect_list') }}"
@@ -1117,8 +1117,8 @@ template:
         - light.led_strip
     light:
       - name: "Theater Lights"
-        level: "{{ state_attr('sensor.theater_brightness', 'lux')|int }}"
-        state: "{{ state_attr('sensor.theater_brightness', 'lux')|int > 0 }}"
+        level: "{{ state_attr('sensor.theater_brightness', 'lux') | int }}"
+        state: "{{ state_attr('sensor.theater_brightness', 'lux') | int > 0 }}"
         temperature: "{{states('input_number.temperature_input') | int}}"
         hs: "({{states('input_number.h_input') | int}}, {{states('input_number.s_input') | int}})"
         effect_list: "{{ state_attr('light.led_strip', 'effect_list') }}"
@@ -1163,7 +1163,7 @@ template:
 
 ### Wrapping WLED presets as light effects
 
-This example creates a template light that wraps an RGBW WLED device and exposes its saved presets — predefined combinations of effects, colors, and brightness stored on the device — as selectable effects directly in the light entity. This is useful if you prefer to pick presets from the effects list in a light card on your dashboard, without having to use a separate select entity.
+This example creates a template light that wraps an RGBW WLED device and exposes its saved presets (predefined combinations of effects, colors, and brightness stored on the device) as selectable effects directly in the light entity. This is useful if you prefer to pick presets from the effects list in a light card on your dashboard, without having to use a separate select entity.
 
 The template light mirrors the state, brightness, and RGBW color of the underlying WLED light entity. Selecting an effect sends the matching preset name to the WLED preset select entity.
 
@@ -1361,10 +1361,10 @@ template:
           target:
             entity_id: media_player.receiver
           data:
-            volume_level: "{{ (brightness / 255 * 100)|int / 100 }}"
+            volume_level: "{{ (brightness / 255 * 100) | int / 100 }}"
         level: >-
           {% if is_state('media_player.receiver', 'on') %}
-            {{ (state_attr('media_player.receiver', 'volume_level')|float * 255)|int }}
+            {{ (state_attr('media_player.receiver', 'volume_level') | float * 255) | int }}
           {% else %}
             0
           {% endif %}
@@ -1380,12 +1380,12 @@ template:
         unique_id: 28208f257b54c44e50deb2d618d44710
         name: Multi-segment Wled control
         state: "{{ states('light.wled_master') }}"
-        level: "{{ state_attr('light.wled_master', 'brightness')|d(0,true)|int }}"
+        level: "{{ state_attr('light.wled_master', 'brightness') | d(0,true) | int }}"
         rgbw: (
-          {{ (state_attr('light.wled_segment_0', 'rgbw_color')[0]|d(0) + state_attr('light.wled_segment_1', 'rgbw_color')[0]|d(0))/2 }},
-          {{ (state_attr('light.wled_segment_0', 'rgbw_color')[1]|d(0) + state_attr('light.wled_segment_1', 'rgbw_color')[1]|d(0))/2 }},
-          {{ (state_attr('light.wled_segment_0', 'rgbw_color')[2]|d(0) + state_attr('light.wled_segment_1', 'rgbw_color')[2]|d(0))/2 }},
-          {{ (state_attr('light.wled_segment_0', 'rgbw_color')[3]|d(0) + state_attr('light.wled_segment_1', 'rgbw_color')[3]|d(0))/2 }}
+          {{ (state_attr('light.wled_segment_0', 'rgbw_color')[0] | d(0) + state_attr('light.wled_segment_1', 'rgbw_color')[0] | d(0))/2 }},
+          {{ (state_attr('light.wled_segment_0', 'rgbw_color')[1] | d(0) + state_attr('light.wled_segment_1', 'rgbw_color')[1] | d(0))/2 }},
+          {{ (state_attr('light.wled_segment_0', 'rgbw_color')[2] | d(0) + state_attr('light.wled_segment_1', 'rgbw_color')[2] | d(0))/2 }},
+          {{ (state_attr('light.wled_segment_0', 'rgbw_color')[3] | d(0) + state_attr('light.wled_segment_1', 'rgbw_color')[3] | d(0))/2 }}
           )
         effect_list: "{{ state_attr('light.wled_segment_0', 'effect_list') }}"
         effect: "{{ state_attr('light.wled_segment_0', 'effect') if state_attr('light.wled_segment_0', 'effect') == state_attr('light.wled_segment_1', 'effect') else none }}"
@@ -1570,7 +1570,7 @@ template:
         unlock:
           - variables:
               pin: !secret garage_door_pin
-          - condition: "{{ code|int == pin|int }}"
+          - condition: "{{ code | int == pin | int }}"
           - action: switch.turn_off
             target:
               entity_id: switch.source
@@ -1678,7 +1678,7 @@ template:
       - name: "Cutting Height"
         unit_of_measurement: "cm"
         unique_id: automower_cutting_height
-        state: "{{ states('number.automower_cutting_height_raw')|int(0) * 0.5 + 1.5 }}"
+        state: "{{ states('number.automower_cutting_height_raw') | int(0) * 0.5 + 1.5 }}"
         set_value:
           - action: number.set_value
             target:
@@ -1786,7 +1786,7 @@ template:
         state: >
           {% if is_state('switch.kettle', 'off') %}
             off
-          {% elif state_attr('switch.kettle', 'W')|float < 1000 %}
+          {% elif state_attr('switch.kettle', 'W') | float < 1000 %}
             standby
           {% elif is_state('switch.kettle', 'on') %}
             on
@@ -1832,7 +1832,7 @@ sensor:
       type: template
       default: None
     state:
-      description: "Defines a template to get the state of the sensor. If the sensor is numeric, i.e. it has a `state_class` or a `unit_of_measurement`, the state template must render to a number or to `none`. The state template must not render to a string, including `unknown` or `unavailable`. An `availability` template may be defined to suppress rendering of the state template."
+      description: "Defines a template to get the state of the sensor. If the sensor is numeric, that is, it has a `state_class` or a `unit_of_measurement`, the state template must render to a number or to `none`. The state template must not render to a string, including `unknown` or `unavailable`. An `availability` template may be defined to suppress rendering of the state template."
       required: true
       type: template
     state_class:
@@ -1857,7 +1857,7 @@ template:
   - sensor:
       - name: Sun Angle
         unit_of_measurement: "°"
-        state: "{{ '%+.1f'|format(state_attr('sun.sun', 'elevation')) }}"
+        state: "{{ '%+.1f' | format(state_attr('sun.sun', 'elevation')) }}"
 ```
 
 ### State based sensor - Modifying another sensor's output
@@ -1887,12 +1887,12 @@ template:
   - sensor:
       - name: "Transmission Down Speed"
         unit_of_measurement: "kB/s"
-        state: "{{ states('sensor.transmission_down_speed')|float * 1024 }}"
+        state: "{{ states('sensor.transmission_down_speed') | float * 1024 }}"
         availability: "{{ is_number(states('sensor.transmission_down_speed')) }}"
 
       - name: "Transmission Up Speed"
         unit_of_measurement: "kB/s"
-        state: "{{ states('sensor.transmission_up_speed')|float * 1024 }}"
+        state: "{{ states('sensor.transmission_up_speed') | float * 1024 }}"
         availability: "{{ is_number(states('sensor.transmission_up_speed')) }}"
 ```
 
@@ -2280,7 +2280,7 @@ vacuum:
     vacuums:
       living_room_vacuum:
         value_template: "{{ states('sensor.vacuum_state') }}"
-        battery_level_template: "{{ states('sensor.vacuum_battery_level')|int }}"
+        battery_level_template: "{{ states('sensor.vacuum_battery_level') | int }}"
         fan_speed_template: "{{ states('sensor.vacuum_fan_speed') }}"
         attribute_templates:
           status: >-


### PR DESCRIPTION
## Proposed change

Full-page grammar and style pass on the Template integration page, including filter-pipe spacing fixes in template examples per the [YAML style guide](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/). In-place fixes only. No section reordering.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
