### PR TITLE
Update UniFi local user creation steps for current UI

### DIFF
--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -47,19 +47,13 @@ Using Early Access Release Candidate versions of UniFi Network or UniFi OS can b
 
 ### Local user
 
-You will need a local user created in your UniFi OS Console to log in with. Ubiquiti SSO Cloud Users will **not** work.
-It is recommended you use the Administrator or a user with full read/write access to get the most out of the integration,
-but it is not required. The entities that are created will automatically adjust based on the permissions of the user you
-use has.
+You need a local user created in your UniFi OS Console. Ubiquiti SSO cloud users will **not** work. Using an administrator or a user with full read/write access is recommended to get the most out of the integration, but it is not required. The entities that are created automatically adjust based on the permissions of the user you use.
 
-1. Login to your _Local Portal_ on your UniFi OS device, and select  **Users**. 
-    - **Note**: This **must** be done from the UniFi OS by accessing it directly by IP address (i.e. _Local Portal_), not via `unifi.ui.com` or within the UniFi Network app.
-2. Go to **Admins & Users** from the left hand side menu or [IP address]/admins/users e.g. 192.168.1.1/admins/users.
-3. Select **Add New Admin**.
-4. Check **Restrict to local access only** and fill out the fields for your user. Select **Full Management** for **Network**. **OS Settings** are not used, so they can be set to **None**.
-5. In the bottom right, select **Add**.
-
-![UniFi OS User Creation](/images/integrations/unifi/user.png)
+1. Sign in to your UniFi OS device.
+2. Go to **Admins & Users** from the left-hand side menu.
+3. Select **Create New**.
+4. Check **Admin**, then check **Restrict to local access only** and fill out the fields for your user. Select **Full Management** for **Network**. **OS Settings** are not used, so they can be set to **None**.
+5. In the bottom right, select **Create**.
 
 There is currently support for the following device types within Home Assistant:
 


### PR DESCRIPTION
## Proposed change

Updates the local user creation steps on the UniFi integration page to match the current UniFi OS console UI. The previous instructions referenced button labels and navigation paths that no longer exist, leaving users unable to follow along.

Changes to the steps:

- **Add New Admin** is now **Create New**.
- **Add** is now **Create**.
- The current UI requires checking **Admin** before **Restrict to local access only**.
- Removed the outdated screenshot reference (shows the old UI).
- Simplified the navigation to just **Admins & Users** from the left-hand side menu.

Also fixes a grammar error ("the permissions of the user you use has") and applies style guide corrections ("Login" to "Sign in").

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43869

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
