### PR TITLE
Refresh Rabbit Air docs description and supported models

### DIFF
--- a/source/_integrations/rabbitair.markdown
+++ b/source/_integrations/rabbitair.markdown
@@ -1,6 +1,6 @@
 ---
 title: Rabbit Air
-description: Instructions on how to integrate Rabbit Air air purifier within Home Assistant.
+description: Instructions on how to integrate Rabbit Air air purifiers within Home Assistant.
 ha_category:
   - Fan
 ha_iot_class: Local Polling
@@ -15,9 +15,10 @@ ha_platforms:
 ha_integration_type: device
 ---
 
-The **Rabbit Air** {% term integration %} lets you control your air purifier over the local network. The following device models are currently supported:
+The **Rabbit Air** {% term integration %} lets you control supported Rabbit Air air purifiers over the local network. The following device models are currently supported:
 
-- MinusA2 (2-nd generation)
+- BioGS 2.0
+- MinusA2 (2nd generation)
 - A3
 
 The fan platform of this integration allows you to turn the unit on/off, select the preset mode, or set the speed manually.


### PR DESCRIPTION
## Proposed change
This refreshes the Rabbit Air integration documentation to better match the current integration support and wording:

- updates the page description to refer to Rabbit Air air purifiers
- updates the intro sentence to refer to supported Rabbit Air air purifiers
- adds BioGS 2.0 to the supported model list to match the current integration code
- fixes the ordinal formatting for MinusA2 (2nd generation)

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [X] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
