### PR TITLE
Proofread and style cleanup for the Default Config integration page

### DIFF
--- a/source/_integrations/default_config.markdown
+++ b/source/_integrations/default_config.markdown
@@ -1,6 +1,6 @@
 ---
 title: Default Config
-description: The default configuration integration will initiate a default configuration for Home Assistant.
+description: The default configuration integration sets up a default set of integrations for Home Assistant.
 ha_category:
   - Other
 ha_release: 0.88
@@ -11,7 +11,7 @@ ha_codeowners:
 ha_integration_type: system
 ---
 
-This {% term integration %} is a meta-component and configures a default set of integrations for Home Assistant to load. The integrations that will be loaded are:
+This {% term integration %} is a meta integration that configures a default set of integrations for Home Assistant to load. The following integrations are loaded:
 
 - [Assist pipeline](/integrations/assist_pipeline/) (`assist_pipeline`)
 - [Backup](/integrations/backup/) (`backup`)
@@ -23,7 +23,7 @@ This {% term integration %} is a meta-component and configures a default set of 
 - [File](/integrations/file/) (`file`)
 - [Go2rtc](/integrations/go2rtc/) (`go2rtc`)
 - [History](/integrations/history/) (`history`)
-- [Home Assistant Alerts](/integrations/homeassistant_alerts) (`homeassistant_alerts`)
+- [Home Assistant Alerts](/integrations/homeassistant_alerts/) (`homeassistant_alerts`)
 - [Home Assistant Cloud](/integrations/cloud/) (`cloud`)
 - [Image upload](/integrations/image_upload/) (`image_upload`)
 - [Activity](/integrations/logbook/) (`logbook`)
@@ -35,7 +35,7 @@ This {% term integration %} is a meta-component and configures a default set of 
 - [Sun](/integrations/sun/) (`sun`)
 - [Usage Prediction](/integrations/usage_prediction/) (`usage_prediction`)
 - [USB](/integrations/usb/) (`usb`)
-- [Webhooks](/integrations/webhook) (`webhook`)
+- [Webhooks](/integrations/webhook/) (`webhook`)
 - [Zero-configuration networking (zeroconf)](/integrations/zeroconf/) (`zeroconf`)
 
 ## Configuration


### PR DESCRIPTION
## Proposed change

Full-page grammar and style pass on the Default Config integration page. Also fixes two `/integrations/` links that were missing trailing slashes, inconsistent with the rest of the list. In-place fixes only. No section reordering.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
