### PR TITLE
Clarify sun trigger offset direction with a worked example

### DIFF
--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -60,22 +60,30 @@ sun:
 
 ## Automation trigger
 
-The sun's event listener will perform the action when the sun rises or sets with
-an offset.
+The sun's event listener performs the action when the sun rises or sets, with an optional offset.
 
-The sun trigger needs the trigger type `sun`, an event (`sunset` or `sunrise`), and an optional offset.
+The sun trigger needs the trigger type `sun`, an event (`sunset` or `sunrise`), and an optional offset:
 
 ```yaml
 triggers:
   - trigger: sun
     event: sunrise
-    offset: "-01:00:01"
+    # Fire one hour before sunrise.
+    offset: "-01:00:00"
 ```
 
-| Key name | Description                                                                                                                                                                                |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `event`  | Possible values: `sunset` or `sunrise`                                                                                                                                                     |
-| `offset` | An optional offset for the sun event trigger, in a positive or negative number of seconds, or specified in `HH:MM:SS` (after sun event trigger) or `-HH:MM:SS` (before sun event trigger). |
+The following keys are available:
+
+- **`event`**: Required. Either `sunrise` or `sunset`.
+- **`offset`**: Optional. A time offset relative to the sun event, specified as a number of seconds or in `HH:MM:SS` format. A negative value fires the trigger _before_ the sun event, a positive value fires it _after_.
+
+For example, if sunrise is at 06:00 and you set `offset: "-01:00:00"`, the automation runs at 05:00. With `offset: "01:00:00"`, it runs at 07:00. The same rule applies to sunset.
+
+{% tip %}
+
+Because the duration of twilight varies throughout the year, a fixed offset is not always the best way to trigger automations around dawn or dusk. For more precise dawn or dusk automations, use a [sun elevation trigger](/docs/automation/trigger/#sun-elevation-trigger) instead.
+
+{% endtip %}
 
 ### Maintains entity `sun.sun`
 


### PR DESCRIPTION
## Proposed change

Rewrites the `offset` explanation on the Sun integration page to directly answer the question "does a negative offset fire before or after the sun event?". Adds a concrete worked example (sunrise at 06:00 with offset `-01:00:00` runs at 05:00) and a tip pointing to the sun elevation trigger for dawn or dusk automations, which is a better fit than a fixed offset across seasons.

Also converts the trigger options table to a bullet list for better mobile rendering, and fixes a stray `"-01:00:01"` in the example YAML.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new feature that has not been released yet, OR improves existing documentation
- [ ] Removed stale documentation

## Additional information

- Closes home-assistant/home-assistant.io#44420
