### PR TITLE
docs: fix typos in blog posts

### DIFF
--- a/source/_posts/2014-12-26-home-control-home-automation-and-the-smart-home.markdown
+++ b/source/_posts/2014-12-26-home-control-home-automation-and-the-smart-home.markdown
@@ -61,7 +61,7 @@ Most first generation IoT devices are only exposing information that is needed f
 
 To increase adoption we will need people to trust their smart home system. It will be very tough to convince people to upgrade all their devices and upload all interactions with each of them to the cloud. This data could reveal their whole life including all bad habits. That's why such a system should be simple and open-source so people can validate that their data generated at home stays home.
 
-Anoter important booster for adoption is that the software should be easy to set up and use by the average user. A lot of people are not burning their hands yet on Home Automation because they are scared of configurating it.
+Another important booster for adoption is that the software should be easy to set up and use by the average user. A lot of people are not burning their hands yet on Home Automation because they are scared of configuring it.
 
 Home Assistant is trying to be this software. It is not there yet but trying hard. Device discovery and a user interface for configuring home automation are problems we hope to tackle in 2015 while not sacrificing any modularity or usability.
 

--- a/source/_posts/2015-01-11-bootstrapping-your-setup-with-discovery.markdown
+++ b/source/_posts/2015-01-11-bootstrapping-your-setup-with-discovery.markdown
@@ -12,7 +12,7 @@ categories:
 
 Most people do not like configuring things. Things just have to work, out of the box. Reaching this scenario is the goal of what we are about to introduce: our new discovery component.
 
-The discovery component will scan the WiFi network from time to time for connected zeroconf/mDNS and uPnP devices. The initial introduction is mainly focussed on getting the right architecture in place and discovers Belkin WeMo switches and Google Chromecasts connected to your network. When found, it will load and notify the appropritate component and it will be ready to use within seconds.
+The discovery component will scan the WiFi network from time to time for connected zeroconf/mDNS and uPnP devices. The initial introduction is mainly focussed on getting the right architecture in place and discovers Belkin WeMo switches and Google Chromecasts connected to your network. When found, it will load and notify the appropriate component and it will be ready to use within seconds.
 
 Most devices still require some sort of interaction from the user after being discovered - be it a button being pressed or some sort of authentication. This is a challenge that will be solved in the future.
 


### PR DESCRIPTION
Fixes spelling errors in historical blog posts:\n- 'Anoter' → 'Another'\n- 'configurating' → 'configuring'\n- 'appropritate' → 'appropriate'