### PR TITLE
Document radio_frequency platform for Broadlink

### DIFF
--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -4,6 +4,7 @@ description: Instructions on setting up Broadlink within Home Assistant.
 ha_category:
   - Climate
   - Light
+  - Radio Frequency
   - Remote
   - Sensor
   - Switch
@@ -19,6 +20,7 @@ ha_config_flow: true
 ha_platforms:
   - climate
   - light
+  - radio_frequency
   - remote
   - select
   - sensor
@@ -53,9 +55,10 @@ There is no more need to set up platforms, except for custom IR/RF switches. Onc
 
 The {% term entities %} have the same name as the device by default. To change the name, icon or entity id, select the entity on the frontend and select the settings icon in the upper right. You can also disable the entity there if you don't think it is useful. Don't forget to select **Update** to save your changes when you're done.
 
-The {% term entities %} are divided into four subdomains:
+The {% term entities %} are divided into the following subdomains:
 
 - [Climate](#climate)
+- [Radio frequency](#radio-frequency)
 - [Remote](#remote)
 - [Select](#select)
 - [Sensor](#sensor)
@@ -66,6 +69,14 @@ The {% term entities %} are divided into four subdomains:
 ## Climate
 
 The `climate` entities allow you to monitor and control Broadlink thermostats.
+
+## Radio frequency
+
+The `radio_frequency` {% term entity %} allows other integrations to send RF commands through your Broadlink device. It is created automatically for `RM pro` and `RM4 pro` devices, which include an RF transmitter. The supported bands are 433 MHz (433.05–434.79 MHz) and 315 MHz (314.95–315.25 MHz).
+
+This entity is intended for use by device-specific integrations that control RF appliances, such as range hoods, garage doors, or smart blinds. When you set up such an integration, you can select your Broadlink RF entity as the transmitter. Refer to the [Radio Frequency](/integrations/radio_frequency/) integration for more information.
+
+The existing `remote.learn_command` and `remote.send_command` actions described below are unaffected and remain available for working with learned RF codes.
 
 ## Remote
 


### PR DESCRIPTION
## Proposed change

Documents the new `radio_frequency` platform for the Broadlink integration, which exposes RM pro and RM4 pro devices as RF transmitters for use by other integrations (such as Honeywell String Lights).

- Adds `Radio Frequency` to `ha_category` and `radio_frequency` to `ha_platforms`.
- Adds a "Radio frequency" subdomain section listing the supported 433 MHz and 315 MHz bands and clarifying that the existing `remote.learn_command` / `remote.send_command` flow is unchanged.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#169128
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
