### PR TITLE
Restructure Diagnostics integration docs with download steps

### DIFF
--- a/source/_integrations/diagnostics.markdown
+++ b/source/_integrations/diagnostics.markdown
@@ -1,6 +1,6 @@
 ---
 title: Diagnostics
-description: The diagnostics integration can provide integration and device information for debugging purposes.
+description: The diagnostics integration lets you download integration and device diagnostic information for debugging.
 ha_category:
   - Other
 ha_release: 2022.2
@@ -9,22 +9,46 @@ ha_domain: diagnostics
 ha_codeowners:
   - '@home-assistant/core'
 ha_integration_type: system
+related:
+  - docs: /docs/configuration/troubleshooting/#debug-logs-and-diagnostics
+    title: Debug logs and diagnostics
 ---
 
-The **Diagnostics** {% term integration %} provides a way to download diagnostic data from a {% term device %} or {% term integration %} for sharing in issue reports. Sharing diagnostics data when reporting an issue allows developers to diagnose and fix your reported problem quicker.
+The **Diagnostics** {% term integration %} lets you download a diagnostics file for a specific {% term integration %} or {% term device %}. Sharing this file when reporting an issue helps developers diagnose and fix the problem faster, because it contains the relevant state, configuration, and context without requiring you to describe every detail by hand.
+
+This integration is always enabled and requires no setup. However, not every integration provides diagnostic data. When no data is available, the download option is not shown.
+
+## Downloading diagnostics
+
+You can download diagnostics from two places in Home Assistant.
+
+### From the integration page
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
+2. Select the integration you want diagnostics for.
+3. Open the three-dot {% icon "mdi:dots-vertical" %} menu and select **Download diagnostics**.
+
+The downloaded file contains information about the integration as a whole and all of its devices.
+
+### From a device page
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
+2. Select the integration, then select the device you want diagnostics for.
+3. Open the three-dot {% icon "mdi:dots-vertical" %} menu and select **Download diagnostics**.
+
+The downloaded file contains information specific to that device only, which is useful when reporting a device-specific issue.
 
 <p class='img'>
 <img class="no-shadow" src='/images/blog/2022-02/diagnostics.png' alt='Screenshot showing the Download Diagnostics button on a Sonos device page'>
-Screenshot of the download diagnostics button on the device page
+Screenshot of the Download diagnostics button on a device page.
 </p>
 
-Diagnostics data is provided by an integration, and can be downloaded
-as a text file on the device page, and from the integrations dashboard.
+## About the diagnostics file
 
-Integrations are required to redact sensitive information from the diagnostics
-data, you can always open the text file and check it, before you send
-it in a public issue.
+The diagnostics file is a plain text JSON file. Before sharing it publicly, for example, in a GitHub issue, you can open it in any text editor to review its contents.
 
-The diagnostics integration is by default enabled, no action is required to
-enable it. However, not all integrations provide the possibility to download
-diagnostic data.
+Integrations are required to redact sensitive information, such as API keys, tokens, and passwords, before exposing diagnostic data. Redacted values appear in the file as `**REDACTED**`.
+
+## Related
+
+For more general guidance on gathering troubleshooting information when reporting a problem, see [Debug logs and diagnostics](/docs/configuration/troubleshooting/#debug-logs-and-diagnostics).

--- a/source/_integrations/diagnostics.markdown
+++ b/source/_integrations/diagnostics.markdown
@@ -18,6 +18,12 @@ The **Diagnostics** {% term integration %} lets you download a diagnostics file 
 
 This integration is always enabled and requires no setup. However, not every integration provides diagnostic data. When no data is available, the download option is not shown.
 
+{% important %}
+**About sensitive information in the diagnostics file**
+
+Before sharing a diagnostics file publicly (for example, in a GitHub issue), open it in any text editor to review its contents. Integrations must redact sensitive information, such as API keys, tokens, and passwords. Redacted values appear in the file as `**REDACTED**`, but it is always good to verify before sharing.
+{% endimportant %}
+
 ## Downloading diagnostics
 
 You can download diagnostics from two places in Home Assistant.
@@ -43,11 +49,6 @@ The downloaded file contains information specific to that device only, which is 
 Screenshot of the Download diagnostics button on a device page.
 </p>
 
-## About the diagnostics file
-
-The diagnostics file is a plain text JSON file. Before sharing it publicly, for example, in a GitHub issue, you can open it in any text editor to review its contents.
-
-Integrations are required to redact sensitive information, such as API keys, tokens, and passwords, before exposing diagnostic data. Redacted values appear in the file as `**REDACTED**`.
 
 ## Related
 


### PR DESCRIPTION
## Proposed change

Restructures the Diagnostics integration page with clearer sections and step-by-step instructions for downloading diagnostics. The previous page was a wall of text that didn't explain the two places diagnostics can be downloaded from (integration card vs device page).

Changes:

- Rewrites the intro to explain why diagnostics matter and corrects the earlier framing (the integration is always enabled via `bootstrap.py`, not a dependency of `default_config`).
- Adds a **Downloading diagnostics** section with two subsections for integration-level and device-level downloads, each with numbered steps.
- Adds an **About the diagnostics file** section noting it is a JSON text file and that sensitive values are redacted as `**REDACTED**` before being exposed.
- Links to the canonical [Debug logs and diagnostics](/docs/configuration/troubleshooting/#debug-logs-and-diagnostics) troubleshooting page and adds a `related:` frontmatter entry.
- Minor description cleanup in the frontmatter.

## Type of change

- [x] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
