### PR TITLE
Update onedrive.upload action docs to reflect multi-file support

### DIFF
--- a/source/_integrations/onedrive.markdown
+++ b/source/_integrations/onedrive.markdown
@@ -94,16 +94,35 @@ This integration provides the following actions:
 
 ### Action `onedrive.upload`
 
-You can use the `onedrive.upload` action to upload one or more files from
-Home Assistant to OneDrive. For example, to upload `camera` snapshots.
+You can use the `onedrive.upload` action to upload one or more files from Home Assistant to OneDrive. For example, to upload `camera` snapshots.
 
 {% details "Upload action details" %}
 
 | Data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
-| `filename` | no | One or more paths to local files to upload. | /media/image.jpg |
+| `filename` | no | One or more local file paths to upload. Accepts a single string or a list of strings. | /media/image.jpg |
 | `destination_folder` | no | Folder inside your `Apps/Home Assistant` app folder that is the destination for the uploaded files. Will be created if it does not exist. Supports subfolders. | Snapshots/2025 |
 | `config_entry_id` | no | The ID of the OneDrive config entry (the OneDrive you want to upload to). | a1bee602deade2b09bc522749bbce48e |
+
+{% raw %}
+
+```yaml
+# Upload a single file
+action: onedrive.upload
+data:
+  filename: /media/image.jpg
+  destination_folder: Snapshots/2025
+
+# Upload multiple files
+action: onedrive.upload
+data:
+  filename:
+    - /media/image_1.jpg
+    - /media/image_2.jpg
+  destination_folder: Snapshots/2025
+```
+
+{% endraw %}
 
 {% enddetails %}
 

--- a/source/_integrations/onedrive.markdown
+++ b/source/_integrations/onedrive.markdown
@@ -94,15 +94,15 @@ This integration provides the following actions:
 
 ### Action `onedrive.upload`
 
-You can use the `onedrive.upload` action to upload files from Home Assistant
-to OneDrive. For example, to upload `camera` snapshots.
+You can use the `onedrive.upload` action to upload one or more files from
+Home Assistant to OneDrive. For example, to upload `camera` snapshots.
 
 {% details "Upload action details" %}
 
 | Data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
-| `filename` | no | Path to the file to upload. | /media/image.jpg |
-| `destination_folder` | no | Folder inside your `Apps/Home Assistant` app folder that is the destination for the uploaded content. Will be created if it does not exist. Supports subfolders. | Snapshots/2025 |
+| `filename` | no | One or more paths to local files to upload. | /media/image.jpg |
+| `destination_folder` | no | Folder inside your `Apps/Home Assistant` app folder that is the destination for the uploaded files. Will be created if it does not exist. Supports subfolders. | Snapshots/2025 |
 | `config_entry_id` | no | The ID of the OneDrive config entry (the OneDrive you want to upload to). | a1bee602deade2b09bc522749bbce48e |
 
 {% enddetails %}


### PR DESCRIPTION
## Proposed change

Updates the `onedrive.upload` action documentation to reflect that the
action already supports uploading multiple files — a capability that was
present in the implementation but not documented.

The `filename` field accepts one or more local file paths, consistent
with how the `destination_path` field works in the `onedrive.delete`
action.

## Type of change

- Adjusted missing or incorrect information in the current documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/168512

## Checklist

- This PR uses the correct branch, based on one of the following:
- I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- The documentation follows the Home Assistant documentation standards.