### PR TITLE
Clean up YAML examples and prose in the Packages configuration page

### DIFF
--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -115,5 +115,5 @@ homeassistant:
 {% important %}
 If you are moving configuration to packages, `auth_providers` must stay within your {% term "`configuration.yaml`" %} file. See the general documentation for [Authentication Providers](/docs/authentication/providers/#configuring-auth-providers).
 
-This is because Home Assistant processes the authentication provided early in the start-up process, even before packages are processed.
+This is because Home Assistant processes the `auth_providers` configuration early during startup, before packages are processed.
 {% endimportant %}

--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -1,16 +1,16 @@
 ---
 title: "Packages"
-description: "Describes all there is to know about configuration packages in Home Assistant."
+description: "Bundle configurations from multiple integrations using configuration packages."
 ---
 
-Packages in Home Assistant provide a way to bundle configurations from multiple integrations. With packages, we have a way to include multiple integrations, or parts of integrations using any of the `!include` directives introduced in [splitting the configuration](/docs/configuration/splitting_configuration).
+Packages in Home Assistant provide a way to bundle configurations from multiple integrations. You can use packages to include multiple integrations, or parts of integrations, using any of the `!include` directives introduced in [splitting the configuration](/docs/configuration/splitting_configuration/).
 
 Packages are configured under the core `homeassistant/packages` in the configuration and take the format of a package name (no spaces, all lowercase) followed by a dictionary with the package configuration. For example, package `pack_1` would be created as:
 
 ```yaml
 homeassistant:
   ...
-  packages: 
+  packages:
     pack_1:
       ...package configuration here...
 ```
@@ -24,7 +24,7 @@ Inline example, main {% term "`configuration.yaml`" %}:
 ```yaml
 homeassistant:
   ...
-  packages: 
+  packages:
     pack_1:
       switch:
         - platform: rest
@@ -39,7 +39,7 @@ Include example, main {% term "`configuration.yaml`" %}:
 ```yaml
 homeassistant:
   ...
-  packages: 
+  packages:
     pack_1: !include my_package.yaml
 ```
 
@@ -81,15 +81,13 @@ homeassistant:
   packages: !include_dir_named packages
 ```
 
-The benefit of this approach is to pull all configurations required to integrate a system into one file&mdash;rather than keeping them spread across several files.
-You can use other `!include` methods for packages. For example: `!include_dir_merge_named`. However, unlike `!include_dir_merge_named`, the `!include_dir_named` method uses the same indentation as the 'configuration.yaml'. This means that you can copy and paste elements from the config file.
+The benefit of this approach is to pull all configurations required to integrate a system into one file, rather than keeping them spread across several files.
 
-With the `!include_dir_merge_named` method, the package name has to be included in the file. The configuration below then needs to be indented accordingly. This means you cannot directly copy and paste from the configuration file.
-
+You can also use `!include_dir_merge_named` for packages. The two directives differ in how they handle the file contents. With `!include_dir_named`, each file's content is placed directly under the package name (which is the filename), so the content uses the same indentation as it would inside the `packages:` key in {% term "`configuration.yaml`" %}. This means you can copy and paste elements from the main config file. With `!include_dir_merge_named`, the package name has to be the top-level key inside the file, so the content needs an additional level of indentation and you cannot directly copy and paste from the configuration file.
 
 ```yaml
 homeassistant:
-  packages: !include_dir_merge_named packages/
+  packages: !include_dir_merge_named packages
 ```
 
 and in `packages/subsystem1/functionality1.yaml`:
@@ -115,7 +113,7 @@ homeassistant:
 
 
 {% important %}
-If you are moving configuration to packages, `auth_providers` must stay within ‘configuration.yaml’. See the general documentation for [Authentication Providers](/docs/authentication/providers/#configuring-auth-providers).
+If you are moving configuration to packages, `auth_providers` must stay within your {% term "`configuration.yaml`" %} file. See the general documentation for [Authentication Providers](/docs/authentication/providers/#configuring-auth-providers).
 
 This is because Home Assistant processes the authentication provided early in the start-up process, even before packages are processed.
 {% endimportant %}


### PR DESCRIPTION
## Proposed change

Addresses home-assistant/home-assistant.io#41886. The most likely cause of the schema warning the reporter saw in VSCode is that the `packages:` key in all three YAML examples on the page had a trailing space after the colon. YAML linters and some Home Assistant schema validators flag trailing whitespace. Removed the trailing spaces.

Also did a small proofread pass on the page while I was there:

- Replaced an HTML em-dash entity (`&mdash;`) with a comma
- Replaced curly quotes around `'configuration.yaml'` with the proper term reference
- Rewrote the confusing paragraph comparing `!include_dir_named` and `!include_dir_merge_named` indentation behavior
- Made the two example YAML snippets consistent (both now use `packages` without the trailing slash)
- Switched a first-person `we have a way to include` to second-person
- Tightened the front matter description
- Added a missing trailing slash on an internal link

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/home-assistant.io#41886

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
