### PR TITLE
Explain how to find a Radio Browser station UUID for YAML automations

### DIFF
--- a/source/_integrations/radio_browser.markdown
+++ b/source/_integrations/radio_browser.markdown
@@ -24,17 +24,23 @@ To start the Radio Browser, in Home Assistant, go to **Media** > **Radio Browser
 
 ## Automation
 
-You can also use the Radio Browser in automations. When creating an automation, use the **Play Media** action to pick a station from the directory. This allows you, for example, to create
-an automation that starts playing your favorite radio station on your Cast devices. 
+You can also use the Radio Browser in automations. When creating an automation in the UI, use the **Play Media** action to browse the Radio Browser directory and select a station. The station identifier is filled in automatically. This allows you, for example, to create an automation that starts playing your favorite radio station on your Cast devices.
 
-If you want to use a YAML for the automation, you would look like this:
+If you prefer to write the automation in YAML, you need the station's UUID. To find it:
+
+1. Open the [Radio Browser website](https://www.radio-browser.info).
+2. Search for the station you want.
+3. Select the station to open its details page. The UUID is shown on that page and is also part of the station's URL.
+
+Then use the UUID in the `media_content_id` as shown below:
 
 ```yaml
 action: media_player.play_media
 target:
   entity_id: media_player.YOUR_MEDIA_PLAYER
 data:
-  media_content_id: media-source://radio_browser/963ccae5-0601-11e8-ae97-52543be04c81
+  media_content_id: >-
+    media-source://radio_browser/963ccae5-0601-11e8-ae97-52543be04c81
   media_content_type: audio/mpeg
 ```
 

--- a/source/_integrations/radio_browser.markdown
+++ b/source/_integrations/radio_browser.markdown
@@ -26,7 +26,7 @@ To start the Radio Browser, in Home Assistant, go to **Media** > **Radio Browser
 
 You can also use the Radio Browser in automations. When creating an automation in the UI, use the **Play Media** action to browse the Radio Browser directory and select a station. The station identifier is filled in automatically. This allows you, for example, to create an automation that starts playing your favorite radio station on your Cast devices.
 
-If you prefer to write the automation in YAML, you need the station's UUID. To find it:
+If you prefer to write an automation in YAML, you need the station's UUID. To find it:
 
 1. Open the [Radio Browser website](https://www.radio-browser.info).
 2. Search for the station you want.


### PR DESCRIPTION
## Proposed change

The Radio Browser docs showed a YAML example with a station UUID in the `media_content_id` but never explained where to find it. Users who wanted to write YAML automations had no way to discover the UUID for their station.

- Mentions that the UI automation editor fills in the identifier automatically when using the Play Media action.
- Adds steps to find the UUID on the Radio Browser website for users who prefer YAML.
- Splits the long `media_content_id` value onto its own line so it stays within 80 characters.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43564

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
