### PR TITLE
Add UCRH sensor module support to Duco integration documentation

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -244,7 +244,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 
 ## Known limitations
 
-- The Duco box enforces a rate limit of 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully, and the firmware resets the quota automatically around midnight.
+- The Duco box enforces a rate limit of 200 write requests per day. When the limit is reached, the integration shows a notification and stops sending write requests until the quota resets automatically around midnight.
 - Timed speed overrides set by a connected wall unit (such as a UCCO2) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
 - When you deregister a sensor module via the Duco app or firmware, the node disappears from the Duco API and Home Assistant removes it automatically on the next data update. However, a BSRH humidity sensor that is physically disconnected from the box PCB (rather than deregistered via software) is not treated as deregistered by the firmware. Its node remains in the API indefinitely, so its entities will stay in Home Assistant until you deregister it through the Duco app.
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -37,6 +37,25 @@ Compatible DucoBox models:
 - DucoBox Energy Comfort / Energy Comfort Plus
 - DucoBox Energy Premium
 
+### Supported sensor modules
+
+The following sensor module types are supported:
+
+- **BOX** — the main ventilation box; provides fan control, ventilation state, and Wi-Fi signal strength
+- **UCCO2** — wall-mounted CO₂ sensor unit; provides CO₂ concentration and CO₂ air quality index
+- **BSRH** — humidity sensor module connected directly to the DucoBox PCB; provides relative humidity and humidity air quality index
+- **UCRH** — wireless humidity sensor module; provides relative humidity and humidity air quality index
+
+### Unsupported sensor modules
+
+The following sensor module types are discovered but not yet supported:
+
+- **UC** — universal control unit (no sensor data exposed)
+- **UCBAT** — battery-powered sensor module
+- **VLV** — valve actuator
+
+When Home Assistant discovers a node with an unsupported type, it logs a warning and skips that node. All other nodes continue to work normally.
+
 ## Prerequisites
 
 - A Duco ventilation box with a DUCO Connectivity Board connected to your local network.
@@ -55,6 +74,7 @@ The Duco system consists of multiple nodes. Each node appears as a separate devi
 - **BOX** — the main DucoBox (fan control, ventilation state)
 - **UCCO2** — a wall-mounted control unit with a built-in CO₂ sensor
 - **BSRH** — a humidity sensor module installed in the duct inlet of the DucoBox
+- **UCRH** — a wireless humidity sensor module
 
 ### Fan
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -110,7 +110,7 @@ Available for CO₂ sensor modules. Shows the current CO₂ concentration in par
 
 #### Humidity
 
-Available for humidity sensor modules (BSRH). Shows the current relative humidity in percent.
+Available for humidity sensor modules (BSRH, UCRH). Shows the current relative humidity in percent.
 
 #### CO₂ air quality index
 
@@ -125,7 +125,7 @@ Indoor air quality ranges for CO₂:
 
 #### Humidity air quality index
 
-Available for humidity sensor modules (BSRH). Shows the humidity air quality score as a percentage (0–100%). This entity is disabled by default.
+Available for humidity sensor modules (BSRH, UCRH). Shows the humidity air quality score as a percentage (0–100%). This entity is disabled by default.
 
 Indoor air quality ranges for humidity:
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -43,7 +43,7 @@ The following sensor module types are supported:
 
 - **BOX** — the main ventilation box; provides fan control, ventilation state, and Wi-Fi signal strength
 - **UCCO2** — wall-mounted CO₂ sensor unit; provides CO₂ concentration and CO₂ air quality index
-- **BSRH** — humidity sensor module connected directly to the DucoBox PCB; provides relative humidity and humidity air quality index
+- **BSRH** — humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity and humidity air quality index
 - **UCRH** — wireless humidity sensor module; provides relative humidity and humidity air quality index
 
 ### Unsupported sensor modules
@@ -244,7 +244,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 
 ## Known limitations
 
-- The Duco box enforces a rate limit of approximately 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully, and the firmware resets the quota automatically around midnight.
+- The Duco box enforces a rate limit of 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully, and the firmware resets the quota automatically around midnight.
 - Timed speed overrides set by a connected wall unit (such as a UCCO2) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
 - When you deregister a sensor module via the Duco app or firmware, the node disappears from the Duco API and Home Assistant removes it automatically on the next data update. However, a BSRH humidity sensor that is physically disconnected from the box PCB (rather than deregistered via software) is not treated as deregistered by the firmware. Its node remains in the API indefinitely, so its entities will stay in Home Assistant until you deregister it through the Duco app.
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -43,10 +43,6 @@ Compatible DucoBox models:
 
 {% include integrations/config_flow.md %}
 
-Your Duco ventilation box can be automatically discovered on your network when the device is connected and powered on. When Home Assistant discovers a new Duco device, it appears as a notification in the UI. Select the notification to complete the setup.
-
-If automatic discovery does not work, you can manually add the integration by providing the IP address or hostname.
-
 {% configuration_basic %}
 Host:
   description: "The IP address or hostname of your DUCO Connectivity Board on the local network, for example `192.168.1.10`. Only needed when setting up the integration manually."
@@ -57,8 +53,8 @@ Host:
 The Duco system consists of multiple nodes. Each node appears as a separate device in Home Assistant, connected to the main ventilation box:
 
 - **BOX** — the main DucoBox (fan control, ventilation state)
-- **UCCO2** — a wireless CO₂ sensor module
-- **BSRH** — a humidity sensor module installed inside the DucoBox
+- **UCCO2** — a wall-mounted control unit with a built-in CO₂ sensor
+- **BSRH** — a humidity sensor module installed in the duct inlet of the DucoBox
 
 ### Fan
 
@@ -74,7 +70,7 @@ The following actions are available:
 - **Speed 100%**: High speed manual override.
 - **Auto preset**: Same as speed 0%; hands control back to Duco.
 
-When an external device (for example a CO₂ sensor or an RF wall switch) triggers a timed speed override on the Duco box, Home Assistant reflects the current ventilation level as a percentage. These timed states cannot be set from Home Assistant; writing a speed always uses the permanent manual mode (a continuous override with no time limit).
+When a connected wall unit (such as a UCCO2) triggers a timed speed override on the Duco box, Home Assistant reflects the current ventilation level as a percentage. These timed states cannot be set from Home Assistant; writing a speed always uses the permanent manual mode (a continuous override with no time limit).
 
 ### Sensors
 
@@ -229,7 +225,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 ## Known limitations
 
 - The Duco box enforces a rate limit of approximately 200 write requests per day (HTTP 429, error code 18). The integration handles this gracefully, and the firmware resets the quota automatically around midnight.
-- Timed speed overrides set by external devices (such as an RF wall switch or a CO₂ sensor) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
+- Timed speed overrides set by a connected wall unit (such as a UCCO2) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
 - When you deregister a sensor module via the Duco app or firmware, the node disappears from the Duco API and Home Assistant removes it automatically on the next data update. However, a BSRH humidity sensor that is physically disconnected from the box PCB (rather than deregistered via software) is not treated as deregistered by the firmware. Its node remains in the API indefinitely, so its entities will stay in Home Assistant until you deregister it through the Duco app.
 
 ## Troubleshooting
@@ -264,15 +260,13 @@ Home Assistant cannot reach the Duco box at the configured address. This can hap
 
 #### Symptom
 
-Setting the fan speed or preset mode fails with an error like:
+Setting the fan speed or preset mode fails with a notification in the Home Assistant UI:
 
-```text
-Failed to set ventilation state: DucoError('Duco API error (429): {"Code":18,"Result":"FAILED"}')
-```
+> The Duco device has reached its daily write limit. Try again tomorrow.
 
 #### Description
 
-The Duco box enforces a write rate limit of 200 write requests per day. When the limit is reached, the box rejects further write requests with a 429 error until the quota resets around midnight.
+The Duco box enforces a write rate limit of 200 write requests per day. When the limit is reached, the box rejects further write requests until the quota resets around midnight.
 
 #### Resolution
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -41,18 +41,18 @@ Compatible DucoBox models:
 
 The following sensor module types are supported:
 
-- **BOX** — the main ventilation box; provides fan control, ventilation state, and Wi-Fi signal strength
-- **UCCO2** — wall-mounted CO₂ sensor unit; provides CO₂ concentration and CO₂ air quality index
-- **BSRH** — humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity and humidity air quality index
-- **UCRH** — wireless humidity sensor module; provides relative humidity and humidity air quality index
+- **BOX**: The main ventilation box; provides fan control, ventilation state, and Wi-Fi signal strength.
+- **UCCO2**: Wall-mounted CO₂ sensor unit; provides CO₂ concentration and CO₂ air quality index.
+- **BSRH**: Humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity and humidity air quality index.
+- **UCRH**: Wireless humidity sensor module; provides relative humidity and humidity air quality index.
 
 ### Unsupported sensor modules
 
 The following sensor module types are discovered but not yet supported:
 
-- **UC** — universal control unit (no sensor data exposed)
-- **UCBAT** — battery-powered sensor module
-- **VLV** — valve actuator
+- **UC**: Universal control unit (no sensor data exposed)
+- **UCBAT**: Battery-powered sensor module
+- **VLV**: Valve actuator
 
 When Home Assistant discovers a node with an unsupported type, it logs a warning and skips that node. All other nodes continue to work normally.
 
@@ -71,10 +71,10 @@ Host:
 
 The Duco system consists of multiple nodes. Each node appears as a separate device in Home Assistant, connected to the main ventilation box:
 
-- **BOX** — the main DucoBox (fan control, ventilation state)
-- **UCCO2** — a wall-mounted control unit with a built-in CO₂ sensor
-- **BSRH** — a humidity sensor module installed in the duct inlet of the DucoBox
-- **UCRH** — a wireless humidity sensor module
+- **BOX**: The main DucoBox (fan control, ventilation state)
+- **UCCO2**: A wall-mounted control unit with a built-in CO₂ sensor
+- **BSRH**: A humidity sensor module installed in the duct inlet of the DucoBox
+- **UCRH**: A wireless humidity sensor module
 
 ### Fan
 


### PR DESCRIPTION
> [!NOTE]
> Besides this PR being linked to the parent PR for core functionality, a few additional changes have been included that are not directly tied to that specific core feature. These are general improvements and optimizations. If you would prefer those to be submitted as a separate PR, I can split them out, but for now this seemed like the most pragmatic approach.

## Proposed change

Documents the UCRH humidity sensor module support added to the Duco integration in home-assistant/core#168758.

Changes:

- Add supported and unsupported sensor modules section listing all known node types (BOX, UCCO2, BSRH, UCRH as supported; UC, UCBAT, VLV as unsupported)
- Update humidity and humidity AQI sensor descriptions to include UCRH alongside BSRH
- Fix rate limit wording in known limitations to match the actual UI message
- Clean up discovery paragraphs and improve node type descriptions

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#168758
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards