### PR TITLE
Clarify which Honeywell account to use during Lyric OAuth login

### DIFF
--- a/source/_integrations/lyric.markdown
+++ b/source/_integrations/lyric.markdown
@@ -42,11 +42,15 @@ Internal examples: `http://192.168.0.2:8123/auth/external/callback`, `http://hom
 
 {% enddetails %}
 
-You can then add the integration in the frontend via the steps below.
+You can then add the integration in Home Assistant.
 
 {% include integrations/config_flow.md %}
 
-The integration configuration will ask for the **Client ID** and **Client Secret**, which correspond to the **Consumer** values in the app you created above. See [Application Credentials](/integrations/application_credentials) for more details.
+The integration setup will ask for the **Client ID** and **Client Secret**. These correspond to the **Consumer Key** and **Consumer Secret** values from the app you created on the Honeywell developer site. See [Application Credentials](/integrations/application_credentials) for more details.
+
+{% important %}
+During setup, you will be redirected to Honeywell to sign in. Use your regular Resideo/Honeywell Home account here, not the developer account you created on the developer site. These are two separate accounts, even if they share the same email address.
+{% endimportant %}
 
 ## Sensors
 


### PR DESCRIPTION
## Proposed change

Adds an important note to the Honeywell Lyric integration page clarifying that the OAuth sign-in step requires your regular Resideo/Honeywell Home account, not the developer account. These are separate accounts even when they share the same email address, and the docs previously gave no indication of which one to use.

Also clarifies that the Client ID and Client Secret come from the app created on the Honeywell developer site, not from within Home Assistant.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #44084

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
