### PR TITLE
Add temperature sensor documentation for Duco integration

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -43,9 +43,9 @@ Compatible DucoBox models:
 The following sensor module types are supported:
 
 - **BOX**: The main ventilation box; provides fan control, ventilation state, and Wi-Fi signal strength.
-- **UCCO2**: Wall-mounted CO₂ sensor unit; provides CO₂ concentration and CO₂ air quality index.
-- **BSRH**: Humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity and humidity air quality index.
-- **UCRH**: Wireless humidity sensor module; provides relative humidity and humidity air quality index.
+- **UCCO2**: Wall-mounted CO₂ sensor unit; provides CO₂ concentration, CO₂ air quality index, and temperature.
+- **BSRH**: Humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity, humidity air quality index, and temperature.
+- **UCRH**: Wireless humidity sensor module; provides relative humidity, humidity air quality index, and temperature.
 
 ### Unsupported sensor modules
 
@@ -135,6 +135,12 @@ Indoor air quality ranges for humidity:
 - 35–50%: Temporarily acceptable
 - 5–20%: Poor
 
+#### Temperature
+
+Available for sensor modules (UCCO2, BSRH, UCRH). Shows the current air temperature in degrees Celsius measured by the sensor module.
+
+The main ventilation box (BOX) also provides a temperature reading. This entity is disabled by default because it reflects the temperature inside the box housing, which is typically not representative of the room temperature.
+
 #### Wi-Fi signal strength
 
 Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in dBm. This entity is disabled by default.
@@ -145,6 +151,7 @@ Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in
 - Return to auto mode when everyone leaves home using a presence-based automation.
 - Monitor ventilation activity over time via the logbook.
 - Trigger automations based on CO₂ levels or humidity reported by connected Duco modules.
+- Use temperature readings from sensor modules to detect rooms that are too hot or too cold and adjust ventilation accordingly.
 
 ## Examples
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -42,7 +42,7 @@ Compatible DucoBox models:
 
 The following sensor module types are supported:
 
-- **BOX**: The main ventilation box; provides fan control, ventilation state, and Wi-Fi signal strength.
+- **BOX**: The main ventilation box; provides fan control, ventilation state, Wi-Fi signal strength, and temperature (measured inside the housing; disabled by default).
 - **UCCO2**: Wall-mounted CO₂ sensor unit; provides CO₂ concentration, CO₂ air quality index, and temperature.
 - **BSRH**: Humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity, humidity air quality index, and temperature.
 - **UCRH**: Wireless humidity sensor module; provides relative humidity, humidity air quality index, and temperature.
@@ -137,7 +137,7 @@ Indoor air quality ranges for humidity:
 
 #### Temperature
 
-Available for sensor modules (UCCO2, BSRH, UCRH). Shows the current air temperature in degrees Celsius measured by the sensor module.
+Available for the external sensor modules (UCCO2, BSRH, and UCRH). Shows the current air temperature in degrees Celsius measured by the sensor module.
 
 The main ventilation box (BOX) also provides a temperature reading. This entity is disabled by default because it reflects the temperature inside the box housing, which is typically not representative of the room temperature.
 


### PR DESCRIPTION
## Proposed change

Documents the temperature sensor entities added to the Duco integration in home-assistant/core#169021.

Changes:

- Update supported sensor module descriptions to include temperature
- Add a **Temperature** sensor section (visible by default for UCCO2, BSRH, and UCRH; disabled by default for BOX because it reflects the temperature inside the box housing)
- Add a use case bullet for temperature-based ventilation automations

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#169021
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards