### PR TITLE
Improve Labs docs to encourage community participation

### DIFF
--- a/source/_integrations/labs.markdown
+++ b/source/_integrations/labs.markdown
@@ -15,30 +15,29 @@ related:
     title: Configuration basics
 ---
 
-The **Labs** {% term integration %} provides a dedicated panel where you can preview and test new features before they become standard in Home Assistant. These preview features are fully functional and free of critical bugs, but may still undergo design changes based on user feedback.
+The **Labs** {% term integration %} provides a dedicated panel where you can play with new Home Assistant features while they are still being shaped. Labs is Home Assistant's way of building in the open with its community: instead of waiting until a feature is finished and polished, you get to try it early, use it in your own setup, and help steer its direction.
 
-Labs preview features are different from beta testing:
+Preview features in Labs are fully functional and tested for stability before they land there. They are not half-broken experiments. If a feature looks interesting to you, we encourage you to enable it and play with it. Your real-world use is exactly what helps decide where a feature goes next.
 
-- *Beta testing* evaluates the stability of upcoming Home Assistant releases.
-- *Labs preview features* are in the process of being refined through real-world usage and feedback.
-  
+Labs is different from beta testing:
+
+- **Beta testing** focuses on the stability of an upcoming Home Assistant release.
+- **Labs** invites you to try, test, and influence new ideas while they are still being forged. Preview features are already tested and usable, but their direction and behavior may still be refined based on what you and other users experience.
+
 ## About Labs
 
 Labs allows you to:
 
 - Preview new functionality before it becomes standard.
-- Experience upcoming features in your setup.
-- Provide feedback to help shape the final design.
+- Experience upcoming features in your own setup, with your own devices.
+- Provide real-world feedback that directly shapes the final direction of a feature.
 
-All preview features in Labs are:
+All preview features in Labs share a few common properties:
 
-- Optional: Disabled by default, you need to explicitly enable them.
-- Free of critical bugs: Fully functional and free of critical bugs.
-- Subject to change: Feature set may be extended, and design and behavior may be refined based on feedback.
-- Reversible: Can be disabled at any time.
-
-
-
+- **Optional**: They are disabled by default. You choose which ones to turn on.
+- **Functional**: They are already usable in real setups. You are not signing up for broken software.
+- **Subject to change**: Their feature set, behavior, and direction may evolve based on community feedback.
+- **Reversible**: You can disable them at any time.
 
 ## About preview features
 
@@ -66,6 +65,9 @@ Optionally they include:
 1. Go to {% my labs title="**Settings** > **System** > **Labs**" %}.
 2. Find the feature you want to try.
 3. Select **Enable**.
+4. When prompted, you can create a [backup](/integrations/backup/) as a quick safety net before enabling the feature.
+   - This gives you an easy one-click way to return to exactly how things were, so you can freely experiment and play with the new feature knowing you can roll back at any time.
+   - Creating a backup is optional, but it makes trying out preview features even more relaxed. You get all the fun of exploring something new, without thinking about having to manually undo anything later.
 
 You can also use My Home Assistant links to directly go to a specific feature in Labs. For example:
 
@@ -90,12 +92,16 @@ These links are useful in release notes, documentation, or when sharing specific
 
 ## Providing feedback
 
-Your feedback helps improve these features! When you enable a preview feature:
+Feedback is what makes Labs work. Preview features evolve based on what real users run into, so a few minutes describing your experience directly influences the final design of the feature.
 
-1. Use the **Give feedback** link to share your experience in the community forum.
+When you enable a preview feature:
+
+1. Use the **Give feedback** link to share your experience on the community forum.
 2. Use the **Report issue** link to report bugs on GitHub.
 3. Be specific about what works well and what could be improved.
-4. Include relevant details like your Home Assistant version and setup.
+4. Include relevant details such as your Home Assistant version and your setup.
+
+Honest feedback is the most useful kind. Even a short note saying "this worked for me" or "this did not fit my setup because X" helps the developers decide how a feature should evolve.
 
 ## Known limitations
 

--- a/source/_integrations/labs.markdown
+++ b/source/_integrations/labs.markdown
@@ -34,10 +34,10 @@ Labs allows you to:
 
 All preview features in Labs share a few common properties:
 
-- **Optional**: They are disabled by default. You choose which ones to turn on.
-- **Functional**: They are already usable in real setups. You are not signing up for broken software.
-- **Subject to change**: Their feature set, behavior, and direction may evolve based on community feedback.
-- **Reversible**: You can disable them at any time.
+- Optional: They are disabled by default. You choose which ones to turn on.
+- Functional: They are already usable in real setups. You are not signing up for broken software.
+- Subject to change: Their feature set, behavior, and direction may evolve based on community feedback.
+- Reversible: You can disable them at any time.
 
 ## About preview features
 


### PR DESCRIPTION
## Proposed change

Reframes the Labs integration page around the "building in the open" philosophy shared during the State of the Open Home 2026 livestream. The previous page was accurate but felt cautious and transactional. The rewrite encourages users to actually try preview features instead of treating them as something to be careful of.

## Type of change

- [x] Spelling, grammar or other readability improvements
- [x] Adjusted missing or incorrect information in the current documentation
- [ ] Added documentation for a new integration I'm adding to Home Assistant
- [ ] Added documentation for a new feature I'm adding to Home Assistant
- [ ] Removed stale or deprecated documentation

## Additional information

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
