### PR TITLE
Improve Time & Date integration docs with setup options and examples

### DIFF
--- a/source/_integrations/time_date.markdown
+++ b/source/_integrations/time_date.markdown
@@ -15,33 +15,53 @@ ha_platforms:
 ha_integration_type: service
 ---
 
-The **Time & Date** {% term integration %} allows one to create sensors for the current date or time in different formats. All values are based on the timezone which is set in "General Configuration". 
+The **Time & Date** {% term integration %} provides sensors for the current date or time in different formats. All values are based on the time zone configured under {% my general title="**Settings** > **System** > **General**" %}.
 
 {% include integrations/config_flow.md %}
 
-Sensors including the time update every minute, the date sensor updates each day at midnight.
+During setup, you select which display format to use. Each format creates a separate sensor. To add multiple formats, set up the integration once for each format you need.
+
+{% configuration_basic %}
+Display options:
+  description: "The date and time format for the sensor. Available options:"
+{% endconfiguration_basic %}
+
+- **Date**: The current date, for example, `2026-04-12`.
+- **Date & Time**: The current date and time, for example, `2026-04-12, 14:30`.
+- **Date & Time (ISO)**: The current date and time in ISO 8601 format, for example, `2026-04-12T14:30:00`.
+- **Date & Time (UTC)**: The current date and time in UTC, for example, `2026-04-12, 12:30`.
+- **Time**: The current local time, for example, `14:30`.
+- **Time & Date**: The current time and date (reversed order), for example, `14:30, 2026-04-12`.
+- **Time (UTC)**: The current time in UTC, for example, `12:30`.
+
+## Data updates
+
+Sensors that include the time update every minute. The date-only sensor updates each day at midnight.
 
 <p class='img'>
   <img src='/images/screenshots/time_date.png' />
 </p>
 
-# Producing your own custom time and date sensor
+## Creating a custom time and date sensor
 
-The following can be used to create a time and date sensor whose output can be properly customised to use your own preferred formatting, specified in the call to timestamp_custom() using standard [Python datetime formatting](https://docs.python.org/3.8/library/datetime.html#strftime-and-strptime-behavior).
+If you want a sensor with a custom date or time format, you can create a [template sensor](/integrations/template/) in your {% term "`configuration.yaml`" %} file. The example below uses the sensor created by the **Date & Time (ISO)** display option as the source and reformats it with [`timestamp_custom()`](/template-functions/timestamp_custom/) using standard [Python datetime formatting](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior).
+
+Add the following to your {% term "`configuration.yaml`" %}:
+{% include integrations/restart_ha_after_config_inclusion.md %}
 
 ```yaml
-sensor:
-  # Minimal configuration of the standard time and date sensor
-  - platform: time_date
-    display_options:
-      - 'date_time_iso'
-  # Build on the standard sensor to produce one that can be customized    
 template:
   - sensor:
       - name: "Date and time"
-        state: "{{ as_timestamp(states('sensor.date_time_iso')) | timestamp_custom('%A %B %-d, %I:%M %p') }}"
+        state: >
+          {{
+            as_timestamp(states('sensor.date_time_iso'))
+            | timestamp_custom('%A %B %-d, %I:%M %p')
+          }}
         icon: "mdi:calendar-clock"
 ```
+
+This requires the **Date & Time (ISO)** display option to be set up in this integration.
 
 ## More time-related resources
 

--- a/source/_integrations/time_date.markdown
+++ b/source/_integrations/time_date.markdown
@@ -19,11 +19,11 @@ The **Time & Date** {% term integration %} provides sensors for the current date
 
 {% include integrations/config_flow.md %}
 
-During setup, you select which display format to use. Each format creates a separate sensor. To add multiple formats, set up the integration once for each format you need.
+During setup, select the display option for the sensor you want to create. The integration creates one sensor in the selected format.
 
 {% configuration_basic %}
-Display options:
-  description: "The date and time format for the sensor. Available options:"
+Display option:
+  description: "The date or time format for the sensor. Available options:"
 {% endconfiguration_basic %}
 
 - **Date**: The current date, for example, `2026-04-12`.


### PR DESCRIPTION
## Proposed change

Improves the Time & Date integration page by documenting the setup field, listing all available display formats, and clarifying where the custom sensor YAML goes.

- Documents the **Display options** config flow field with all seven available formats and example output for each.
- Explains that each format creates a separate sensor and you add the integration once per format.
- Moves the update frequency info into a proper `Data updates` section.
- Rewrites the custom sensor section to explicitly state the YAML goes in `configuration.yaml`, includes the restart-after-config note, and links to the template integration.
- Splits the long single-line template into a multi-line block scalar per the YAML style guide.
- Fixes the heading level from `#` (h1) to `##` (h2).
- Uses UI labels in bold (like **Date & Time (ISO)**) instead of config keys in backticks.
- Updates the intro to link the time zone setting with a My link.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #44532

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
