### PR TITLE
Expand Season integration docs with use cases, sensor details, and examples

### DIFF
--- a/source/_integrations/season.markdown
+++ b/source/_integrations/season.markdown
@@ -16,23 +16,104 @@ ha_codeowners:
 ha_integration_type: service
 ---
 
-The **Season** {% term integration %} will provide the current astronomical or meteorological season (Spring, Summer, Autumn, Winter)
-as a sensor.
+The **Season** {% term integration %} provides a sensor that reports the current season (spring, summer, autumn, or winter) based on your configured home location.
+
+Use cases for this integration include:
+
+- Adjusting your heating or cooling schedule based on the current season.
+- Changing irrigation duration or frequency throughout the year.
+- Toggling seasonal automations on and off when the season changes.
+- Setting different default lighting scenes for summer evenings versus winter evenings.
 
 {% include integrations/config_flow.md %}
+
 {% configuration_basic %}
 Type of season definition:
-    description: "Choose how seasons are set: by astronomical dates or by meteorological months."
+  description: "Choose how seasons are determined."
 {% endconfiguration_basic %}
 
-For information on the difference between astronomical and meteorological seasons please see the link below:
+You can choose between two types:
 
-- [https://www.ncei.noaa.gov/news/meteorological-versus-astronomical-seasons](https://www.ncei.noaa.gov/news/meteorological-versus-astronomical-seasons)
+- **Astronomical**: Seasons are based on the actual solstice and equinox dates, calculated using the position of the Earth relative to the Sun. In the Northern Hemisphere, spring starts around March 20.
+- **Meteorological**: Seasons are based on fixed calendar months. In the Northern Hemisphere, spring starts on March 1.
 
-All information about how the seasons work was taken from Wikipedia:
+You can set up the integration twice to have both types available at the same time.
 
-- [https://en.wikipedia.org/wiki/Season#Astronomical](https://en.wikipedia.org/wiki/Season#Astronomical)
-- [https://en.wikipedia.org/wiki/Equinox](https://en.wikipedia.org/wiki/Equinox)
-- [https://en.wikipedia.org/wiki/Solstice](https://en.wikipedia.org/wiki/Solstice)
+For more information on the difference between the two, see [Meteorological versus astronomical seasons](https://www.ncei.noaa.gov/news/meteorological-versus-astronomical-seasons) from NOAA.
 
-To cut a long read short, Astronomical gives seasons based on the shortest/longest day and equinoxes. So in the Northern Hemisphere spring starts on 20 March. Meteorological gives seasons based on months so in the Northern Hemisphere spring starts on 1 March.
+## Supported functionality
+
+### Sensors
+
+- **Season**
+  - **Description**: The current season.
+  - **Device class**: Enum.
+  - **Possible states**: `spring`, `summer`, `autumn`, `winter`.
+
+The sensor automatically determines your hemisphere from the latitude configured under {% my general title="**Settings** > **System** > **General**" %}:
+
+- **Northern Hemisphere** (latitude above 0): spring, summer, autumn, winter follow the standard Northern Hemisphere dates.
+- **Southern Hemisphere** (latitude below 0): seasons are swapped. For example, when it is summer in the Northern Hemisphere, the sensor reports winter.
+- **Equator** (latitude exactly 0): the sensor does not report a season because the equator does not experience traditional seasons.
+
+## Examples
+
+### Running an automation only in a specific season
+
+You can use the season sensor as a condition to limit an automation to a specific season. For example, to only run a heating automation during winter:
+
+```yaml
+conditions:
+  - condition: state
+    entity_id: sensor.season
+    state: winter
+```
+
+### Triggering an automation when the season changes
+
+You can trigger an automation when the season changes, for example, to adjust your thermostat schedule or toggle seasonal automations on and off:
+
+```yaml
+triggers:
+  - trigger: state
+    entity_id: sensor.season
+```
+
+### Adjusting behavior based on the current season
+
+You can use `choose` to vary what an automation does depending on the season. For example, to set different default temperatures:
+
+```yaml
+actions:
+  - choose:
+      - conditions:
+          - condition: state
+            entity_id: sensor.season
+            state: winter
+        sequence:
+          - action: climate.set_temperature
+            target:
+              entity_id: climate.living_room
+            data:
+              temperature: 21
+      - conditions:
+          - condition: state
+            entity_id: sensor.season
+            state: summer
+        sequence:
+          - action: climate.set_temperature
+            target:
+              entity_id: climate.living_room
+            data:
+              temperature: 25
+```
+
+## Data updates
+
+The sensor updates its value on a regular polling interval. Because seasons change infrequently, updates are only meaningful around the transition dates.
+
+## Removing the integration
+
+This integration follows standard integration removal, no extra steps are required.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Rewrites the Season integration page from a 38-line stub to a complete page following the integration template. The previous page had bare URLs, a run-on closing paragraph, and no information about the sensor entity, hemisphere behavior, or automation examples.

Adds:

- **Use cases**: HVAC scheduling, irrigation, toggling seasonal automations, lighting scenes.
- **Setup field**: documented with descriptions of both astronomical (solstice/equinox-based) and meteorological (fixed calendar months) types, and a note that both can be set up simultaneously.
- **Sensor documentation**: device class (Enum), the four possible states, and automatic hemisphere detection from latitude, including the equator edge case.
- **Examples**: three automation patterns based on common community use cases: season as a condition, triggering on season change, and using `choose` for per-season behavior.
- **Data updates** and **Removing the integration** sections.

Replaced bare Wikipedia/NOAA URLs with proper inline links.

All details verified against `sensor.py`, `config_flow.py`, `const.py`, and `strings.json` in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
