### PR TITLE
Document MikroTik setup and configuration options

### DIFF
--- a/source/_integrations/mikrotik.markdown
+++ b/source/_integrations/mikrotik.markdown
@@ -43,6 +43,32 @@ Make sure that port 8728 or the port you choose is accessible from your network.
 
 {% include integrations/config_flow.md %}
 
+{% configuration_basic %}
+Host:
+  description: "The hostname or IP address of your MikroTik router."
+Username:
+  description: "The username used to authenticate with the RouterOS API."
+Password:
+  description: "The password for the username above."
+Port:
+  description: "The port the RouterOS API listens on. The default is `8728`. If you use SSL, the default `api-ssl` port is `8729`."
+Verify SSL certificate:
+  description: "When enabled, the SSL certificate presented by the router is verified. Disable this if you use a self-signed certificate."
+{% endconfiguration_basic %}
+
+## Configuration options
+
+The integration provides the following configuration options:
+
+{% configuration_basic %}
+Force scanning using DHCP:
+  description: "When disabled (default), the integration detects devices from the wireless registration table (CAPSman, wireless, wifiwave2, or wifi). When enabled, it uses the DHCP lease table instead. Enable this if you also want to detect wired (non-wireless) devices connected to your router."
+Enable ARP ping:
+  description: "When enabled, the integration sends an ARP ping to each non-wireless device that has an active DHCP address to verify that the device is actually reachable on the network. This prevents stale DHCP leases from keeping a device marked as home after it has left."
+Consider home interval:
+  description: "The time in seconds a device must be unseen before it is considered away. The default is 300 seconds (5 minutes)."
+{% endconfiguration_basic %}
+
 ## Use a certificate
 
 To use SSL to connect to the API (via `api-ssl` instead of `api` service) further configuration is required at RouterOS side. You have to upload or generate a certificate and configure `api-ssl` service to use it. Here is an example of a self-signed certificate:


### PR DESCRIPTION
## Proposed change

Documents the five setup fields and three configuration options for the MikroTik integration, which were previously undocumented. Users selecting **Configure** on the integration card found options with no explanation in the docs or the UI help buttons.

Adds a `configuration_basic` block after the config flow include for the setup fields (host, username, password, port, verify SSL), and a `Configuration options` section for the options flow settings:

- **Force scanning using DHCP**: explains the difference between wireless registration table detection and DHCP lease table detection, and when to enable it (wired devices).
- **Enable ARP ping**: explains that it verifies non-wireless devices are actually reachable, preventing stale DHCP leases from keeping devices marked as home.
- **Consider home interval**: documents the default of 300 seconds.

Verified all fields and defaults against `config_flow.py`, `coordinator.py`, and `const.py` in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new feature that has not been released yet, OR improves existing documentation
- [ ] Removed stale documentation

## Additional information

- Closes home-assistant/home-assistant.io#43608
