### PR TITLE
Clarify log viewing methods for Home Assistant OS vs Container

### DIFF
--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -171,26 +171,27 @@ data:
 
 ## Viewing logs
 
-The log information can be viewed and downloaded from {% my logs title="**Settings** > **System** > **Logs**" %}
+The primary way to view logs is through the Home Assistant UI. Go to {% my logs title="**Settings** > **System** > **Logs**" %} and select **Home Assistant Core**. To see the full unformatted log output, enable **Show raw logs** at the top of the page. You can also download the log file from this page.
+
+### Viewing logs on Home Assistant OS
+
+On {% term "Home Assistant Operating System" %} installations, logs are not written to a file in the configuration directory. Use the UI as described above, or run the following command from the [SSH app for Home Assistant](/common-tasks/os/#installing-and-using-the-ssh-app):
+
+```bash
+ha core logs --follow
+```
 
 ### Viewing logs on Container installations
 
-For {% term "Home Assistant Container" %} installations, the log information is stored in the
-[configuration directory](/docs/configuration/) as `home-assistant.log`.
-You can read it with the command-line tool `cat` or follow it dynamically
-with `tail -f`.
+For {% term "Home Assistant Container" %} installations, the log information is also written to a file called `home-assistant.log` in the [configuration directory](/docs/configuration/). You can follow it dynamically with the following command:
 
-You can use the example below, when logged in through the [SSH app for Home Assistant](/common-tasks/os/#installing-and-using-the-ssh-app) (formerly known as SSH add-on):
+```bash
+# Follow the log dynamically
+docker logs --follow MY_CONTAINER_ID
+```
+
+Or read the file directly:
 
 ```bash
 tail -f /config/home-assistant.log
 ```
-
-On Docker, you can use your host command line directly. Follow the logs dynamically with the following command:
-
-```bash
-# follow the log dynamically
-docker logs --follow  MY_CONTAINER_ID
-```
-
-To see other options, use `--help` instead, or simply leave with no options to display the entire log.


### PR DESCRIPTION
## Proposed change

Rewrites the "Viewing logs" section on the Logger integration page. Since version 2025.11, Home Assistant OS no longer writes `home-assistant.log` to the config directory, but the docs still pointed users there. Users spent significant time looking for a file that no longer exists.

- Leads with the UI as the primary way to view logs and documents the **Show raw logs** toggle.
- Adds a dedicated Home Assistant OS subsection explaining that logs are not file-based and documenting the `ha core logs --follow` command as an alternative.
- Keeps the Container subsection for file-based and Docker log access.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43594

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
