### PR TITLE
Document Lutron keypad device triggers

### DIFF
--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -55,6 +55,11 @@ Keypads also appear as devices in Home Assistant. You can use their button
 actions as [device triggers](/integrations/device_automation/) in automations
 created from the UI.
 
+If you automate directly from `lutron_event`, include the controller-scoped
+fields in your filters. The event payload now includes `controller_guid`,
+`keypad_uuid`, and `button_subtype` so events stay unambiguous when more than
+one Lutron controller is configured.
+
 For Pico remotes, trigger subtypes use the standard Lutron button positions:
 
 - `top`
@@ -113,6 +118,9 @@ Example using the `lutron_event` event:
     - trigger: event
       event_type: lutron_event
       event_data:
+        controller_guid: YOUR_CONTROLLER_GUID
+        keypad_uuid: keypad_uuid
+        button_subtype: button_1
         id: office_pico_on
         action: single
   actions:

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -49,7 +49,24 @@ If you are using RadioRA2 software version 12 or later, the default `lutron` use
 
 ## Keypad buttons
 
-Keypad buttons actions are provided in event entities.
+Keypad button actions are provided in event entities.
+
+Keypads also appear as devices in Home Assistant. You can use their button
+actions as [device triggers](/integrations/device_automation/) in automations
+created from the UI.
+
+For Pico remotes, trigger subtypes use the standard Lutron button positions:
+
+- `top`
+- `favorite`
+- `bottom`
+- `raise`
+- `lower`
+
+Other keypads use numbered trigger subtypes such as `button_1`.
+
+Buttons that support press-and-hold expose `press` and `release` triggers.
+Other buttons expose a `single_press` trigger.
 
 ## Keypad LEDs
 
@@ -72,7 +89,25 @@ Any configured Powr Savr occupancy sensors will be added as occupancy binary sen
 
 ## Example automations
 
-``` yaml
+Example using a device trigger:
+
+```yaml
+- alias: "Pico raise button pressed"
+  triggers:
+    - trigger: device
+      domain: lutron
+      device_id: YOUR_DEVICE_ID
+      type: press
+      subtype: raise
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.office
+```
+
+Example using the `lutron_event` event:
+
+```yaml
 - alias: "keypad button pressed notification"
   triggers:
     - trigger: event


### PR DESCRIPTION
## Proposed change

Document the new Lutron keypad device triggers on the integration page.

This updates the existing Lutron documentation to explain that keypad buttons can now be used as Home Assistant device triggers in UI automations. It also documents the Pico-specific semantic subtypes and notes that `lutron_event` now includes controller-scoped fields (`controller_guid`, `keypad_uuid`, and `button_subtype`) so event-based automations remain unambiguous when multiple Lutron controllers are configured.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167639
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
