### PR TITLE
Document that the integral sensor persists across restarts

### DIFF
--- a/source/_integrations/integration.markdown
+++ b/source/_integrations/integration.markdown
@@ -100,6 +100,10 @@ max_sub_interval:
 
 The unit of `source` together with `unit_prefix` and `unit_time` is used to generate a unit for the integral product (e.g. a source in `W` with prefix `k` and time `h` would result in `kWh`). Note that `unit_prefix` and `unit_time` are _also_ relevant to the Riemann sum calculation. 
 
+## Data updates
+
+The integral sensor keeps its accumulated value when Home Assistant restarts. After a restart, it picks up where it left off and continues integrating from the restored value as soon as the source sensor starts providing new readings.
+
 ## Integration method
 
 The Riemann Sum is an approximation of an integral by a finite sum and is therefore intrinsically inaccurate. Nonetheless, depending on the method used, values can be more or less accurate.


### PR DESCRIPTION
## Proposed change

Adds a short `Data updates` section to the Integral integration page stating that the accumulated value is kept across Home Assistant restarts.

Verified against `homeassistant/components/integration/sensor.py` in core, where `IntegrationSensor` extends `RestoreSensor` and restores its value via `async_get_last_sensor_data()` in `async_added_to_hass()`.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new feature that has not been released yet, OR improves existing documentation
- [ ] Removed stale documentation

## Additional information

- Closes home-assistant/home-assistant.io#44495
