### PR TITLE
Document Android location permission requirement for Matter commissioning

### DIFF
--- a/source/_integrations/matter.markdown
+++ b/source/_integrations/matter.markdown
@@ -146,6 +146,7 @@ Make sure you have all these components ready before trying to add a Matter devi
   - **Android**:
     - At a minimum, have Android version 8.1. Recommended is version 12 or higher.
     - Have the latest version of the Home Assistant Companion app, installed from the Play Store (full version).
+    - Set the Home Assistant Companion app's **Location** permission to **Allow all the time**. During commissioning, the Google Matter UI takes the foreground and the Companion App runs in the background. Android restricts Wi-Fi SSID access for background apps when Location is set to "While using the app," which can cause commissioning to fail.
     - If you are using {% term Thread %}: Make sure there is a Thread border router device (Nest Hub (2nd Gen) or Nest Wi-Fi Pro or Home Assistant with the Home Assistant OpenThread Border Router app) present in your home network.
       - If you are using OpenThread (for Connect ZBT-1, ZBT-2, or SkyConnect) as border router, make sure you followed the steps in the [Thread documentation](/integrations/thread#turning-home-assistant-into-a-thread-border-router).
   - **iPhone**


### PR DESCRIPTION
## Proposed change

Adds a prerequisite to the Android section of the Matter device setup instructions: the Home Assistant Companion app's Location permission must be set to **Allow all the time**. During commissioning, the Google Matter UI takes the foreground and the Companion App runs in the background, where Android restricts Wi-Fi SSID access if Location is set to "While using the app." This causes internal URL detection to fail and commissioning to error out with a generic message.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43829

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
