### PR TITLE
Proofread and style cleanup for the Google Translate TTS integration …

### DIFF
--- a/source/_integrations/google_translate.markdown
+++ b/source/_integrations/google_translate.markdown
@@ -1,6 +1,6 @@
 ---
 title: Google Translate text-to-speech
-description: Instructions on how to setup Google Translate text-to-speech with Home Assistant.
+description: Instructions on how to set up Google Translate text-to-speech with Home Assistant.
 ha_category:
   - Text-to-speech
 ha_release: 0.35
@@ -12,14 +12,13 @@ ha_config_flow: true
 ha_integration_type: service
 ---
 
-The **Google Translate text-to-speech** {% term integration %} uses the unofficial [Google Translate text-to-speech engine](https://translate.google.com/) to read a text with natural sounding voices. Contrary to what the name suggests, the integration only does text-to-speech and does not translate messages sent to it.
+The **Google Translate text-to-speech** {% term integration %} uses the unofficial [Google Translate text-to-speech engine](https://translate.google.com/) to read text with natural-sounding voices. Despite the name, the integration only does text-to-speech and does not translate the messages you send to it.
 
 {% include integrations/config_flow.md %}
 
-<details>
-<summary><b>Supported Languages </b></summary>
-  
-All languages where the "Talk" feature is enabled in Google Translate are supported. The following is the current list of languages supported by Google. 
+{% details "Supported languages" %}
+
+All languages where the "Talk" feature is enabled in Google Translate are supported. The current list of supported languages is:
   
 | Language Code | Language                      |
 | ------------- | ----------------------------- |
@@ -88,12 +87,11 @@ All languages where the "Talk" feature is enabled in Google Translate are suppor
 | ur            | Urdu                          |
 | vi            | Vietnamese                    |
 
+{% enddetails %}
 
-</details>
+Check the [complete list of supported TLDs](https://www.google.com/supported_domains) for allowed TLD values. This is used to force the dialect when multiple dialects fall into the same 2-digit language code (for example, _US_, _UK_, or _AU_).
 
-Check the [complete list of supported tld](https://www.google.com/supported_domains) for allowed TLD values. This is used to force the dialect used when multiple fall into the same 2-digit language code(i.e., _US, UK, AU_)
-
-You can also use supported BCP 47 tags like the below or the 2-2 digit format for your supported dialect(`en-gb` or `en-us`). Below is a list of the currently implemented mappings:
+You can also use supported BCP 47 tags or the 2-2 digit format for your supported dialect (`en-gb` or `en-us`). The currently implemented mappings are:
 
 | Dialect | Language | TLD    |
 | ------- | -------- | ------ |
@@ -113,29 +111,30 @@ You can also use supported BCP 47 tags like the below or the 2-2 digit format fo
 | es-us   | es       | com    |
 
 
-## Action speak
+## Action: Speak
 
-The `tts.speak` action is the modern way to use Google translate TTS action. Add the `speak` action, select the entity for your Google translate TTS (it's named for the language you created it with), select the media player entity or group to send the TTS audio to, and enter the message to speak.
+The `tts.speak` action is the modern way to use Google Translate text-to-speech. Add the `speak` action, select the entity for your Google Translate text-to-speech (it is named for the language you created it with), select the media player entity or group to send the TTS audio to, and enter the message to speak.
 
 For more options about `speak`, see the Speak section on the main [TTS](/integrations/tts/#action-speak) building block page.
 
 In YAML, your action will look like this:
+
 ```yaml
 action: tts.speak
 target:
   entity_id: tts.google_en_com
 data:
   media_player_entity_id: media_player.giant_tv
-  message: Hello, can you hear me now?
+  message: "Hello, can you hear me now?"
 ```
 
-## Action say (legacy)
+## Action: Say (legacy)
 
 {% tip %}
-The `google_translate_say` action can be used when configuring the legacy `google_translate` text-to-speech platform in `configuration.yaml`. We recommend new users to instead set up the integration in the UI and use the `tts.speak` action with the corresponding Google Translate text-to-speech entity as target.
+The `google_translate_say` action can be used when configuring the legacy `google_translate` text-to-speech platform in `configuration.yaml`. We recommend that new users instead set up the integration in the UI and use the `tts.speak` action with the corresponding Google Translate text-to-speech entity as the target.
 {% endtip %}
 
-The `google_translate_say` action supports `language` and also `options` for setting `tld`. The text for speech is set with `message`. Since release 0.92, the action name can be defined in the configuration `service_name` option.
+The `google_translate_say` action supports `language` and also `options` for setting `tld`. You set the text to speak with the `message` option. The action name can be customized with the `service_name` configuration option.
 
 Say to all `media_player` device entities:
 


### PR DESCRIPTION
## Proposed change

Full-page grammar and style pass on the Google Translate text-to-speech integration page. Converts the HTML `<details>` block to the Liquid `{% details %}` variant per style guide, fixes a YAML string that should have been quoted, and aligns action headings with the integration page template. In-place fixes only. No section reordering.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
