### PR TITLE
Document RESTful sensor polling and manual updates

### DIFF
--- a/source/_integrations/sensor.rest.markdown
+++ b/source/_integrations/sensor.rest.markdown
@@ -172,6 +172,14 @@ The response is expected to be a dictionary or a list with a dictionary as its 0
 
 {% include integrations/using_templates.md %}
 
+## Data updates
+
+The RESTful sensor {% term polling polls %} the configured endpoint every 30 seconds by default. To change how often it polls, set the `scan_interval` option to a different value in seconds.
+
+If you want to refresh the sensor manually, for example, from an automation or a script, call the [`homeassistant.update_entity` action](/integrations/homeassistant/#action-update-entity) and target the sensor. This triggers an immediate request to the endpoint, outside of the normal polling schedule.
+
+The `force_update` option changes how state updates are published, not how often the endpoint is polled. When `force_update` is enabled, the sensor still polls on the configured interval, but it emits a state change event on every poll even if the returned value has not changed. This is useful for long-term statistics and history graphs that rely on state change events.
+
 ## Examples
 
 In this section you find some real-life examples of how to use this sensor.


### PR DESCRIPTION
## Proposed change

Adds a `Data updates` section to the RESTful Sensor integration page. Users had a hard time figuring out when the sensor actually polls, whether `homeassistant.update_entity` works on it, and what `force_update` really does — the configuration block had `scan_interval` listed but no discoverable explanation of the update behavior.

The new section states:

- The sensor polls the configured endpoint every 30 seconds by default, and the interval can be changed via `scan_interval` in seconds.
- `homeassistant.update_entity` triggers an immediate request to the endpoint outside of the normal polling schedule, with a link to the action.
- `force_update` only affects how state updates are published, not how often the endpoint is polled. It still polls on the configured interval but emits a state change event on every poll even when the returned value has not changed.

Verified against `homeassistant/components/rest/entity.py` in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new feature that has not been released yet, OR improves existing documentation
- [ ] Removed stale documentation

## Additional information

- Closes home-assistant/home-assistant.io#43691
