### PR TITLE
Fix Supla section in Cast docs with correct media ID instructions

### DIFF
--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -341,29 +341,22 @@ To cast media directly from a configured Plex server, set the fields [as documen
 
 ### [Supla](https://www.supla.fi/)
 
-Note: Media ID is NOT the 8 digit alphanumeric in the URL, it can be found by right-clicking the playing audio clip. E.g., [this episode](https://www.bbc.co.uk/sounds/play/p009ycqy) shows:
-
-|          |                                         |
-| -------- | --------------------------------------- |
-| 128bps   | dash (mf_cloudfront_nonbidi_dash_https) |
-| p009ycqz |                                         |
-
-With p009ycqz being the `media_id`
+[Supla](https://www.supla.fi/) is a Finnish audio streaming service. The `media_id` is the numeric ID from the Supla URL. For example, the ID for `https://www.supla.fi/audio/3601824` is `3601824`.
 
 #### Media parameters
 
 Mandatory:
 
 - `app_name`: `supla`
-- `media_id`: Supla item ID
+- `media_id`: The numeric ID from the Supla audio URL
 
 Optional:
 
-- `is_live`: Item is a livestream
+- `is_live`: Set to `true` if the item is a livestream
 
 #### Example
 
-Example values to cast the item at <https://www.supla.fi/audio/3601824>
+Example values to cast the item at `https://www.supla.fi/audio/3601824`:
 
 ```yaml
 'cast_supla_to_my_chromecast':


### PR DESCRIPTION
## Proposed change

The Supla section on the Cast integration page was copy-pasted from the BBC iPlayer section and still contained BBC-specific content: a link to a BBC Sounds episode, a BBC metadata table, and text saying the media ID is "NOT the alphanumeric in the URL." For Supla, the media ID is simply the numeric ID from the URL, as the example on the same page already demonstrated.

Replaces the incorrect BBC content with a short intro explaining what Supla is and how to find the media ID from the URL.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43422

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
