### PR TITLE
Proofread and style cleanup for the Backup integration page

### DIFF
--- a/source/_integrations/backup.markdown
+++ b/source/_integrations/backup.markdown
@@ -1,6 +1,6 @@
 ---
 title: Backup
-description: Allow creating backups of container and core installations.
+description: Create and restore backups of your Home Assistant installation.
 ha_category:
   - Event
   - Other
@@ -24,19 +24,18 @@ related:
   - docs: /getting-started/onboarding/
     title: Recover from backup during onboarding
   - docs: /more-info/backup-emergency-kit/
-    title: backup emergency kit
+    title: Backup emergency kit
 ---
 
-The **Backup** {% term integration %} is used by all [installation types](/installation/#about-installation-methods) to create and restore backups.
+The **Backup** {% term integration %} creates and restores backups across all [installation types](/installation/#about-installation-methods).
 
 To learn how to create and restore a backup, refer to the backup section under [common tasks](/common-tasks/general/#backups).
 
 ## Actions
 
-The **Backup** integration exposes actions that can be used to automate the backup
-process.
+The **Backup** integration exposes actions you can use to automate the backup process.
 
-However, it is no longer needed to create your own automation. Follow these steps to [set up an automatic backup from the UI](/common-tasks/general/#setting-up-an-automatic-backup-process).
+However, you no longer need to create your own automation. You can [set up an automatic backup from the UI](/common-tasks/general/#setting-up-an-automatic-backup-process) instead.
 
 ### Action: Create automatic
 
@@ -44,8 +43,7 @@ The `backup.create_automatic` action allows you to create a backup of your Home 
 
 The automation editor does not show a UI editor because the action uses the same settings you defined under {% my backup title="**Settings** > **System** > **Backups**" %}, under **Backup settings**. For a more detailed description, refer to the documentation on [automatic backups](/common-tasks/general/#setting-up-an-automatic-backup-process).
 
-This action can be called to create backups with pre-defined settings at a more flexible
-schedule than the schedule which can be configured for automatic backups.
+Use this action to create backups with predefined settings on a more flexible schedule than the built-in automatic backup schedule.
 
 The action has no additional options or parameters.
 
@@ -61,9 +59,9 @@ The `backup.create` action allows you to create a backup of your Home Assistant 
 
 - This action is only available in [core and container installations](/installation/#about-installation-methods).
 - The action has no additional options or parameters.
-- The backup will only be saved on the local storage.
+- The backup is only saved to local storage.
 - The backup created with `backup.create` always includes the database.
-- The backup will be created without a password.
+- The backup is created without a password.
 
 Example action:
 
@@ -73,9 +71,7 @@ action: backup.create
 
 ### Example: Backing up every night at 3:00 AM
 
-This is a YAML example for an automation that initiate a backup every night
-at 3 AM:
-
+Here's a YAML example of an automation that creates a backup every night at 3 AM:
 
 ```yaml
 automation:
@@ -88,28 +84,26 @@ automation:
         action: backup.create
 ```
 
-
 ## Restoring a backup
 
 To restore a backup, follow the steps described in [Restoring a backup](/common-tasks/general/#restoring-a-backup).
 
 ## Event entity
 
-The **Backup** {% term integration %} provides an {% term "Event entity" %} which represents the state of the last automatic backup (_completed, in progress, failed_). It also provides several event attributes which can be used in automations.
+The **Backup** {% term integration %} provides an {% term "Event entity" %} that represents the state of the last automatic backup (_completed_, _in progress_, or _failed_). It also provides several event attributes you can use in automations.
 
 | Attribute | Description |
 | --- | --- |
-| `event_type` | The translated state of the last automatic backup task (_possible states: completed, in progress, failed_)
-| `backup_stage` | The current automatic backup stage (_is `None` when `event_type` is not in progress_) |
-| `failed_reason` | The reason for a failed automatic backup (_is `None` when `event_type` is completed or in progress_) |
+| `event_type` | The translated state of the last automatic backup task (_possible states: completed, in progress, failed_). |
+| `backup_stage` | The current automatic backup stage (_is `None` when `event_type` is not in progress_). |
+| `failed_reason` | The reason for a failed automatic backup (_is `None` when `event_type` is completed or in progress_). |
 
 ### Usage examples
 
-Send notification to mobile app, when an automatic backup failed.
-
+Send a notification to the mobile app when an automatic backup fails:
 
 ```yaml
-alias: Backup failed
+alias: "Backup failed"
 triggers:
   - trigger: state
     entity_id:
@@ -120,11 +114,10 @@ conditions:
     attribute: event_type
     state: failed
 actions:
-  - data:
-      title: Automatic backup failed
-      message: The last automatic backup failed due to {{ state_attr('event.backup_automatic_backup', 'failed_reason') }}
-    action: notify.mobile-app
-mode: single
+  - action: notify.mobile-app
+    data:
+      title: "Automatic backup failed"
+      message: "The last automatic backup failed due to {{ state_attr('event.backup_automatic_backup', 'failed_reason') }}"
 ```
 
 
@@ -132,7 +125,7 @@ mode: single
 
 The **Backup** {% term integration %} provides several sensors.
 
-### Backup Manager State
+### Backup manager state
 
 The current state of the backup system. Possible states are:
 

--- a/source/_integrations/backup.markdown
+++ b/source/_integrations/backup.markdown
@@ -114,10 +114,12 @@ conditions:
     attribute: event_type
     state: failed
 actions:
-  - action: notify.mobile-app
+  - action: notify.mobile_app_your_phone
     data:
       title: "Automatic backup failed"
-      message: "The last automatic backup failed due to {{ state_attr('event.backup_automatic_backup', 'failed_reason') }}"
+      message: >-
+        The last automatic backup failed due to
+        {{ state_attr('event.backup_automatic_backup', 'failed_reason') }}
 ```
 
 


### PR DESCRIPTION
## Proposed change

Full-page grammar and style pass on the Backup integration page, including YAML example cleanup per the [YAML style guide](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/). Also fixes a broken markdown table row that was missing its trailing pipe. In-place fixes only. No section reordering.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
