### PR TITLE
Clarify Discord integration capabilities and limitations

### DIFF
--- a/source/_integrations/discord.markdown
+++ b/source/_integrations/discord.markdown
@@ -14,7 +14,7 @@ ha_platforms:
 ha_integration_type: service
 ---
 
-The **Discord** {% term integration %} lets you send notifications from Home Assistant to [Discord](https://discordapp.com/) channels and users via a bot. You can send text messages, attach images from local files or remote URLs, and use Discord embeds for rich formatting.
+The **Discord** {% term integration %} lets you send notifications from Home Assistant to [Discord](https://discordapp.com/) channels and users via a bot. You can send text messages, attach files, like images or videos, from local paths or remote URLs, and use Discord embeds for rich formatting.
 
 {% note %}
 This integration is for outgoing messages only. It cannot read incoming Discord messages or use them as triggers for automations.

--- a/source/_integrations/discord.markdown
+++ b/source/_integrations/discord.markdown
@@ -14,7 +14,11 @@ ha_platforms:
 ha_integration_type: service
 ---
 
-The [Discord service](https://discordapp.com/) is a platform for the notify integration. This allows integrations to send messages to the user using Discord.
+The **Discord** {% term integration %} lets you send notifications from Home Assistant to [Discord](https://discordapp.com/) channels and users via a bot. You can send text messages, attach images from local files or remote URLs, and use Discord embeds for rich formatting.
+
+{% note %}
+This integration is for outgoing messages only. It cannot read incoming Discord messages or use them as triggers for automations.
+{% endnote %}
 
 ## Prerequisites
 


### PR DESCRIPTION
## Proposed change

Rewrites the Discord integration intro to clearly state what it can do (send text messages, attach images, use embeds) and adds a note that the integration is outgoing only and cannot read incoming messages or use them as automation triggers.

The previous intro was vague about directionality, leading users to spend time investigating whether incoming message triggers were possible.

Verified against core: the `discord` component only contains `notify.py`, confirming it is strictly outgoing notifications.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #42754

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
