### PR TITLE
Clarify Pi-hole v6 vs v5 credentials and fix typos

### DIFF
--- a/source/_integrations/pi_hole.markdown
+++ b/source/_integrations/pi_hole.markdown
@@ -42,9 +42,11 @@ The combined host, port, and location should take you to the login page of Pi-ho
 
 ### Pi-hole v6 and later
 
-For Pi-hole v6 (released in February 2025) and later, the integration authenticates with an _app password_. To create one, sign in to your Pi-hole and go to **Settings** > **Web Interface/API**. Switch from **Basic** to **Expert** mode, then select **Configure app password**.
 
-You can also use your Pi-hole admin login password, but creating a dedicated app password is recommended.
+For Pi-hole v6 and later, the integration uses an app password. To find it, log into your Pi-hole and go to **Settings** > **Web Interface/API**. Switch from **Basic** to **Expert** mode, then select **Configure app password**. Your admin login password may be used instead, but this is not recommended. 
+
+For Pi-hole v5 and earlier, see below.
+
 
 ### Pi-hole v5 and earlier
 

--- a/source/_integrations/pi_hole.markdown
+++ b/source/_integrations/pi_hole.markdown
@@ -30,19 +30,25 @@ During the setup, it will ask for the following:
 
 | Item | Description | Example |
 | ---- | ----------- | ------- |
-| `Host` | The IP or domain name to Pi-Hole. | 192.168.1.1 |
+| `Host` | The IP or domain name of your Pi-hole. | 192.168.1.1 |
 | `Port` | Port used to get to the admin page, typically `80` for `http` connections and `443` for `https` connections. | 80 |
-| `Name` | Name to for this Pi-Hole. | Pi-Hole |
-| `Location` | the path to the admin page. In the version 6 API this will be ignored. | /admin |
-| `API Key or App Password` | This can be found in your Pi-hole's **Settings** > **API (expert mode)**. | `585a2fe...` |
-| `Uses an SSL certificate` | Whether your Pi-hole has an Certificate, typically true for `https` connections and false for `http`. | {% icon "openmoji:check-mark" %} |
-| `Verify SSL certificate` | Whether to use verify your Pi-hole's certificate, ignored in Pi-hole API version 5. | {% icon "openmoji:check-mark" %} |
+| `Name` | Name for this Pi-hole. | Pi-hole |
+| `Location` | The path to the admin page. This is ignored for the Pi-hole version 6 API. | /admin |
+| `App password or API key` | The credential used to authenticate with Pi-hole. See below for details on where to find it for Pi-hole v6 and for older versions. | `585a2fe...` |
+| `Uses an SSL certificate` | Whether your Pi-hole uses a certificate, typically true for `https` connections and false for `http`. | {% icon "openmoji:check-mark" %} |
+| `Verify SSL certificate` | Whether to verify your Pi-hole's certificate. Ignored in Pi-hole API version 5. | {% icon "openmoji:check-mark" %} |
 
-The combined host, port and location should take you to the login page of Pi-Hole. Using the example above, it would be `http://192.168.1.1:80/admin`.
+The combined host, port, and location should take you to the login page of Pi-hole. Using the example above, it would be `http://192.168.1.1:80/admin`.
 
-To find your App Password, log into your Pi-Hole and go to **Settings** > **Web Interface/API**. Switch from **Basic** to **Expert** mode, then select **Configure app password**.  Your admin login password may be used instead but this is not recommended.
+### Pi-hole v6 and later
 
-Versions of Pi-hole before version 6 (released in Feb 2025) use an API Key if the Pi-hole was password protected, this can be found in _Settings > API Tab_ and clicking **Show API token**.
+For Pi-hole v6 (released in February 2025) and later, the integration authenticates with an _app password_. To create one, sign in to your Pi-hole and go to **Settings** > **Web Interface/API**. Switch from **Basic** to **Expert** mode, then select **Configure app password**.
+
+You can also use your Pi-hole admin login password, but creating a dedicated app password is recommended.
+
+### Pi-hole v5 and earlier
+
+For Pi-hole versions before v6, the integration uses an _API token_ if the Pi-hole was password-protected. To find it, go to **Settings** > **API** and select **Show API token**.
 
 ## Actions
 
@@ -60,17 +66,18 @@ The `pi_hole.disable` action disables configured Pi-hole(s) for the specified am
 Example action:
 
 ```yaml
-# Example action to disable Pi-Hole for 30 minutes
+# Example action to disable Pi-hole for 30 minutes
 action: pi_hole.disable
 data:
-  duration: '00:30'
+  duration: "00:30"
 target:
   entity_id: all
 ```
+
 ## Switches
 
 The integration creates a switch for the Pi-hole allowing you to toggle ad-blocking on and off.
 
 ## Sensors
 
-The integration creates a number of sensors which report various ad-blocking metrics as well as diagnostic information about the pi-hole itself.
+The integration creates a number of sensors that report various ad-blocking metrics as well as diagnostic information about the Pi-hole itself.


### PR DESCRIPTION
## Proposed change

Addresses home-assistant/home-assistant.io#43638: the credentials field is unclear for Pi-hole v6 users. Split the explanation into two subsections (v6 and later, v5 and earlier) and updated the setup table to match the actual UI label (`App password or API key`, in that order per `strings.json` in core).

Also fixed a batch of typos and brand inconsistencies spotted during the read-through: `Pi-Hole`/`pi-hole` → `Pi-hole`, `Name to for` → `Name for`, `has an Certificate` → `uses a certificate`, `Whether to use verify` → `Whether to verify`, italic breadcrumb → bold, forbidden `clicking` verb → `selecting`, single-quoted YAML string → double-quoted, and a missing Oxford comma.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/home-assistant.io#43638

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
