### PR TITLE
Expand Last.fm integration docs with setup fields, entities, and options

### DIFF
--- a/source/_integrations/lastfm.markdown
+++ b/source/_integrations/lastfm.markdown
@@ -62,6 +62,6 @@ The integration {% term polling polls %} Last.fm every 30 seconds for updated li
 
 ## Removing the integration
 
-This integration follows standard integration removal, no extra steps are required.
+This integration follows standard integration removal. No extra steps are required.
 
 {% include integrations/remove_device_service.md %}

--- a/source/_integrations/lastfm.markdown
+++ b/source/_integrations/lastfm.markdown
@@ -14,10 +14,54 @@ ha_codeowners:
   - '@joostlek'
 ---
 
-The **Last.fm** {% term integration %} will allow you to see whenever a user starts scrobbling, their play count, last song played, and top song played on [Last.fm](https://www.last.fm/).
+The **Last.fm** {% term integration %} lets you monitor the listening activity of [Last.fm](https://www.last.fm/) users. It creates a sensor for each user you add, showing whether they are currently scrobbling and what they are listening to.
 
 ## Prerequisites
 
-To get an API key you need to create an [API account](https://www.last.fm/api/account/create).
+- A [Last.fm](https://www.last.fm/) account.
+- A Last.fm API key. You can create one by registering an [API account](https://www.last.fm/api/account/create) on the Last.fm website.
 
 {% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+API key:
+  description: "The API key from your Last.fm API account."
+Last.fm username:
+  description: "Your Last.fm username. This is the main user for the integration and is used to look up your friends list in the next step."
+{% endconfiguration_basic %}
+
+After entering your API key and username, you are asked to select additional Last.fm users to track. Your friends list is shown for convenience, but you can also enter any Last.fm username manually.
+
+## Configuration options
+
+To add or remove tracked users after setup, go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Last.fm** integration, and select **Configure**.
+
+{% configuration_basic %}
+Last.fm usernames:
+  description: "The Last.fm users to track. You can select from your friends list or enter usernames manually."
+{% endconfiguration_basic %}
+
+## Supported functionality
+
+### Sensors
+
+The integration creates one sensor per tracked Last.fm user.
+
+- **State**: The currently playing track, formatted as "Artist - Title". When the user is not listening, the state is "Not Scrobbling".
+- **Entity picture**: The user's Last.fm avatar.
+
+Each sensor also provides the following attributes:
+
+- **`last_played`**: The last track the user scrobbled, formatted as "Artist - Title".
+- **`play_count`**: The total number of tracks the user has scrobbled on Last.fm.
+- **`top_played`**: The user's most played track, formatted as "Artist - Title".
+
+## Data updates
+
+The integration {% term polling polls %} Last.fm every 30 seconds for updated listening data.
+
+## Removing the integration
+
+This integration follows standard integration removal, no extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/lastfm.markdown
+++ b/source/_integrations/lastfm.markdown
@@ -30,7 +30,7 @@ Last.fm username:
   description: "Your Last.fm username. This is the main user for the integration and is used to look up your friends list in the next step."
 {% endconfiguration_basic %}
 
-After entering your API key and username, you are asked to select additional Last.fm users to track. Your friends list is shown for convenience, but you can also enter any Last.fm username manually.
+After entering your API key and Last.fm username, you are asked to select additional Last.fm users to track. Your friends list is shown for convenience, but you can also enter any Last.fm username manually.
 
 ## Configuration options
 


### PR DESCRIPTION
## Proposed change

Expands the Last.fm integration page from a bare 24-line stub to a complete page following the integration template. The previous page had no information about what entities are created, what attributes they provide, or how to configure the integration after setup.

Adds:

- **Prerequisites**: listed as bullet points.
- **Setup fields**: API key and Last.fm username, plus the friends selection step.
- **Configuration options**: documents the options flow for adding or removing tracked users after setup.
- **Supported functionality**: documents the sensor state ("Artist - Title" or "Not Scrobbling"), entity picture, and the three attributes (`last_played`, `play_count`, `top_played`) with their formats.
- **Data updates**: 30-second polling interval.
- **Removing the integration**: standard removal include.

All details verified against `sensor.py`, `coordinator.py`, `config_flow.py`, and `strings.json` in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #40883

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
