### PR TITLE
Expand Sensor.Community integration docs with entities, examples, and troubleshooting

### DIFF
--- a/source/_integrations/luftdaten.markdown
+++ b/source/_integrations/luftdaten.markdown
@@ -85,7 +85,7 @@ The integration polls the Sensor.Community API every 10 minutes over the interne
 
 ### Warn when PM2.5 levels are unhealthy
 
-Send a notification when the PM2.5 concentration exceeds 35 µg/m³, which the WHO considers unhealthy for sensitive groups:
+Send a notification when the PM2.5 concentration exceeds 35 µg/m³. You can adjust this example threshold to match the air quality guidance or standard you want to follow:
 
 ```yaml
 alias: "Unhealthy air quality alert"

--- a/source/_integrations/luftdaten.markdown
+++ b/source/_integrations/luftdaten.markdown
@@ -132,7 +132,7 @@ actions:
 
 If you see a "Sensor not available or invalid" error during setup, verify that:
 
-1. The Sensor ID you entered is correct. The ID is the number with `#` in front on the [Sensor.Community map](https://maps.sensor.community/), not the sensor's physical location or name.
+1. The Sensor ID you entered is correct. The ID is the number with `#` in front of it on the [Sensor.Community map](https://maps.sensor.community/), not the sensor's physical location or name.
 2. The sensor is still online and uploading data to Sensor.Community. Check its recent values on the map.
 3. Your Home Assistant instance can reach the internet.
 

--- a/source/_integrations/luftdaten.markdown
+++ b/source/_integrations/luftdaten.markdown
@@ -15,13 +15,129 @@ ha_platforms:
   - diagnostics
   - sensor
 ha_integration_type: device
+related:
+  - docs: /docs/configuration/troubleshooting/#debug-logs-and-diagnostics
+    title: Debug logs and diagnostics
 ---
 
-The **Sensor.Community** {% term integration %} will query the open data API of [Sensor.Community](https://sensor.community) to monitor air quality and other weather data from a specific (self build) sensor station.
+The **Sensor.Community** {% term integration %} brings readings from the [Sensor.Community](https://sensor.community) open data air quality network into Home Assistant. Sensor.Community (formerly known as luftdaten.info) is a global citizen science project that maps air quality and environmental data from thousands of DIY sensor stations around the world.
+
+Use cases for this integration include:
+
+- Tracking air quality in your neighborhood using a nearby public sensor.
+- Displaying readings from your own [DIY Sensor.Community sensor](https://sensor.community/en/sensors/) without running its web interface.
+- Triggering automations, such as closing windows or turning on an air purifier, when particulate matter levels rise.
+- Comparing outdoor air quality against indoor sensors on a single dashboard.
 
 ## Prerequisites
 
-To get the ID of a particle, pressure, noise, temperature, or humidity sensor by selecting it on the [Sensor.Community map](https://maps.sensor.community/).
-After selecting the sensor, it will show the needed ID in the sidebar with a `#` in front of it.
+You need the **sensor ID** of the Sensor.Community sensor you want to track. The ID is a numeric value, not the sensor type.
+
+To find a sensor ID:
+
+1. Open the [Sensor.Community map](https://maps.sensor.community/).
+2. Select the sensor you want to track on the map.
+3. The sensor ID is shown in the sidebar with a `#` in front of it, for example, `#12345`.
+
+Each physical sensor station usually has multiple sensor IDs, one for each sensor type (particulate matter, temperature, humidity, pressure). Add the integration once per sensor ID you want to track.
 
 {% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Sensor ID:
+  description: "The numeric ID of the Sensor.Community sensor you want to track. You can find it on the [Sensor.Community map](https://maps.sensor.community/)."
+Show on map:
+  description: "When enabled, the sensor's latitude and longitude are added as attributes so the sensor can be placed on the map dashboard. Disabled by default."
+{% endconfiguration_basic %}
+
+## Supported functionality
+
+### Sensors
+
+The integration creates sensor entities based on the data that the selected Sensor.Community sensor reports. Not every sensor reports every measurement. Sensors that the selected sensor does not provide are not created.
+
+- **PM10 particulate matter**
+  - **Description**: Concentration of particulate matter up to 10 micrometers in diameter, in µg/m³.
+  - **Device class**: PM10
+- **PM2.5 particulate matter**
+  - **Description**: Concentration of particulate matter up to 2.5 micrometers in diameter, in µg/m³.
+  - **Device class**: PM2.5
+- **Temperature**
+  - **Description**: Ambient temperature reported by the sensor, in °C.
+  - **Device class**: Temperature
+- **Humidity**
+  - **Description**: Relative humidity reported by the sensor, in %.
+  - **Device class**: Humidity
+- **Pressure**
+  - **Description**: Atmospheric pressure at the sensor location, in Pa.
+  - **Device class**: Pressure
+- **Pressure at sea level**
+  - **Description**: Atmospheric pressure adjusted to sea level, in Pa.
+  - **Device class**: Pressure
+
+Each sensor includes the Sensor.Community sensor ID as an attribute. When the **Show on map** option is enabled, the sensor's latitude and longitude are also added as attributes so the entity appears on the map dashboard.
+
+## Data updates
+
+The integration polls the Sensor.Community API every 10 minutes over the internet for new readings. This matches how often most Sensor.Community stations upload new data.
+
+## Examples
+
+### Warn when PM2.5 levels are unhealthy
+
+Send a notification when the PM2.5 concentration exceeds 35 µg/m³, which the WHO considers unhealthy for sensitive groups:
+
+```yaml
+alias: "Unhealthy air quality alert"
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.sensor_12345_pm25
+    above: 35
+    for:
+      minutes: 15
+actions:
+  - action: notify.mobile_app_my_phone
+    data:
+      title: "Air quality"
+      message: >
+        PM2.5 is currently {{ states('sensor.sensor_12345_pm25') }} µg/m³.
+        Consider closing windows.
+```
+
+### Turn on an air purifier based on outdoor air quality
+
+Automatically turn on an indoor air purifier when outdoor particulate matter rises above a threshold:
+
+```yaml
+alias: "Air purifier on high PM"
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.sensor_12345_pm10
+    above: 50
+actions:
+  - action: switch.turn_on
+    target:
+      entity_id: switch.living_room_air_purifier
+```
+
+## Known limitations
+
+- The integration is read-only and relies on data that Sensor.Community stations upload to the public API. If a station stops uploading, the sensors become unavailable.
+- Each Sensor.Community station usually has separate sensor IDs per sensor type. To track particulate matter and temperature from the same station, set up the integration once per sensor ID.
+- The 10-minute polling interval is fixed and matches the upload frequency of most stations. Polling more often does not give you fresher data.
+
+## Troubleshooting
+
+### Sensor not available or invalid
+
+If you see a "Sensor not available or invalid" error during setup, verify that:
+
+1. The Sensor ID you entered is correct. The ID is the number with `#` in front on the [Sensor.Community map](https://maps.sensor.community/), not the sensor's physical location or name.
+2. The sensor is still online and uploading data to Sensor.Community. Check its recent values on the map.
+3. Your Home Assistant instance can reach the internet.
+
+## Removing the integration
+
+This integration follows standard integration removal, no extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/luftdaten.markdown
+++ b/source/_integrations/luftdaten.markdown
@@ -20,7 +20,7 @@ related:
     title: Debug logs and diagnostics
 ---
 
-The **Sensor.Community** {% term integration %} brings readings from the [Sensor.Community](https://sensor.community) open data air quality network into Home Assistant. Sensor.Community (formerly known as luftdaten.info) is a global citizen science project that maps air quality and environmental data from thousands of DIY sensor stations around the world.
+The **Sensor.Community** {% term integration %} brings readings from the [Sensor.Community](https://sensor.community) open data air quality network into Home Assistant. Sensor.Community (formerly known as luftdaten.info) is a global citizen science project that maps air quality and environmental data from thousands of do-it-yourself (DIY) sensor stations around the world.
 
 Use cases for this integration include:
 


### PR DESCRIPTION
## Proposed change

Expands the Sensor.Community (luftdaten) integration page from a 28-line stub to a complete page following the integration template.

All details verified against `sensor.py`, `config_flow.py`, `const.py`, `coordinator.py`, `strings.json`, and `manifest.json` in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
