### PR TITLE
Add DHCP discovery documentation for Duco integration

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -15,6 +15,7 @@ ha_platforms:
   - sensor
 ha_integration_type: hub
 ha_quality_scale: bronze
+ha_dhcp: true
 ha_zeroconf: true
 ---
 
@@ -239,7 +240,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 If your Duco ventilation box is not automatically discovered:
 
 - Ensure the device is powered on and connected to the same network as Home Assistant.
-- Check that mDNS/Bonjour traffic is not blocked by your router or firewall.
+- Check that mDNS/Bonjour traffic is not blocked by your router or firewall. If it is, the integration can still discover the device automatically via DHCP the next time the device renews its IP address lease.
 - Verify the device name shows as "DUCO [MAC address]" in your router's device list or network scanner.
 - Manually add the integration using the device's IP address if discovery continues to fail.
 


### PR DESCRIPTION
## Proposed change

Documents the DHCP discovery fallback added to the Duco integration in home-assistant/core#168730.

On networks where mDNS multicast is blocked, zeroconf discovery does not work. DHCP discovery serves as an automatic fallback: whenever the Duco box renews its IP address lease, Home Assistant picks it up via the DHCP watcher without any user action.

Changes:

- Add `ha_dhcp: true` to the front matter
- Update the "Device is not automatically discovered" troubleshooting bullet to mention DHCP as an automatic fallback when mDNS is blocked

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#168730
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards