### PR TITLE
Add Honeywell String Lights integration

### DIFF
--- a/source/_integrations/honeywell_string_lights.markdown
+++ b/source/_integrations/honeywell_string_lights.markdown
@@ -21,7 +21,10 @@ The integration uses the [Radio Frequency](/integrations/radio_frequency/) {% te
 
 {% include integrations/config_flow.md %}
 
-During configuration, you will be asked to select the radio frequency transmitter that is used to control the lights. Only transmitters that support 433.92&nbsp;MHz OOK transmissions are shown.
+{% configuration_basic %}
+Radio frequency transmitter:
+  description: "Select the RF transmitter that Home Assistant should use to control the lights. Only transmitters that support 433.92&nbsp;MHz OOK transmissions are shown."
+{% endconfiguration_basic %}
 
 ## Assumed state
 

--- a/source/_integrations/honeywell_string_lights.markdown
+++ b/source/_integrations/honeywell_string_lights.markdown
@@ -1,0 +1,38 @@
+---
+title: Honeywell String Lights
+description: Instructions on how to integrate Honeywell String Lights into Home Assistant.
+ha_category:
+  - Light
+ha_release: 2026.5
+ha_iot_class: Assumed State
+ha_config_flow: true
+ha_codeowners:
+  - '@balloob'
+ha_domain: honeywell_string_lights
+ha_platforms:
+  - light
+ha_integration_type: device
+ha_quality_scale: bronze
+---
+
+The **Honeywell String Lights** {% term integration %} lets you control a Honeywell radio frequency (RF) remote-controlled string light set from Home Assistant.
+
+The integration uses the [Radio Frequency](/integrations/radio_frequency/) {% term entity %} platform to send the turn on and turn off commands. This means you need a compatible RF transmitter (for example, an ESPHome device with a 433.92&nbsp;MHz OOK transmitter) set up before you can add the Honeywell String Lights.
+
+{% include integrations/config_flow.md %}
+
+During configuration, you will be asked to select the radio frequency transmitter that is used to control the lights. Only transmitters that support 433.92&nbsp;MHz OOK transmissions are shown.
+
+## Assumed state
+
+Because RF transmission is a one-way broadcast, Home Assistant cannot confirm whether the lights actually turned on or off. The integration therefore uses the [assumed state](/integrations/light#assumed-state) pattern: the state is the last state Home Assistant set, and it is restored across restarts.
+
+## Supported devices
+
+The integration has been tested with the Honeywell String Lights sold with a 433.92&nbsp;MHz OOK remote.
+
+## Removing the integration
+
+This integration follows standard integration removal.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for the new `honeywell_string_lights` integration. It drives a Honeywell RF remote-controlled string light set via the new [Radio Frequency](/integrations/radio_frequency/) entity platform.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/168450
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/10164
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards