### PR TITLE
Document where the Withings webhook URL comes from and how to change it

### DIFF
--- a/source/_integrations/withings.markdown
+++ b/source/_integrations/withings.markdown
@@ -81,13 +81,34 @@ The binary sensor for sleep will only work if the {% term integration %} can est
 
 For webhooks to work, your Home Assistant instance must be reachable by the Withings cloud service. The following requirements must be met:
 
-- **Publicly accessible** - Your Home Assistant instance must be reachable from the internet
-- **HTTPS on port 443** - Withings requires HTTPS specifically on port 443. Using HTTPS on a non-standard port (such as 8443) will not work
-- **Valid SSL certificate** - The certificate must be signed by a globally recognized Certificate Authority (for example, Let's Encrypt). Self-signed certificates will not work
+- **Publicly accessible**: Your Home Assistant instance must be reachable from the internet.
+- **HTTPS on port 443**: Withings requires HTTPS specifically on port 443. Using HTTPS on a non-standard port (such as 8443) will not work.
+- **Valid SSL certificate**: The certificate must be signed by a globally recognized Certificate Authority, for example, Let's Encrypt. Self-signed certificates will not work.
 
 {% important %}
 If webhooks cannot be established, some sensors will not be available. In particular, the sleep binary sensor has no polling fallback and requires working webhooks to function.
 {% endimportant %}
+
+#### How the webhook URL is determined
+
+You do not enter the webhook URL anywhere in the integration. Home Assistant builds it automatically from the URLs configured under {% my network title="**Settings** > **System** > **Network**" %}, followed by an internal webhook path.
+
+Home Assistant prefers the **Internet** URL and falls back to the **Local Network** URL. For Withings webhooks to register successfully, the URL that Home Assistant selects must be a public HTTPS URL on port 443 with a valid certificate.
+
+If you use Home Assistant Cloud from [Nabu Casa](https://www.nabucasa.com/), a cloudhook is registered instead. Cloudhooks meet all requirements above automatically and do not need any network configuration.
+
+#### Changing the webhook URL
+
+If you see a warning like `Webhook not registered - HTTPS is required` or `Webhook not registered - port 443 is required` in your logs, the URL that Home Assistant selected is not a valid public HTTPS URL. This often happens when the **Internet** URL is empty and the **Local Network** URL points to a local HTTP address.
+
+To resolve this:
+
+1. Make sure **Advanced mode** is enabled in your {% my profile title="**User profile**" %}.
+2. Go to {% my network title="**Settings** > **System** > **Network**" %}.
+3. Under **Internet**, enter the public HTTPS URL that Withings should use to reach your instance, for example, `https://home.example.com`.
+4. Select **Save**.
+
+You can keep the **Local Network** URL set to your internal HTTP address. Home Assistant uses the **Internet** URL for webhooks, while integrations that prefer local communication continue to use the **Local Network** URL.
 
 ## Available data
 


### PR DESCRIPTION
## Proposed change

Explains how Home Assistant determines the webhook URL registered with Withings and how to change it, addressing feedback from users who get `HTTPS is required` or `port 443 is required` warnings despite fronting their instance with a valid public HTTPS reverse proxy.

Adds two subsections under **Webhook requirements**:

- **How the webhook URL is determined**: clarifies that the URL is not entered in the integration, that it is built from the **Internet** / **Local Network** URLs under **Settings** > **System** > **Network**, that the **Internet** URL is preferred, and that Nabu Casa cloudhooks bypass these requirements automatically.
- **Changing the webhook URL**: quotes the exact warning text from the logs so users searching for it land on a matching answer, and gives step-by-step instructions to set the **Internet** URL to a public HTTPS URL while keeping **Local Network** as a local HTTP address for fast local lookups.

Also normalizes the existing requirements list (separator and terminal punctuation).

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [ ] Adjusted missing or incorrect information in the current documentation
- [x] Added documentation for a new feature that has not been released yet, OR improves existing documentation
- [ ] Removed stale documentation

## Additional information

- Closes home-assistant/home-assistant.io#44213
