### PR TITLE
Fix button automation example to exclude availability transitions

### DIFF
--- a/source/_integrations/button.markdown
+++ b/source/_integrations/button.markdown
@@ -16,20 +16,17 @@ related:
     title: Dashboard
 ---
 
-A button {% term entity %} is an entity that can fire an {% term event %} / trigger an {% term action %} towards
-a {% term device %} or {% term service %} but remains stateless from the Home Assistant perspective.
+A button {% term entity %} is an entity that can fire an {% term event %} or trigger an {% term action %} towards a {% term device %} or {% term service %}, but remains stateless from the Home Assistant perspective.
 
-It can be compared to a real live momentary switch, push-button, or some other
-form of a stateless switch.
+It can be compared to a momentary switch, push-button, or other form of stateless switch.
 
 {% include integrations/building_block_integration.md %}
 
 ## The state of a button
 
-The button {% term entity %} is stateless, as in, it cannot have a state like the `on` or
-`off` state that, for example, a normal switch entity has.
+The button {% term entity %} is stateless. Unlike a normal switch entity, it does not have an `on` or `off` state.
 
-The state of a button is a timestamp showing the date and time of the last time the button had been pressed in the Home Assistant UI or via an action.
+The state of a button is a timestamp showing when the button was last pressed via the Home Assistant UI or an action.
 
 <p class='img'>
 <img src='/images/integrations/button/state_button.png' alt='Screenshot showing the state of a button entity in the developer tools' />
@@ -41,16 +38,20 @@ In addition, the entity can have the following states:
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
 
-Because the {% term state %} of a button entity in Home Assistant is a timestamp, it
-changes every time the button is pressed. This means we can trigger automations on
-any state change of the button entity, which effectively captures when the button
-is pressed. We don't need to use the actual timestamp value; we only care that the
-state changed, indicating a button press:
+Because the {% term state %} of a button entity in Home Assistant is a timestamp, it changes every time the button is pressed. You can trigger an automation on any state change of the button entity, which effectively captures when the button is pressed. You don't need to use the actual timestamp value; you only care that the state changed, indicating a button press.
+
+Make sure to exclude transitions to and from `unavailable` and `unknown`, so the automation doesn't fire when the button becomes temporarily unavailable (for example, due to a network interruption) and then returns to its previous state:
 
 ```yaml
 triggers:
   - trigger: state
     entity_id: button.my_button
+    not_from:
+      - unavailable
+      - unknown
+    not_to:
+      - unavailable
+      - unknown
 actions:
   - action: notify.frenck
     data:
@@ -59,7 +60,7 @@ actions:
 
 ## Actions
 
-The button entities exposes a single {% term action %}: {% my developer_call_service service="button.press" %}
+The button entity exposes a single {% term action %}: {% my developer_call_service service="button.press" %}
 
 This action can be called to trigger a button press for that entity.
 
@@ -76,7 +77,7 @@ This action can be called to trigger a button press for that entity.
 The screenshot shows different icons representing different device classes for buttons:
 
 <p class='img'>
-<img src='/images/screenshots/button_classes_icons.png' />
+<img src='/images/screenshots/button_classes_icons.png' alt='Screenshot showing different button icons for the identify, restart, and update device classes.' />
 Example of device class icons.
 </p>
 


### PR DESCRIPTION
## Proposed change

Addresses home-assistant/home-assistant.io#26866 (open since April 2023). The button automation example used `trigger: state` without any filter, which fired on every state change including transitions to and from `unavailable`. When a button device briefly lost its connection and returned, the state trigger fired twice with no real button press. This caused spurious automation runs reported in the issue.

Updated the example to use `not_from` and `not_to` filters so the trigger only fires on real timestamp-to-timestamp transitions, and added a short paragraph explaining why the filters are needed.

Also did a small proofread pass: fixed a subject-verb agreement bug (`entities exposes` → `entity exposes`), switched first-person `we` to second-person `you`, dropped `as in,` and `real live` informal phrases, added missing alt text on the device classes screenshot, and tightened a past-perfect tense.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/home-assistant.io#26866

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
