### PR TITLE
Add diagnostics download instructions to Matter integration page

### DIFF
--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -52,6 +52,8 @@ related:
     title: HomeKit
   - docs: /integrations/homekit_controller/#adding-a-homekit-device-through-thread
     title: Adding an Apple HomeKit device through Thread
+  - docs: /docs/configuration/troubleshooting/#debug-logs-and-diagnostics
+    title: Debug logs and diagnostics
 ha_zeroconf: true
 ---
 
@@ -622,6 +624,23 @@ NOTE for Android users: You need to follow the instructions at the bottom of the
 11. Use the QR code to add the device using one of the above instructions on your phone, e.g. using the Home Assistant Companion app.
 
 ## Troubleshooting
+
+### Downloading diagnostics
+
+When reporting an issue with a Matter device, you will usually be asked for a diagnostics file. The Matter integration supports diagnostics at both the integration and device level.
+
+To download integration-level diagnostics:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
+2. On the **Matter** integration card, open the three-dot {% icon "mdi:dots-vertical" %} menu and select **Download diagnostics**.
+
+To download device-level diagnostics:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Matter** integration.
+2. Select the device you want diagnostics for.
+3. Open the three-dot {% icon "mdi:dots-vertical" %} menu and select **Download diagnostics**.
+
+The diagnostics file contains device attributes, cluster data, and network information with sensitive data redacted. For more general information, see [Download diagnostics](/docs/configuration/troubleshooting/#download-diagnostics).
 
 ### General recommendations
 

--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -627,7 +627,7 @@ NOTE for Android users: You need to follow the instructions at the bottom of the
 
 ### Downloading diagnostics
 
-When reporting an issue with a Matter device, you will usually be asked for a diagnostics file. The Matter integration supports diagnostics at both the integration and device level.
+When you report an issue with a Matter device, you're usually asked for a diagnostics file. The Matter integration supports diagnostics at both the integration and device level.
 
 To download integration-level diagnostics:
 

--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -632,13 +632,13 @@ When you report an issue with a Matter device, you're usually asked for a diagno
 To download integration-level diagnostics:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
-2. On the **Matter** integration card, open the three-dot {% icon "mdi:dots-vertical" %} menu and select **Download diagnostics**.
+2. On the **Matter** integration card, select the three dots {% icon "mdi:dots-vertical" %} menu, and then select **Download diagnostics**.
 
 To download device-level diagnostics:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Matter** integration.
 2. Select the device you want diagnostics for.
-3. Open the three-dot {% icon "mdi:dots-vertical" %} menu and select **Download diagnostics**.
+3. Select the three dots {% icon "mdi:dots-vertical" %} menu, and then select **Download diagnostics**.
 
 The diagnostics file contains device attributes, cluster data, and network information with sensitive data redacted. For more general information, see [Download diagnostics](/docs/configuration/troubleshooting/#download-diagnostics).
 


### PR DESCRIPTION
## Proposed change

Adds a `Downloading diagnostics` subsection to the Matter integration troubleshooting section with step-by-step instructions for downloading both integration-level and device-level diagnostics. Users reporting Matter issues are regularly asked for diagnostics but the page had no guidance on how to generate them.

Also adds a `related:` frontmatter link to the general debug logs and diagnostics documentation.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43433

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
