### PR TITLE
Document QNAP QSW single-session limitation and workaround

### DIFF
--- a/source/_integrations/qnap_qsw.markdown
+++ b/source/_integrations/qnap_qsw.markdown
@@ -91,6 +91,12 @@ The following *sensors* are created for each port (or LACP):
 | :------------------ | :--------------------------------- |
 | firmware_update     | Firmware update status.            |
 
+## Known limitations
+
+The QNAP QSW firmware allows only one authenticated session at a time. Because this integration maintains a persistent session to poll the switch, you cannot sign in to the switch's web management console (QSS) while the integration is active. Attempting to do so results in a "Duplicate login detected" error.
+
+To access the switch's web console, temporarily disable the integration under {% my integrations title="**Settings** > **Devices & services**" %}, then re-enable it when you are done.
+
 ## Removing the integration
 
 This integration follows standard integration removal. No extra steps are required.


### PR DESCRIPTION
## Proposed change

Adds a Known limitations section to the QNAP QSW integration page documenting that the switch firmware only allows one authenticated session at a time. Because the integration maintains a persistent session for polling, users cannot sign in to the switch's web management console while the integration is active.

Includes the workaround: temporarily disable the integration to access the web console, then re-enable it.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43739

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
