### PR TITLE
Add room priority select to Lyric integration docs

### DIFF
--- a/source/_integrations/lyric.markdown
+++ b/source/_integrations/lyric.markdown
@@ -50,16 +50,12 @@ You can then add the integration in the frontend via the steps below.
 
 The integration configuration will ask for the **Client ID** and **Client Secret**, which correspond to the **Consumer** values in the app you created above. See [Application Credentials](/integrations/application_credentials) for more details.
 
-## Room priority
+## Selects
 
-For thermostats with wireless room sensors (such as the T9 and T10), a **Room priority** select entity is created. This lets you choose which room sensor the thermostat uses for its temperature reading.
-
-Available options:
-
-- **Follow me** — The thermostat automatically switches to the room where motion is detected.
-- The names of all rooms with sensors paired to the thermostat appear as individual options (for example, "Bedroom", "Office"). Selecting one tells the thermostat to use that room's sensor for its temperature reading.
-
-This entity only appears for thermostats that support room sensors and have room sensor accessories paired.
+- **Room priority**
+  - **Description**: Controls which room sensor the thermostat uses for its temperature reading.
+  - **Options**: **Follow me**, and the name of each paired room sensor (such as "Bedroom" or "Office").
+  - **Available for**: T9 and T10 thermostats with at least one paired room sensor.
 
 ## Sensors
 

--- a/source/_integrations/lyric.markdown
+++ b/source/_integrations/lyric.markdown
@@ -59,7 +59,7 @@ Available options:
 - **Follow me** — The thermostat automatically switches to the room where motion is detected.
 - **Each paired room** — The names of all rooms with sensors paired to the thermostat appear as individual options (for example, "Bedroom", "Office"). Selecting one tells the thermostat to use that room's sensor for its temperature reading.
 
-This entity only appears for LCC thermostats that have room sensor accessories paired.
+This entity only appears for thermostats that support room sensors and have room sensor accessories paired.
 
 ## Sensors
 

--- a/source/_integrations/lyric.markdown
+++ b/source/_integrations/lyric.markdown
@@ -57,7 +57,7 @@ For thermostats with wireless room sensors (such as the T9 and T10), a **Room pr
 Available options:
 
 - **Follow me** — The thermostat automatically switches to the room where motion is detected.
-- **Each paired room** — The names of all rooms with sensors paired to the thermostat appear as individual options (for example, "Bedroom", "Office"). Selecting one tells the thermostat to use that room's sensor for its temperature reading.
+- The names of all rooms with sensors paired to the thermostat appear as individual options (for example, "Bedroom", "Office"). Selecting one tells the thermostat to use that room's sensor for its temperature reading.
 
 This entity only appears for thermostats that support room sensors and have room sensor accessories paired.
 

--- a/source/_integrations/lyric.markdown
+++ b/source/_integrations/lyric.markdown
@@ -3,6 +3,7 @@ title: Honeywell Lyric
 description: How to integrate the Honeywell Lyric integration into Home Assistant.
 ha_category:
   - Climate
+  - Select
   - Sensor
 ha_release: 2021.3
 ha_iot_class: Cloud Polling
@@ -12,6 +13,7 @@ ha_codeowners:
 ha_domain: lyric
 ha_platforms:
   - climate
+  - select
   - sensor
 ha_dhcp: true
 ha_integration_type: hub
@@ -47,6 +49,17 @@ You can then add the integration in the frontend via the steps below.
 {% include integrations/config_flow.md %}
 
 The integration configuration will ask for the **Client ID** and **Client Secret**, which correspond to the **Consumer** values in the app you created above. See [Application Credentials](/integrations/application_credentials) for more details.
+
+## Room priority
+
+For thermostats with wireless room sensors (such as the T9 and T10), a **Room priority** select entity is created. This lets you choose which room sensor the thermostat uses for its temperature reading.
+
+Available options:
+
+- **Follow me** — The thermostat automatically switches to the room where motion is detected.
+- **Each paired room** — The names of all rooms with sensors paired to the thermostat appear as individual options (for example, "Bedroom", "Office"). Selecting one tells the thermostat to use that room's sensor for its temperature reading.
+
+This entity only appears for LCC thermostats that have room sensor accessories paired.
 
 ## Sensors
 


### PR DESCRIPTION
Adds documentation for the new room priority select entity in the Lyric integration.

- Added `select` to `ha_category` and `ha_platforms` in frontmatter
- Added a "Room priority" section describing the select entity, available options (Follow me, paired room names), and which devices support it

Companion to home-assistant/core#167942.