### PR TITLE
Add Wi-Fi signal strength sensor documentation to Duco

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -118,10 +118,6 @@ Indoor air quality ranges for humidity:
 
 Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in dBm. This entity is disabled by default.
 
-#### Write requests remaining
-
-Available for the main ventilation box (BOX). Shows the number of write requests remaining for today. The Duco box enforces a daily limit of 200 write requests. This entity is disabled by default.
-
 ## Use cases
 
 - Switch to high ventilation automatically when cooking or showering.
@@ -229,7 +225,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds.
 ## Known limitations
 
 - The integration does not support automatic discovery; the IP address or hostname must be entered manually.
-- The Duco box enforces a rate limit of 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully, and the firmware resets the quota automatically.
+- The Duco box enforces a rate limit of 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully; the quota resets automatically around midnight.
 - Timed speed overrides set by external devices (such as an RF wall switch or a CO₂ sensor) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
 
 ## Troubleshooting
@@ -263,15 +259,11 @@ Failed to set ventilation state: DucoError('Duco API error (429): {"Code":18,"Re
 
 #### Description
 
-The Duco box enforces a write rate limit of 200 write requests per day via the public API. Each time you change the ventilation state (speed or preset), the counter decrements. When it reaches 0, the box rejects further write requests with a 429 error. The counter resets daily around midnight (after at least 24 hours).
-
-For normal daily use, the limit should be sufficient.
+The Duco box enforces a write rate limit of 200 write requests per day. When the limit is reached, the box rejects further write requests with a 429 error until the quota resets around midnight.
 
 #### Resolution
 
-Wait until midnight for the counter to reset. To avoid hitting the limit in the future, reduce the number of automations or scripts that change the ventilation state frequently.
-
-To diagnose which automations are consuming write requests, enable the **Write requests remaining** sensor on the Duco box device. This sensor shows the current remaining quota and decrements with each write action. By monitoring it over time via the logbook, you can identify the automations that trigger the most writes and adjust their frequency.
+Wait until midnight for the quota to reset. To avoid hitting the limit, reduce the frequency of automations that change the ventilation state.
 
 ## Removing the integration
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -114,6 +114,14 @@ Indoor air quality ranges for humidity:
 - 35–50%: Temporarily acceptable
 - 5–20%: Poor
 
+#### Wi-Fi signal strength
+
+Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in dBm. This entity is disabled by default.
+
+#### Write requests remaining
+
+Available for the main ventilation box (BOX). Shows the number of write requests remaining for today. The Duco box enforces a daily limit of approximately 200 write requests. This entity is disabled by default.
+
 ## Use cases
 
 - Switch to high ventilation automatically when cooking or showering.

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -122,6 +122,8 @@ Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in
 
 Available for the main ventilation box (BOX). Shows the number of write requests remaining for today. The Duco box enforces a daily limit of 200 write requests. This entity is disabled by default.
 
+You can use this sensor as a condition in automations to prevent hitting the daily limit. For example, only allow an automation to change the ventilation speed when at least 10 write requests are still available.
+
 ## Use cases
 
 - Switch to high ventilation automatically when cooking or showering.
@@ -270,6 +272,26 @@ For normal daily use, the limit should be sufficient.
 #### Resolution
 
 Wait until midnight for the counter to reset. To avoid hitting the limit in the future, reduce the number of automations or scripts that change the ventilation state frequently.
+
+To diagnose which automations are consuming write requests, enable the **Write requests remaining** sensor on the Duco box device. This sensor shows the current remaining quota and decrements with each write action. By monitoring it over time, you can identify the automations that trigger the most writes and adjust their frequency. You can also use the sensor as a condition in automations to stop sending commands when the quota is low:
+
+```yaml
+- alias: "Boost ventilation on high CO2 (with rate limit guard)"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.office_co2_carbon_dioxide
+      above: 1000
+  conditions:
+    - condition: numeric_state
+      entity_id: sensor.duco_write_requests_remaining
+      above: 10
+  actions:
+    - action: fan.set_percentage
+      target:
+        entity_id: fan.living_ventilation
+      data:
+        percentage: 100
+```
 
 ## Removing the integration
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -122,8 +122,6 @@ Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in
 
 Available for the main ventilation box (BOX). Shows the number of write requests remaining for today. The Duco box enforces a daily limit of 200 write requests. This entity is disabled by default.
 
-You can use this sensor as a condition in automations to prevent hitting the daily limit. For example, only allow an automation to change the ventilation speed when at least 10 write requests are still available.
-
 ## Use cases
 
 - Switch to high ventilation automatically when cooking or showering.
@@ -273,25 +271,7 @@ For normal daily use, the limit should be sufficient.
 
 Wait until midnight for the counter to reset. To avoid hitting the limit in the future, reduce the number of automations or scripts that change the ventilation state frequently.
 
-To diagnose which automations are consuming write requests, enable the **Write requests remaining** sensor on the Duco box device. This sensor shows the current remaining quota and decrements with each write action. By monitoring it over time, you can identify the automations that trigger the most writes and adjust their frequency. You can also use the sensor as a condition in automations to stop sending commands when the quota is low:
-
-```yaml
-- alias: "Boost ventilation on high CO2 (with rate limit guard)"
-  triggers:
-    - trigger: numeric_state
-      entity_id: sensor.office_co2_carbon_dioxide
-      above: 1000
-  conditions:
-    - condition: numeric_state
-      entity_id: sensor.duco_write_requests_remaining
-      above: 10
-  actions:
-    - action: fan.set_percentage
-      target:
-        entity_id: fan.living_ventilation
-      data:
-        percentage: 100
-```
+To diagnose which automations are consuming write requests, enable the **Write requests remaining** sensor on the Duco box device. This sensor shows the current remaining quota and decrements with each write action. By monitoring it over time via the logbook, you can identify the automations that trigger the most writes and adjust their frequency.
 
 ## Removing the integration
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -120,7 +120,7 @@ Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in
 
 #### Write requests remaining
 
-Available for the main ventilation box (BOX). Shows the number of write requests remaining for today. The Duco box enforces a daily limit of approximately 200 write requests. This entity is disabled by default.
+Available for the main ventilation box (BOX). Shows the number of write requests remaining for today. The Duco box enforces a daily limit of 200 write requests. This entity is disabled by default.
 
 ## Use cases
 
@@ -229,7 +229,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds.
 ## Known limitations
 
 - The integration does not support automatic discovery; the IP address or hostname must be entered manually.
-- The Duco box enforces a rate limit of approximately 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully, and the firmware resets the quota automatically.
+- The Duco box enforces a rate limit of 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully, and the firmware resets the quota automatically.
 - Timed speed overrides set by external devices (such as an RF wall switch or a CO₂ sensor) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
 
 ## Troubleshooting


### PR DESCRIPTION
## Proposed change

Adds documentation for a new diagnostic sensor entity introduced in the Duco integration:

- **Wi-Fi signal strength**: Reports the RSSI of the DUCO Connectivity Board's Wi-Fi connection in dBm. Disabled by default.

This entitiy is available for the main ventilation box (BOX node) and is categorized as diagnostic sensors.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/168290
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards