### PR TITLE
Document color and show_current_temperature options for forecast features

### DIFF
--- a/source/dashboards/features.markdown
+++ b/source/dashboards/features.markdown
@@ -626,6 +626,11 @@ show_temperature:
   description: Whether to show the temperature range bars and the current-temperature line.
   type: boolean
   default: true
+show_current_temperature:
+  required: false
+  description: Whether to show a thin horizontal line marking the current temperature across the bars.
+  type: boolean
+  default: true
 show_precipitation:
   required: false
   description: Whether to overlay precipitation forecast as translucent bars.
@@ -636,6 +641,11 @@ precipitation_type:
   description: "Which precipitation value to plot when `show_precipitation` is enabled. One of `amount` (forecasted volume, scaled relative to the period's maximum) or `probability` (chance of precipitation on a fixed 0–100% scale). Pick `probability` when your weather integration provides a chance of precipitation but no volume forecast."
   type: string
   default: amount
+color:
+  required: false
+  description: "Color of the temperature bars and the current temperature line. When set to `state` or omitted, each bar is colored by its forecasted weather condition. Set to a named color (like `blue` or `red`) or a hex value to use a single static color instead."
+  type: string
+  default: state
 {% endconfiguration %}
 
 {% note %}
@@ -685,6 +695,11 @@ precipitation_type:
   description: "Which precipitation value to plot when `show_precipitation` is enabled. One of `amount` (forecasted volume, scaled relative to the visible window's maximum) or `probability` (chance of precipitation on a fixed 0–100% scale). Pick `probability` when your weather integration provides a chance of precipitation but no volume forecast."
   type: string
   default: amount
+color:
+  required: false
+  description: "Color of the temperature line. When set to `state` or omitted, the line uses the tile's feature color. Set to a named color (like `blue` or `red`) or a hex value to use a single static color instead."
+  type: string
+  default: state
 {% endconfiguration %}
 
 {% note %}


### PR DESCRIPTION
## Proposed change

Documents the new options added to the daily and hourly forecast tile card features:

- `show_current_temperature` (daily) — toggles the horizontal current-temperature line.
- `color` (daily and hourly) — sets a static color for the temperature visualization, or defaults to `state` for the existing per-condition / feature color behavior.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/frontend#51761
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the \`current\` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the \`next\` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards