### PR TITLE
Clarify iZone multicast discovery requirements

### DIFF
--- a/source/_integrations/izone.markdown
+++ b/source/_integrations/izone.markdown
@@ -49,7 +49,11 @@ exclude:
 
 ## Network settings
 
-The iZone system uses UDP broadcasts over the local network to find and communicate with iZone devices. For this to work properly, UDP port  12107 must be able to be broadcasted on, 7005 needs to be listened to for broadcasted messages, and TCP port 80 for HTTP data to the bridge. The integration currently listens on `0.0.0.0` and broadcasts to all broadcast IPv4 local addresses, which is not configurable.
+The iZone system uses UDP multicast/broadcast discovery on the local network to find and communicate with iZone devices. For discovery to work reliably, Home Assistant must be able to receive these multicast messages, which this means Home Assistant should be on the same L2 network as the iZone bridge, or your network must be configured to retransmit/forward multicast traffic between segments.
+
+For connectivity, UDP port 12107 must be reachable for discovery traffic, UDP port 7005 must be reachable for incoming iZone messages, and TCP port 80 is used for HTTP communication with the bridge. The integration currently listens on `0.0.0.0` and sends discovery to local IPv4 broadcast addresses, which is not configurable.
+
+Direct setup by IP address is planned for a future update, but is not available yet.
 
 ## Master controller
 


### PR DESCRIPTION
## Proposed change

Clarify the network requirements for the iZone integration's discovery mechanism. The existing text did not make it clear that Home Assistant must be able to receive multicast/broadcast traffic from the iZone bridge. This update explains that:

- The iZone system relies on multicast/broadcast discovery messages that Home Assistant must be able to receive.
- Home Assistant should be on the same L2 network as the iZone bridge, or multicast forwarding/retransmission must be configured between network segments.
- Direct setup by IP address is planned for a future update but is not yet available.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#169251
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards