### PR TITLE
Complete Tailwind integration documentation for quality scale

### DIFF
--- a/source/_integrations/tailwind.markdown
+++ b/source/_integrations/tailwind.markdown
@@ -18,47 +18,159 @@ ha_platforms:
   - number
 ha_integration_type: device
 ha_dhcp: true
+related:
+  - docs: /docs/configuration/troubleshooting/#debug-logs-and-diagnostics
+    title: Debug logs and diagnostics
 ---
 
-The **Tailwind** {% term integration %} integrates [Tailwind](https://gotailwind.com/)
-garage door controllers fully locally.
+The **Tailwind** {% term integration %} lets you control your [Tailwind](https://gotailwind.com/) garage door controller fully locally, without relying on cloud services.
 
-This integration has been tested with the following Tailwind devices:
+Use cases for this integration include:
+
+- Opening and closing your garage door from the Home Assistant UI or automations.
+- Monitoring whether the garage door is currently open or closed.
+- Automating your garage door based on presence detection, for example, opening it when you arrive home.
+- Adjusting the brightness of the status LED on the Tailwind device.
+
+## Supported devices
+
+The following Tailwind devices are supported:
 
 - [Tailwind iQ3](https://gotailwind.com/products/iq3-smart-garage-controller)
 
 ## Prerequisites
 
-To use your Tailwind device with Home Assistant, you need to have your Tailwind
-device setup, connected to your network, and configured in the Tailwind app.
+Before setting up this integration, make sure your Tailwind device is set up, connected to your network, and configured in the Tailwind app.
 
-You will need two pieces of information:
+You will need the following information during setup:
 
-- **The IP address of your Tailwind device.** You can find the IP address by
-  going into the Tailwind app and selecting your Tailwind device's cog icon.
-  The IP address is shown in the **Device Info** section.
-- **Local control key token.** To find local control key token, browse to the
-  [Tailwind web portal][token], log in with your Tailwind account, and select
-  the [**Local Control Key**][token] tab. The 6-digit number shown is your
-  local control key token.
-
-[token]: https://web.gotailwind.com/client/integration/local-control-key
+- **The IP address of your Tailwind device.** In the Tailwind app, select the cog icon on your device. The IP address is shown in the **Device Info** section.
+- **The local control key token.** Go to the [Tailwind web portal](https://web.gotailwind.com/client/integration/local-control-key), sign in with your Tailwind account, and select the **Local Control Key** tab. The 6-digit number shown is your local control key token.
 
 {% include integrations/config_flow.md %}
 
-## Provided entities
+{% configuration_basic %}
+Host:
+  description: "The hostname or IP address of your Tailwind device."
+Local control key token:
+  description: "The 6-digit local control key token from the [Tailwind web portal](https://web.gotailwind.com/client/integration/local-control-key)."
+{% endconfiguration_basic %}
 
-The Tailwind integration provides a cover entity for each garage door that is
-connected to your Tailwind garage door controller.
+To change the host or local control key token after setup, go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Tailwind** integration, and select **Reconfigure**.
 
-Using the cover entity, you can open and close your garage door and see the
-current state of your garage door.
+## Supported functionality
 
-Additionally, the integration provides the following entities:
+### Covers
 
-- **Identify** - A button entity that allows you to identify your Tailwind
-  device by flashing the status LED on the device.
-- **Operational status** - A binary sensor entity that shows the operational
-  status of your Tailwind device.
-- **Status LED brightness control** - A number entity that allows you to control
-  the brightness of the status LED on the Tailwind device.
+The integration creates a cover entity for each garage door connected to your Tailwind controller. You can open and close the door and see its current state (open or closed).
+
+### Binary sensors
+
+- **Operational problem**
+  - **Description**: Indicates whether the door has an operational problem (locked out).
+  - **Entity category**: Diagnostic
+
+### Buttons
+
+- **Identify**
+  - **Description**: Flashes the status LED on the Tailwind device so you can identify it.
+  - **Entity category**: Configuration
+
+### Numbers
+
+- **Status LED brightness**
+  - **Description**: Controls the brightness of the status LED on the Tailwind device (0 to 100%).
+  - **Entity category**: Configuration
+
+## Examples
+
+### Notify when the garage door is left open
+
+Send a mobile notification when the garage door has been open for more than 10 minutes:
+
+```yaml
+alias: "Notify when garage door left open"
+triggers:
+  - trigger: state
+    entity_id: cover.garage_door
+    to: "open"
+    for:
+      minutes: 10
+actions:
+  - action: notify.mobile_app_my_phone
+    data:
+      title: "Garage door"
+      message: "The garage door has been open for 10 minutes."
+```
+
+### Close the garage door at bedtime if left open
+
+Automatically close the garage door when you activate your bedtime scene, but only if it is currently open:
+
+```yaml
+alias: "Close garage door at bedtime"
+triggers:
+  - trigger: state
+    entity_id: scene.bedtime
+conditions:
+  - condition: state
+    entity_id: cover.garage_door
+    state: "open"
+actions:
+  - action: cover.close_cover
+    target:
+      entity_id: cover.garage_door
+```
+
+### Close the garage door when everyone leaves home
+
+Close the garage door automatically when nobody is home:
+
+```yaml
+alias: "Close garage door when leaving home"
+triggers:
+  - trigger: state
+    entity_id: zone.home
+    to: "0"
+conditions:
+  - condition: state
+    entity_id: cover.garage_door
+    state: "open"
+actions:
+  - action: cover.close_cover
+    target:
+      entity_id: cover.garage_door
+```
+
+## Data updates
+
+The integration polls the Tailwind device every 5 seconds over the local network for updated door and device status.
+
+## Known limitations
+
+- The integration communicates with the Tailwind device over the local network. If the device is not reachable, the entities become unavailable.
+- The Tailwind device requires a minimum firmware version. If your firmware is too old, the integration will not set up. Update your device to the latest firmware using the Tailwind app.
+
+## Troubleshooting
+
+### Cannot connect during setup
+
+If you see a "Cannot connect" error during setup, verify that:
+
+1. The Tailwind device is powered on and connected to your network.
+2. The IP address you entered is correct. You can find it in the Tailwind app under the device's cog icon in the **Device Info** section.
+3. Home Assistant can reach the device on the local network.
+
+### Invalid authentication
+
+If you see an "Invalid authentication" error, your local control key token may have changed. Go to the [Tailwind web portal](https://web.gotailwind.com/client/integration/local-control-key) and verify the current token. You can update it in Home Assistant by selecting **Reconfigure** on the integration card.
+
+### Unsupported firmware
+
+If you see an "Unsupported firmware" message, update your Tailwind device to the latest firmware version using the Tailwind app, then try setting up the integration again.
+
+## Removing the integration
+
+This integration follows standard integration removal, no extra steps are required.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Completes the Tailwind integration documentation to address all `todo` items in the integration's quality scale (`quality_scale.yaml` in core). The previous page covered only installation basics.

Adds or rewrites:

- **High-level description**: intro now mentions fully local operation without cloud services.
- **Use cases**: four practical examples (open/close from UI, monitoring, presence-based automation, LED brightness).
- **Installation parameters**: `configuration_basic` block for Host and Local control key token.
- **Reconfiguration**: how to change the host or token after setup via the reconfigure flow.
- **Supported functionality**: full entity list with descriptions and entity categories for covers, binary sensors, buttons, and numbers.
- **Data updates**: 5-second local polling interval.
- **Known limitations**: local network requirement and minimum firmware version.
- **Examples**: three automation examples (notify when left open, close at bedtime, close when everyone leaves).
- **Troubleshooting**: sections for cannot connect, invalid authentication, and unsupported firmware, all derived from the config flow error handling in core.
- **Removing the integration**: standard removal include.
- **Related**: link to debug logs and diagnostics in frontmatter.

All details verified against `config_flow.py`, `coordinator.py`, `cover.py`, `binary_sensor.py`, `button.py`, `number.py`, `strings.json`, and `quality_scale.yaml` in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
