### PR TITLE
Fix OpenWrt ubus docs to use dedicated hass user instead of root

### DIFF
--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -26,8 +26,14 @@ opkg install rpcd-mod-file uhttpd-mod-ubus
 
 Add a new system user `hass` (or do it in any other way that you prefer):
 
-- Add line to /etc/passwd: hass:x:10001:10001:hass:/var:/bin/false
-- Add line to /etc/shadow: hass:x:0:0:99999:7:::
+- Add line to `/etc/passwd`: `hass:x:10001:10001:hass:/var:/bin/false`
+- Add line to `/etc/shadow`: `hass:x:0:0:99999:7:::`
+
+Then set a password for the `hass` user:
+
+```bash
+passwd hass
+```
 
 Edit the `/etc/config/rpcd` and add the following lines:
 
@@ -78,21 +84,21 @@ After this is done, add the following to your {% term "`configuration.yaml`" %} 
 device_tracker:
   - platform: ubus
     host: ROUTER_IP_ADDRESS
-    username: YOUR_ADMIN_USERNAME
-    password: YOUR_ADMIN_PASSWORD
+    username: hass
+    password: YOUR_HASS_PASSWORD
 ```
 
 {% configuration %}
 host:
-  description: The IP address of your router, e.g., 192.168.1.1.
+  description: The IP address of your router, for example, `192.168.1.1`.
   required: true
   type: string
 username:
-  description: The username of a user with administrative privileges, usually `root`.
+  description: The username for the account you created on the router. Use the dedicated `hass` user rather than `root` to follow the principle of least privilege.
   required: true
   type: string
 password:
-  description: The password for your given admin account.
+  description: The password for the user above.
   required: true
   type: string
 dhcp_software:


### PR DESCRIPTION
## Proposed change

The OpenWrt ubus integration docs walk through creating a dedicated `hass` user with restricted ACL, but then the configuration example and variable descriptions tell users to enter their admin/root credentials. This contradicts the security setup and gives Home Assistant full admin access to the router.

- Adds the missing `passwd hass` step after creating the system user.
- Updates the `configuration.yaml` example to use `hass` instead of `YOUR_ADMIN_USERNAME`.
- Rewrites the `username` and `password` config descriptions to reference the dedicated `hass` user instead of root/admin.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #32186

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
