### PR TITLE
Fix action name and related errors on the ADS integration page

### DIFF
--- a/source/_integrations/ads.markdown
+++ b/source/_integrations/ads.markdown
@@ -70,7 +70,7 @@ ip_address:
 {% endconfiguration %}
 
 <!-- omit in toc -->
-## Action
+## Actions
 
 The ADS integration registers the `ads.write_data_by_name` action, allowing you to write a value to a variable on your ADS device.
 

--- a/source/_integrations/ads.markdown
+++ b/source/_integrations/ads.markdown
@@ -1,6 +1,6 @@
 ---
 title: ADS
-description: Connect Home Assistant to TwinCAT devices via the ADS interface
+description: Connect Home Assistant to TwinCAT devices via the ADS interface.
 ha_category:
   - Binary sensor
   - Cover
@@ -29,7 +29,7 @@ ha_codeowners:
 ha_quality_scale: legacy
 ---
 
-The **ADS** (automation device specification) {% term integration %} describes a device-independent and fieldbus independent interface for communication between [Beckhoff](https://www.beckhoff.com/) automation devices running [TwinCAT](https://www.beckhoff.com/en-en/products/automation/twincat/) and other devices implementing this interface.
+The **ADS** (automation device specification) {% term integration %} describes a device-independent and fieldbus-independent interface for communication between [Beckhoff](https://www.beckhoff.com/) automation devices running [TwinCAT](https://www.beckhoff.com/en-en/products/automation/twincat/) and other devices implementing this interface.
 
 There is currently support for the following device types within Home Assistant:
 
@@ -72,7 +72,7 @@ ip_address:
 <!-- omit in toc -->
 ## Action
 
-The ADS integration will register the `write_by_name` action allowing you to write a value to a variable on your ADS device.
+The ADS integration registers the `write_data_by_name` action, allowing you to write a value to a variable on your ADS device.
 
 ```json
 {
@@ -84,9 +84,9 @@ The ADS integration will register the `write_by_name` action allowing you to wri
 
 Action parameters:
 
-- **adsvar**: Name of the variable on the ADS device. To access global variables on *TwinCAT2* use a prepending dot `.myvariable`, for TwinCAT3 use `GBL.myvariable`.
-- **adstype**: Specify the type of the variable. Use one of the following: `int`, `byte`, `uint`, `bool`
-- **value**: The value that will be written in the variable.
+- **adsvar**: Name of the variable on the ADS device. To access global variables on *TwinCAT2*, use a prepending dot (`.myvariable`). For TwinCAT3, use `GBL.myvariable`.
+- **adstype**: Specify the type of the variable. Use one of the following: `bool`, `byte`, `dint`, `int`, `udint`, or `uint`.
+- **value**: The value to write to the variable.
 
 ## Binary sensor
 
@@ -104,11 +104,11 @@ binary_sensor:
 
 {% configuration %}
 adsvar:
-  description: The name of the variable which you want to access on the ADS device.
+  description: The name of the variable that you want to access on the ADS device.
   required: true
   type: string
 name:
-  description: An identifier for the light in the frontend.
+  description: An identifier for the binary sensor in the frontend.
   required: false
   type: string
 device_class:
@@ -138,27 +138,29 @@ light:
 {% configuration %}
 adsvar:
   required: true
-  description: The name of the boolean variable that switches the light on
+  description: The name of the boolean variable that switches the light on.
   type: string
 adsvar_brightness:
   required: false
-  description: The name of the variable that controls the brightness, use an unsigned integer on the PLC side
+  description: The name of the variable that controls the brightness. Use an unsigned integer on the PLC side.
   type: string
 adsvar_color_temp_kelvin:
   required: false
-  description: The name of the variable that controls the color temperature in Kelvin, use an unsigned integer on the PLC side
+  description: The name of the variable that controls the color temperature in Kelvin. Use an unsigned integer on the PLC side.
   type: string
 min_color_temp_kelvin:
   required: false
-  description: The minimum color temperature in Kelvin (default is 2000)
+  description: The minimum color temperature in Kelvin.
   type: integer
+  default: 2000
 max_color_temp_kelvin:
   required: false
-  description: The maximum color temperature in Kelvin (default is 6500)
+  description: The maximum color temperature in Kelvin.
   type: integer
+  default: 6500
 name:
   required: false
-  description: An identifier for the Light in the frontend
+  description: An identifier for the light in the frontend.
   type: string
 {% endconfiguration %}
 
@@ -181,11 +183,11 @@ sensor:
 {% configuration %}
 adsvar:
   required: true
-  description: The name of the variable which you want to access.
+  description: The name of the variable that you want to access.
   type: string
 adstype:
   required: false
-  description: The datatype of the ADS variable, possible values are bool, byte, int, uint, sint, usint, dint, udint, word, dword, real and lreal.
+  description: "The data type of the ADS variable. Possible values: `bool`, `byte`, `int`, `uint`, `sint`, `usint`, `dint`, `udint`, `word`, `dword`, `real`, and `lreal`."
   default: int
   type: string
 name:
@@ -194,12 +196,12 @@ name:
   type: string
 factor:
   required: false
-  description: A factor that divides the stored value before displaying in Home Assistant.
+  description: A factor that divides the stored value before displaying it in Home Assistant.
   default: 1
   type: integer
 {% endconfiguration %}
 
-The *factor* can be used to implement fixed decimals. E.g., set *factor* to 100 if you want to display a fixed decimal value with two decimals. A variable value of `123` will be displayed as `1.23`.
+The *factor* can be used to implement fixed decimals. For example, set *factor* to 100 if you want to display a fixed decimal value with two decimals. A variable value of `123` will be displayed as `1.23`.
 
 ## Switch
 
@@ -218,7 +220,7 @@ switch:
 {% configuration %}
 adsvar:
   required: true
-  description: The name of the variable which you want to access on the ADS device.
+  description: The name of the variable that you want to access on the ADS device.
   type: string
 name:
   required: false
@@ -248,31 +250,31 @@ cover:
 {% configuration %}
 adsvar:
   required: true
-  description: The name of the boolean variable that returns the current status of the cover (`True` = closed)
+  description: "The name of the boolean variable that returns the current status of the cover (`true` means closed)."
   type: string
 adsvar_position:
   required: false
-  description: The name of the variable that returns the current cover position, use a byte variable on the PLC side
+  description: The name of the variable that returns the current cover position. Use a byte variable on the PLC side.
   type: string
 adsvar_set_position:
   required: false
-  description: The name of the variable that sets the new cover position, use a byte variable on the PLC side
+  description: The name of the variable that sets the new cover position. Use a byte variable on the PLC side.
   type: string
 adsvar_open:
   required: false
-  description: The name of the boolean variable that triggers the cover to open
+  description: The name of the boolean variable that triggers the cover to open.
   type: string
 adsvar_close:
   required: false
-  description: The name of the boolean variable that triggers the cover to close
+  description: The name of the boolean variable that triggers the cover to close.
   type: string
 adsvar_stop:
   required: false
-  description: The name of the boolean variable that triggers the cover to stop
+  description: The name of the boolean variable that triggers the cover to stop.
   type: string
 name:
   required: false
-  description: An identifier for the Cover in the frontend
+  description: An identifier for the cover in the frontend.
   type: string
 device_class:
   required: false
@@ -284,12 +286,12 @@ device_class:
 
 The `ads` select entity accesses an ENUM (int) variable on the connected ADS device. The variable is identified by its name. You have to set up a corresponding ENUM in the TwinCAT PLC. It is recommended to use explicit values starting from `0`.
 
-```yaml
+```text
 TYPE E_SampleA :
 (
     e1 := 0,
     e2 := 1,
-    e3 := 2, 
+    e3 := 2,
 );
 END_TYPE
 ```
@@ -314,7 +316,7 @@ select:
 {% configuration %}
 adsvar:
   required: true
-  description: The name of the variable which you want to access on the ADS device.
+  description: The name of the variable that you want to access on the ADS device.
   type: string
 options:
   required: true
@@ -343,7 +345,7 @@ valve:
 {% configuration %}
 adsvar:
   required: true
-  description: The name of the variable which you want to access on the ADS device.
+  description: The name of the variable that you want to access on the ADS device.
   type: string
 name:
   required: false

--- a/source/_integrations/ads.markdown
+++ b/source/_integrations/ads.markdown
@@ -72,7 +72,7 @@ ip_address:
 <!-- omit in toc -->
 ## Action
 
-The ADS integration registers the `write_data_by_name` action, allowing you to write a value to a variable on your ADS device.
+The ADS integration registers the `ads.write_data_by_name` action, allowing you to write a value to a variable on your ADS device.
 
 ```json
 {


### PR DESCRIPTION
## Proposed change

Addresses home-assistant/home-assistant.io#43434. The Action section documented the ADS action as `ads.write_by_name`, but the actual service name in core `homeassistant/components/ads/services.yaml` is `write_data_by_name`. Users following the docs would get "action not found" errors.

Fixed the action name, then did a proofread pass of the rest of the page and found several other factual errors while I was there:

- The `adstype` parameter list for the action was missing two valid types (`dint` and `udint`) per the core services definition.
- The binary sensor `name` field description was a copy-paste from a light integration and said "identifier for the light" instead of "identifier for the binary sensor".
- The light `min_color_temp_kelvin` and `max_color_temp_kelvin` defaults were embedded as prose in the description fields instead of in the proper `default:` field of the `{% configuration %}` block.
- The select section's TwinCAT structured text code block was marked as `yaml` instead of `text`.

Also fixed a batch of smaller style issues: `E.g.,` in prose, a `which` that should be `that`, capitalized field names in the middle of descriptions (`Light`, `Cover`), missing trailing periods and Oxford commas on description fields, `datatype` → `data type`, a `True` YAML value that should be lowercase `true`, a missing hyphen in `fieldbus-independent`, and a missing trailing period on the front matter description.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/home-assistant.io#43434

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
