### PR TITLE
Document default allowlist_external_dirs entries for camera snapshots

### DIFF
--- a/source/_integrations/camera.markdown
+++ b/source/_integrations/camera.markdown
@@ -95,9 +95,9 @@ Both `duration` and `lookback` options are suggestions, but should be consistent
 | `duration`     | yes      | Target recording length (in seconds). Default: 30                                                                                              |
 | `lookback`     | yes      | Target lookback period (in seconds) to include in addition to duration.  Only available if there is currently an active HLS stream. Default: 0 |
 
-The path part of `filename` must be an entry in the `allowlist_external_dirs` in your [`homeassistant:`](/integrations/homeassistant/#allowlist_external_dirs) section of your {% term "`configuration.yaml`" %} file.
+The path part of `filename` must be inside a directory that Home Assistant is allowed to write to. By default, the `www` folder in your configuration directory and each configured [media directory](/integrations/homeassistant/#media_dirs) are both allowed, so a path like `/config/www/recording.mp4` or `/media/recording.mp4` works without any extra configuration. To save to another location, such as `/tmp`, add that directory to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs) in the [`homeassistant:`](/integrations/homeassistant/) section of your {% term "`configuration.yaml`" %} file.
 
-For example, the following action in an automation would take a recording from "yourcamera" and save it to /tmp with a timestamped filename.
+For example, the following action in an automation would take a recording from "yourcamera" and save it to `/tmp` with a timestamped filename. This only works when `/tmp` is listed under `allowlist_external_dirs`.
 
 
 ```yaml
@@ -121,9 +121,9 @@ The `camera.snapshot` action allows you to take a snapshot from a camera.
 | `entity_id`    | no       | Name(s) of entities to create a snapshot from, for example, `camera.living_room_camera`.                                  |
 | `filename`     | no       | Snapshot file name.                                                                                                |
 
-The path part of `filename` must be an entry in the `allowlist_external_dirs` in your [`homeassistant:`](/integrations/homeassistant/) section of your {% term "`configuration.yaml`" %} file.
+The path part of `filename` must be inside a directory that Home Assistant is allowed to write to. By default, the `www` folder in your configuration directory and each configured [media directory](/integrations/homeassistant/#media_dirs) are both allowed, so a path like `/config/www/snapshot.jpg` or `/media/snapshot.jpg` works without any extra configuration. To save to another location, such as `/tmp`, add that directory to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs) in the [`homeassistant:`](/integrations/homeassistant/) section of your {% term "`configuration.yaml`" %} file.
 
-For example, the following action in an automation would take a snapshot from "yourcamera" and save it to /tmp with a timestamped filename.
+For example, the following action in an automation would take a snapshot from "yourcamera" and save it to `/tmp` with a timestamped filename. This only works when `/tmp` is listed under `allowlist_external_dirs`.
 
 
 ```yaml

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -119,7 +119,7 @@ customize_glob:
   required: false
   type: string
 allowlist_external_dirs:
-  description: List of folders that can be used as sources for sending files.
+  description: "Extra folders that integrations are allowed to read from or write to, on top of the defaults. By default, the `www` folder inside your configuration directory and every folder listed under `media_dirs` are already allowed, and you do not need to repeat them here. Only add directories outside of those defaults."
   required: false
   type: list
 allowlist_external_urls:


### PR DESCRIPTION
## Proposed change

The camera `record` and `snapshot` action docs told users that the `filename` path must be an entry in `allowlist_external_dirs`, but did not mention that Home Assistant already allows the `www` folder in the configuration directory and every configured media directory by default. This led users to successfully write to `/config/www/...` and then assume the documentation was wrong.

Rewrites the allowlist paragraphs on the Camera integration page to:

- Name the two default-allowed directories with concrete example paths (`/config/www/snapshot.jpg`, `/media/snapshot.jpg`) that work without any extra configuration.
- Explain that other locations such as `/tmp` need an `allowlist_external_dirs` entry.
- Note on each existing `/tmp` example that the example only works when `/tmp` is listed in `allowlist_external_dirs`, so copying it without the extra configuration does not silently fail.

Also updates the `allowlist_external_dirs` description on the Home Assistant Core integration page to explicitly state that `www` and every `media_dirs` folder are allowed by default, and that only directories outside those defaults need to be listed.

Verified against `homeassistant/core_config.py` in core, which initializes `allowlist_external_dirs` with `{hass.config.path("www"), *hac.media_dirs.values()}`.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new feature that has not been released yet, OR improves existing documentation
- [ ] Removed stale documentation

## Additional information

- Closes home-assistant/home-assistant.io#43847
