### PR TITLE
Add Duco fan preset mode documentation

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -191,7 +191,7 @@ This automation switches the ventilation to high speed when the kitchen hood is 
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.living
       data:
         percentage: 100
 
@@ -204,7 +204,7 @@ This automation switches the ventilation to high speed when the kitchen hood is 
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.living
       data:
         percentage: 0
 ```
@@ -222,7 +222,7 @@ When the last person leaves home, the ventilation switches to empty house mode. 
   actions:
     - action: fan.set_preset_mode
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.living
       data:
         preset_mode: "empt"
 
@@ -234,7 +234,7 @@ When the last person leaves home, the ventilation switches to empty house mode. 
   actions:
     - action: fan.set_preset_mode
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.living
       data:
         preset_mode: "auto"
 ```
@@ -252,7 +252,7 @@ This automation switches to high speed when the CO₂ level in the office rises 
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.living
       data:
         percentage: 100
 
@@ -264,7 +264,7 @@ This automation switches to high speed when the CO₂ level in the office rises 
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.living
       data:
         percentage: 0
 ```

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -79,23 +79,34 @@ The Duco system consists of multiple nodes. Each node appears as a separate devi
 
 ### Fan
 
-The fan entity lets you control the ventilation speed of a node. You can set the speed as a percentage or switch back to automatic mode.
+The fan entity lets you control the ventilation speed in two ways: by setting a speed percentage for a continuous override, or by selecting a preset mode for a timed or special ventilation behavior.
 
-The fan is always on. Setting the speed to 0% returns control to Duco (automatic mode), after which the firmware automatically resumes ventilation.
+The fan is always on. Turning off the fan is not supported.
 
-The following actions are available:
+#### Speed control
 
-- **Speed 0%**: Hands control back to Duco (automatic mode).
-- **Speed 33%**: Low speed manual override.
-- **Speed 66%**: Medium speed manual override.
-- **Speed 100%**: High speed manual override.
-- **Auto preset**: Same as speed 0%; hands control back to Duco.
+Setting a speed percentage activates a continuous override with no time limit:
 
-When a connected wall unit (such as a UCCO2) triggers a timed speed override on the Duco box, Home Assistant reflects the current ventilation level as a percentage. These timed states cannot be set from Home Assistant; writing a speed always uses the permanent manual mode (a continuous override with no time limit).
+- **Speed 0%**: Returns control to Duco (automatic mode).
+- **Speed 33%**: Continuous low speed override.
+- **Speed 66%**: Continuous medium speed override.
+- **Speed 100%**: Continuous high speed override.
 
 {% note %}
 The percentages 33%, 66%, and 100% are abstract speed levels used in the Home Assistant fan UI and do not match the actual airflow percentages configured in the Duco firmware. To see the real airflow target, use the **Target flow level** sensor.
 {% endnote %}
+
+#### Preset modes
+
+Selecting a preset mode lets you activate a specific ventilation behavior:
+
+- **Auto**: Returns control to Duco (automatic mode).
+- **Timed low speed**: Activates a low speed override for 15 minutes, after which the Duco firmware automatically returns to the previous mode.
+- **Timed medium speed**: Activates a medium speed override for 15 minutes.
+- **Timed high speed**: Activates a high speed override for 15 minutes.
+- **Empty house**: Activates the empty house ventilation mode.
+
+When a sensor module (such as a UCCO2) triggers an automatic boost, the fan entity does not reflect a percentage or a preset. Use the **Ventilation state** sensor to see the current state.
 
 ### Sensors
 
@@ -160,7 +171,7 @@ Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in
 ## Use cases
 
 - Switch to high ventilation automatically when cooking or showering.
-- Return to auto mode when everyone leaves home using a presence-based automation.
+- Switch to empty house mode when everyone leaves home using a presence-based automation.
 - Monitor ventilation activity over time via the logbook.
 - Trigger automations based on CO₂ levels or humidity reported by connected Duco modules.
 - Use temperature readings from sensor modules to detect rooms that are too hot or too cold and adjust ventilation accordingly.
@@ -200,32 +211,32 @@ This automation switches the ventilation to high speed when the kitchen hood is 
 
 ### Reduce ventilation when nobody is home
 
-When the last person leaves home, the ventilation hands control back to Duco (automatic mode). When someone returns, it switches to medium speed.
+When the last person leaves home, the ventilation switches to empty house mode. When someone returns, it switches back to automatic mode.
 
 ```yaml
-- alias: "Ventilation auto mode on leave"
+- alias: "Ventilation empty house mode on leave"
   triggers:
     - trigger: numeric_state
       entity_id: zone.home
       below: 1
   actions:
-    - action: fan.set_percentage
+    - action: fan.set_preset_mode
       target:
         entity_id: fan.living_ventilation
       data:
-        percentage: 0
+        preset_mode: "empt"
 
-- alias: "Ventilation medium speed on arrive"
+- alias: "Ventilation auto mode on arrive"
   triggers:
     - trigger: numeric_state
       entity_id: zone.home
       above: 0
   actions:
-    - action: fan.set_percentage
+    - action: fan.set_preset_mode
       target:
         entity_id: fan.living_ventilation
       data:
-        percentage: 66
+        preset_mode: "auto"
 ```
 
 ### Boost ventilation when CO₂ is high
@@ -265,7 +276,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 ## Known limitations
 
 - The Duco box enforces a rate limit of 200 write requests per day. When the limit is reached, the integration shows a notification and stops sending write requests until the quota resets automatically around midnight.
-- Timed speed overrides set by a connected wall unit (such as a UCCO2) cannot be triggered from Home Assistant. They are read-only: the current ventilation level is shown as a percentage, but setting a speed from Home Assistant always uses the permanent manual mode (a continuous override with no time limit).
+- Automatic boost states triggered by a sensor module (such as a UCCO2 detecting high CO₂ or humidity) cannot be set from Home Assistant. They are visible in the **Ventilation state** sensor but are not reflected in the fan entity.
 - When you deregister a sensor module via the Duco app or firmware, the node disappears from the Duco API and Home Assistant removes it automatically on the next data update. However, a BSRH humidity sensor that is physically disconnected from the box PCB (rather than deregistered via software) is not treated as deregistered by the firmware. Its node remains in the API indefinitely, so its entities will stay in Home Assistant until you deregister it through the Duco app.
 
 ## Troubleshooting

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -85,9 +85,9 @@ The fan is always on. Turning off the fan is not supported.
 
 #### Speed control
 
-Setting a speed percentage activates a continuous override with no time limit:
+Setting a speed percentage to 33%, 66%, or 100% activates a continuous override with no time limit. Setting it to 0% clears the override and hands control back to Duco:
 
-- **Speed 0%**: Returns control to Duco (automatic mode).
+- **Speed 0%**: Clears the override and returns to automatic mode.
 - **Speed 33%**: Continuous low speed override.
 - **Speed 66%**: Continuous medium speed override.
 - **Speed 100%**: Continuous high speed override.
@@ -278,7 +278,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 ## Known limitations
 
 - The Duco box enforces a rate limit of 200 write requests per day. When the limit is reached, the integration shows a notification and stops sending write requests until the quota resets automatically around midnight.
-- Automatic boost states triggered by a sensor module (such as a UCCO2 detecting high CO₂ or humidity) cannot be set from Home Assistant. They are shown as the **Auto** preset in the fan entity. Use the **Ventilation state** sensor to see the exact active state.
+- Automatic boost states triggered by a sensor module (such as a UCCO2 detecting high CO₂, or a UCRH detecting high humidity) cannot be set from Home Assistant. They are shown as the **Auto** preset in the fan entity. Use the **Ventilation state** sensor to see the exact active state.
 - When you deregister a sensor module via the Duco app or firmware, the node disappears from the Duco API and Home Assistant removes it automatically on the next data update. However, a BSRH humidity sensor that is physically disconnected from the box PCB (rather than deregistered via software) is not treated as deregistered by the firmware. Its node remains in the API indefinitely, so its entities will stay in Home Assistant until you deregister it through the Duco app.
 
 ## Troubleshooting

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -191,7 +191,7 @@ This automation switches the ventilation to high speed when the kitchen hood is 
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living
+        entity_id: fan.node_1
       data:
         percentage: 100
 
@@ -204,7 +204,7 @@ This automation switches the ventilation to high speed when the kitchen hood is 
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living
+        entity_id: fan.node_1
       data:
         percentage: 0
 ```
@@ -222,7 +222,7 @@ When the last person leaves home, the ventilation switches to empty house mode. 
   actions:
     - action: fan.set_preset_mode
       target:
-        entity_id: fan.living
+        entity_id: fan.node_1
       data:
         preset_mode: "empt"
 
@@ -234,7 +234,7 @@ When the last person leaves home, the ventilation switches to empty house mode. 
   actions:
     - action: fan.set_preset_mode
       target:
-        entity_id: fan.living
+        entity_id: fan.node_1
       data:
         preset_mode: "auto"
 ```
@@ -252,7 +252,7 @@ This automation switches to high speed when the CO₂ level in the office rises 
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living
+        entity_id: fan.node_1
       data:
         percentage: 100
 
@@ -264,7 +264,7 @@ This automation switches to high speed when the CO₂ level in the office rises 
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living
+        entity_id: fan.node_1
       data:
         percentage: 0
 ```

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -100,11 +100,11 @@ The percentages 33%, 66%, and 100% are abstract speed levels used in the Home As
 
 Selecting a preset mode lets you activate a specific ventilation behavior:
 
-- **Auto**: Returns control to Duco (automatic mode).
-- **Timed low speed**: Activates a low speed override for 15 minutes, after which the Duco firmware automatically returns to the previous mode.
-- **Timed medium speed**: Activates a medium speed override for 15 minutes.
-- **Timed high speed**: Activates a high speed override for 15 minutes.
-- **Empty house**: Activates the empty house ventilation mode.
+- **Auto** (`auto`): Returns control to Duco (automatic mode).
+- **Timed low speed** (`man1`): Activates a low speed override for 15 minutes, after which the Duco firmware automatically returns to the previous mode.
+- **Timed medium speed** (`man2`): Activates a medium speed override for 15 minutes.
+- **Timed high speed** (`man3`): Activates a high speed override for 15 minutes.
+- **Empty house** (`empt`): Activates the empty house ventilation mode.
 
 When a sensor module (such as a UCCO2) triggers an automatic boost, the fan entity does not reflect a percentage or a preset. Use the **Ventilation state** sensor to see the current state.
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -243,13 +243,13 @@ When the last person leaves home, the ventilation switches to empty house mode. 
 
 ### Boost ventilation when CO₂ is high
 
-This automation switches to high speed when the CO₂ level in the office rises above 1000 ppm, and returns to automatic mode when it drops back below 800 ppm.
+This automation switches to high speed when the CO₂ level rises above 1000 ppm on a UCCO2 sensor module (node 2 in this example), and returns to automatic mode when it drops back below 800 ppm.
 
 ```yaml
 - alias: "Boost ventilation on high CO2"
   triggers:
     - trigger: numeric_state
-      entity_id: sensor.office_co2_carbon_dioxide
+      entity_id: sensor.node_2_carbon_dioxide
       above: 1000
   actions:
     - action: fan.set_percentage
@@ -261,8 +261,38 @@ This automation switches to high speed when the CO₂ level in the office rises 
 - alias: "Return to auto when CO2 is low"
   triggers:
     - trigger: numeric_state
-      entity_id: sensor.office_co2_carbon_dioxide
+      entity_id: sensor.node_2_carbon_dioxide
       below: 800
+  actions:
+    - action: fan.set_percentage
+      target:
+        entity_id: fan.node_1
+      data:
+        percentage: 0
+```
+
+### Boost ventilation when humidity is high
+
+This automation switches to medium speed when relative humidity rises above 70% on a UCRH or BSRH sensor module (node 113 in this example), and returns to automatic mode when it drops back below 60%.
+
+```yaml
+- alias: "Boost ventilation on high humidity"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.node_113_humidity
+      above: 70
+  actions:
+    - action: fan.set_percentage
+      target:
+        entity_id: fan.node_1
+      data:
+        percentage: 66
+
+- alias: "Return to auto when humidity is normal"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.node_113_humidity
+      below: 60
   actions:
     - action: fan.set_percentage
       target:

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -106,6 +106,8 @@ Selecting a preset mode lets you activate a specific ventilation behavior:
 - **Timed high speed** (`man3`): Activates a high speed override for 15 minutes.
 - **Empty house** (`empt`): Activates the empty house ventilation mode.
 
+When a timed preset or the **Auto** preset is active, the speed slider shows no value. The slider only reflects a level when a continuous override is active.
+
 When a sensor module (such as a UCCO2) triggers an automatic boost, the fan entity shows the **Auto** preset. Use the **Ventilation state** sensor to see the exact active state.
 
 ### Sensors

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -106,7 +106,7 @@ Selecting a preset mode lets you activate a specific ventilation behavior:
 - **Timed high speed** (`man3`): Activates a high speed override for 15 minutes.
 - **Empty house** (`empt`): Activates the empty house ventilation mode.
 
-When a sensor module (such as a UCCO2) triggers an automatic boost, the fan entity does not reflect a percentage or a preset. Use the **Ventilation state** sensor to see the current state.
+When a sensor module (such as a UCCO2) triggers an automatic boost, the fan entity shows the **Auto** preset. Use the **Ventilation state** sensor to see the exact active state.
 
 ### Sensors
 
@@ -276,7 +276,7 @@ The integration {% term polling polls %} the Duco box every 30 seconds. If you a
 ## Known limitations
 
 - The Duco box enforces a rate limit of 200 write requests per day. When the limit is reached, the integration shows a notification and stops sending write requests until the quota resets automatically around midnight.
-- Automatic boost states triggered by a sensor module (such as a UCCO2 detecting high CO₂ or humidity) cannot be set from Home Assistant. They are visible in the **Ventilation state** sensor but are not reflected in the fan entity.
+- Automatic boost states triggered by a sensor module (such as a UCCO2 detecting high CO₂ or humidity) cannot be set from Home Assistant. They are shown as the **Auto** preset in the fan entity. Use the **Ventilation state** sensor to see the exact active state.
 - When you deregister a sensor module via the Duco app or firmware, the node disappears from the Duco API and Home Assistant removes it automatically on the next data update. However, a BSRH humidity sensor that is physically disconnected from the box PCB (rather than deregistered via software) is not treated as deregistered by the firmware. Its node remains in the API indefinitely, so its entities will stay in Home Assistant until you deregister it through the Duco app.
 
 ## Troubleshooting


### PR DESCRIPTION
## Proposed change

Documents the new ventilation preset modes added to the Duco fan entity in home-assistant/core#169685.

The fan section now covers both the speed slider and the preset modes (`auto`, `man1`, `man2`, `man3`, `empt`), including automation examples using the preset keys.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/169685
- Link to parent pull request in the Brands repository: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards