### PR TITLE
Make Toon paid subscription requirement prominent

### DIFF
--- a/source/_integrations/toon.markdown
+++ b/source/_integrations/toon.markdown
@@ -34,19 +34,12 @@ Sensors for energy, power and gas consumption, sensors for solar production and
 several binary sensors for things like boiler burner on/off, hot tap water and
 boiler health status.
 
-For the Toon integration to work, you'll need an active Toon subscription
-and a Toon API developer account.
+## Prerequisites
 
-There is currently support for the following device types within Home Assistant:
-
-- [Binary sensor](#binary-sensor)
-- [Climate](#climate)
-- [Sensor](#sensor)
-- [Switch](#switch)
+- An active, paid Toon subscription with one of the supported providers (Eneco, Engie Electrabel, or Viesgo). The integration communicates with the Toon cloud service, which requires an active subscription.
+- A free Toon API developer account (see steps below).
 
 ## Setting up a developer account
-
-In order to be able to use this integration, you'll need to sign up for a free Toon API developer account.
 
 1. Visit the [Toon API developers website](https://developer.toon.eu/), and [sign in](https://developer.toon.eu/user/login). [Create an account](https://developer.toon.eu/user/register) if you don’t have one already.
 2. Open the "[My Apps](https://developer.toon.eu/user/me/apps)" page and click on "Add a new App" button on the top right.


### PR DESCRIPTION
## Proposed change

Adds a `Prerequisites` section to the Toon integration page that clearly lists the paid subscription requirement before users start setting up a developer account. The previous text mentioned the requirement in a flowing paragraph that was easy to miss, and the setup section started with "sign up for a free Toon API developer account," which led users to believe the entire setup was free.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #44450

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
