### PR TITLE
Add button platform docs to HP iLO integration

### DIFF
--- a/source/_integrations/hp_ilo.markdown
+++ b/source/_integrations/hp_ilo.markdown
@@ -16,7 +16,7 @@ related:
 ha_quality_scale: legacy
 ---
 
-The **HP Integrated Lights-Out** {% term integration %} allows you to do an API call to the HP ILO (Integrated Lights-Out) sensor of your server, and use this data in Home Assistant sensors. You can also send power-control commands to the server via button entities.
+The **HP Integrated Lights-Out** {% term integration %} allows you to do an API call to the HP ILO (Integrated Lights-Out) sensor of your server, and use this data in Home Assistant sensors. It also provides button entities to control server power.
 
 If the ILO or specified jsonpath query returns only a single value (e.g., a temperature or state), it will be put in the state field. If a data structure is returned, it will be placed in the `ilo_data` attribute.
 
@@ -26,55 +26,7 @@ Some more details about what can be retrieved from these sensors is available in
   <img src='/images/screenshots/hp_ilo.png' />
 </p>
 
-## Button entities
-
-The following button entities are available for power control:
-
-| Button | Description |
-|--------|-------------|
-| Power On | Powers on the server |
-| Power Off | Powers off the server |
-| Press Power Button | Simulates a physical press of the power button |
-| Cold Boot | Performs a cold (hard) reboot |
-| Warm Boot | Performs a warm (graceful) reboot |
-
-### Button configuration
-
-```yaml
-# Example configuration.yaml entry
-button:
-  - platform: hp_ilo
-    host: IP_ADDRESS or HOSTNAME
-    username: YOUR_USERNAME
-    password: YOUR_PASSWORD
-```
-
-{% configuration %}
-host:
-  description: The hostname or IP address on which the ILO can be reached.
-  required: true
-  type: string
-port:
-  description: The port on which the ILO can be reached.
-  required: false
-  default: 443
-  type: integer
-username:
-  description: The username used to connect to the ILO.
-  required: true
-  type: string
-password:
-  description: The password used to connect to the ILO.
-  required: true
-  type: string
-name:
-  description: Friendly name prefix for the button entities.
-  required: false
-  default: HP ILO
-  type: string
-{% endconfiguration %}
-
-## Sensor configuration
+## Configuration
 
 To use this integration in your installation, add the following to your {% term "`configuration.yaml`" %} file.
 {% include integrations/restart_ha_after_config_inclusion.md %}
@@ -150,6 +102,8 @@ Valid sensor_types:
 
 In order to get two sensors reporting CPU fan speed and Ambient Inlet Temperature, as well as a dump of `server_health` on a HP Microserver Gen8, you could use the following in your {% term "`configuration.yaml`" %} file
 
+{% raw %}
+
 ```yaml
 sensor:
   - platform: hp_ilo
@@ -170,9 +124,59 @@ sensor:
         value_template: '{{ ilo_data.health_at_a_glance }}'
 ```
 
+{% endraw %}
+
 <p class='img'>
   <img src='/images/screenshots/hp_ilo_sensors.png' />
 </p>
+
+## Power control buttons
+
+The integration provides button entities for controlling server power. Add the following to your {% term "`configuration.yaml`" %} file:
+
+```yaml
+# Example configuration.yaml entry
+button:
+  - platform: hp_ilo
+    host: IP_ADDRESS or HOSTNAME
+    username: YOUR_USERNAME
+    password: YOUR_PASSWORD
+```
+
+{% configuration %}
+host:
+  description: The hostname or IP address on which the ILO can be reached.
+  required: true
+  type: string
+port:
+  description: The port on which the ILO can be reached.
+  required: false
+  default: 443
+  type: integer
+username:
+  description: The username used to connect to the ILO.
+  required: true
+  type: string
+password:
+  description: The password used to connect to the ILO.
+  required: true
+  type: string
+name:
+  description: Friendly name prefix for the button entities.
+  required: false
+  default: HP ILO
+  type: string
+{% endconfiguration %}
+
+The following button entities are created:
+
+| Button | Description |
+|--------|-------------|
+| Power On | Powers on the server |
+| Power Off | Powers off the server |
+| Press Power Button | Simulates a physical press of the power button |
+| Cold Boot | Performs a cold (hard) reboot |
+| Warm Boot | Performs a warm (graceful) reboot |
 
 ## Hardware specifics
 

--- a/source/_integrations/hp_ilo.markdown
+++ b/source/_integrations/hp_ilo.markdown
@@ -7,6 +7,7 @@ ha_release: 0.27
 ha_iot_class: Local Polling
 ha_domain: hp_ilo
 ha_platforms:
+  - button
   - sensor
 ha_integration_type: integration
 related:
@@ -15,7 +16,7 @@ related:
 ha_quality_scale: legacy
 ---
 
-The **HP Integrated Lights-Out** {% term integration %} allows you to do an API call to the HP ILO (Integrated Lights-Out) sensor of your server, and use this data in Home Assistant sensors.
+The **HP Integrated Lights-Out** {% term integration %} allows you to do an API call to the HP ILO (Integrated Lights-Out) sensor of your server, and use this data in Home Assistant sensors. You can also send power-control commands to the server via button entities.
 
 If the ILO or specified jsonpath query returns only a single value (e.g., a temperature or state), it will be put in the state field. If a data structure is returned, it will be placed in the `ilo_data` attribute.
 
@@ -25,7 +26,55 @@ Some more details about what can be retrieved from these sensors is available in
   <img src='/images/screenshots/hp_ilo.png' />
 </p>
 
-## Configuration
+## Button entities
+
+The following button entities are available for power control:
+
+| Button | Description |
+|--------|-------------|
+| Power On | Powers on the server |
+| Power Off | Powers off the server |
+| Press Power Button | Simulates a physical press of the power button |
+| Cold Boot | Performs a cold (hard) reboot |
+| Warm Boot | Performs a warm (graceful) reboot |
+
+### Button configuration
+
+```yaml
+# Example configuration.yaml entry
+button:
+  - platform: hp_ilo
+    host: IP_ADDRESS or HOSTNAME
+    username: YOUR_USERNAME
+    password: YOUR_PASSWORD
+```
+
+{% configuration %}
+host:
+  description: The hostname or IP address on which the ILO can be reached.
+  required: true
+  type: string
+port:
+  description: The port on which the ILO can be reached.
+  required: false
+  default: 443
+  type: integer
+username:
+  description: The username used to connect to the ILO.
+  required: true
+  type: string
+password:
+  description: The password used to connect to the ILO.
+  required: true
+  type: string
+name:
+  description: Friendly name prefix for the button entities.
+  required: false
+  default: HP ILO
+  type: string
+{% endconfiguration %}
+
+## Sensor configuration
 
 To use this integration in your installation, add the following to your {% term "`configuration.yaml`" %} file.
 {% include integrations/restart_ha_after_config_inclusion.md %}
@@ -101,8 +150,6 @@ Valid sensor_types:
 
 In order to get two sensors reporting CPU fan speed and Ambient Inlet Temperature, as well as a dump of `server_health` on a HP Microserver Gen8, you could use the following in your {% term "`configuration.yaml`" %} file
 
-{% raw %}
-
 ```yaml
 sensor:
   - platform: hp_ilo
@@ -122,8 +169,6 @@ sensor:
         sensor_type: server_health
         value_template: '{{ ilo_data.health_at_a_glance }}'
 ```
-
-{% endraw %}
 
 <p class='img'>
   <img src='/images/screenshots/hp_ilo_sensors.png' />


### PR DESCRIPTION
## Proposed change

Documents the new `button` platform added to the HP iLO integration in home-assistant/core#168848.

Changes:
- Added `button` to `ha_platforms`
- Added a "Button entities" section describing the five power-control buttons (Power On, Power Off, Press Power Button, Cold Boot, Warm Boot) and their YAML configuration
- Moved the existing sensor docs under a "Sensor configuration" heading for clarity

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch)
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch)
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`current` branch)
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`current` branch)
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR is related to home-assistant/core#168848

## Checklist

- [x] This PR fixes or closes issue: home-assistant/core#168848
- [x] The documentation follows the [documentation standards]