### PR TITLE
Fix assist_satellite action examples to put fields under data, not ta…

### DIFF
--- a/source/_integrations/assist_satellite.markdown
+++ b/source/_integrations/assist_satellite.markdown
@@ -35,6 +35,7 @@ Examples in YAML:
 action: assist_satellite.announce
 target:
   entity_id: assist_satellite.my_entity
+data:
   message: "Dinner is ready!"
 ```
 
@@ -42,6 +43,7 @@ target:
 action: assist_satellite.announce
 target:
   entity_id: assist_satellite.my_entity
+data:
   media_id: ITEM_ID
 ```
 
@@ -53,16 +55,18 @@ Examples in YAML:
 action: assist_satellite.announce
 target:
   entity_id: assist_satellite.my_entity
+data:
   message: "Dinner is ready!"
-  preannounce_media_id: ITEM_ID  # custom chime
+  preannounce_media_id: ITEM_ID  # Custom chime
 ```
 
 ```yaml
 action: assist_satellite.announce
 target:
   entity_id: assist_satellite.my_entity
+data:
   message: "Dinner is ready!"
-  preannounce: false  # chime disabled
+  preannounce: false  # Chime disabled
 ```
 
 ### Action: Start conversation
@@ -81,6 +85,7 @@ Examples in YAML:
 action: assist_satellite.start_conversation
 target:
   entity_id: assist_satellite.my_entity
+data:
   start_message: "You left the lights on in the living room. Turn them off?"
   extra_system_prompt: "The user has left the lights on in the living room and is being asked if they'd like to turn them off."
 ```
@@ -89,6 +94,7 @@ target:
 action: assist_satellite.start_conversation
 target:
   entity_id: assist_satellite.my_entity
+data:
   start_media_id: ITEM_ID
 ```
 
@@ -100,18 +106,20 @@ Examples in YAML:
 action: assist_satellite.start_conversation
 target:
   entity_id: assist_satellite.my_entity
+data:
   start_message: "You left the lights on in the living room. Turn them off?"
   extra_system_prompt: "The user has left the lights on in the living room and is being asked if they'd like to turn them off."
-  preannounce_media_id: ITEM_ID  # custom chime
+  preannounce_media_id: ITEM_ID  # Custom chime
 ```
 
 ```yaml
 action: assist_satellite.start_conversation
 target:
   entity_id: assist_satellite.my_entity
+data:
   start_message: "You left the lights on in the living room. Turn them off?"
   extra_system_prompt: "The user has left the lights on in the living room and is being asked if they'd like to turn them off."
-  preannounce: false  # chime disabled
+  preannounce: false  # Chime disabled
 ```
 
 ### Action: Ask question


### PR DESCRIPTION
## Proposed change

Addresses home-assistant/home-assistant.io#44113. The `assist_satellite.announce` examples on the page placed `message`, `preannounce`, and other action parameters under `target:`, which is only valid for entity, area, and device IDs. Home Assistant's service validation rejects these examples with errors like `extra keys not allowed @ data['sequence'][0]['target']['preannounce']`.

Verified against `homeassistant/components/assist_satellite/services.yaml` in core: both `announce` and `start_conversation` declare their action parameters under `fields:`, not as target entities. These must go under `data:` in an action call.

Fixed all 8 affected examples on the page (4 for `announce` and 4 for `start_conversation`, so the issue was broader than initially reported). Each example now correctly splits the entity target (under `target:`) from the action parameters (under `data:`).

Also capitalized the inline YAML comments in those blocks to match the YAML style guide rule that comments should start with a capital letter.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/home-assistant.io#44113

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
