### PR TITLE
Proofread Hue integration page and add configuration options, data updates

### DIFF
--- a/source/_integrations/hue.markdown
+++ b/source/_integrations/hue.markdown
@@ -24,13 +24,11 @@ ha_zeroconf: true
 ha_integration_type: hub
 ---
 
-The **Philips Hue** {% term integration %} allows you to control and monitor the lights and sensors connected to your Hue bridge.
-
-There is currently support for the following device types within Home Assistant:
+The **Philips Hue** {% term integration %} allows you to control and monitor the lights and sensors connected to your Hue bridge. The integration supports:
 
 - Lights
 - Motion sensors (including temperature and light level sensors)
-- Hue remotes/switches (as device triggers for automations and also exposed as battery sensors when they are battery-powered)
+- Remotes and switches (as device triggers for automations, and also exposed as battery sensors when they are battery-powered)
 
 {% include integrations/config_flow.md %}
 
@@ -38,45 +36,87 @@ There is currently support for the following device types within Home Assistant:
 
 The Hue concept is based on Rooms and Zones. Although the underlying Hue lights are exposed directly to Home Assistant, it might also be useful to interact with the `grouped lights` of the Hue ecosystem, for example, to turn all lights in a Hue group on/off at the same time.
 
-Home Assistant creates lights for each Hue zone/room automatically but disables them by default.
-If you'd like to use those `grouped lights`, you can enable them from Settings --> Integrations --> Hue --> entities.
+Home Assistant creates lights for each Hue zone and room automatically but disables them by default. To enable them, go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Hue** integration, and enable the grouped light entities you want to use.
 
 ## Scenes
 
-In the Hue concept you can create (dynamic) scenes for the lights within rooms and zones. You can create, edit and delete Hue scenes from the (official) Hue app on iOS and Android. Each Zone/Room can have its own scenes assigned and there is a large library of preset scenes for specific moods. These Hue scenes are automatically imported in Home Assistant and they're available as `scene entities`. Creating or editing Hue scenes in Home Assistant is not supported.
+You can create, edit, and delete Hue scenes from the official Hue app on iOS and Android. Each room and zone can have its own scenes, and there is a large library of preset scenes for specific moods. These Hue scenes are automatically imported into Home Assistant and available as scene entities. Creating or editing Hue scenes in Home Assistant is not supported.
 
-It is advised to use Hue scenes for controlling multiple lights at once for a smooth experience. If you individually control multiple lights and/or use Home Assistant scenes, each light command will be sent to each light one by one which doesn't give a very good user experience, while using a Hue scene sends commands to all lights at once in an optimized way, resulting in a smooth experience.
+Using Hue scenes is recommended when you want to control multiple lights at once. If you control multiple lights individually or use Home Assistant scenes, each command is sent to each light one by one. A Hue scene sends commands to all lights at once in an optimized way, resulting in a smoother experience.
 
 ### Action: Activate scene
 
-The `hue.activate_scene` action provides more control over Hue scenes by allowing you to activate a Hue scene and set some properties at the same time, such as the Dynamic mode and/or brightness.
+The `hue.activate_scene` action lets you activate a Hue scene and set properties like dynamic mode or brightness at the same time.
 
-| Data attribute | Required | Description                                                                                   |
-| ---------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `entity_id`            | yes      | Entity ID of the Hue Scene entity you want to activate.                                       |
-| `transition`           | no       | Transition duration (in seconds) it takes to bring devices to the state defined in the scene. |
-| `dynamic`              | no       | Enable (true) or Disable (false) dynamic mode for the scene.                                  |
-| `speed`                | no       | Set the speed (of the dynamic palette) for this scene.                                        |
-| `brightness`           | no       | Set the brightness for this scene.                                                             |
+- **Data attribute**: `entity_id`
+  - **Description**: The entity ID of the Hue scene to activate.
+  - **Required**: Yes
 
-You can use this action for example if you'd like to start/stop Dynamic Mode.
+- **Data attribute**: `transition`
+  - **Description**: Transition duration in seconds to bring devices to the state defined in the scene.
+  - **Required**: No
+
+- **Data attribute**: `dynamic`
+  - **Description**: Enable (`true`) or disable (`false`) dynamic mode for the scene.
+  - **Required**: No
+
+- **Data attribute**: `speed`
+  - **Description**: The speed of the dynamic palette for this scene.
+  - **Required**: No
+
+- **Data attribute**: `brightness`
+  - **Description**: The brightness for this scene.
+  - **Required**: No
+
+You can use this action, for example, to start or stop dynamic mode on a scene.
+
+## Configuration options
+
+After setting up the integration, the following options can be configured by going to {% my integrations title="**Settings** > **Devices & services**" %}, selecting the **Hue** integration, and selecting **Configure**.
+
+### V2 bridges (square shape)
+
+{% configuration_basic %}
+Ignore connectivity status for the given devices:
+  description: "Select devices for which the connectivity (availability) status should be ignored. This is useful for battery-powered devices like remotes that are reported as unavailable when they go to sleep."
+{% endconfiguration_basic %}
+
+### V1 bridges (round shape)
+
+{% configuration_basic %}
+Allow Hue groups:
+  description: "When enabled, creates light entities for Hue rooms."
+Allow unreachable bulbs to report their state correctly:
+  description: "When enabled, allows bulbs that are reported as unreachable by the bridge to still report their last known state."
+{% endconfiguration_basic %}
 
 ## Hue remotes and switches
 
-Hue remotes such as the Dimmer Switch are stateless devices, meaning that they do not have an on/off state like regular entities in Home Assistant. Instead, such devices emit the event `hue_event` when a button is pressed. You can test what events come in using the event {% my developer_events title="**Settings** > **Developer tools** > **Events**" %} in Home Assistant and subscribe to the `hue_event`. Once you know what the event data looks like, you can use this to create automations.
+Hue remotes such as the Dimmer Switch are stateless devices, meaning that they do not have an on/off state like regular entities in Home Assistant. Instead, these devices emit the event `hue_event` when a button is pressed. You can test what events come in by going to {% my developer_events title="**Settings** > **Developer tools** > **Events**" %} and subscribing to `hue_event`. Once you know what the event data looks like, you can use it to create automations.
 
 {% note %}
-At the time of writing, there's a limitation on the Hue API that each device can only send one event per second. This means that button events are rate-limited to 1 per second. This is brought to the attention of Signify and it will hopefully be fixed soon.
+The Hue API limits each device to one event per second. This means that button events are rate-limited to one per second.
 {% endnote %}
 
 ## Support for legacy (V1) Hue bridges
 
-Philips/Signify released a new version of their Hue bridge (square shape) and their legacy/V1 bridge (round shape) is now end of life and no longer supported by them. Home Assistant will continue to support the V1 Hue bridge as long as it is technically possible, although with a few limitations:
+Signify released a newer version of the Hue bridge (square shape), and the legacy V1 bridge (round shape) is now end of life and no longer supported by Signify. Home Assistant will continue to support the V1 Hue bridge as long as it is technically possible, with the following limitations:
 
-- Scene entities are not automatically created for V1 bridges. To activate a Hue scene on a V1 bridge from Home Assistant there is an action to do so by name.
-- State updates for devices/entities on a V1 bridges are not received instantly but polled on interval.
-- Light entities for Hue rooms are not automatically created for V1 bridges, you can opt-in for creating entities for rooms within the Integration's options.
+- Scene entities are not automatically created for V1 bridges. To activate a Hue scene on a V1 bridge from Home Assistant, use the action described below.
+- State updates for devices on V1 bridges are not received instantly but polled on an interval.
+- Light entities for Hue rooms are not automatically created for V1 bridges. You can opt in to creating room entities in the integration's options.
 
-For v1 Hue bridges, you can create a script using the **Scripts** tab.  
-1. Select **Add New Script** > **Add Action** > **Philips Hue: Activate Scene**
-2. Then select the appropriate room name in the **Group** field and the scene name in the **Scene** field stored on your Hue bridge.
+To activate a scene on a V1 bridge:
+
+1. Go to **Scripts** and select **Add New Script** > **Add Action** > **Philips Hue: Activate Scene**.
+2. Select the room name in the **Group** field and the scene name in the **Scene** field.
+
+## Data updates
+
+V2 Hue bridges (square shape) push state changes to Home Assistant instantly over their local event stream. V1 Hue bridges (round shape) are polled on an interval because the V1 API does not support push updates.
+
+## Removing the integration
+
+This integration follows standard integration removal, no extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/hue.markdown
+++ b/source/_integrations/hue.markdown
@@ -117,6 +117,6 @@ V2 Hue bridges (square shape) push state changes to Home Assistant instantly ove
 
 ## Removing the integration
 
-This integration follows standard integration removal, no extra steps are required.
+This integration follows standard integration removal. No extra steps are required.
 
 {% include integrations/remove_device_service.md %}

--- a/source/_integrations/hue.markdown
+++ b/source/_integrations/hue.markdown
@@ -72,7 +72,7 @@ You can use this action, for example, to start or stop dynamic mode on a scene.
 
 ## Configuration options
 
-After setting up the integration, the following options can be configured by going to {% my integrations title="**Settings** > **Devices & services**" %}, selecting the **Hue** integration, and selecting **Configure**.
+After setting up the integration, the following options can be configured by going to {% my integrations title="**Settings** > **Devices & services**" %}, selecting the **Philips Hue** integration, and selecting **Configure**.
 
 ### V2 bridges (square shape)
 

--- a/source/_integrations/hue.markdown
+++ b/source/_integrations/hue.markdown
@@ -36,7 +36,7 @@ The **Philips Hue** {% term integration %} allows you to control and monitor the
 
 The Hue concept is based on Rooms and Zones. Although the underlying Hue lights are exposed directly to Home Assistant, it might also be useful to interact with the `grouped lights` of the Hue ecosystem, for example, to turn all lights in a Hue group on/off at the same time.
 
-Home Assistant creates lights for each Hue zone and room automatically but disables them by default. To enable them, go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Hue** integration, and enable the grouped light entities you want to use.
+Home Assistant creates lights for each Hue zone and room automatically but disables them by default. To enable them, go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Philips Hue** integration, and enable the grouped light entities you want to use.
 
 ## Scenes
 


### PR DESCRIPTION
## Proposed change

Proofreads the Philips Hue integration page and adds missing sections from the integration template.

Style and readability fixes:

- Replaces `Settings --> Integrations --> Hue --> entities` with bold breadcrumbs and a My link.
- Converts the `hue.activate_scene` action parameters table to a bullet list.
- Removes stale "At the time of writing" and "hopefully fixed soon" from the rate-limit note.
- Fixes grammar ("a V1 bridges", "polled on interval") and inconsistent V1/v1 casing.
- Tightens prose throughout and adds missing Oxford commas.

New sections:

- **Configuration options**: documents the V2 options flow (ignore connectivity status for battery-powered devices) and V1 options flow (allow Hue groups, allow unreachable bulbs), verified against `config_flow.py` and `strings.json`.
- **Data updates**: explains that V2 bridges push state changes instantly while V1 bridges are polled.
- **Removing the integration**: standard removal include.

## Type of change

- [x] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
