### PR TITLE
Clarify that update_entity only accepts entity targets

### DIFF
--- a/source/_includes/common-tasks/define_custom_polling.md
+++ b/source/_includes/common-tasks/define_custom_polling.md
@@ -11,8 +11,8 @@ To add the automation:
 3. To define your custom polling interval, create an automation.
    - Go to {% my automations title="**Settings** > **Automations & scenes**" %} and create a new automation.
    - Define any trigger and condition you like.
-   - Select **Add action**, then, select **Other actions**.
+   - Select **Add action**, then select **Other actions**.
    - Select **Perform action**, and from the list, select the [`homeassistant.update_entity` action](/integrations/homeassistant/#action-homeassistantupdate_entity).
-   - Choose your targets by selecting the **Choose area**, **Choose device**, **Choose entity**, or **Choose label** buttons. 
+   - Add the entities you want to poll to the **Entity** field. The `homeassistant.update_entity` action only supports targeting by entity. Selecting an area, device, or label is not supported.
    ![Update entity](/images/screenshots/custom_polling_02.png)
 4. Save your new automation to poll for data.


### PR DESCRIPTION
## Proposed change

Addresses home-assistant/home-assistant.io#43549. The shared custom polling include told users to select targets via "Choose area / Choose device / Choose entity / Choose label" buttons, but the `homeassistant.update_entity` action only accepts entity targets. In the UI, only the entity selector appears, which confused the reporter and anyone else following the docs.

Updated the shared include to match the action's actual behavior: users add entities to the **Entity** field, and the include now explicitly states that area, device, and label targeting is not supported.

This fix propagates to all pages that use this include (20 pages total, including Tado, HomeWizard, Plugwise, Ping, SQL, Speedtest, and the common-tasks general page).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/home-assistant.io#43549

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
