### PR TITLE
Clarify docker.io registry value and fix broken link on Docker Hub ra…

### DIFF
--- a/source/more-info/dockerhub-rate-limit.markdown
+++ b/source/more-info/dockerhub-rate-limit.markdown
@@ -1,21 +1,21 @@
 ---
 title: "Docker Hub Rate Limit"
-description: "Docker Hub is rate-limiting how many pull you can do."
+description: "Docker Hub is rate limiting how many pulls you can do."
 ---
 
 ## The issue
 
-Docker Hub enforces a limit on how much you are allowed to fetch container information from their container registry. [Read more about how it's handled here][docker-rate-limit].
+Docker Hub enforces a limit on how often you can fetch container information from their container registry. For more details, see the [Docker Hub rate limit documentation][docker-rate-limit].
 
-Home Assistant uses Docker Hub as the container registry. When your IP address is rate limited updating our containers will fail.
+Home Assistant uses Docker Hub as the container registry. When your IP address is rate limited, updating Home Assistant containers will fail.
 
 ## The solutions
 
-If you are running watchtower or similar solutions to keep your containers up to date, you need to reconfigure them to check less often than the default configuration. If you are running a Supervised installation, you should also consider removing them completely since running those alongside the Supervisor is [not supported][unsupported-container].
+If you are running watchtower or similar solutions to keep your containers up to date, reconfigure them to check less often. If you are running a Supervised installation, you should also consider removing them completely, since running software alongside the Supervisor is [not supported][unsupported-software].
 
-When this is done, you need to wait until the limit has lifted, this can take up to 6 hours.
+Once you've done that, you need to wait until the limit is lifted. This can take up to 6 hours.
 
-If you are sharing the IP address with other parties, their usage will also affect you. The Supervisor supports logging in to Docker Hub with an account, with this approach, all the fetches between the Supervisor and Docker Hub will be using authentication and will not be limited by the anonymous rate limits. Authenticated users are also rate limited, but that is a dedicated limit tied to your account.
+If you are sharing the IP address with other parties, their usage will also affect you. The Supervisor supports signing in to Docker Hub with an account. With an account, all fetches between the Supervisor and Docker Hub are authenticated and are not limited by the anonymous rate limits. Authenticated users are also rate limited, but that is a dedicated limit tied to your account.
 
 _If you do not have a Docker Hub account [you can create one here][dockerhub-signup]._
 
@@ -25,16 +25,20 @@ To use your Docker Hub credentials with the Supervisor:
 2. Go to {% my supervisor_store title="**Settings** > **Apps** > **Install app**" %}.
 3. In the top-right corner of the screen, select the three dots {% icon "mdi:dots-vertical" %} menu, and select **Registries**.
 
-4. In the dialog that opens up, select **Add new registry** and enter `docker.io` as the registry followed by your credentials:
+4. In the dialog that opens up, select **Add new registry** and enter `docker.io` as the registry, followed by your credentials:
 
     <p class='img'>
     <img src='/images/screenshots/supervisor_registry_dockerhub.png' alt='Adding authentication for Docker Hub in the Supervisor panel.'>
-    Adding authentication for Docker Hub in the Supervisor panel
+    Adding authentication for Docker Hub in the Supervisor panel.
     </p>
+
+    {% note %}
+    The screenshot above may show `hub.docker.com` as the registry value, but the correct value is `docker.io`. `hub.docker.com` is the website for browsing Docker Hub, while `docker.io` is the registry hostname the Supervisor uses to authenticate.
+    {% endnote %}
 
 _If you do not want to use the UI, this can also be done with the [CLI]_
 
 [docker-rate-limit]: https://docs.docker.com/docker-hub/download-rate-limit/
 [dockerhub-signup]: https://hub.docker.com/signup
-[unsupported-container]: /more-info/unsupported/container.md
+[unsupported-software]: /more-info/unsupported/software/
 [CLI]: https://github.com/home-assistant/cli


### PR DESCRIPTION
## Proposed change

Addresses home-assistant/home-assistant.io#43577. The page text says to enter `docker.io` as the registry, but the screenshot shows `hub.docker.com`. Users who looked at the screenshot entered the wrong value and stayed rate-limited.

Verified in `home-assistant/supervisor` (`supervisor/docker/const.py`) that `docker.io` is the correct registry hostname. The screenshot is outdated. Since I can't regenerate the screenshot, I added a note directly below it calling out the discrepancy and explaining why.

While I was there, I also fixed a broken link: `[unsupported-container]: /more-info/unsupported/container.md` pointed to a non-existent file and used a wrong `.md` extension for a Jekyll link. The actual target for the "running software alongside Supervisor is not supported" reference is `/more-info/unsupported/software/`, so I updated the link.

Also did a small proofread pass: fixed a grammar bug in the front matter description (`how many pull you can do` → `how many pulls you can do`), a missing comma in the main paragraph, a comma splice, a few wordy phrases, `logging in` → `signing in` per Microsoft Style Guide, and rephrased a first-person `our containers` to `Home Assistant containers`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/home-assistant.io#43577

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
