### PR TITLE
Fix battery interval default format in Bluetooth LE Tracker docs

### DIFF
--- a/source/_integrations/bluetooth_le_tracker.markdown
+++ b/source/_integrations/bluetooth_le_tracker.markdown
@@ -46,9 +46,9 @@ track_battery:
   default: false
   type: boolean
 track_battery_interval:
-  description: Minimum interval to ask the device for its battery status. The battery status will be checked at most once every interval. If `track_battery` is false, this will be ignored.
+  description: "Minimum interval between battery status checks for tracked devices. The battery status is checked at most once per interval. Ignored if `track_battery` is `false`. Accepts a time period, for example, `\"01:00:00\"` for one hour or a mapping like `days: 1`."
   required: false
-  default: 1 day
+  default: "24:00:00"
   type: time
 interval_seconds:
   description: Seconds between each scan for new devices.

--- a/source/_integrations/bluetooth_le_tracker.markdown
+++ b/source/_integrations/bluetooth_le_tracker.markdown
@@ -46,7 +46,7 @@ track_battery:
   default: false
   type: boolean
 track_battery_interval:
-  description: "Minimum interval between battery status checks for tracked devices. The battery status is checked at most once per interval. Ignored if `track_battery` is `false`. Accepts a time period, for example, `\"01:00:00\"` for one hour or a mapping like `days: 1`."
+  description: "Minimum interval between battery status checks for tracked devices. The battery status is checked at most once per interval. Ignored if `track_battery` is `false`. Accepts a time period, for example, `\"01:00:00\"` for one hour, or a mapping nested under `track_battery_interval`, for example `track_battery_interval:` followed by `days: 1` on the next indented line."
   required: false
   default: "24:00:00"
   type: time


### PR DESCRIPTION
## Proposed change

Fixes the `track_battery_interval` default value on the Bluetooth LE Tracker page from `1 day` (not valid YAML) to `"24:00:00"` (valid `HH:MM:SS` format). Users who copied the documented default got a config error because the `time` type does not accept human-readable strings.

Also adds examples of the accepted formats (`"01:00:00"` and `days: 1`) to the description so users know what to write.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #31934

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
