### PR TITLE
Add fallback step for Apple TV PIN not showing during pairing

### DIFF
--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -215,7 +215,7 @@ No
 
 This can happen when pairing the AirPlay protocol if the access settings are too restrictive. On your Apple TV, go to **Settings** > **AirPlay and HomeKit** and make sure the access setting is set to **Everyone on the Same Network**, then try again.
 
-If that does not resolve the issue, open the **Home** app on your iPhone or iPad, go to **Home Settings** > **Speakers & TV**, and set the access to **Everyone**. In some network configurations, the **Everyone on the Same Network** setting is not sufficient for Home Assistant to receive the PIN prompt.
+If that does not resolve the issue, open the **Home** app on your iPhone or iPad, go to **Home Settings** > **Speakers & TV**, and set the access to **Everyone**. In some network configurations, the **Everyone on the Same Network** setting is not sufficient for the Apple TV to display the PIN prompt or for pairing to complete.
 
 ### The buttons (play, pause, etc.) do not work
 

--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -213,9 +213,9 @@ No
 
 ### When adding a new device, a PIN code is requested, but none is shown on the screen
 
-This can happen when pairing the AirPlay protocol in case the access settings are wrong. On your
-Apple TV, navigate to Settings, find the AirPlay menu and make sure that the access setting
-is set to "Everyone on the same network" and try again.
+This can happen when pairing the AirPlay protocol if the access settings are too restrictive. On your Apple TV, go to **Settings** > **AirPlay and HomeKit** and make sure the access setting is set to **Everyone on the Same Network**, then try again.
+
+If that does not resolve the issue, open the **Home** app on your iPhone or iPad, go to **Home Settings** > **Speakers & TV**, and set the access to **Everyone**. In some network configurations, the **Everyone on the Same Network** setting is not sufficient for Home Assistant to receive the PIN prompt.
 
 ### The buttons (play, pause, etc.) do not work
 


### PR DESCRIPTION
## Proposed change

Expands the Apple TV troubleshooting section for "PIN code is requested, but none is shown on the screen." The existing step only mentions setting AirPlay access to **Everyone on the Same Network** on the Apple TV itself. For some network configurations, this is not sufficient and the access must be set to **Everyone** via the Home app's **Speakers & TV** settings.

Adds a second paragraph with this fallback step and updates the existing step to use bold for UI strings and the correct navigation path.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43541

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
