### PR TITLE
Document ZHA UI missing QR code scanning support for Zigbee device provision

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -667,8 +667,6 @@ The list of ZHA limitations may not be exhaustive.
 **Support for commissioning Zigbee 3.0 devices via "Install Code" or "QR Code" via the `zha.permit` action:**
 
 - Home Assistant's user interface does not currently support scanning a QR code for Zigbee 3.0 secure provisioning for device pre-commissioning in ZHA's UI (instead, you currently need to use the `zha.permit` action with the qr_code parameter).
-- Actions have so far only been implemented for 'ezsp' (Silicon Labs EmberZNet) and 'znp' (Texas Instruments) radio types in ZHA.
-  - Other radio types are missing support for these actions in their respective [radio libraries for zigpy](https://github.com/zigpy/) or manufacturer's firmware commands/APIs.
 
 **ZHA does _not_ currently support devices that can only use:**
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -668,6 +668,7 @@ The list of ZHA limitations may not be exhaustive.
 
 - This has so far only been implemented for 'ezsp' (Silicon Labs EmberZNet) or 'znp' (Texas Instruments) radio type in ZHA.
 - Other radio types are missing support in their respective [radio libraries for zigpy](https://github.com/zigpy/) or manufacturer's firmware commands/APIs.
+- There is no frontend implementation for Zigbee 3.0 device secure provisioning that allow QR code scanning for device provisioning in ZHA integration UI.
 
 **ZHA does _not_ currently support devices that can only use:**
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -666,9 +666,9 @@ The list of ZHA limitations may not be exhaustive.
 
 **Support for commissioning Zigbee 3.0 devices via "Install Code" or "QR Code" via the `zha.permit` action:**
 
-- This has so far only been implemented for 'ezsp' (Silicon Labs EmberZNet) or 'znp' (Texas Instruments) radio type in ZHA.
-- Other radio types are missing support in their respective [radio libraries for zigpy](https://github.com/zigpy/) or manufacturer's firmware commands/APIs.
-- There is no frontend implementation for Zigbee 3.0 device secure provisioning that allow QR code scanning for device provisioning in ZHA integration UI.
+- Home Assistant's user interface (frontend codebase) does not currently support scanning a QR code for Zigbee 3.0 secure provisioning for device pre-commissioning in ZHA's UI (instead you currently need to use the zha.permit action with the qr_code parameter instead).
+- Actions for this has so far only been implemented for 'ezsp' (Silicon Labs EmberZNet) and 'znp' (Texas Instruments) radio types in ZHA.
+  - Other radio types are missing support in their respective [radio libraries for zigpy](https://github.com/zigpy/) or manufacturer's firmware commands/APIs.
 
 **ZHA does _not_ currently support devices that can only use:**
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -666,9 +666,9 @@ The list of ZHA limitations may not be exhaustive.
 
 **Support for commissioning Zigbee 3.0 devices via "Install Code" or "QR Code" via the `zha.permit` action:**
 
-- Home Assistant's user interface (frontend codebase) does not currently support scanning a QR code for Zigbee 3.0 secure provisioning for device pre-commissioning in ZHA's UI (instead you currently need to use the zha.permit action with the qr_code parameter instead).
-- Actions for this has so far only been implemented for 'ezsp' (Silicon Labs EmberZNet) and 'znp' (Texas Instruments) radio types in ZHA.
-  - Other radio types are missing support in their respective [radio libraries for zigpy](https://github.com/zigpy/) or manufacturer's firmware commands/APIs.
+- Home Assistant's user interface does not currently support scanning a QR code for Zigbee 3.0 secure provisioning for device pre-commissioning in ZHA's UI (instead, you currently need to use the `zha.permit` action with the qr_code parameter).
+- Actions have so far only been implemented for 'ezsp' (Silicon Labs EmberZNet) and 'znp' (Texas Instruments) radio types in ZHA.
+  - Other radio types are missing support for these actions in their respective [radio libraries for zigpy](https://github.com/zigpy/) or manufacturer's firmware commands/APIs.
 
 **ZHA does _not_ currently support devices that can only use:**
 


### PR DESCRIPTION
Added note under the listed limitations section in ZHA end-user documention about Home Assistant frontend currently missing UI implementation for Zigbee 3.0 device secure provisioning in ZHA integration's user interface. Related to these:

* https://github.com/OpenHomeFoundation/roadmap/issues/93

* https://github.com/zigpy/backlog/issues/3

* https://community.home-assistant.io/t/zigbee-device-secure-provisioning-by-scanning-qr-code-on-product-using-native-qr-scanner-via-camera-from-zhas-ui-config-and-home-assistant-companion-app-s-to-include-new-zigbee-3-0-devices-to-the-zha-integration/231185

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
