### PR TITLE
Enhance STIPS IR Remote integration documentation and details

### DIFF
--- a/source/_integrations/stips_iru1.markdown
+++ b/source/_integrations/stips_iru1.markdown
@@ -1,0 +1,69 @@
+---
+title: "STIPS IR Remote"
+description: "Control AC units through STIPS IRU1 over your local network."
+ha_category:
+  - Climate
+ha_iot_class: "Local Push"
+ha_domain: "stips_iru1"
+ha_platforms:
+  - climate
+ha_config_flow: true
+---
+
+# STIPS IR Remote
+
+The **STIPS IR Remote** integration lets Home Assistant control supported air conditioners through a **STIPS IRU1** device.
+
+During setup, Home Assistant signs in to your STIPS account to download your IR catalog, including areas, devices, and remotes. After setup, climate commands are sent locally on your LAN to the IRU1 device.
+
+## Prerequisites
+
+- A STIPS account with access to your IR catalog.
+- At least one STIPS IRU1 device linked to your account.
+- The IRU1 device and Home Assistant must be on the same local network.
+- The IRU1 device should be online and reachable by hostname on your LAN.
+
+## Configuration
+
+1. In Home Assistant, go to **Settings** > **Devices and Services**.
+2. Select **Add Integration**.
+3. Search for **STIPS IR Remote**.
+4. Enter:
+   - API host
+   - Username
+   - Password
+5. Finish setup.
+
+If setup succeeds, Home Assistant imports supported climate remotes from your STIPS catalog.
+
+## Supported functionality
+
+Climate platform support for:
+
+- Protocol AC remotes
+- Learned AC remotes
+- HVAC mode control
+- Target temperature control
+- Fan mode control
+- Swing mode control, where supported by the remote model
+- Turn on and turn off
+
+## Notes
+
+- Internet access is required during setup to fetch catalog data.
+- Normal climate command dispatch is local over LAN after setup.
+- If the device hostname cannot be resolved, ensure the IRU1 is online and reachable on your network, then reload or reconfigure the integration.
+
+## Limitations
+
+- This initial version supports climate entities only.
+- Non-climate remote features are planned for a follow-up release.
+
+## Troubleshooting
+
+If entities appear unavailable or commands fail:
+
+1. Confirm the IRU1 is powered on and connected to your LAN.
+2. Confirm Home Assistant can resolve and reach the device hostname.
+3. Reload the integration from **Devices and Services**.
+4. Reconfigure the integration if catalog data has changed.

--- a/source/_integrations/stips_iru1.markdown
+++ b/source/_integrations/stips_iru1.markdown
@@ -8,9 +8,10 @@ ha_domain: "stips_iru1"
 ha_platforms:
   - climate
 ha_config_flow: true
+ha_release: "2026.4"
 ---
 
-# STIPS IR Remote
+## STIPS IR Remote
 
 The **STIPS IR Remote** integration lets Home Assistant control supported air conditioners through a **STIPS IRU1** device.
 
@@ -25,7 +26,7 @@ During setup, Home Assistant signs in to your STIPS account to download your IR 
 
 ## Configuration
 
-1. In Home Assistant, go to **Settings** > **Devices and Services**.
+1. In Home Assistant, go to **Settings** > **Devices & services**.
 2. Select **Add Integration**.
 3. Search for **STIPS IR Remote**.
 4. Enter:
@@ -65,5 +66,5 @@ If entities appear unavailable or commands fail:
 
 1. Confirm the IRU1 is powered on and connected to your LAN.
 2. Confirm Home Assistant can resolve and reach the device hostname.
-3. Reload the integration from **Devices and Services**.
+3. From **Devices & services**, open STIPS IR Remote integration and reload the integration from (three-dots menu).
 4. Reconfigure the integration if catalog data has changed.


### PR DESCRIPTION
This pull request adds and fixes documentation for the new STIPS IR Remote integration, which enables Home Assistant to control air conditioners via the STIPS IRU1 device. The documentation covers setup instructions, supported features, requirements, limitations, and troubleshooting steps.

New integration documentation:

* Added a new markdown file `source/_integrations/stips_iru1.markdown` describing the STIPS IR Remote integration, including prerequisites, configuration steps, supported climate features, limitations, and troubleshooting guidance.

Related core PR:

* [https://github.com/home-assistant/core/pull/168264](https://github.com/home-assistant/core/pull/168264)

Related brands PR:

* [https://github.com/home-assistant/brands/pull/10147](https://github.com/home-assistant/brands/pull/10147)
