### PR TITLE
Document FRITZ!Powerline username behavior

### DIFF
--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -58,10 +58,8 @@ It is recommended to create a separate user to connect Home Assistant to your FR
 
 {% note %}
 If you still want to use the predefined user, please note that as of FRITZ!OS 7.24, the FRITZ!Box creates a random username for the admin user if you didn't set one yourself. This can be found after logging into the FRITZ!Box and visiting **System** > **FRITZ!Box Users** > **Users**. The username starts with `fritz` followed by four random numbers. Under properties on the right it says `created automatically`. Before FRITZ!OS 7.24, the default username was `admin`.
-{% endnote %}
 
-{% note %}
-FRITZ!Powerline devices ignore the username — only the password is validated. Enter any value in the username field.
+FRITZ!Powerline devices do not validate the **Username** value. Only the **Password** value is checked, so you can enter any value in **Username**.
 {% endnote %}
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -60,6 +60,10 @@ It is recommended to create a separate user to connect Home Assistant to your FR
 If you still want to use the predefined user, please note that as of FRITZ!OS 7.24, the FRITZ!Box creates a random username for the admin user if you didn't set one yourself. This can be found after logging into the FRITZ!Box and visiting **System** > **FRITZ!Box Users** > **Users**. The username starts with `fritz` followed by four random numbers. Under properties on the right it says `created automatically`. Before FRITZ!OS 7.24, the default username was `admin`.
 {% endnote %}
 
+{% note %}
+FRITZ!Powerline devices ignore the username — only the password is validated. Enter any value in the username field.
+{% endnote %}
+
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}


### PR DESCRIPTION
## Proposed change

Add a note to the Username section of the Fritz integration docs clarifying that FRITZ!Powerline devices ignore the username field — only the password is validated. Setup via SSDP auto-discovery would otherwise leave users guessing what to enter.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#167473
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

Companion to home-assistant/core#167473, which adds a matching hint to the `data_description_username` string shown in the config flow form. Targeting `next` because this pairs with an open core PR against `dev`; happy to rebase to `current` if maintainers prefer.

Verified against a real FRITZ!Powerline 1240E and AVM documentation: the device ignores the username entirely and authenticates by password only.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards