### PR TITLE
Expand the Met.no integration page following the integration template

### DIFF
--- a/source/_integrations/met.markdown
+++ b/source/_integrations/met.markdown
@@ -1,6 +1,6 @@
 ---
 title: Meteorologisk institutt (Met.no)
-description: Instructions on how to integrate Met.no within Home Assistant.
+description: Instructions on how to integrate Met.no with Home Assistant.
 ha_category:
   - Weather
 ha_release: 0.79
@@ -13,8 +13,59 @@ ha_platforms:
   - diagnostics
   - weather
 ha_integration_type: service
+related:
+  - docs: /integrations/weather/
+    title: Weather entity
+  - url: https://api.met.no/doc/TermsOfService
+    title: Met.no terms of service
 ---
 
-The **Meteorologisk institutt (Met.no)** {% term integration %} uses the [Met.no](https://met.no/) web service as a source for meteorological data for your location. The weather forecast is delivered by the Norwegian Meteorological Institute and the NRK.
+The **Meteorologisk institutt (Met.no)** {% term integration %} uses the [Met.no](https://met.no/) web service to retrieve meteorological data for your location. The Norwegian Meteorological Institute and NRK provide the weather forecast. The service is free and does not require an API key.
 
 {% include integrations/config_flow.md %}
+
+By default, the integration uses your Home Assistant [home location](/docs/configuration/basic/). To retrieve weather data for additional locations, add the integration multiple times and specify different coordinates for each instance.
+
+## Configuration options
+
+{% configuration_basic %}
+Name:
+  description: "A name for this weather location. It is shown in the UI and used to form the entity ID."
+Latitude:
+  description: "The latitude of the location for which to retrieve weather data."
+Longitude:
+  description: "The longitude of the location for which to retrieve weather data."
+Elevation:
+  description: "The elevation (in meters) of the location. This affects the accuracy of the temperature forecast, especially in mountainous areas."
+{% endconfiguration_basic %}
+
+## Supported functionality
+
+The integration creates one `weather` entity per configured location. Each entity provides the current weather, a daily forecast, and an hourly forecast.
+
+The entity exposes the following current-weather attributes:
+
+- Temperature and dew point
+- Humidity and pressure
+- Visibility
+- Wind speed, wind gust, and wind bearing
+- Cloud coverage
+- UV index
+
+Forecasts additionally include precipitation and precipitation probability.
+
+## Data updates
+
+The integration {% term polling polls %} weather data every 55 to 65 minutes. The polling interval is randomized to spread load across the Met.no API.
+
+When you update your Home Assistant home location, the integration automatically refreshes the weather data for instances tracking the home location.
+
+## Known limitations
+
+The integration uses the free Met.no public API. Usage is subject to the [Met.no terms of service](https://api.met.no/doc/TermsOfService), which include fair-use policies and attribution requirements.
+
+## Removing the integration
+
+This integration follows standard integration removal.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Expand the Met.no integration page following the integration page template in `CLAUDE.md` / `copilot-instructions.md`. Adds Configuration options, Supported functionality, Data updates, Known limitations, and Removing the integration sections. All facts are sourced directly from `homeassistant/components/met/` in core.

Also fixes a minor `within Home Assistant` → `with Home Assistant` issue in the front matter description and improves the intro prose.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
