### PR TITLE
Add dynamic device discovery and stale device documentation for Duco integration

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -224,7 +224,7 @@ This automation switches to high speed when the CO₂ level in the office rises 
 
 ## Data updates
 
-The integration {% term polling polls %} the Duco box every 30 seconds. If you add a new sensor module (such as a CO₂ or humidity sensor) to your Duco system after the integration is already set up, it will automatically appear in Home Assistant the next time the integration polls for data — no restart or reconfiguration required.
+The integration {% term polling polls %} the Duco box every 30 seconds. If you add a new sensor module (such as a CO₂ or humidity sensor) to your Duco system after the integration is already set up, it will automatically appear in Home Assistant the next time the integration polls for data. No restart or reconfiguration required.
 
 ## Known limitations
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -230,7 +230,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 
 - The Duco box enforces a rate limit of approximately 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully, and the firmware resets the quota automatically around midnight.
 - Timed speed overrides set by external devices (such as an RF wall switch or a CO₂ sensor) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
-- Once a sensor module is paired with the Duco box, the firmware retains it permanently. If you physically remove a sensor, its entities will continue to appear in Home Assistant because the device still shows up in the Duco API. There is no way to permanently remove such a device from Home Assistant: if you delete it manually, it will be re-added automatically on the next data update.
+- When you deregister a sensor module via the Duco app or firmware, the node disappears from the Duco API and Home Assistant removes it automatically on the next data update. However, a BSRH humidity sensor that is physically disconnected from the box PCB (rather than deregistered via software) is not treated as deregistered by the firmware. Its node remains in the API indefinitely, so its entities will stay in Home Assistant until you deregister it through the Duco app.
 
 ## Troubleshooting
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -230,7 +230,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 
 - The Duco box enforces a rate limit of approximately 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully, and the firmware resets the quota automatically around midnight.
 - Timed speed overrides set by external devices (such as an RF wall switch or a CO₂ sensor) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
-- Once a sensor module is paired with the Duco box, the firmware retains it permanently. If you physically remove a sensor, its entities will continue to appear in Home Assistant because the device still shows up in the Duco API. To remove the entities, delete the corresponding device from Home Assistant manually via {% my integrations title="**Settings** > **Devices & services**" %} > **Duco**.
+- Once a sensor module is paired with the Duco box, the firmware retains it permanently. If you physically remove a sensor, its entities will continue to appear in Home Assistant because the device still shows up in the Duco API. There is no way to permanently remove such a device from Home Assistant: if you delete it manually, it will be re-added automatically on the next data update.
 
 ## Troubleshooting
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -230,6 +230,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 
 - The Duco box enforces a rate limit of approximately 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully, and the firmware resets the quota automatically around midnight.
 - Timed speed overrides set by external devices (such as an RF wall switch or a CO₂ sensor) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
+- Once a sensor module is paired with the Duco box, the firmware retains it permanently. If you physically remove a sensor, its entities will continue to appear in Home Assistant because the device still shows up in the Duco API. To remove the entities, delete the corresponding device from Home Assistant manually via {% my integrations title="**Settings** > **Devices & services**" %} > **Duco**.
 
 ## Troubleshooting
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -224,7 +224,7 @@ This automation switches to high speed when the CO₂ level in the office rises 
 
 ## Data updates
 
-The integration {% term polling polls %} the Duco box every 30 seconds.
+The integration {% term polling polls %} the Duco box every 30 seconds. If you add a new sensor module (such as a CO₂ or humidity sensor) to your Duco system after the integration is already set up, it will automatically appear in Home Assistant the next time the integration polls for data — no restart or reconfiguration required.
 
 ## Known limitations
 


### PR DESCRIPTION
## Proposed change

Documents the dynamic device discovery and stale device removal behavior added to the Duco integration in home-assistant/core#168675.

Changes:

- Update the Known limitations bullet about sensor removal: deregistered RF/wired nodes now disappear from Home Assistant automatically; only a BSRH physically disconnected from the box PCB (without software deregistration) remains in the API indefinitely

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#168675
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards