### PR TITLE
Fix GPSLogger HTTP body to only include reliably-present parameters

### DIFF
--- a/source/_integrations/gpslogger.markdown
+++ b/source/_integrations/gpslogger.markdown
@@ -53,11 +53,20 @@ https://YOUR.DNS.HOSTNAME:PORT/api/webhook/WEBHOOK_ID
 - It's HIGHLY recommended to use SSL/TLS.
 - Use the domain that Home Assistant is available on the internet (or the public IP address if you have a static IP address). This can be a local IP address if you are using an always on VPN from your mobile device to your home network.
 - Only remove `PORT` if your Home Assistant instance is using port 443. Otherwise set it to the port you're using.
-- Add the following to **HTTP Body**
+- Add the following to **HTTP Body**:
+
 ```text
-latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT
+latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC
 ```
-- You can change the `device_id` of your phone by replacing `&device=%SER` with `&device=SOME_DEVICE_ID`, otherwise your phone's serial number will be used.
+
+You can change the device identifier by replacing `%SER` with a custom value, for example, `device=my_phone`. Otherwise, your phone's serial number is used.
+
+{% tip %}
+
+The following optional parameters can be appended to the HTTP body if GPSLogger provides them: `&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT`. Only include parameters that your device actually reports values for. If GPSLogger sends an empty value for a numeric parameter (such as `battery`, `speed`, `direction`, or `altitude`), the webhook returns a 422 error.
+
+{% endtip %}
+
 - Check that the **HTTP Headers** setting contains
 ```text
 Content-Type: application/x-www-form-urlencoded

--- a/source/_integrations/gpslogger.markdown
+++ b/source/_integrations/gpslogger.markdown
@@ -59,11 +59,20 @@ https://YOUR.DNS.HOSTNAME:PORT/api/webhook/WEBHOOK_ID
 latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC
 ```
 
-You can change the device identifier by replacing `%SER` with a custom value, for example, `device=my_phone`. Otherwise, your phone's serial number is used.
+You can change the device identifier by replacing `device=%SER` with `device=my_phone`. Otherwise, your phone's serial number is used.
 
 {% tip %}
 
-The following optional parameters can be appended to the HTTP body if GPSLogger provides them: `&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT`. Only include parameters that your device actually reports values for. If GPSLogger sends an empty value for a numeric parameter (such as `battery`, `speed`, `direction`, or `altitude`), the webhook returns a 422 error.
+You can append optional parameters to the HTTP body if GPSLogger provides them. Add only the parameters your device actually reports:
+
+- `&battery=%BATT`
+- `&speed=%SPD`
+- `&direction=%DIR`
+- `&altitude=%ALT`
+- `&provider=%PROV`
+- `&activity=%ACT`
+
+If GPSLogger sends an empty value for a numeric parameter, like `battery`, `speed`, `direction`, or `altitude`, the webhook returns a 422 error.
 
 {% endtip %}
 


### PR DESCRIPTION
## Proposed change

The GPSLogger docs recommended including all optional parameters (`battery`, `speed`, `direction`, `altitude`, `provider`, `activity`) in the HTTP body by default. When GPSLogger has no data for a numeric parameter, it sends an empty string, which causes the webhook to return a 422 error.

Changes the default HTTP body example to only include the required and reliably-present parameters. Adds a tip listing the optional parameters and explaining they should only be included when the device actually reports values for them.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43614

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
