### PR TITLE
Document mutesync discontinuation and proofread

### DIFF
--- a/source/_integrations/mutesync.markdown
+++ b/source/_integrations/mutesync.markdown
@@ -1,6 +1,6 @@
 ---
 title: mutesync
-description: Instructions on how to integrate Mutesync button with Home Assistant.
+description: Instructions on how to integrate the mütesync button with Home Assistant.
 ha_category:
   - Presence detection
 ha_release: 2021.5
@@ -14,16 +14,22 @@ ha_platforms:
 ha_integration_type: service
 ---
 
-The **mutesync** {% term integration %} for Home Assistant connects to the [mütesync virtual button](https://mutesync.com/). This tray app pairs with popular video conferencing tools such as Zoom, Google Meet, Discord, and Teams.
+{% important %}
 
-With this integration, Home Assistant can track when you're in a meeting and whether your mic is muted/unmuted.
+The **mutesync** desktop app that this integration depends on was [discontinued on 16 November 2024](https://mutesync.com/download). mütesync has since been acquired by MuteMe, and MuteSync devices are now supported through the MuteMe software, which does not expose a compatible API.
+
+Because of this, new setups of this integration are no longer possible. Existing installations that rely on the mütesync desktop app may continue to work for a while, but will stop working once you migrate to the MuteMe software.
+
+{% endimportant %}
+
+The **mutesync** {% term integration %} for Home Assistant connects to the [mütesync virtual button](https://mutesync.com/). The mütesync tray app pairs with popular video conferencing tools such as Zoom, Google Meet, Discord, and Teams.
+
+With this integration, Home Assistant can track when you're in a meeting and whether your microphone is muted.
 
 There is currently support for the following platforms within Home Assistant:
 
-- Binary sensor - mic muted/unmuted and meeting live/not-live
+- Binary sensor: microphone muted/unmuted and meeting live/not-live
 
 {% include integrations/config_flow.md %}
 
-Please note, when setting the integration, the UI will ask for "Host". This is
-the hostname or IP address of the machine you run MuteSync on (which is most
-likely your desktop computer).
+When setting up the integration, the UI will ask for the **Host**. This is the hostname or IP address of the machine you run mütesync on, most likely your desktop computer.


### PR DESCRIPTION
## Proposed change

Addresses home-assistant/home-assistant.io#39182 by adding an `{% important %}` notice at the top of the mutesync integration page explaining that the mütesync desktop app was discontinued on 16 November 2024 when mütesync was acquired by MuteMe. The MuteMe software that replaces it does not expose a compatible API, so new setups of this integration are no longer possible and existing installs will stop working once users migrate to MuteMe. Facts are sourced from the [mütesync download page](https://mutesync.com/download) and the closed core issue home-assistant/core#139053.

Also did a small proofread pass: brand casing cleanup, dropped `Please`, bolded a UI string that was in double quotes, and fixed the dangling `This tray app` subject.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/home-assistant.io#39182

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
