### PR TITLE
Complete Elgato Light integration documentation for quality scale

### DIFF
--- a/source/_integrations/elgato.markdown
+++ b/source/_integrations/elgato.markdown
@@ -17,14 +17,23 @@ ha_platforms:
   - sensor
   - switch
 ha_integration_type: device
+related:
+  - docs: /docs/configuration/troubleshooting/#debug-logs-and-diagnostics
+    title: Debug logs and diagnostics
 ---
 
-The [Elgato](https://www.elgato.com/) Lights sets the bar for high-end studio
-lightning. The LED lights are created and designed specifically for streamers
-and content creators, many of whom operate on platforms like YouTube and Twitch.
+The **Elgato Light** {% term integration %} lets you control [Elgato](https://www.elgato.com/) LED lighting devices locally over your network. Elgato Lights are designed for streamers, content creators, and home studio setups, and are commonly used on platforms like YouTube and Twitch.
 
-The following light productions from Elgato have been tested with this
-integration:
+Use cases for this integration include:
+
+- Turning your studio lights on and off automatically when your streaming software starts or stops.
+- Adjusting brightness and color temperature based on the time of day.
+- Using a light as a visual notification, for example, to flash when a doorbell is pressed or a timer finishes.
+- Monitoring the battery level of portable Key Light Mini devices.
+
+## Supported devices
+
+The following Elgato lighting devices are known to be supported:
 
 - [Elgato Key Light](https://www.elgato.com/en/key-light)
 - [Elgato Key Light Air](https://www.elgato.com/en/key-light-air)
@@ -32,61 +41,140 @@ integration:
 - [Elgato Ring Light](https://www.elgato.com/en/ring-light)
 - [Elgato Light Strip](https://www.elgato.com/en/light-strip)
 
+## Prerequisites
+
+Your Elgato Light must be powered on and connected to your local network. In most cases, the integration automatically discovers the device on your network.
+
 {% include integrations/config_flow.md %}
 
-## Lights
+{% configuration_basic %}
+Host:
+  description: "The hostname or IP address of your Elgato Light device. This is only shown when adding the device manually. Devices discovered automatically through zeroconf are added without any input required."
+{% endconfiguration_basic %}
 
-This integration adds the Key Light device as a light in Home Assistant, and
-allows you to control the color temperature, brightness, and its on/off state.
+## Supported functionality
 
-When using the Elgato Light Strip, color support is automatically detected
-and enabled in Home Assistant.
+### Lights
 
-## Other entities
+The integration creates a light entity for each Elgato Light device. You can control:
 
-Besides the above mentioned light entity, this integration also provides other
-secondary entities that can be useful for monitoring and controlling your
-Elgato light.
+- On/off state
+- Brightness
+- Color temperature
+- Color (for devices that support color, such as the Light Strip, detected automatically)
+
+### Buttons
+
+- **Identify**
+  - **Description**: Briefly flashes the Elgato Light so you can identify which device it is. Also usable as a visual notification.
+  - **Entity category**: Configuration
+
+- **Restart**
+  - **Description**: Restarts the Elgato Light device.
+  - **Entity category**: Configuration
 
 ### Sensors
 
-If you have a Key Light Mini, Home Assistant will provide an additional
-sensor that indicates the level of your battery in percent (%).
+- **Battery**
+  - **Description**: The current battery level of your Elgato Key Light Mini, as a percentage. Only available on Key Light Mini.
 
 ### Switches
 
-If you have a Key Light Mini, Home Assistant will provide an additional
-switch that allows the control of the "Studio mode" of your light. When
-studio mode is enabled, your battery will not be used and bypassed.
+- **Studio mode**
+  - **Description**: Toggles studio mode on the Key Light Mini. When studio mode is enabled, the device bypasses the battery and runs directly from the power adapter. Only available on Key Light Mini.
 
 ## Actions
 
 ### Action: Identify
 
-The `elgato.identify` action allows you to shortly blink the Elgato light. Originally meant as
-a way to identify which light you are talking to; it can also be used as
-an action to create a visual notification.
+The `elgato.identify` action briefly blinks the Elgato Light. It was originally meant as a way to identify which light you are talking to, but it can also be used as a visual notification.
 
-This action also works when the light is turned off and will turn off the
-light after the identification sequence has been completed.
+This action works even when the light is turned off and turns the light back off after the identification sequence completes.
 
 {% my developer_call_service badge service="elgato.identify" %}
 
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | Yes | String or list of Elgato light entity IDs.
+- **Data attribute**: `entity_id`
+  - **Description**: String or list of Elgato light entity IDs.
+  - **Optional**: Yes
 
-Example automation, in YAML format, that triggers a visual notification when
-a binary sensor (a doorbell) is triggered:
+## Examples
+
+### Visual doorbell notification
+
+Briefly flash the Elgato Light when your doorbell is pressed:
 
 ```yaml
-- alias: "Visual doorbell notification example"
-  triggers:
-    - trigger: state
-      entity_id: binary_sensor.doorbell
-      to: "on"
-  actions:
-    - action: elgato.identify
-      target:
-        entity_id: light.elgato_key_light
+alias: "Visual doorbell notification"
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.doorbell
+    to: "on"
+actions:
+  - action: elgato.identify
+    target:
+      entity_id: light.elgato_key_light
 ```
+
+### Turn on lights when streaming software starts
+
+Automatically turn on your Elgato Key Light when OBS (or any other streaming software) starts streaming, using an entity exposed by an OBS integration:
+
+```yaml
+alias: "Turn on key light when streaming"
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.obs_streaming
+    to: "on"
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.elgato_key_light
+    data:
+      brightness_pct: 80
+      color_temp_kelvin: 5600
+```
+
+### Low battery notification for Key Light Mini
+
+Send a mobile notification when the Key Light Mini battery drops below 20%:
+
+```yaml
+alias: "Key Light Mini low battery"
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.elgato_key_light_mini_battery
+    below: 20
+actions:
+  - action: notify.mobile_app_my_phone
+    data:
+      title: "Key Light Mini"
+      message: "Battery is below 20%."
+```
+
+## Data updates
+
+The integration polls the Elgato Light device every 10 seconds over the local network for its current state.
+
+## Known limitations
+
+- The integration communicates with the Elgato Light device over the local network. If the device is not reachable, its entities become unavailable.
+- Color control is only available on devices that support it, such as the Light Strip. Color temperature and brightness are available on all supported models.
+- The battery level sensor and studio mode switch are only available on the Key Light Mini, as other models do not have a built-in battery.
+
+## Troubleshooting
+
+### Cannot connect during setup
+
+If you see a "Cannot connect" error during setup, verify that:
+
+1. The Elgato Light device is powered on and connected to your network.
+2. The IP address you entered is correct.
+3. Home Assistant can reach the device on the local network.
+
+Most Elgato Lights are discovered automatically via zeroconf, so manual setup is rarely needed. If the device is not discovered, check that zeroconf/mDNS traffic is not blocked on your network.
+
+## Removing the integration
+
+This integration follows standard integration removal, no extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/elgato.markdown
+++ b/source/_integrations/elgato.markdown
@@ -168,7 +168,7 @@ The integration polls the Elgato Light device every 10 seconds over the local ne
 If you see a "Cannot connect" error during setup, verify that:
 
 1. The Elgato Light device is powered on and connected to your network.
-2. The IP address you entered is correct.
+2. The hostname or IP address you entered in **Host** is correct.
 3. Home Assistant can reach the device on the local network.
 
 Most Elgato Lights are discovered automatically via zeroconf, so manual setup is rarely needed. If the device is not discovered, check that zeroconf/mDNS traffic is not blocked on your network.


### PR DESCRIPTION
## Proposed change

Completes the Elgato Light integration documentation to address all `todo` items in the integration's quality scale.

Adds or rewrites:

- **Use cases**: four practical examples (streaming automation, time-based adjustments, visual notifications, battery monitoring).
- **Installation parameters**: `configuration_basic` block for the Host field, noting that zeroconf auto-discovery is the normal path.
- **Supported functionality**: full entity breakdown for lights, buttons (including the previously undocumented Restart button), sensors, and switches, with entity categories and per-model restrictions.
- **Data updates**: 10-second polling interval over the local network.
- **Known limitations**: local network requirement, color support limitations, and Key Light Mini-only entities.
- **Examples**: three automation examples (visual doorbell notification from the old page, streaming software trigger, low-battery mobile notification).
- **Troubleshooting**: cannot connect section with a note about zeroconf/mDNS traffic.
- **Removing the integration**: standard removal include.
- **Related**: link to debug logs and diagnostics in frontmatter.

All details verified against `config_flow.py`, `coordinator.py`, `button.py`, `const.py`, `services.yaml`, and `quality_scale.yaml` in core, plus the `python-elgato` library README.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
