### PR TITLE
Fix misleading offsets in Twente Milieu automation examples

### DIFF
--- a/source/_integrations/twentemilieu.markdown
+++ b/source/_integrations/twentemilieu.markdown
@@ -78,9 +78,9 @@ automation:
       - trigger: calendar
         event: start
         entity_id: calendar.twente_milieu
-        offset: "-6:00:00"
-        # This triggers 6 hours before the calendar event starts
-
+        # Fire 12 hours before the calendar event starts,
+        # so you get notified the evening before the pickup day.
+        offset: "-12:00:00"
     actions:
       - action: notify.mobile_app_your_device
         data:
@@ -101,9 +101,9 @@ automation:
       - trigger: calendar
         event: end
         entity_id: calendar.twente_milieu
+        # Fire 4 hours before the calendar event ends,
+        # so you get notified in the evening of the pickup day.
         offset: "-4:00:00"
-        # This triggers 4 hours before the calendar event ends
-
     actions:
       - action: notify.mobile_app_your_device
         data:


### PR DESCRIPTION
## Proposed change

Fixes two small issues in the Twente Milieu automation examples:

- The first example claimed to notify "the evening before" the pickup day but used an offset of `-6:00:00`. With a typical morning pickup at 7 AM, that fires at 1 AM, which is not the evening before. Changed to `-12:00:00` so it fires around 7 PM the previous evening.
- Moved the trigger offset comments above the `offset:` line they describe, which is clearer and removes the need for a blank line splitting the trigger block.

## Type of change

- [x] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
