### PR TITLE
Add troubleshooting section to handle duplicate MQTT messages when there are overlapping subscriptions

### DIFF
--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -1469,13 +1469,13 @@ MQTT devices often continuously generate numerous state updates. MQTT does not u
 
 ## Troubleshooting
 
-### Device triggers or entities are triggered receive duplicate updates
+### Device triggers or entities receive duplicate updates
 
-When there are overlapping subscriptions, the MQTT broker might send the same message for all matching subscription. This is an issue for MQTT protocol version 3.1 and 3.1.1. Try to use MQTT protocol version 5 to allow matching subscriptions with the incoming messages to resolve duplicate messages.
+When you have overlapping subscriptions, the MQTT broker might send the same message for all matching subscriptions. This can happen with MQTT protocol version 3.1 and 3.1.1. To help resolve duplicate messages, set [**MQTT Protocol**](#mqtt-protocol) to `5` instead of the default `3.1.1`, so Home Assistant can match incoming messages to the correct subscriptions.
 
-Overlapping subscriptions are caused when wildcard subscriptions or a simple subscription trigger the same message.
+Overlapping subscriptions happen when multiple subscriptions, whether wildcard subscriptions, specific subscriptions, or both, match the same message topic.
 
-For example, the subscriptions `test/bla/status`, `test/+/status` and `test/#` match with a message published at topic `test/bla/status`. With protocol version 3.1 or 3.1.1, it is possible the broker sends 3 messages, one for each match. But there is no way to link the incoming message to the subscription. With protocol version 5, an identifier is assigned to each subscription which allows to process each message for its matching subscription.
+For example, the subscriptions `test/bla/status`, `test/+/status`, and `test/#` all match a message published to the topic `test/bla/status`. With protocol version 3.1 or 3.1.1, it is possible that the broker sends 3 messages, one for each match. However, there is no way to link an incoming message to the matching subscription. With protocol version 5, an identifier is assigned to each subscription, which makes it possible to process each message for the subscription that matched it.
 
 ## Using Templates
 

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -1467,6 +1467,16 @@ Because MQTT state updates are often repeated frequently, even when no actual ch
 
 MQTT devices often continuously generate numerous state updates. MQTT does not update `last_reported` to avoid impacting system stability unless `force_update` is set. Alternatively, an MQTT sensor can be created to measure the last update.
 
+## Troubleshooting
+
+### Device triggers or entities are triggered receive duplicate updates
+
+When there are overlapping subscriptions, the MQTT broker might send the same message for all matching subscription. This is an issue for MQTT protocol version 3.1 and 3.1.1. Try to use MQTT protocol version 5 to allow matching subscriptions with the incoming messages to resolve duplicate messages.
+
+Overlapping subscriptions are caused when wildcard subscriptions or a simple subscription trigger the same message.
+
+For example, the subscriptions `test/bla/status`, `test/+/status` and `test/#` match with a message published at topic `test/bla/status`. With protocol version 3.1 or 3.1.1, it is possible the broker sends 3 messages, one for each match. But there is no way to link the incoming message to the subscription. With protocol version 5, an identifier is assigned to each subscription which allows to process each message for its matching subscription.
+
 ## Using Templates
 
 The MQTT integration supports templating. Read more [about using templates with the MQTT integration](/docs/templating/where-to-use/#mqtt).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add troubleshooting section in case of duplicate MQTT messages when there are overlapping subscriptions


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/169604
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
