### PR TITLE
Note that Venstar HTTPS and auth are ColorTouch-only

### DIFF
--- a/source/_integrations/venstar.markdown
+++ b/source/_integrations/venstar.markdown
@@ -78,14 +78,18 @@ If the local API is successfully enabled on the thermostat, you should see some 
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}
-host:
-  description: Address of your thermostat, e.g., `192.168.1.32`.
-username:
-  description: Username for the thermostat.
-password:
-  description:  Password for the thermostat.
-pin:
-  description: Pin for Lockscreen (required if lock screen enabled)
-ssl:
-  description: Whether to use SSL or not when communicating.
+Host:
+  description: "The IP address of your thermostat, for example, `192.168.1.32`."
+Username:
+  description: "Username for the thermostat. Only supported on ColorTouch models."
+Password:
+  description: "Password for the thermostat. Only supported on ColorTouch models."
+PIN:
+  description: "The lock screen PIN, if you have enabled the lock screen on the thermostat."
+SSL:
+  description: "Whether to use HTTPS when communicating with the thermostat. Only supported on ColorTouch models."
 {% endconfiguration_basic %}
+
+{% note %}
+HTTPS, username, and password authentication are only available on ColorTouch thermostats. Other models, such as the Explorer Mini and Explorer IAQ, only support unencrypted HTTP connections with no authentication.
+{% endnote %}


### PR DESCRIPTION
## Proposed change

Clarifies on the Venstar integration page that HTTPS, username, and password authentication are only supported on ColorTouch thermostats. Other models like the Explorer Mini and Explorer IAQ only support unencrypted HTTP with no authentication. Users were spending time trying to configure these fields on unsupported models.

Adds "Only supported on ColorTouch models" to the relevant field descriptions and a note block below the config fields stating the limitation explicitly.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #43576

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
