### PR TITLE
Fix deprecated trigger/action keys in weather template example

### DIFF
--- a/source/_integrations/weather.markdown
+++ b/source/_integrations/weather.markdown
@@ -110,7 +110,6 @@ The response data field is a mapping of called target entities, each containing 
 | `wind_gust_speed`           | The wind gust speed in the unit indicated by the `wind_speed_unit` state attribute.                                                             | 34.41                     |
 | `wind_speed`                | The wind speed in the unit indicated by the `wind_speed_unit` state attribute.                                                                  | 24.41                     |
 
-
 ## Examples
 
 {% details "Example template sensor using get_forecasts" %}
@@ -119,10 +118,10 @@ Example [template sensor](/integrations/template#yaml-configuration) that contai
 
 ```yaml
 template:
-  - trigger:
+  - triggers:
       - trigger: time_pattern
         hours: /1
-    action:
+    actions:
       - action: weather.get_forecasts
         data:
           type: hourly
@@ -132,13 +131,14 @@ template:
     sensor:
       - name: Temperature forecast next hour
         unique_id: temperature_forecast_next_hour
-        state: "{{ hourly['weather.home'].forecast[0].temperature }}"
-        unit_of_measurement: °C
-
+        state: >
+          {{
+            hourly['weather.home'].forecast[0].temperature
+          }}
+        unit_of_measurement: "°C"
 ```
 
 {% enddetails %}
-
 
 {% details "Example action response" %}
 


### PR DESCRIPTION
## Proposed change

Updates the template sensor example on the Weather integration page to use the modern plural `triggers:` and `actions:` keys instead of the deprecated singular `trigger:` and `action:`. Also applies YAML style guide fixes (multi-line template value, quoted unit string) and removes double blank lines flagged by the linter.

Verified against `homeassistant/components/template/config.py` in core, where `cv.renamed(CONF_TRIGGER, CONF_TRIGGERS)` and `cv.renamed(CONF_ACTION, CONF_ACTIONS)` confirm the singular forms are deprecated.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new feature that has not been released yet, OR improves existing documentation
- [ ] Removed stale documentation

## Additional information

- Closes home-assistant/home-assistant.io#43971
