### PR TITLE
Velux: add link for KIG/KIX 300 integration

### DIFF
--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -79,8 +79,11 @@ The Velux KLF 150 is not supported by this {% term integration %}, even though V
 
 However, there is a community [project](https://github.com/uncaught/gpio-shutter-bridge) that bridges the KLF 150's GPIO interface with MQTT. Using this project with additional hardware, you can control your KLF 150 through the [MQTT Cover integration](/integrations/cover.mqtt/).
 
-### Velux Active (KIX 300)
+### Velux Active (KIG 300 / KIX 300)
 
-The Velux Active (KIX 300) set is not supported by this {% term integration %}. To integrate Velux Active (KIX 300) with Home Assistant, you can use the [HomeKit Controller](/integrations/homekit_controller) {% term integration %} and get full control over your windows, curtains, covers, the air quality sensor KLA 300, etc.
+The Velux Active gateway family is not supported by this {% term integration %}. This includes the `KIG 300` gateway used by Velux App Control and the `KIX 300` Velux Active with Netatmo starter kit.
 
-Add the Velux Active gateway using HomeKit pairing (with the pairing code on the sticker at the bottom of the Velux Active gateway) and the devices connected to the gateway - including sensors - will be automatically discovered and added to Home Assistant.
+If you want to integrate these gateways with Home Assistant, you can use the community custom integration [ha-velux-active](https://github.com/Niek/ha-velux-active), which connects to the Velux cloud service directly and exposes supported covers in Home Assistant.
+
+As an alternative, you can use the [HomeKit Controller](/integrations/homekit_controller) {% term integration %}. Add the Velux Active gateway using HomeKit pairing with the pairing code on the sticker on the bottom of the gateway. Devices connected to the gateway, including supported sensors, will then be discovered by Home Assistant.
+


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Update the unsupported hardware section for Velux Active gateways to reflect the currently used product names and integration options.

This rewrites the existing `Velux Active (KIX 300)` section to cover both the `KIG 300` gateway used by Velux App Control and the `KIX 300` Velux Active with Netatmo starter kit. It also adds a link to the community custom integration `ha-velux-active` as the primary non-HomeKit option, while keeping the existing HomeKit Controller approach as an alternative.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
