### PR TITLE
Add total disk size to glances

### DIFF
--- a/source/_integrations/glances.markdown
+++ b/source/_integrations/glances.markdown
@@ -37,6 +37,7 @@ Glances integration will add the following sensors if available in the platform:
   - disk_use_percent: The used disk space in percent.
   - disk_use: The used disk space.
   - disk_free: The free disk space.
+  - disk_size: The total size of the disk.
 - For each detected physical disk, the following sensors will be created:
   - diskio_read: Average rate of data read from the device in megabytes per second.
   - diskio_write: Average rate of data written to the device in megabytes per second.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds total disk size to the data exposed by glances. Use case is a long-term storage graph for a btrfs array, where the total fs size may change as disks are added and removed. I'd like to graph the fs usage with the fs total size rather than using the percentage used. This means that if the total size changes it can be represented more cleanly on the graph by showing the GiB available has grown.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/168131
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
