### PR TITLE
Clarify that InfluxDB exports all entity types, not just sensors

### DIFF
--- a/source/_integrations/influxdb.markdown
+++ b/source/_integrations/influxdb.markdown
@@ -28,12 +28,10 @@ The **InfluxDB** {% term integration %} lets you transfer all state changes to a
 
 For more information on configuration of InfluxDB, refer to the [InfluxDB configuration](#influxdb-configuration) section below.
 
-There is currently support for the following device types within Home Assistant:
-
-- [Sensor](#sensor)
+The integration exports state changes for all entity types to InfluxDB, not just sensors. In addition, it can create [sensor](#sensor) entities in Home Assistant that query data back from InfluxDB.
 
 {% note %}
-The `influxdb` database integration runs parallel to the Home Assistant database. It does not replace it.
+The `influxdb` integration runs parallel to the Home Assistant database. It does not replace it.
 {% endnote %}
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/influxdb.markdown
+++ b/source/_integrations/influxdb.markdown
@@ -28,7 +28,7 @@ The **InfluxDB** {% term integration %} lets you transfer all state changes to a
 
 For more information on configuration of InfluxDB, refer to the [InfluxDB configuration](#influxdb-configuration) section below.
 
-The integration exports state changes for all entity types to InfluxDB, not just sensors. In addition, it can create [sensor](#sensor) entities in Home Assistant that query data back from InfluxDB.
+The integration can export state changes for all entity types to InfluxDB, not just sensors. In addition, it can create [Sensor](#sensor) entities in Home Assistant that query data back from InfluxDB.
 
 {% note %}
 The `influxdb` integration runs parallel to the Home Assistant database. It does not replace it.


### PR DESCRIPTION
## Proposed change

Replaces the misleading "There is currently support for the following device types: Sensor" statement on the InfluxDB integration page. Users read this as "only sensor entities are exported to InfluxDB," when in reality the integration exports state changes for all entity types. The "Sensor" entry refers to sensor entities the integration can create in Home Assistant by querying data back from InfluxDB.

The new text explicitly states that all entity types are exported and that the integration can additionally create sensor entities from InfluxDB queries.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43952

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
