### PR TITLE
Add troubleshooting section to Thread integration docs

### DIFF
--- a/source/_integrations/thread.markdown
+++ b/source/_integrations/thread.markdown
@@ -332,3 +332,147 @@ You can only set a Thread network as preferred if the credentials are known.
 ### Combining Thread networks
 
 In the current implementation, having multiple <abbr title="Thread border routers">TBRs</abbr> from different vendors results in separate networks using different credentials. This prevents devices from roaming between the Thread networks. In theory, it would be better to join all Thread networks into a single network to increase the size of the mesh network. A dense mesh network should lead to better <abbr title="radio frequency">RF</abbr> coverage and better link quality, which lowers transmission latencies, making communication faster.
+
+## Troubleshooting
+
+This section helps you resolve common issues with Thread networks and device commissioning.
+
+### IPv6 is not working
+
+#### Symptom: "IPv6 routing/forwarding is not enabled" warning in the OTBR app logs, or Thread devices join the network but cannot be reached
+
+Thread is an IPv6-only protocol. For Thread devices to communicate with Home Assistant and other devices on your network, IPv6 forwarding must be enabled at every layer of your network stack. If any layer is missing IPv6 support, Thread devices may join the mesh but fail to communicate beyond it.
+
+##### Layers to check
+
+Every setup has at least two layers that need IPv6 forwarding:
+
+- **Home Assistant host** — the system where Home Assistant runs
+- **Network router** — the device that manages traffic on your local network
+
+Depending on how Home Assistant is deployed, there may be additional layers:
+
+- **Hypervisor host** — if Home Assistant runs inside a virtual machine (for example, Proxmox, ESXi, or VirtualBox), the hypervisor also needs IPv6 forwarding enabled
+- **Docker daemon** — if Home Assistant runs as a container, the Docker daemon needs IPv6 enabled in its configuration
+- **Host operating system** — if Home Assistant runs as a container on Linux, the host OS needs IPv6 forwarding enabled at the kernel level
+
+{% note %}
+The warning in the OTBR app logs only detects whether IPv6 forwarding is enabled on the Home Assistant host itself. Issues at the hypervisor, Docker, host OS, or router layer will not trigger this warning but can still prevent Thread devices from communicating.
+{% endnote %}
+
+##### Home Assistant Operating System
+
+IPv6 may not be enabled in Docker on your Home Assistant OS installation. There is currently no UI option for this setting — it must be changed from the command line. To check and enable it:
+
+1. Open the **Terminal & SSH** app (or any equivalent terminal app).
+2. Check the current setting:
+
+   ```text
+   ha docker info
+   ```
+
+   If `enable_ipv6` shows `null` or `false`, enable it:
+
+   ```text
+   ha docker options --enable-ipv6=true
+   ```
+
+3. Reboot the Home Assistant host for the change to take effect:
+
+   ```text
+   ha host reboot
+   ```
+
+If Home Assistant OS is running inside a virtual machine, the hypervisor host also needs IPv6 forwarding enabled. Refer to your hypervisor's documentation for instructions.
+
+##### Home Assistant Container
+
+If you are running Home Assistant Container, there are two additional layers to check on the machine that hosts the container:
+
+- **Docker daemon** — IPv6 must be enabled in the Docker daemon configuration. Refer to the [Docker documentation on enabling IPv6](https://docs.docker.com/config/daemon/ipv6/) for instructions.
+- **Host operating system** — the Linux host needs IPv6 forwarding enabled at the kernel level. Refer to your distribution's documentation for instructions on enabling IPv6 forwarding.
+
+If the host machine is itself a virtual machine, the hypervisor also needs IPv6 forwarding enabled. Refer to your hypervisor's documentation for instructions.
+
+##### Network router
+
+Your network router needs IPv6 forwarding enabled so that IPv6 traffic can flow between your local network and the Thread mesh. Refer to your router's documentation for details on enabling IPv6 support and forwarding.
+
+### Changing the Thread channel
+
+#### Symptom: frequent pairing failures or poor device communication
+
+If you experience frequent pairing failures or devices that drop off the network, the Thread channel may be suffering from interference.
+
+##### Description
+
+Thread uses the IEEE 802.15.4 radio standard, which operates in the 2.4 GHz band — the same band used by Wi-Fi and Bluetooth. Thread channels 11 through 22 overlap with common Wi-Fi channels 1, 6, and 11. This overlap can cause interference that prevents the Thread radio from transmitting successfully.
+
+A sign of interference in the OTBR app logs is repeated `ChannelAccessFailure` errors. This means the radio attempted to send a frame but the channel was too busy, even after multiple retries.
+
+Thread channels 25 and 26 sit above the Wi-Fi band and are the least likely to experience Wi-Fi interference. Channel 26 is a common recommendation for environments with heavy Wi-Fi traffic.
+
+##### Resolution
+
+You can change the Thread channel through the Thread integration in Home Assistant.
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Thread** integration.
+2. Select **Configure**.
+3. Change the channel to your desired value (for example, **26**).
+4. After you confirm the change, the network will continue to operate normally on the current channel. The border router schedules the switch for approximately five minutes later so that all devices on the mesh can learn about the new channel and switch simultaneously. During this waiting period, nothing will appear to have changed — this is expected. Do not restart the border router or make additional changes while the switch is pending.
+
+{% important %}
+If you already have Thread devices paired, changing the channel will temporarily disrupt communication while devices transition. For best results, change the channel before pairing devices if possible.
+{% endimportant %}
+
+### Pairing a Thread device fails
+
+#### Symptom: the device is in pairing mode, but commissioning does not complete
+
+You are trying to add a Thread device through the Home Assistant Companion app, but the process fails or times out.
+
+##### Description
+
+Pairing a Thread device involves multiple steps that happen automatically: your phone connects to the device over Bluetooth Low Energy (BLE), shares the Thread network credentials, and then the device joins the Thread mesh and gets commissioned into Home Assistant. A failure at any of these steps can cause pairing to fail.
+
+##### Resolution
+
+First, make sure you have followed all the prerequisites for adding a Matter device, including phone setup and Bluetooth requirements. Refer to the [adding a Matter device to Home Assistant](/integrations/matter/#adding-a-matter-device-to-home-assistant) procedure for the full checklist.
+
+If pairing still fails after verifying the prerequisites, check the following:
+
+- **The device is still in pairing mode.** Most devices only stay in pairing mode for a limited time. If it expires, reset the device to pairing mode and try again.
+- **Mesh Wi-Fi access points are not blocking multicast.** Some mesh Wi-Fi systems aggressively filter multicast traffic on Wi-Fi. This can prevent your phone from discovering the border router via mDNS. If you suspect this, check your mesh system's settings for options related to multicast, IGMP snooping, or mDNS.
+
+### Understanding OTBR log messages
+
+The OpenThread Border Router app logs can contain messages that look alarming but are often normal behavior. Here is what some of the most common messages mean.
+
+#### ChannelAccessFailure
+
+```text
+Handle transmit done failed: ChannelAccessFailure
+```
+
+This means the radio tried to transmit but the channel was too busy. The radio performs a "clear channel assessment" before sending, and if it detects other traffic, it backs off and retries. After 16 failed attempts, it reports this error.
+
+Occasional `ChannelAccessFailure` messages are normal, especially on channels that overlap with Wi-Fi. If you see them frequently (multiple times per minute), consider [changing the Thread channel](#changing-the-thread-channel) to one with less interference, such as channel 25 or 26.
+
+#### NoAck
+
+```text
+Failed to send IPv6 UDP msg... error:NoAck
+```
+
+This means the border router sent a message to a device, but the device did not acknowledge it. For battery-powered devices (known as Sleepy End Devices), this is expected. These devices turn off their radio most of the time to conserve battery and only wake up periodically to check for messages. The border router queues messages and delivers them when the device wakes up.
+
+If you see `NoAck` errors for a device that should be powered on and responsive, the device may be out of range or experiencing a hardware issue.
+
+#### mDNSPlatformSendUDP errors
+
+```text
+mDNSPlatformSendUDP got error 99
+(Cannot assign requested address)
+```
+
+These errors typically appear for Docker virtual network interfaces (`veth` devices) and are cosmetic. The mDNS responder inside the OTBR container tries to send multicast on all network interfaces, including internal Docker bridge interfaces that cannot send multicast. These errors do not affect the border router's ability to advertise on your actual network.

--- a/source/_integrations/thread.markdown
+++ b/source/_integrations/thread.markdown
@@ -341,23 +341,23 @@ This section helps you resolve common issues with Thread networks and device com
 
 #### Symptom: "IPv6 routing/forwarding is not enabled" warning in the OTBR app logs, or Thread devices join the network but cannot be reached
 
-Thread is an IPv6-only protocol. For Thread devices to communicate with Home Assistant and other devices on your network, IPv6 forwarding must be enabled at every layer of your network stack. If any layer is missing IPv6 support, Thread devices may join the mesh but fail to communicate beyond it.
+Thread is an IPv6-only protocol. For Thread devices to communicate with Home Assistant and other devices on your network, your Home Assistant system must have working IPv6 connectivity. In setups that route traffic between networks, IPv6 forwarding must also be enabled on the system acting as the router. If any required layer is missing IPv6 support, Thread devices may join the mesh but fail to communicate beyond it.
 
 ##### Layers to check
 
-Every setup has at least two layers that need IPv6 forwarding:
+Every setup should have these basics in place:
 
-- **Home Assistant host** — the system where Home Assistant runs
-- **Network router** — the device that manages traffic on your local network
+- **Home Assistant host** — the system where Home Assistant runs must have working IPv6 connectivity
+- **Network router** — the device that manages traffic on your local network must support IPv6 routing for your network
 
-Depending on how Home Assistant is deployed, there may be additional layers:
+Depending on how Home Assistant is deployed, there may be additional layers to check:
 
-- **Hypervisor host** — if Home Assistant runs inside a virtual machine (for example, Proxmox, ESXi, or VirtualBox), the hypervisor also needs IPv6 forwarding enabled
-- **Docker daemon** — if Home Assistant runs as a container, the Docker daemon needs IPv6 enabled in its configuration
-- **Host operating system** — if Home Assistant runs as a container on Linux, the host OS needs IPv6 forwarding enabled at the kernel level
+- **Hypervisor host** — if Home Assistant runs inside a virtual machine, like Proxmox, ESXi, or VirtualBox, make sure the virtual NIC connected to the Home Assistant VM has IPv6 connectivity. In bridged setups, the hypervisor usually does not need IPv6 forwarding. If the hypervisor is routing traffic, IPv6 forwarding may be required there
+- **Docker daemon** — if Home Assistant runs as a container, Docker may need IPv6 enabled in its configuration
+- **Host operating system** — if Home Assistant runs as a container on Linux, the host OS may need IPv6 forwarding enabled at the kernel level when it is routing container traffic
 
 {% note %}
-The warning in the OTBR app logs only detects whether IPv6 forwarding is enabled on the Home Assistant host itself. Issues at the hypervisor, Docker, host OS, or router layer will not trigger this warning but can still prevent Thread devices from communicating.
+The warning in the OTBR app logs only detects whether IPv6 forwarding is enabled on the Home Assistant host itself. Issues at the hypervisor, Docker, host OS, virtual network, or router layer will not trigger this warning but can still prevent Thread devices from communicating.
 {% endnote %}
 
 ##### Home Assistant Operating System
@@ -383,7 +383,7 @@ IPv6 may not be enabled in Docker on your Home Assistant OS installation. There 
    ha host reboot
    ```
 
-If Home Assistant OS is running inside a virtual machine, the hypervisor host also needs IPv6 forwarding enabled. Refer to your hypervisor's documentation for instructions.
+If Home Assistant OS is running inside a virtual machine, make sure the VM has IPv6 connectivity. If the hypervisor is routing traffic (rather than bridging), IPv6 forwarding may also need to be enabled. Refer to your hypervisor's documentation for instructions.
 
 ##### Home Assistant Container
 
@@ -392,7 +392,7 @@ If you are running Home Assistant Container, there are two additional layers to 
 - **Docker daemon** — IPv6 must be enabled in the Docker daemon configuration. Refer to the [Docker documentation on enabling IPv6](https://docs.docker.com/config/daemon/ipv6/) for instructions.
 - **Host operating system** — the Linux host needs IPv6 forwarding enabled at the kernel level. Refer to your distribution's documentation for instructions on enabling IPv6 forwarding.
 
-If the host machine is itself a virtual machine, the hypervisor also needs IPv6 forwarding enabled. Refer to your hypervisor's documentation for instructions.
+If the host machine is itself a virtual machine, make sure the VM has IPv6 connectivity. If the hypervisor is routing traffic (rather than bridging), IPv6 forwarding may also need to be enabled. Refer to your hypervisor's documentation for instructions.
 
 ##### Network router
 
@@ -406,11 +406,11 @@ If you experience frequent pairing failures or devices that drop off the network
 
 ##### Description
 
-Thread uses the IEEE 802.15.4 radio standard, which operates in the 2.4 GHz band — the same band used by Wi-Fi and Bluetooth. Thread channels 11 through 22 overlap with common Wi-Fi channels 1, 6, and 11. This overlap can cause interference that prevents the Thread radio from transmitting successfully.
+Thread uses the IEEE 802.15.4 radio standard, which operates in the 2.4 GHz band — the same band used by Wi-Fi and Bluetooth. Thread channels 11 through 24 can overlap with 2.4 GHz Wi-Fi, including common Wi-Fi channels like 1, 6, and 11. This overlap can cause interference that prevents the Thread radio from transmitting successfully.
 
 A sign of interference in the OTBR app logs is repeated `ChannelAccessFailure` errors. This means the radio attempted to send a frame but the channel was too busy, even after multiple retries.
 
-Thread channels 25 and 26 sit above the Wi-Fi band and are the least likely to experience Wi-Fi interference. Channel 26 is a common recommendation for environments with heavy Wi-Fi traffic.
+Thread channel 26 is the least likely to experience Wi-Fi interference. Channel 25 can also help reduce interference, but it may still partially overlap with some Wi-Fi configurations, depending on channel width. Channel 26 is a common recommendation for environments with heavy Wi-Fi traffic.
 
 ##### Resolution
 


### PR DESCRIPTION
## Proposed change

Add a troubleshooting section to the Thread integration documentation covering common issues encountered when setting up and using Thread networks with Home Assistant. This is based on personal troubleshooting experience setting up an OpenThread Border Router with a ZBT-2 on Home Assistant OS (running on Proxmox).

The new section covers:

- **IPv6 configuration** — how to verify and enable IPv6 at each layer of the network stack (HAOS, Docker host, hypervisor, router), with specific guidance for each supported installation method
- **Channel interference** — how to identify Wi-Fi interference from OTBR logs and change the Thread channel, including details on the delayed channel switch behavior
- **Pairing failures** — Thread-specific troubleshooting tips that complement the existing Matter commissioning prerequisites
- **Understanding OTBR log messages** — explains common log messages (ChannelAccessFailure, NoAck, mDNS errors) that can look alarming but are often normal

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

- Related issue: https://github.com/raman325/lock_code_manager/issues/984#issuecomment-4264757098
- This PR does not fix or close any issue in this repository. It adds documentation that was previously missing.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards