### PR TITLE
Add box state sensor documentation for Duco integration

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -275,7 +275,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 ## Known limitations
 
 - The Duco box enforces a rate limit of 200 write requests per day. When the limit is reached, the integration shows a notification and stops sending write requests until the quota resets automatically around midnight.
-- Timed speed overrides set by a connected wall unit (such as a UCCO2) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
+- Setting a speed from Home Assistant always uses permanent manual mode (a continuous override with no time limit). Timed speed overrides, such as those triggered by a connected wall unit (like a UCCO2), are not exposed as a separate control. The current ventilation level is always visible as a percentage.
 - When you deregister a sensor module via the Duco app or firmware, the node disappears from the Duco API and Home Assistant removes it automatically on the next data update. However, a BSRH humidity sensor that is physically disconnected from the box PCB (rather than deregistered via software) is not treated as deregistered by the firmware. Its node remains in the API indefinitely, so its entities will stay in Home Assistant until you deregister it through the Duco app.
 
 ## Troubleshooting

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -122,7 +122,7 @@ Available for the main ventilation box (BOX). Shows the current ventilation stat
 
 #### Ventilation state end time
 
-Available for the main ventilation box (BOX). Shows the timestamp at which the current timed ventilation state will end. When no timer is active, this sensor shows no value.
+Available for the main ventilation box (BOX). Shows the timestamp at which the current timed ventilation state will end. When no timer is active, this sensor state is `unknown`.
 
 #### Ventilation state remaining time
 
@@ -241,7 +241,7 @@ actions:
 This automation switches to high speed when the CO₂ level in the office rises above 1000 ppm, and returns to automatic mode when it drops back below 800 ppm.
 
 ```yaml
-alias: "Boost ventilation on high CO2"
+alias: "Boost ventilation on high CO₂"
 triggers:
   - trigger: numeric_state
     entity_id: sensor.office_co2_carbon_dioxide
@@ -255,7 +255,7 @@ actions:
 ```
 
 ```yaml
-alias: "Return to auto when CO2 is low"
+alias: "Return to auto when CO₂ is low"
 triggers:
   - trigger: numeric_state
     entity_id: sensor.office_co2_carbon_dioxide

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -91,11 +91,26 @@ The following actions are available:
 - **Speed 100%**: High speed manual override.
 - **Auto preset**: Same as speed 0%; hands control back to Duco.
 
+{% note %}
+The percentages 33%, 66%, and 100% are abstract speed levels used in the Home Assistant fan UI and do not match the actual airflow percentages configured in the Duco firmware. To see the real airflow target, use the **Airflow target level** sensor.
+{% endnote %}
+
 When a connected wall unit (such as a UCCO2) triggers a timed speed override on the Duco box, Home Assistant reflects the current ventilation level as a percentage. These timed states cannot be set from Home Assistant; writing a speed always uses the permanent manual mode (a continuous override with no time limit).
 
 ### Sensors
 
 The following sensor entities are created per node, depending on the node type:
+
+#### Airflow target level
+
+Available for the main ventilation box (BOX). Shows the actual airflow target as reported by the Duco box, as a percentage (0–100%). This value reflects the real airflow configured in the Duco firmware and will differ from the fan entity speed (33%, 66%, or 100%) shown in Home Assistant. For example, if your Duco system is configured with manual speed levels of 15%, 30%, and 100%, this sensor shows those values rather than the abstract speed levels used by the fan entity.
+
+#### Ventilation mode
+
+Available for the main ventilation box (BOX). Shows whether ventilation is controlled automatically by the Duco firmware or manually through an override.
+
+- **Auto**: The Duco firmware determines the ventilation speed based on sensor readings.
+- **Manual**: A manual override is active, for example because you set a speed from Home Assistant or a connected wall switch.
 
 #### Ventilation state
 
@@ -104,6 +119,14 @@ Available for the main ventilation box (BOX). Shows the current ventilation stat
 - Automatic
 - Continuous high speed
 - Manual low speed (15 min)
+
+#### Ventilation state end time
+
+Available for the main ventilation box (BOX). Shows the timestamp at which the current timed ventilation state will end. When no timer is active, this sensor shows no value.
+
+#### Ventilation state remaining time
+
+Available for the main ventilation box (BOX). Shows the number of seconds remaining in the current timed ventilation state. When no timer is active, the value is 0.
 
 #### CO₂ concentration
 
@@ -153,30 +176,32 @@ Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in
 This automation switches the ventilation to high speed when the kitchen hood is turned on, and returns it to automatic mode five minutes after the hood is switched off.
 
 ```yaml
-- alias: "High ventilation while cooking"
-  triggers:
-    - trigger: state
-      entity_id: switch.kitchen_hood
-      to: "on"
-  actions:
-    - action: fan.set_percentage
-      target:
-        entity_id: fan.living_ventilation
-      data:
-        percentage: 100
+alias: "High ventilation while cooking"
+triggers:
+  - trigger: state
+    entity_id: switch.kitchen_hood
+    to: "on"
+actions:
+  - action: fan.set_percentage
+    target:
+      entity_id: fan.living_ventilation
+    data:
+      percentage: 100
+```
 
-- alias: "Return to auto after cooking"
-  triggers:
-    - trigger: state
-      entity_id: switch.kitchen_hood
-      to: "off"
-      for: "00:05:00"
-  actions:
-    - action: fan.set_percentage
-      target:
-        entity_id: fan.living_ventilation
-      data:
-        percentage: 0
+```yaml
+alias: "Return to auto after cooking"
+triggers:
+  - trigger: state
+    entity_id: switch.kitchen_hood
+    to: "off"
+    for: "00:05:00"
+actions:
+  - action: fan.set_percentage
+    target:
+      entity_id: fan.living_ventilation
+    data:
+      percentage: 0
 ```
 
 ### Reduce ventilation when nobody is home
@@ -184,29 +209,31 @@ This automation switches the ventilation to high speed when the kitchen hood is 
 When the last person leaves home, the ventilation hands control back to Duco (automatic mode). When someone returns, it switches to medium speed.
 
 ```yaml
-- alias: "Ventilation auto mode on leave"
-  triggers:
-    - trigger: numeric_state
-      entity_id: zone.home
-      below: 1
-  actions:
-    - action: fan.set_percentage
-      target:
-        entity_id: fan.living_ventilation
-      data:
-        percentage: 0
+alias: "Ventilation auto mode on leave"
+triggers:
+  - trigger: numeric_state
+    entity_id: zone.home
+    below: 1
+actions:
+  - action: fan.set_percentage
+    target:
+      entity_id: fan.living_ventilation
+    data:
+      percentage: 0
+```
 
-- alias: "Ventilation medium speed on arrive"
-  triggers:
-    - trigger: numeric_state
-      entity_id: zone.home
-      above: 0
-  actions:
-    - action: fan.set_percentage
-      target:
-        entity_id: fan.living_ventilation
-      data:
-        percentage: 66
+```yaml
+alias: "Ventilation medium speed on arrive"
+triggers:
+  - trigger: numeric_state
+    entity_id: zone.home
+    above: 0
+actions:
+  - action: fan.set_percentage
+    target:
+      entity_id: fan.living_ventilation
+    data:
+      percentage: 66
 ```
 
 ### Boost ventilation when CO₂ is high
@@ -214,29 +241,31 @@ When the last person leaves home, the ventilation hands control back to Duco (au
 This automation switches to high speed when the CO₂ level in the office rises above 1000 ppm, and returns to automatic mode when it drops back below 800 ppm.
 
 ```yaml
-- alias: "Boost ventilation on high CO2"
-  triggers:
-    - trigger: numeric_state
-      entity_id: sensor.office_co2_carbon_dioxide
-      above: 1000
-  actions:
-    - action: fan.set_percentage
-      target:
-        entity_id: fan.living_ventilation
-      data:
-        percentage: 100
+alias: "Boost ventilation on high CO2"
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.office_co2_carbon_dioxide
+    above: 1000
+actions:
+  - action: fan.set_percentage
+    target:
+      entity_id: fan.living_ventilation
+    data:
+      percentage: 100
+```
 
-- alias: "Return to auto when CO2 is low"
-  triggers:
-    - trigger: numeric_state
-      entity_id: sensor.office_co2_carbon_dioxide
-      below: 800
-  actions:
-    - action: fan.set_percentage
-      target:
-        entity_id: fan.living_ventilation
-      data:
-        percentage: 0
+```yaml
+alias: "Return to auto when CO2 is low"
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.office_co2_carbon_dioxide
+    below: 800
+actions:
+  - action: fan.set_percentage
+    target:
+      entity_id: fan.living_ventilation
+    data:
+      percentage: 0
 ```
 
 ## Data updates


### PR DESCRIPTION
## Proposed change

Documents four new BOX-level sensor entities added to the Duco integration in home-assistant/core#168999.

Changes:

- Add documentation for the **Airflow target level** sensor, including an explanation of how it differs from the abstract 33/66/100% speed levels shown in the fan entity.
- Add documentation for the **Ventilation mode** sensor (Auto/Manual).
- Add documentation for the **Ventilation state remaining time** sensor.
- Add documentation for the **Ventilation state end time** sensor.
- Add a note to the fan section clarifying that the 33%, 66%, and 100% speed levels are abstract HA values and do not match real firmware airflow percentages.
- Split automation examples into individual code blocks so they can be pasted directly into the Home Assistant automation editor.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#168999
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
