### PR TITLE
Update Duco integration to Silver quality scale

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -43,7 +43,7 @@ Compatible DucoBox models:
 
 {% include integrations/config_flow.md %}
 
-Your Duco ventilation box can be **automatically discovered** on your network when the device is connected and powered on. When Home Assistant discovers a new Duco device, it appears as a notification in the UI. Select the notification to complete the setup with one click.
+Your Duco ventilation box can be automatically discovered on your network when the device is connected and powered on. When Home Assistant discovers a new Duco device, it appears as a notification in the UI. Select the notification to complete the setup.
 
 If automatic discovery does not work, you can manually add the integration by providing the IP address or hostname.
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -14,7 +14,7 @@ ha_platforms:
   - fan
   - sensor
 ha_integration_type: hub
-ha_quality_scale: bronze
+ha_quality_scale: silver
 ha_zeroconf: true
 ---
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -43,7 +43,7 @@ Compatible DucoBox models:
 
 {% include integrations/config_flow.md %}
 
-Your Duco ventilation box can be automatically discovered on your network when the device is connected and powered on. When Home Assistant discovers a new Duco device, it appears as a notification in the UI. Select the notification to complete the setup with one click.
+Your Duco ventilation box can be **automatically discovered** on your network when the device is connected and powered on. When Home Assistant discovers a new Duco device, it appears as a notification in the UI. Select the notification to complete the setup with one click.
 
 If automatic discovery does not work, you can manually add the integration by providing the IP address or hostname.
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -14,7 +14,7 @@ ha_platforms:
   - fan
   - sensor
 ha_integration_type: hub
-ha_quality_scale: silver
+ha_quality_scale: bronze
 ha_zeroconf: true
 ---
 


### PR DESCRIPTION
## Proposed change

Update the Duco integration documentation page to reflect the Silver quality scale claim:

- Update `ha_quality_scale` from `bronze` to `silver` in the front matter
- Minor formatting: emphasize "automatically discovered" text in the prerequisites section

This accompanies home-assistant/core#168620 which updates `quality_scale` in `manifest.json`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#168620
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
