### PR TITLE
Kodi: document screensaver binary sensor

### DIFF
--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -31,6 +31,12 @@ There is currently support for the following device types within Home Assistant:
 
 {% include integrations/config_flow.md %}
 
+If you previously had Kodi configured through {% term "`configuration.yaml`" %}, it's advisable to remove it, and configure from the UI.
+If you do not remove it, your configuration will be imported with the following limitations:
+- Your turn on/off actions will not be imported. This functionality is now available through device triggers.
+- You may have duplicate entities.
+- Kodi must be on when Home Assistant is loading for the first time for the configuration to be imported.
+
 ### Turning On/Off
 
 You can customize your turn on and off actions through automations. Simply use the relevant Kodi device triggers and your automation will be called to perform the `turn_on` or `turn_off` sequence; see the [Kodi turn on/off samples](#kodi-turn-onoff-samples) section for scripts that can be used.
@@ -461,8 +467,3 @@ The integration provides the following binary sensor entity:
 - **Screensaver**
   - **Description**: Indicates whether the Kodi screensaver is currently active.
 
-If you previously had Kodi configured through {% term "`configuration.yaml`" %}, it's advisable to remove it, and configure from the UI.
-If you do not remove it, your configuration will be imported with the following limitations:
-- Your turn on/off actions will not be imported. This functionality is now available through device triggers.
-- You may have duplicate entities.
-- Kodi must be on when Home Assistant is loading for the first time for the configuration to be imported.

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -31,19 +31,6 @@ There is currently support for the following device types within Home Assistant:
 
 {% include integrations/config_flow.md %}
 
-## Binary sensors
-
-The integration provides the following binary sensor entity:
-
-- **Screensaver**
-  - **Description**: Indicates whether the Kodi screensaver is currently active.
-
-If you previously had Kodi configured through {% term "`configuration.yaml`" %}, it's advisable to remove it, and configure from the UI.
-If you do not remove it, your configuration will be imported with the following limitations:
-- Your turn on/off actions will not be imported. This functionality is now available through device triggers.
-- You may have duplicate entities.
-- Kodi must be on when Home Assistant is loading for the first time for the configuration to be imported.
-
 ### Turning On/Off
 
 You can customize your turn on and off actions through automations. Simply use the relevant Kodi device triggers and your automation will be called to perform the `turn_on` or `turn_off` sequence; see the [Kodi turn on/off samples](#kodi-turn-onoff-samples) section for scripts that can be used.
@@ -465,3 +452,17 @@ actions:
 ```
 
 {% endraw %}
+
+
+## Binary sensors
+
+The integration provides the following binary sensor entity:
+
+- **Screensaver**
+  - **Description**: Indicates whether the Kodi screensaver is currently active.
+
+If you previously had Kodi configured through {% term "`configuration.yaml`" %}, it's advisable to remove it, and configure from the UI.
+If you do not remove it, your configuration will be imported with the following limitations:
+- Your turn on/off actions will not be imported. This functionality is now available through device triggers.
+- You may have duplicate entities.
+- Kodi must be on when Home Assistant is loading for the first time for the configuration to be imported.

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -13,6 +13,7 @@ ha_domain: kodi
 ha_config_flow: true
 ha_zeroconf: true
 ha_platforms:
+  - binary_sensor
   - media_player
   - notify
 ha_integration_type: service
@@ -24,10 +25,18 @@ The preferred way to set up the Kodi platform is through discovery, which requir
 
 There is currently support for the following device types within Home Assistant:
 
+- [Binary sensors](#binary-sensors)
 - [Media player](#configuration)
 - [Notifications](#notifications)
 
 {% include integrations/config_flow.md %}
+
+## Binary sensors
+
+The integration provides the following binary sensor entity:
+
+- **Screensaver**
+  - **Description**: Indicates whether the Kodi screensaver is currently active.
 
 If you previously had Kodi configured through {% term "`configuration.yaml`" %}, it's advisable to remove it, and configure from the UI.
 If you do not remove it, your configuration will be imported with the following limitations:


### PR DESCRIPTION
## Proposed change

Document the new Kodi screensaver binary sensor added in core PR #167999.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167999
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards