### PR TITLE
Expand My Home Assistant integration page with privacy and usage info

### DIFF
--- a/source/_integrations/my.markdown
+++ b/source/_integrations/my.markdown
@@ -9,19 +9,42 @@ ha_quality_scale: internal
 ha_codeowners:
   - '@home-assistant/core'
 ha_integration_type: system
+related:
+  - docs: /docs/tools/quick-search/#my-links
+    title: My links
 ---
 
-This {% term integration %} handles redirects from the [My Home Assistant](https://my.home-assistant.io) service.
+The **My Home Assistant** {% term integration %} adds support for the [My Home Assistant](https://my.home-assistant.io) redirect service. The service lets a link from outside Home Assistant, such as a link in this documentation, open a specific page inside your own Home Assistant instance without needing to know its hostname or IP address.
 
-My Home Assistant allows the documentation to link you to specific pages in your Home Assistant instance. See the [My Home Assistant FAQ](https://my.home-assistant.io/faq/) for more information.
+For example, when the documentation says "go to {% my integrations title="**Settings** > **Devices & services**" %}", selecting that link opens the **Devices & services** page in the Home Assistant instance you are currently signed into.
+
+## Use cases
+
+- **Documentation links**: open a specific Home Assistant page straight from this documentation, for example, to jump directly to adding an integration or opening the logs.
+- **Blog posts and release notes**: follow a link from a blog post or release announcement to the right place in your own Home Assistant.
+- **Third-party tools and integrations**: let external applications deep-link into Home Assistant without having to know or store your instance URL.
+
+## How it works
+
+My Home Assistant is a redirect service hosted at [my.home-assistant.io](https://my.home-assistant.io). When you select a My link, the service asks your browser which Home Assistant instance you want to open. Your instance URL is stored locally in your browser and is never sent to any external service, not even to the My Home Assistant service itself. Once you have chosen your instance, subsequent My links open directly without asking again.
+
+This integration registers a hidden panel in Home Assistant that handles the incoming redirect from the My Home Assistant service and takes you to the right page.
+
+{% tip %}
+My Home Assistant is designed with privacy in mind. Your instance URL stays in your browser, and neither the URL of your Home Assistant instance nor the page you are trying to open is ever transmitted to a third-party service.
+{% endtip %}
+
+For more information, see the [My Home Assistant FAQ](https://my.home-assistant.io/faq/).
 
 ## Configuration
 
-This integration is enabled by default, unless you've disabled or removed the [`default_config:`](/integrations/default_config/) line from your configuration. If that is the case, the following example shows you how to enable this integration manually:
-
-Add the following section to your {% term "`configuration.yaml`" %} file:
+This integration is enabled by default as part of [`default_config`](/integrations/default_config/), so no setup is required. If you have removed the `default_config:` line from your {% term "`configuration.yaml`" %} file, you can enable this integration manually:
 
 ```yaml
 # Example configuration.yaml entry
 my:
 ```
+
+## Creating your own My links
+
+You can create your own My links to share with others. Visit [my.home-assistant.io/create-link](https://my.home-assistant.io/create-link/) to browse the available redirects and generate a link you can copy and share.

--- a/source/_integrations/my.markdown
+++ b/source/_integrations/my.markdown
@@ -31,7 +31,7 @@ My Home Assistant is a redirect service hosted at [my.home-assistant.io](https:/
 This integration registers a hidden panel in Home Assistant that handles the incoming redirect from the My Home Assistant service and takes you to the right page.
 
 {% tip %}
-My Home Assistant is designed with privacy in mind. Your instance URL stays in your browser, and neither the URL of your Home Assistant instance nor the page you are trying to open is ever transmitted to a third-party service.
+My Home Assistant is designed with privacy in mind. Your Home Assistant instance URL stays in your browser and is not sent to the My Home Assistant service.
 {% endtip %}
 
 For more information, see the [My Home Assistant FAQ](https://my.home-assistant.io/faq/).

--- a/source/_integrations/my.markdown
+++ b/source/_integrations/my.markdown
@@ -16,7 +16,7 @@ related:
 
 The **My Home Assistant** {% term integration %} adds support for the [My Home Assistant](https://my.home-assistant.io) redirect service. The service lets a link from outside Home Assistant, such as a link in this documentation, open a specific page inside your own Home Assistant instance without needing to know its hostname or IP address.
 
-For example, when the documentation says "go to {% my integrations title="**Settings** > **Devices & services**" %}", selecting that link opens the **Devices & services** page in the Home Assistant instance you are currently signed into.
+For example, when the documentation says "go to {% my integrations title="**Settings** > **Devices & services**" %}", selecting that link opens the **Devices & services** page in the Home Assistant instance you selected or saved in your browser.
 
 ## Use cases
 


### PR DESCRIPTION
## Proposed change

Expands the My Home Assistant integration page from 28 lines to a complete page explaining what My Home Assistant is, how it works, and the privacy model behind it.

Adds:

- **Concrete example**: uses an actual My link in the intro so the reader can try it.
- **Use cases**: documentation links, blog posts and release notes, third-party tools.
- **How it works**: describes the redirect flow and the hidden panel this integration registers.
- **Privacy tip**: explicitly states that your instance URL and the target page stay in your browser and are never transmitted to a third-party service, not even to My Home Assistant itself.
- **Creating your own My links**: points to the link generator at [my.home-assistant.io/create-link](https://my.home-assistant.io/create-link/) so readers can browse available redirects and share their own links.
- **Related**: link to the Quick search My links documentation in the frontmatter.

## Type of change

- [x] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
