### PR TITLE
Clarify WeatherFlow Cloud condition mapping and link canonical states

### DIFF
--- a/source/_integrations/weatherflow_cloud.markdown
+++ b/source/_integrations/weatherflow_cloud.markdown
@@ -59,28 +59,28 @@ There are two integrations for WeatherFlow devices, and you are not limited to s
 | Lightning last | The most recent lightning strike. |
 | Lightning last distance | The distance of the most recent lightning strike. |
 
-## Weather icons
+## Weather conditions
 
-There is not a straight 1-1 mapping between the Home Assistant supported weather conditions and what tempest provides - as such you may see a difference between what is displayed in the tempest app and what is displayed in Home Assistant.
+The Home Assistant `weather` entity reports its current state as one of a fixed set of condition values, listed under [Condition mapping](/integrations/weather/#condition-mapping) on the Weather integration page. The WeatherFlow API returns a larger set of condition identifiers, so this integration maps each WeatherFlow value to the closest Home Assistant condition. Because there is no one-to-one mapping between the two, the state shown in Home Assistant may differ slightly from the condition shown in the Tempest app.
 
-| Weather Flow icon | Home Assistant icon |
-|-------------------|----------------------|
-| clear-day | sunny |
-| clear-night | clear-night |
-| cloudy | cloudy |
-| foggy | fog |
-| partly-cloudy-day | partlycloudy |
-| partly-cloudy-night | partlycloudy |
-| possibly-rainy-day | rainy |
-| possibly-rainy-night | rainy |
-| possibly-sleet-day | snowy-rainy |
-| possibly-sleet-night | snowy-rainy |
-| possibly-snow-day | snowy |
-| possibly-snow-night | snowy |
-| possibly-thunderstorm-day | lightning-rainy |
-| possibly-thunderstorm-night | lightning-rainy |
-| rainy | rainy |
-| sleet | snowy-rainy |
-| snow | snowy |
-| thunderstorm | lightning |
-| windy | windy |
+The mapping from the WeatherFlow condition to the Home Assistant weather state is:
+
+- `clear-day` is reported as `sunny`
+- `clear-night` is reported as `clear-night`
+- `cloudy` is reported as `cloudy`
+- `foggy` is reported as `fog`
+- `partly-cloudy-day` is reported as `partlycloudy`
+- `partly-cloudy-night` is reported as `partlycloudy`
+- `possibly-rainy-day` is reported as `rainy`
+- `possibly-rainy-night` is reported as `rainy`
+- `possibly-sleet-day` is reported as `snowy-rainy`
+- `possibly-sleet-night` is reported as `snowy-rainy`
+- `possibly-snow-day` is reported as `snowy`
+- `possibly-snow-night` is reported as `snowy`
+- `possibly-thunderstorm-day` is reported as `lightning-rainy`
+- `possibly-thunderstorm-night` is reported as `lightning-rainy`
+- `rainy` is reported as `rainy`
+- `sleet` is reported as `snowy-rainy`
+- `snow` is reported as `snowy`
+- `thunderstorm` is reported as `lightning`
+- `windy` is reported as `windy`


### PR DESCRIPTION
## Proposed change

Clarifies the WeatherFlow Cloud condition mapping section. A reader looking for the list of states a weather entity can report landed on this page, but the section was titled `Weather icons` and the right column was labeled `Home Assistant icon` even though the values are actually weather entity state strings, not MDI icon names. The canonical list on the Weather integration page was also not linked.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new feature that has not been released yet, OR improves existing documentation
- [ ] Removed stale documentation

## Additional information

- Closes home-assistant/home-assistant.io#43634
