### PR TITLE
Expand Uptime integration docs with sensor details and automation exa…

### DIFF
--- a/source/_integrations/uptime.markdown
+++ b/source/_integrations/uptime.markdown
@@ -16,7 +16,44 @@ ha_codeowners:
 ha_integration_type: service
 ---
 
-The **Uptime** {% term integration %} provides a sensor that stores the timestamp
-(date and time) when Home Assistant was last started.
+The **Uptime** {% term integration %} provides a sensor that stores the date and time when Home Assistant was last started. This is useful for automations that should behave differently right after a restart, for example, to avoid triggering actions while devices are still coming online.
 
 {% include integrations/config_flow.md %}
+
+## Supported functionality
+
+### Sensors
+
+- **Uptime**
+  - **Description**: The date and time when Home Assistant was last started.
+  - **Device class**: Timestamp. The state is a UTC datetime.
+
+The sensor value is set once at startup and does not change until Home Assistant is restarted again.
+
+## Examples
+
+### Skipping automations right after a restart
+
+You can use the uptime sensor in a condition to prevent an automation from running within the first few minutes after Home Assistant starts. This avoids false triggers while devices and integrations are still initializing.
+
+```yaml
+conditions:
+  - condition: template
+    value_template: >
+      {{
+        now() - as_datetime(states('sensor.uptime'))
+        > timedelta(minutes=5)
+      }}
+```
+
+This condition passes only when Home Assistant has been running for more than 5 minutes.
+
+## Data updates
+
+The sensor value is set once when Home Assistant starts and is not polled or updated after that.
+
+## Removing the integration
+
+This integration follows standard integration removal, no extra steps are required.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Expands the Uptime integration page from a 23-line stub to a complete page. Users wanted to know the sensor format and how to use it in automations.

- Documents the sensor (device class Timestamp, UTC datetime, set once at startup).
- Adds an automation example showing how to skip triggers within the first 5 minutes after a restart using a condition template.
- Adds Data updates section explaining the sensor is not polled.
- Adds standard removal section.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #41880

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
