### PR TITLE
Add information on state of charge input for Ohme

### DIFF
--- a/source/_integrations/ohme.markdown
+++ b/source/_integrations/ohme.markdown
@@ -68,7 +68,7 @@ The Ohme integration provides the following entities.
 - **Preconditioning duration**
   - **Description**: Defines how long to precondition your vehicle before the target time. `0` means preconditioning is disabled.
   - **Available for devices**: all
-- **State of charge input**:
+- **State of charge input**
   - **Description**: Used to set the current state of charge for non-API connected vehicles. This will only function when a vehicle is connected. For more information, refer to the related [Ohme documentation](https://ohme-ev.com/support/how-to-set-your-battery-level-when-you-plug-in).
   - **Available for devices**: all
   - **Note**: This input is disabled by default.

--- a/source/_integrations/ohme.markdown
+++ b/source/_integrations/ohme.markdown
@@ -68,6 +68,10 @@ The Ohme integration provides the following entities.
 - **Preconditioning duration**
   - **Description**: Defines how long to precondition your vehicle before the target time. `0` means preconditioning is disabled.
   - **Available for devices**: all
+- **State of charge input**:
+  - **Description**: Used to set the current state of charge for non-API connected vehicles. This will only function when a vehicle is connected. For more information please see the related [Ohme documentation](https://ohme-ev.com/support/how-to-set-your-battery-level-when-you-plug-in).
+  - **Available for devices**: all
+  - **Note**: This input is disabled by default.
 
 #### Selects
 

--- a/source/_integrations/ohme.markdown
+++ b/source/_integrations/ohme.markdown
@@ -69,7 +69,7 @@ The Ohme integration provides the following entities.
   - **Description**: Defines how long to precondition your vehicle before the target time. `0` means preconditioning is disabled.
   - **Available for devices**: all
 - **State of charge input**:
-  - **Description**: Used to set the current state of charge for non-API connected vehicles. This will only function when a vehicle is connected. For more information please see the related [Ohme documentation](https://ohme-ev.com/support/how-to-set-your-battery-level-when-you-plug-in).
+  - **Description**: Used to set the current state of charge for non-API connected vehicles. This will only function when a vehicle is connected. For more information, refer to the related [Ohme documentation](https://ohme-ev.com/support/how-to-set-your-battery-level-when-you-plug-in).
   - **Available for devices**: all
   - **Note**: This input is disabled by default.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add information on a new number input.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/169557
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
