### PR TITLE
Expand Recovery mode integration docs with clearer guidance

### DIFF
--- a/source/_integrations/recovery_mode.markdown
+++ b/source/_integrations/recovery_mode.markdown
@@ -42,7 +42,7 @@ When recovery mode is active, Home Assistant loads only a minimal set of system 
 2. Fix the reported issue. This often means:
    - Correcting a YAML syntax error in {% term "`configuration.yaml`" %}.
    - Removing or updating a configuration option that was changed. Check the [backward-incompatible changes](/blog/categories/core/) of a recent release if the issue appeared after an update.
-   - Restoring a [{% term backup %}](/integrations/backup/) from before the problem started.
+   - Restoring a [backup](/integrations/backup/) from before the problem started.
 3. Restart Home Assistant from {% my general title="**Settings** > **System**" %} by selecting **Restart Home Assistant**, or by rebooting your host.
 4. If Home Assistant starts normally, the issue is resolved. If recovery mode reactivates, the underlying issue is still there. Check the logs again for the current error.
 

--- a/source/_integrations/recovery_mode.markdown
+++ b/source/_integrations/recovery_mode.markdown
@@ -55,7 +55,7 @@ If you are unsure how to fix the error, copy the relevant log lines and search t
 When recovery mode does happen, these are the most common reasons:
 
 - **YAML syntax errors**: incorrect indentation, missing colons, or unmatched quotes in {% term "`configuration.yaml`" %} or any included YAML files.
-- **Missing include files**: a `!include` reference in {% term "`configuration.yaml`" %} points to a file that no longer exists.
+- **Missing include files**: an `!include` reference in {% term "`configuration.yaml`" %} points to a file that no longer exists.
 - **Backward-incompatible changes after an update**: a manually configured option was changed or removed in a release. Check the [backward-incompatible changes](/blog/categories/core/) section of the release notes for the version you upgraded to.
 - **Corrupted configuration storage**: can happen after a sudden power loss during a write.
 

--- a/source/_integrations/recovery_mode.markdown
+++ b/source/_integrations/recovery_mode.markdown
@@ -43,7 +43,7 @@ When recovery mode is active, Home Assistant loads only a minimal set of system 
    - Correcting a YAML syntax error in {% term "`configuration.yaml`" %}.
    - Removing or updating a configuration option that was changed. Check the [backward-incompatible changes](/blog/categories/core/) of a recent release if the issue appeared after an update.
    - Restoring a [{% term backup %}](/integrations/backup/) from before the problem started.
-3. Restart Home Assistant from {% my server_controls title="**Developer tools**" %} or by rebooting your host.
+3. Restart Home Assistant from {% my general title="**Settings** > **System**" %} by selecting **Restart Home Assistant**, or by rebooting your host.
 4. If Home Assistant starts normally, the issue is resolved. If recovery mode reactivates, the underlying issue is still there. Check the logs again for the current error.
 
 {% tip %}

--- a/source/_integrations/recovery_mode.markdown
+++ b/source/_integrations/recovery_mode.markdown
@@ -57,7 +57,7 @@ When recovery mode does happen, these are the most common reasons:
 - **YAML syntax errors**: incorrect indentation, missing colons, or unmatched quotes in {% term "`configuration.yaml`" %} or any included YAML files.
 - **Missing include files**: an `!include` reference in {% term "`configuration.yaml`" %} points to a file that no longer exists.
 - **Backward-incompatible changes after an update**: a manually configured option was changed or removed in a release. Check the [backward-incompatible changes](/blog/categories/core/) section of the release notes for the version you upgraded to.
-- **Corrupted configuration storage**: can happen after a sudden power loss during a write.
+- **Corrupted configuration storage**: it can happen after a sudden power loss during a write.
 
 ## Known limitations
 

--- a/source/_integrations/recovery_mode.markdown
+++ b/source/_integrations/recovery_mode.markdown
@@ -1,6 +1,6 @@
 ---
 title: Recovery mode
-description: Allows Home Assistant to start up in recovery mode.
+description: How Home Assistant starts in recovery mode when the configuration cannot be loaded.
 ha_category: []
 ha_release: 0.105
 ha_codeowners:
@@ -11,21 +11,55 @@ ha_integration_type: system
 related:
   - docs: /docs/troubleshooting_general/
     title: General troubleshooting
+  - docs: /docs/configuration/troubleshooting/#debug-logs-and-diagnostics
+    title: Debug logs and diagnostics
 ---
 
-The **Recovery mode** {% term integration %} is an internal integration used by the
-Home Assistant Core.
+The **Recovery mode** {% term integration %} is an internal integration that Home Assistant activates automatically when, in rare cases, something unexpected prevents it from starting normally. It is a safety net. Home Assistant is designed to handle updates, configuration changes, and day-to-day operation without needing recovery mode, and in practice, you are unlikely to ever see it.
 
-You don't have to configure it since it is automatically always
-available when Home Assistant needs it.
+When it is needed, recovery mode gives you a minimal but working Home Assistant so you can investigate and fix the problem without having to edit files directly on disk.
 
-If, during startup, Home Assistant has problems reading your configuration,
-it will still continue to start using parts of the configuration
-from the last time Home Assistant did start.
+You do not install or configure this integration. Home Assistant starts it for you when needed.
 
-When this happens, Home Assistant will start in **Recovery mode** using this
-integration. In this mode, no user configured integrations are loaded, but it does give you access to
-the Home Assistant frontend, settings, and apps.
+{% important %}
+Recovery mode does not delete, reset, or modify your configuration, {% term entities %}, or history. Your data is safe. Recovery mode only starts with a minimal set of {% term integrations %} so you can reach the UI and fix whatever went wrong.
+{% endimportant %}
 
-This gives you the possibility to correct the issue and restart Home Assistant
-to re-try.
+## When Home Assistant starts in recovery mode
+
+Recovery mode is rarely needed. Home Assistant only falls back to it when something unexpected prevents a normal startup, for example:
+
+- The {% term "`configuration.yaml`" %} file cannot be parsed because of a YAML syntax error.
+- A manually edited configuration file contains options that are no longer valid.
+- One or more core {% term integrations %}, such as the frontend, fail to load due to an unexpected environmental issue.
+- The configuration storage was corrupted, for example, after a sudden power loss.
+
+When recovery mode is active, Home Assistant loads only a minimal set of system {% term integrations %} (such as the frontend, backup, and cloud) and skips all your user-configured {% term integrations %}. You see a **Recovery Mode** notification on the dashboard when you sign in.
+
+## What to do when you are in recovery mode
+
+1. Open {% my logs title="**Settings** > **System** > **Logs**" %} and look for the error that caused the problem. The log entry usually points at the exact line in {% term "`configuration.yaml`" %} or the {% term integration %} that failed.
+2. Fix the reported issue. This often means:
+   - Correcting a YAML syntax error in {% term "`configuration.yaml`" %}.
+   - Removing or updating a configuration option that was changed. Check the [backward-incompatible changes](/blog/categories/core/) of a recent release if the issue appeared after an update.
+   - Restoring a [{% term backup %}](/integrations/backup/) from before the problem started.
+3. Restart Home Assistant from {% my server_controls title="**Developer tools**" %} or by rebooting your host.
+4. If Home Assistant starts normally, the issue is resolved. If recovery mode reactivates, the underlying issue is still there. Check the logs again for the current error.
+
+{% tip %}
+If you are unsure how to fix the error, copy the relevant log lines and search the [Home Assistant Community Forum](https://community.home-assistant.io/). Many recovery mode errors, especially after an update, have been reported and solved by other users.
+{% endtip %}
+
+## Common causes
+
+When recovery mode does happen, these are the most common reasons:
+
+- **YAML syntax errors**: incorrect indentation, missing colons, or unmatched quotes in {% term "`configuration.yaml`" %} or any included YAML files.
+- **Missing include files**: a `!include` reference in {% term "`configuration.yaml`" %} points to a file that no longer exists.
+- **Backward-incompatible changes after an update**: a manually configured option was changed or removed in a release. Check the [backward-incompatible changes](/blog/categories/core/) section of the release notes for the version you upgraded to.
+- **Corrupted configuration storage**: can happen after a sudden power loss during a write.
+
+## Known limitations
+
+- In recovery mode, your {% term integrations %}, {% term devices %}, {% term automations %}, and {% term "scripts" %} are not active. Recovery mode is only meant for fixing the problem, not for continuing to run Home Assistant.
+- The recovery mode notification disappears as soon as Home Assistant starts normally again.


### PR DESCRIPTION
## Proposed change

Expands the Recovery mode integration page with a clearer explanation of what recovery mode is, when it activates, and what to do when you see it. Also addresses a common panic point from the community forum: users who hit recovery mode after an update worry that their data is lost.

Reframes recovery mode as a safety net for rare, unexpected situations rather than something users should expect to encounter during normal use, since Home Assistant is designed to handle updates and everyday operation without needing it.

Adds:

- Reassuring intro explaining recovery mode is rarely needed and is a safety net.
- An `important` block stating that no data, configuration, entities, or history is modified when recovery mode activates.
- A **When Home Assistant starts in recovery mode** section listing the rare triggers (YAML syntax errors, no-longer-valid manually edited options, core integration failures, corrupted storage).
- A **What to do when you are in recovery mode** section with concrete steps (check logs, fix, restart, verify).
- A tip pointing to the Community Forum for errors that others have already solved.
- A **Common causes** section listing YAML syntax errors, missing `!include` files, backward-incompatible changes after a manually configured option changed, and corrupted storage.
- A **Known limitations** note explaining recovery mode is for fixing, not for running.
- Glossary term references (`{% term %}`) for configuration.yaml, integrations, entities, devices, automations, scripts, and backup.
- A `related:` frontmatter entry for the Debug logs and diagnostics troubleshooting page.

Verified against `bootstrap.py` in core for the actual triggers (`CRITICAL_INTEGRATIONS = {"frontend"}`, `DEFAULT_INTEGRATIONS_RECOVERY_MODE = {"backup", "cloud", "frontend"}`).

## Type of change

- [x] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
