### PR TITLE
Note the heading card auto height change in 2026.4 release notes

### DIFF
--- a/source/_posts/2026-04-01-release-20264.markdown
+++ b/source/_posts/2026-04-01-release-20264.markdown
@@ -490,6 +490,12 @@ Cards can automatically adjust their height based on their content, instead of o
 
 Some cards, like the entities card and vertical stack card, already default to auto height. For other cards, you can now enable it yourself in the card's layout settings. This is especially handy for cards with variable content, so they no longer leave empty space or cut off content.
 
+{% note %}
+
+As part of this change, heading cards now default to auto height as well, making them shorter (about half a grid row). This is only visible for heading cards placed between other cards; headings at the top of a section are unaffected. The default row gap between sections also increased from 8 pixels to 24 pixels, giving sections a bit more breathing room. To restore the previous compact layout, set the `ha-view-sections-row-gap` theme variable to `8px` in your theme.
+
+{% endnote %}
+
 ### What is an AI-powered Assist thinking?
 
 If you use an <abbr title="Large Language Model">LLM</abbr>-powered conversation agent with Assist, you may have wondered what's going on behind the scenes when it's processing your request. Now you can find out! The Assist dialog now shows you the thinking steps and tool calls your AI agent makes while working on your request.


### PR DESCRIPTION
## Proposed change

Addresses home-assistant/home-assistant.io#44310 by adding a note to the "Auto height for cards" section of the 2026.4 release notes explaining that heading cards now default to auto height (grid row size `auto` instead of `1`), making them shorter when placed between other cards. Also documents the new 24-pixel default section row gap and the `ha-view-sections-row-gap` theme variable workaround for users who want the previous compact layout.

Facts sourced from home-assistant/frontend#30295.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/frontend#30295
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/home-assistant.io#44310

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
