### PR TITLE
Explain what Sentry is and why it is useful for Home Assistant users

### DIFF
--- a/source/_integrations/sentry.markdown
+++ b/source/_integrations/sentry.markdown
@@ -17,7 +17,7 @@ ha_integration_type: service
 The free Sentry account allows 5000 events per month. Depending on the amount of events sent to Sentry, you will either have to upgrade your Sentry account or have a period without data flowing from Home Assistant to Sentry.
 {% endimportant %}
 
-The **Sentry** {% term integration %} connects Home Assistant to [Sentry](https://sentry.io/), a cloud-based error tracking service. It captures logged errors and unhandled exceptions and sends them to your Sentry account, where you can browse, search, and get alerted on them.
+The **Sentry** {% term integration %} connects Home Assistant to [Sentry](https://sentry.io/), an error tracking service that can be cloud-hosted or self-hosted. It captures logged errors and unhandled exceptions and sends them to your Sentry instance, where you can browse, search, and get alerted on them.
 
 This is primarily useful if you are developing custom integrations or want deeper insight into errors happening inside your Home Assistant instance. Sentry groups repeated errors, shows stack traces, and can notify you when new issues appear, so you do not have to watch the logs manually.
 

--- a/source/_integrations/sentry.markdown
+++ b/source/_integrations/sentry.markdown
@@ -17,11 +17,13 @@ ha_integration_type: service
 The free Sentry account allows 5000 events per month. Depending on the amount of events sent to Sentry, you will either have to upgrade your Sentry account or have a period without data flowing from Home Assistant to Sentry.
 {% endimportant %}
 
-The **Sentry** {% term integration %} in Home Assistant integrates with [Sentry](https://sentry.io/) to capture both logged errors as well as unhandled exceptions in Home Assistant.
+The **Sentry** {% term integration %} connects Home Assistant to [Sentry](https://sentry.io/), a cloud-based error tracking service. It captures logged errors and unhandled exceptions and sends them to your Sentry account, where you can browse, search, and get alerted on them.
 
-## Preparation
+This is primarily useful if you are developing custom integrations or want deeper insight into errors happening inside your Home Assistant instance. Sentry groups repeated errors, shows stack traces, and can notify you when new issues appear, so you do not have to watch the logs manually.
 
-Before configuring the Sentry integration, you'll need to get Sentry account and a DSN.
+## Prerequisites
+
+Before setting up the integration, you need a Sentry account and a DSN (Data Source Name). The DSN tells Home Assistant where to send error events.
 
 Follow these steps to get the DSN:
 


### PR DESCRIPTION
## Proposed change

Adds context to the Sentry integration page explaining what Sentry is and why a Home Assistant user might want it. The previous intro jumped straight into setup without explaining the purpose.

- Rewrites the intro to describe Sentry as a cloud-based error tracking service and lists what it provides (error grouping, stack traces, alerting).
- Adds a sentence about who benefits most (custom integration developers, users wanting deeper error insight).
- Renames `Preparation` to `Prerequisites` per the integration template and clarifies what a DSN is.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43509

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
