### PR TITLE
ElkM1 integration: add number entities

### DIFF
--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -50,6 +50,7 @@ There is currently support for the following device types within Home Assistant:
 - **Scene** - Elk-M1 tasks are represented as `scene` entities
 - **Sensor** - Elk-M1 counters, keypads, panel status, settings, and zones are represented as `sensor` entities
 - **Switch** - Elk-M1 outputs are represented as `switch` entities
+- **Time** - Elk-M1 number and duration settings are represented as `time` entities
 
 The implementation follows the Elk Products ElkM1 "ASCII Protocol & Interface Specification, Revision 1.84" document. This document can be found on the Internet.
 

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -498,10 +498,11 @@ The panel does not automatically send counter value updates under certain condit
 | `entity_id`    | No       | ElkM1 counter to refresh or set             |
 | `value`        | Yes (for `sensor_counter_set`) | Value to set the counter to (0-65536) |
 
-#### (Custom) Settings management
+#### Custom settings
 
-- `elkm1.sensor_setting_set` - Update a custom setting
+These settings are configurable values stored on your Elk-M1 panel, such as integer, timer, and time-based settings.
 
+- `elkm1.sensor_setting_set` - Update an Elk-M1 panel setting
 | Data attribute | Required | Description                                                  |
 | -------------- | -------- | ------------------------------------------------------------ |
 | `entity_id`    | No       | ElkM1 setting to set                                          |

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -24,6 +24,7 @@ ha_platforms:
   - binary_sensor
   - climate
   - light
+  - number
   - scene
   - sensor
   - switch

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -498,15 +498,35 @@ The panel does not automatically send counter value updates under certain condit
 | `entity_id`    | No       | ElkM1 counter to refresh or set             |
 | `value`        | Yes (for `sensor_counter_set`) | Value to set the counter to (0-65536) |
 
+#### (Custom) Settings management
+
+- `elkm1.sensor_setting_set` - Update a custom setting
+
+| Data attribute | Required | Description                                                  |
+| -------------- | -------- | ------------------------------------------------------------ |
+| `entity_id`    | No       | ElkM1 setting to set                                          |
+| `value`        | Yes      | Value can be an integer (0-65536) for integer and timer settings, or a 24-hour time for time settings (HH:MM) |
+
+
+#### Output management
+
+- `elkm1.switch_output_turn_on` - Turn on a switch passing a duration time to the ElkM1
+
+| Data attribute | Required | Description                                                  |
+| -------------- | -------- | ------------------------------------------------------------ |
+| `entity_id`    | No       | ElkM1 output to set                                          |
+| `value`        | Yes      | Value for the duration that the output is to be on (0-65536) |
+
 #### Zone management
 
 - `elkm1.sensor_zone_bypass` - Bypass a zone
 - `elkm1.sensor_zone_trigger` - Trigger a zone virtually
+- `elkm1.sensor_zone_update_voltage` - Update the voltage for a sensor of type zone
 
-| Data attribute | Required | Description                                     |
-| -------------- | -------- | ----------------------------------------------- |
-| `entity_id`    | No       | ElkM1 zone to bypass or trigger                |
-| `code`         | Yes (for bypass only) | Alarm code (4 or 6 digits)                |
+| Data attribute | Required | Description                                      |
+| -------------- | -------- | ------------------------------------------------ |
+| `entity_id`    | No       | ElkM1 zone to bypass, trigger, or update voltage |
+| `code`         | Yes (for bypass only) | Alarm code (4 or 6 digits)          |
 
 {% note %}
 The only mechanism ElkM1 offers to clear zone bypass is to clear all bypassed zones in a given alarm panel (area).

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -46,6 +46,7 @@ There is currently support for the following device types within Home Assistant:
 - **Binary sensor** - Elk-M1 zones with 4 states (non-analog zones) are represented as `binary_sensor` entities. `Normal` state is `off` and any other state is `on`
 - **Climate** - Elk-M1 thermostats are represented as `climate` entities
 - **Light** - Elk-M1 lights (X10, Insteon, UPB) are represented as `light` entities
+- **Number** - Elk-M1 number and duration settings are represented as `number` entities
 - **Scene** - Elk-M1 tasks are represented as `scene` entities
 - **Sensor** - Elk-M1 counters, keypads, panel status, settings, and zones are represented as `sensor` entities
 - **Switch** - Elk-M1 outputs are represented as `switch` entities
@@ -498,36 +499,24 @@ The panel does not automatically send counter value updates under certain condit
 | `entity_id`    | No       | ElkM1 counter to refresh or set             |
 | `value`        | Yes (for `sensor_counter_set`) | Value to set the counter to (0-65536) |
 
-#### Custom settings
-
-These settings are configurable values stored on your Elk-M1 panel, such as integer, timer, and time-based settings.
-
-- `elkm1.sensor_setting_set` - Update an Elk-M1 panel setting
-| Data attribute | Required | Description                                                  |
-| -------------- | -------- | ------------------------------------------------------------ |
-| `entity_id`    | No       | ElkM1 setting to set                                          |
-| `value`        | Yes      | Value can be an integer (0-65536) for integer and timer settings, or a 24-hour time for time settings (HH:MM) |
-
-
 #### Output management
 
-- `elkm1.switch_output_turn_on` - Turn on the output for a specified duration
+- `elkm1.switch_output_turn_on_for` - Turn on the output for a specified duration
 
-| Data attribute | Required | Description                                                                 |
-| -------------- | -------- | --------------------------------------------------------------------------- |
-| `entity_id`    | No       | ElkM1 output to turn on                                                     |
-| `value`        | Yes      | Duration to keep the output on, as an ElkM1 integer value from 0 to 65536   |
+| Data attribute | Required | Description                                                               |
+| -------------- | -------- | ------------------------------------------------------------------------- |
+| `entity_id`    | No       | ElkM1 output to turn on                                                   |
+| `duration`     | Yes      | Duration to keep the output on, as an ElkM1 integer value from 0 to 65535 |
 
 #### Zone management
 
 - `elkm1.sensor_zone_bypass` - Bypass a zone
 - `elkm1.sensor_zone_trigger` - Trigger a zone virtually
-- `elkm1.sensor_zone_update_voltage` - Update the voltage for a sensor of type zone
 
-| Data attribute | Required | Description                                      |
-| -------------- | -------- | ------------------------------------------------ |
-| `entity_id`    | No       | ElkM1 zone to bypass, trigger, or update voltage |
-| `code`         | Yes (for bypass only) | Alarm code (4 or 6 digits)          |
+| Data attribute | Required | Description                             |
+| -------------- | -------- | --------------------------------------- |
+| `entity_id`    | No       | ElkM1 zone to bypass or trigger         |
+| `code`         | Yes (for bypass only) | Alarm code (4 or 6 digits) |
 
 {% note %}
 The only mechanism ElkM1 offers to clear zone bypass is to clear all bypassed zones in a given alarm panel (area).

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -8,6 +8,7 @@ ha_category:
   - Climate
   - Hub
   - Light
+  - Number
   - Scene
   - Sensor
   - Switch
@@ -50,7 +51,6 @@ There is currently support for the following device types within Home Assistant:
 - **Scene** - Elk-M1 tasks are represented as `scene` entities
 - **Sensor** - Elk-M1 counters, keypads, panel status, settings, and zones are represented as `sensor` entities
 - **Switch** - Elk-M1 outputs are represented as `switch` entities
-- **Time** - Elk-M1 number and duration settings are represented as `time` entities
 
 The implementation follows the Elk Products ElkM1 "ASCII Protocol & Interface Specification, Revision 1.84" document. This document can be found on the Internet.
 
@@ -499,15 +499,6 @@ The panel does not automatically send counter value updates under certain condit
 | -------------- | -------- | ------------------------------------------- |
 | `entity_id`    | No       | ElkM1 counter to refresh or set             |
 | `value`        | Yes (for `sensor_counter_set`) | Value to set the counter to (0-65536) |
-
-#### Output management
-
-- `elkm1.switch_output_turn_on_for` - Turn on the output for a specified duration
-
-| Data attribute | Required | Description                                                               |
-| -------------- | -------- | ------------------------------------------------------------------------- |
-| `entity_id`    | No       | ElkM1 output to turn on                                                   |
-| `duration`     | Yes      | Duration to keep the output on, as an ElkM1 integer value from 0 to 65535 |
 
 #### Zone management
 

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -510,12 +510,12 @@ The panel does not automatically send counter value updates under certain condit
 
 #### Output management
 
-- `elkm1.switch_output_turn_on` - Turn on a switch passing a duration time to the ElkM1
+- `elkm1.switch_output_turn_on` - Turn on the output for a specified duration
 
-| Data attribute | Required | Description                                                  |
-| -------------- | -------- | ------------------------------------------------------------ |
-| `entity_id`    | No       | ElkM1 output to set                                          |
-| `value`        | Yes      | Value for the duration that the output is to be on (0-65536) |
+| Data attribute | Required | Description                                                                 |
+| -------------- | -------- | --------------------------------------------------------------------------- |
+| `entity_id`    | No       | ElkM1 output to turn on                                                     |
+| `value`        | Yes      | Duration to keep the output on, as an ElkM1 integer value from 0 to 65536   |
 
 #### Zone management
 


### PR DESCRIPTION

## Proposed change

Adds number and time entities to ElkM1 and switch_output_turn_on_for action.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/169861
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
