### PR TITLE
Document new moon sensors and binary sensor.

### DIFF
--- a/source/_integrations/moon.markdown
+++ b/source/_integrations/moon.markdown
@@ -2,24 +2,22 @@
 title: Moon
 description: Instructions on how to use the Moon integration in Home Assistant.
 ha_category:
-  - Environment
+    - Environment
 ha_iot_class: Calculated
 ha_release: 0.38
 ha_quality_scale: internal
 ha_codeowners:
-  - '@fabaff'
-  - '@frenck'
+    - "@fabaff"
+    - "@frenck"
 ha_domain: moon
 ha_platforms:
-  - binary_sensor
-  - sensor
+    - binary_sensor
+    - sensor
 ha_config_flow: true
 ha_integration_type: service
 ---
 
-The **Moon** {% term integration %} tracks the moon based on your configured home location. In addition to the moon phase, it also provides data like illumination, rise and set times, the next major lunar phases, and whether the moon is currently above the horizon.
-
-You can use these entities in automations and dashboards. For example, you can use the phase sensor to show the current moon phase, or use the `above_horizon` binary sensor in automations that should only run when the moon is visible.
+The **Moon** {% term integration %} tracks the moon based on your configured home location.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/moon.markdown
+++ b/source/_integrations/moon.markdown
@@ -1,6 +1,6 @@
 ---
 title: Moon
-description: Instructions on how to integrate the moon sensor into Home Assistant.
+description: Instructions on how to use the Moon integration in Home Assistant.
 ha_category:
   - Environment
 ha_iot_class: Calculated
@@ -11,16 +11,37 @@ ha_codeowners:
   - '@frenck'
 ha_domain: moon
 ha_platforms:
+  - binary_sensor
   - sensor
 ha_config_flow: true
 ha_integration_type: service
 ---
 
-The **Moon** {% term integration %} tracks the phases of the moon.
+The **Moon** {% term integration %} tracks the moon based on your configured home location. In addition to the moon phase, it also provides data like illumination, rise and set times, the next major lunar phases, and whether the moon is currently above the horizon.
+
+You can use these entities in automations and dashboards. For example, you can use the phase sensor to show the current moon phase, or use the `above_horizon` binary sensor in automations that should only run when the moon is visible.
 
 {% include integrations/config_flow.md %}
 
-The sensor provided by this integration will return one of the following values:
+<p class='img'>
+<img src='/images/screenshots/more-info-dialog-moon.png' />
+</p>
+
+## Sensors
+
+The Moon integration provides the following sensors:
+
+- **Phase**
+- **Illumination**
+- **Next rising**
+- **Next setting**
+- **Next transit**
+- **Next new moon**
+- **Next first quarter**
+- **Next full moon**
+- **Next last quarter**
+
+The **Phase** sensor returns one of the following values:
 
 - `new_moon`
 - `waxing_crescent`
@@ -31,6 +52,17 @@ The sensor provided by this integration will return one of the following values:
 - `last_quarter`
 - `waning_crescent`
 
-<p class='img'>
-<img src='/images/screenshots/more-info-dialog-moon.png' />
-</p>
+The **Illumination** sensor shows the illuminated percentage of the moon that is visible from Earth.
+
+The timestamp sensors provide the date and time for the moon's next rise, set, transit, and next major phases.
+
+The following diagnostic sensors are also available, but they are disabled by default. You can enable them if you want more detailed location-based lunar data:
+
+- **Elevation**
+- **Azimuth**
+
+## Binary sensors
+
+The Moon integration provides one binary sensor:
+
+- **Above horizon**: `on` when the moon is above the horizon, `off` when it is below the horizon.


### PR DESCRIPTION
## Summary
- Update the Moon integration docs to reflect the expanded lunar entities added in core
- Document the new illumination, timestamp, and diagnostic sensors, plus the `above_horizon` binary sensor
- Align the page structure more closely with the existing Sun integration docs

## Related
- Core coordinator PR: home-assistant/core#169514
- Core binary sensor PR: home-assistant/core#169515
- Core sensor entities PR: home-assistant/core#169516
- Supersedes original core PR: home-assistant/core#168009

## Test plan
- [x] Review the updated `moon.markdown` content
- [x] Run doc linting for `source/_integrations/moon.markdown`