### PR TITLE
Fix MySQL/MariaDB TLS connection string in recorder docs

### DIFF
--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -315,7 +315,7 @@ MariaDB (omit pymysql):
     `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8mb4`
 MariaDB (omit pymysql, using TLS encryption):
   description: >
-    `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8mb4;ssl=true`
+    `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8mb4&ssl_mode=REQUIRED`
 MariaDB (omit pymysql, Socket):
   description: >
     `mysql://user:password@SERVER_IP/DB_NAME?unix_socket=/var/run/mysqld/mysqld.sock&charset=utf8mb4`
@@ -324,7 +324,7 @@ MySQL:
     `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8mb4`
 MySQL (using TLS encryption):
   description: >
-    `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8mb4;ssl=true`
+    `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8mb4&ssl_mode=REQUIRED`
 MySQL (Socket):
   description: >
     `mysql://user:password@localhost/DB_NAME?unix_socket=/var/run/mysqld/mysqld.sock&charset=utf8mb4`


### PR DESCRIPTION
## Proposed change

Fixes the MySQL and MariaDB TLS encryption connection string examples on the Recorder integration page. The previous examples used `?charset=utf8mb4;ssl=true`, which has two problems: `;` is not a valid query parameter separator in SQLAlchemy URLs, and `ssl=true` is not recognized by the `mysqlclient` driver. The correct syntax is `?charset=utf8mb4&ssl_mode=REQUIRED`.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #42850

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
