### PR TITLE
Use the full Home Assistant name consistently in documentation

### DIFF
--- a/source/_includes/installation/container/alternative.md
+++ b/source/_includes/installation/container/alternative.md
@@ -23,7 +23,7 @@ The steps would be:
 
 If you are using the built-in firewall, you must also add the port 8123 to allowed list. This can be found in **Control Panel** > **Security** and then the **Firewall** tab. Select **Edit Rules** besides the **Firewall Profile** dropdown box. Create a new rule and select **Custom** for Ports and add 8123. Edit Source IP if you like or leave it at default **All**. Action should stay at **Allow**.
 
-To use a Z-Wave USB stick for Z-Wave control, the HA Docker container needs extra configuration to access to the USB stick. While there are multiple ways to do this, the least privileged way of granting access can only be performed via the Terminal, at the time of writing. See this page for configuring Terminal access to your Synology NAS:
+To use a Z-Wave USB stick for Z-Wave control, the Home Assistant Docker container needs extra configuration to access to the USB stick. While there are multiple ways to do this, the least privileged way of granting access can only be performed via the Terminal, at the time of writing. See this page for configuring Terminal access to your Synology NAS:
 
 <https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal>
 

--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -212,7 +212,7 @@ Add a sample utterance:
 ActivateSceneIntent activate {Scene}
 ```
 
-Then add the intent to your `intent_script` section in your HA configuration file:
+Then add the intent to your `intent_script` section in your Home Assistant configuration file:
 
 
 ```yaml
@@ -264,7 +264,7 @@ Add a sample utterance:
 RunScriptIntent run {Script}
 ```
 
-Then add the intent to your intent_script section in your HA configuration file:
+Then add the intent to your intent_script section in your Home Assistant configuration file:
 
 
 ```yaml

--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -34,7 +34,7 @@ There is currently support for the following device types within Home Assistant:
 - The Australian version of the Daikin Wifi Controller Unit BRP072A42, which is operated by the [Daikin Mobile Controller (iOS)](https://apps.apple.com/au/app/id917168708) ([Android](https://play.google.com/store/apps/details?id=ao.daikin.remoapp)) application. Confirmed working on a Daikin Cora Series Reverse Cycle Split System Air Conditioner 2.5kW Cooling FTXM25QVMA with operation mode, temp, fan swing (3d, horizontal, vertical).
   - BRP072Cxx based units (including Zena devices)*.
 - The United States version of the Wifi Controller Unit (BRP072A43), which is powered by the [Daikin Comfort Control](https://play.google.com/store/apps/details?id=us.daikin.comfortcontrols) application. Confirmed working on a Daikin Wall Units FTXS09LVJU, FTXS15LVJU, FTXS18LVJU and a Floor Unit FVXS15NVJU with operation mode, temp, fan swing (3d, horizontal, vertical).
-- BRP069C4x/BRP084Cxx units using firmware 2.8.0 was added in HA 2025.9.
+- BRP069C4x/BRP084Cxx units using firmware 2.8.0 was added in Home Assistant 2025.9.
 - The Australian version of the Daikin Wifi Controller for **AirBase** units (BRP15B61), which is operated by the [Daikin Airbase](https://play.google.com/store/apps/details?id=au.com.daikin.airbase) application.
 - **SKYFi** based units, which is operated by the SKYFi application*.
 

--- a/source/_integrations/enphase_envoy.markdown
+++ b/source/_integrations/enphase_envoy.markdown
@@ -779,7 +779,7 @@ In multiphase installations with batteries, in countries with phase-balancing gr
 If you experience authentication errors during the configuration of the Envoy, ensure if Multi Factor Authentication (MFA) is disabled for your Enlighten account. Currently, this integration does not support MFA for token retrieval. If any of the below errors show, verify if MFA is disabled.
 
 - Before HA version 2026.1.2: KeyError: 'is_consumer'
-- As of HA version 2026.1.2
+- As of Home Assistant version 2026.1.2
   - KeyError: 'session_id'
   - EnvoyAuthenticationError: No session id in Enlighten login reply, disable Multi Factor Authentication
 

--- a/source/_integrations/forked_daapd.markdown
+++ b/source/_integrations/forked_daapd.markdown
@@ -25,7 +25,7 @@ The OwnTone integration requires an OwnTone server built with libwebsockets enab
 
 ## Outputs
 
-Once the OwnTone integration is set up, outputs will automatically be loaded from the server and added to HA in real-time.
+Once the OwnTone integration is set up, outputs will automatically be loaded from the server and added to Home Assistant in real-time.
 
 ## Pipes
 

--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -250,7 +250,7 @@ Executable by administrators or within the context of an automation:
 
 ### Action examples
 
-`accesspoint_id` (SGTIN) is optional for all actions and only relevant if you have multiple Homematic IP Accesspoints connected to HA. If empty, the action will be performed for all configured Homematic IP Access Points.
+`accesspoint_id` (SGTIN) is optional for all actions and only relevant if you have multiple Homematic IP Accesspoints connected to Home Assistant. If empty, the action will be performed for all configured Homematic IP Access Points.
 The `accesspoint_id` (SGTIN) can be found on top of the integration page, or on the back of your Homematic IP Accesspoint.
 
 Activate eco mode with duration. 

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -176,7 +176,7 @@ Please see the dedicated platform sections below about how to configure them cor
 
 Group addresses are configured as strings or integers in the format "1/2/3" for 3-level GA-structure, "1/2" for 2-level GA-structure or "1" for free GA-structure.
 
-The HA KNX integration uses configured `state_address` or `*_state_address` to update the state of a function. These addresses are read by GroupValueRead requests on startup and when there was no incoming telegram for one hour (default `sync_state`).
+The Home Assistant KNX integration uses configured `state_address` or `*_state_address` to update the state of a function. These addresses are read by GroupValueRead requests on startup and when there was no incoming telegram for one hour (default `sync_state`).
 
 It is possible to configure passive/listening group addresses for all functions of every KNX platform (except `expose` and `notify`). This allows having multiple group addresses to update the state of its function (e.g., the brightness of a light). When group addresses are configured as a list of strings, the first item is the active sending or state-reading address and the rest is registered as passive addresses. This schema behaves like in ETS configuration where the first is the "sending" address and others are just for updating the group object.
 

--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -44,7 +44,7 @@ integrations:
 logger:
   default: critical
   logs:
-    # log level for HA core
+    # log level for Home Assistant Core
     homeassistant.core: fatal
 
     # log level for MQTT integration

--- a/source/_integrations/music_assistant.markdown
+++ b/source/_integrations/music_assistant.markdown
@@ -152,7 +152,7 @@ automation:
 
 ### Action `music_assistant.search`
 
-Perform a global search on the Music Assistant library and all providers. This allows programmatic access to all of the music provider's catalogs and could be used to build a HA dashboard where any track could be found for playback.
+Perform a global search on the Music Assistant library and all providers. This allows programmatic access to all of the music provider's catalogs and could be used to build a Home Assistant dashboard where any track could be found for playback.
 
 - **Data attribute**: `config_entry_id`
   - **Optional**: No.
@@ -286,7 +286,7 @@ script:
 
 This integration requires Music Assistant server version 2.4 or later. The integration can connect to Music Assistant servers hosted as an app or in a separate Docker container.
 
-Music Assistant supports a [wide range of devices](https://www.music-assistant.io/player-support/) both natively and through the [Home Assistant provider](https://www.music-assistant.io/player-support/ha/). The Home Assistant provider, when installed, allows any Home Assistant media player to appear as a player in Music Assistant and thereby benefit from the advanced playback functionality that Music Assistant provides. As a general note, if there is a native Music Assistant provider then devices should be added via that method instead of using the HA media player. Any limitations associated with the providers are described on the related Player Provider page in the [Music Assistant documentation](https://www.music-assistant.io/).
+Music Assistant supports a [wide range of devices](https://www.music-assistant.io/player-support/) both natively and through the [Home Assistant provider](https://www.music-assistant.io/player-support/ha/). The Home Assistant provider, when installed, allows any Home Assistant media player to appear as a player in Music Assistant and thereby benefit from the advanced playback functionality that Music Assistant provides. As a general note, if there is a native Music Assistant provider then devices should be added via that method instead of using the Home Assistant media player. Any limitations associated with the providers are described on the related Player Provider page in the [Music Assistant documentation](https://www.music-assistant.io/).
 
 ## Known limitations
 

--- a/source/_integrations/owntracks.markdown
+++ b/source/_integrations/owntracks.markdown
@@ -118,7 +118,7 @@ OwnTracks can track regions, and send region entry and exit information to Home 
 
 Home Assistant uses the enter and leave messages to set your zone location. Your location will be set to the center of zone when you enter. Location updates from OwnTracks will be ignored while you are inside a zone.
 
-When you exit a zone, Home Assistant will start using location updates to track you again. To make sure that Home Assistant correctly exits a zone (which it calculates based on your GPS coordinates), you may want to set your Zone radius in HA to be slightly smaller that the OwnTracks region radius.
+When you exit a zone, Home Assistant will start using location updates to track you again. To make sure that Home Assistant correctly exits a zone (which it calculates based on your GPS coordinates), you may want to set your Zone radius in Home Assistant to be slightly smaller that the OwnTracks region radius.
 
 ## Using OwnTracks regions - forcing OwnTracks to update using iBeaconsOwntracks
 
@@ -130,19 +130,19 @@ When run in the usual *significant changes mode* (which is kind to your phone ba
 
 iBeacons are simple Bluetooth devices that send out an "I'm here" message. They are supported by iOS and some Android devices. OwnTracks explain more [here](https://owntracks.org/booklet/guide/beacons/).
 
-When you enter an iBeacon region, OwnTracks will send a `region enter` message to HA as described above. So if you want to have an event triggered when you arrive home, you can put an iBeacon outside your front door. If you set up an OwnTracks iBeacon region called `home` then getting close to the beacon will trigger an update to HA that will set your zone to be `home`.
+When you enter an iBeacon region, OwnTracks will send a `region enter` message to Home Assistant as described above. So if you want to have an event triggered when you arrive home, you can put an iBeacon outside your front door. If you set up an OwnTracks iBeacon region called `home` then getting close to the beacon will trigger an update to Home Assistant that will set your zone to be `home`.
 
-When you exit an iBeacon region HA will switch back to using GPS to determine your location. Depending on the size of your zone, and the accuracy of your GPS location this may change your HA zone.
+When you exit an iBeacon region Home Assistant will switch back to using GPS to determine your location. Depending on the size of your zone, and the accuracy of your GPS location this may change your Home Assistant zone.
 
-Sometimes OwnTracks will lose connection with an iBeacon for a few seconds. If you name your beacon starting with `-` OwnTracks will wait longer before deciding it has exited the beacon zone. HA will ignore the `-` when it matches the OwnTracks region with Zones. So if you call your OwnTracks region `-home` then HA will recognize it as `home`, but you will have a more stable iBeacon connection.
+Sometimes OwnTracks will lose connection with an iBeacon for a few seconds. If you name your beacon starting with `-` OwnTracks will wait longer before deciding it has exited the beacon zone. Home Assistant will ignore the `-` when it matches the OwnTracks region with Zones. So if you call your OwnTracks region `-home` then Home Assistant will recognize it as `home`, but you will have a more stable iBeacon connection.
 
 ## Using OwnTracks iBeacons to track devices
 
 iBeacons don't need to be stationary. You could put one on your key ring, or in your car.
 
-When your phone sees a mobile iBeacon that it knows about, it will tell HA the location of that iBeacon. If your phone moves while you are connected to the iBeacon, HA will update the location of the iBeacon. But when your phone loses the connection, HA will stop updating the iBeacon location.
+When your phone sees a mobile iBeacon that it knows about, it will tell Home Assistant the location of that iBeacon. If your phone moves while you are connected to the iBeacon, Home Assistant will update the location of the iBeacon. But when your phone loses the connection, Home Assistant will stop updating the iBeacon location.
 
-To use mobile iBeacons with HA, you just set up a region that doesn't match your Zone names. If HA sees an entry event for an iBeacon region that doesn't match a Zone name (say `keys`) - it will start tracking it, calling the device `device_tracker.beacon_keys`).
+To use mobile iBeacons with Home Assistant, you just set up a region that doesn't match your Zone names. If Home Assistant sees an entry event for an iBeacon region that doesn't match a Zone name (say `keys`) - it will start tracking it, calling the device `device_tracker.beacon_keys`).
 
 This allows you to write zone automations for devices that can't track themselves (for example *alert me if I leave the house and my keys are still at home*). Another example would be *open the gates if my car arrives home*.
 

--- a/source/_integrations/pilight.markdown
+++ b/source/_integrations/pilight.markdown
@@ -61,7 +61,7 @@ send_delay:
   default: 0.0
   type: float
 whitelist:
-  description: You can define a whitelist to prevent that too many unwanted RF codes (e.g., the neighbors weather station) are put on your HA event bus. All defined subsections have to be matched. A subsection is matched if one of the items are true.
+  description: You can define a whitelist to prevent that too many unwanted RF codes (e.g., the neighbors weather station) are put on your Home Assistant event bus. All defined subsections have to be matched. A subsection is matched if one of the items are true.
   required: false
   type: string
 {% endconfiguration %}

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -101,7 +101,7 @@ rflink:
 
 ### TCP mode
 
-TCP mode allows you to connect to an RFLink device over a TCP/IP network. This is useful if placing the RFLink device next to the HA server is not optimal or desired (eg: bad reception).
+TCP mode allows you to connect to an RFLink device over a TCP/IP network. This is useful if placing the RFLink device next to the Home Assistant server is not optimal or desired (eg: bad reception).
 
 The following command can be used to expose the USB/serial interface over TCP on a different host (Linux). The arguments are separated by spaces, further info on all arguments can be found for example [on the Debian manpages](https://manpages.debian.org/stretch/socat/socat.1.en.html).
 
@@ -535,7 +535,7 @@ After configuring the RFLink hub, lights will be automatically discovered and ad
 
 RFLink binary_sensor/switch/light IDs are composed of: protocol, id, switch/channel. For example: `newkaku_0000c6c2_1`.
 
-Once the ID of a light is known, it can be used to configure the light in HA, for example to add it to a different group or configure a nice name.
+Once the ID of a light is known, it can be used to configure the light in Home Assistant, for example to add it to a different group or configure a nice name.
 
 Configuring devices as a light:
 
@@ -825,7 +825,7 @@ The RFLink integration does not know the difference between a `switch`, a `binar
 
 RFLink binary_sensor/switch/light IDs are composed of: protocol, id, switch/channel. For example: `newkaku_0000c6c2_1`.
 
-Once the ID of a switch is known, it can be used to configure it as a switch type in HA and, for example, to add it to a different group or configure a nice name.
+Once the ID of a switch is known, it can be used to configure it as a switch type in Home Assistant and, for example, to add it to a different group or configure a nice name.
 
 Configuring devices as switch :
 

--- a/source/_integrations/risco.markdown
+++ b/source/_integrations/risco.markdown
@@ -1,6 +1,6 @@
 ---
 title: Risco
-description: Instructions on how to integrate Risco alarms into HA using Risco Cloud.
+description: Instructions on how to integrate Risco alarms into Home Assistant using Risco Cloud.
 ha_category:
   - Alarm
   - Binary sensor

--- a/source/_integrations/sia.markdown
+++ b/source/_integrations/sia.markdown
@@ -27,8 +27,8 @@ To use this platform, you need to setup your alarm system to communicate using t
 4. Place Account Id - 3-16 ASCII hex characters. For example AAA.
 5. Insert Home Assistant IP address. The hub must be able to reach this IP address. There is no cloud connection necessary.
 6. Insert Home Assistant listening port. This port must not be used by anything else on the machine Home Assistant is running on, see the notes on [port usage](#port-usage) below.
-7. Select Preferred Network. Ethernet is preferred if hub and HA in same network. Multiple networks are not tested.
-8. Enable Periodic Reports. The interval with which the alarm systems reports to the monitoring station, default is 1 minute. This component adds 30 seconds before setting the alarm unavailable to deal with slights latencies between ajax and HA and the async nature of HA.
+7. Select Preferred Network. Ethernet is preferred if hub and Home Assistant in same network. Multiple networks are not tested.
+8. Enable Periodic Reports. The interval with which the alarm systems reports to the monitoring station, default is 1 minute. This component adds 30 seconds before setting the alarm unavailable to deal with slights latencies between ajax and Home Assistant and the async nature of Home Assistant.
 9. Encryption is preferred but optional. Password is 16, 24 or 32 ASCII characters.
 
 {% include integrations/config_flow.md %}
@@ -56,7 +56,7 @@ If you have multiple accounts (alarm systems) that you want to monitor you can c
 
 ### Port usage
 
-The port used with this component must be a port no other processes use on the machine your HA instance is running. If you have a complex network setup or want to monitor alarm systems at other locations you will most likely have to open firewalls and/or create network routes for that purpose, the integration will just listen for messages coming into that port, and will not proactively send, only responding with an acknowledgement to the alarm system.
+The port used with this component must be a port no other processes use on the machine your Home Assistant instance is running. If you have a complex network setup or want to monitor alarm systems at other locations you will most likely have to open firewalls and/or create network routes for that purpose, the integration will just listen for messages coming into that port, and will not proactively send, only responding with an acknowledgement to the alarm system.
 
 ### Entities
 

--- a/source/_integrations/thread.markdown
+++ b/source/_integrations/thread.markdown
@@ -128,7 +128,7 @@ Find out if you already have Thread networks:
 - If you do not see a **Thread** integration, add it.
 - Then, select **Configure** and check if you see any Thread networks on the overview page.
 - Case 1: If you do not have any Thread networks yet, follow [Case 1: Make Home Assistant your first Thread network](#case-1-making-home-assistant-your-first-thread-network)
-- Case 2: If you have existing networks, follow [Case 2: Create a HA border router when there is an existing network](#case-2-creating-a-ha-border-router-when-there-is-an-existing-network)
+- Case 2: If you have existing networks, follow [Case 2: Create a Home Assistant border router when there is an existing network](#case-2-creating-a-home-assistant-border-router-when-there-is-an-existing-network)
 
 ### Case 1: Making Home Assistant your first Thread network
 
@@ -167,7 +167,7 @@ Follow these steps if you want to turn Home Assistant into a Thread border route
      - At the bottom of the preferred network box, select **Send credentials to phone**.
 4. To add Matter-based Thread devices, follow the steps on [Adding a matter device to Home Assistant](/integrations/matter/#adding-a-matter-device-to-home-assistant).
 
-### Case 2: Creating a HA border router when there is an existing network
+### Case 2: Creating a Home Assistant border router when there is an existing network
 
 Follow these steps if you want to turn Home Assistant into a Thread border router using the Thread radio of Yellow, Connect&nbsp;ZBT-1, or another compatible radio but you already have third-party Thread networks present. These steps will join the Home Assistant Thread border router with the existing Thread network.
 
@@ -181,7 +181,7 @@ If you have both Google and Apple Thread networks present, decide which one you 
 - Third-party Thread network listed
 - Android phone if you have a Google Thread network, iPhone if you have an Apple Thread network
 
-#### To create a HA border router when there is an existing network
+#### To create a Home Assistant border router when there is an existing network
 
 Note: the steps and images here show the process with a Google Thread network. But the process is very similar if you have an Apple Thread network with an iPhone.
 

--- a/source/_integrations/zimi.markdown
+++ b/source/_integrations/zimi.markdown
@@ -77,7 +77,7 @@ It is possible to add multiple Zimi Cloud Connect devices.
 
 The integration will support all Zimi devices. Note that the naming conventions and default integration types may not be what you expect.
 
-1. Zimi devices that are generic switches will be shown in the UI as a switch and not as a light. The **Identify as light for voice control** is not available in the API to pass the necessary information to HA to correctly classify. For more details on the concept and how to change your device to the correct type after the initial integration, see [Change device type of a switch](/integrations/switch_as_x/).
+1. Zimi devices that are generic switches will be shown in the UI as a switch and not as a light. The **Identify as light for voice control** is not available in the API to pass the necessary information to Home Assistant to correctly classify. For more details on the concept and how to change your device to the correct type after the initial integration, see [Change device type of a switch](/integrations/switch_as_x/).
 2. Zimi devices and names will be mapped per HA guidelines in the table below. The user may change these names to more friendly names - see [Customizing entities](/docs/configuration/customizing-devices/).
 
 When you add a supported device, the following entities will be created:

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1169,7 +1169,7 @@ Entities will be created only after the node is ready (the interview is complete
 
 If you are certain that your device should have entities and you do not see them (even after a restart of Home Assistant Core), create an issue about your problem on the GitHub issue tracker.
 
-### My device doesn't automatically update its status in HA if I control it manually
+### My device doesn't automatically update its status in Home Assistant if I control it manually
 
 Your device might not send automatic status updates to the adapter. While the best advice would be to update to recent Z-Wave Plus devices, there is a workaround with active polling (request the status).
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Replaces the abbreviation "HA" with the full name "Home Assistant" in documentation prose across integration pages and shared includes.

Our style guide and `.textlintrc.json` already require the full name ("Home Assistant"), but a number of pages still used "HA" in prose. Using the full name consistently:

- Matches our existing style guide and textlint rules.
- Helps search engines and language models recognize "Home Assistant" as a single, well-defined entity, instead of fragmenting it across several abbreviations and aliases.
- Reads more clearly for users who are new to the project or who do not speak English as a first language.

Only documentation prose was changed. The following were intentionally left alone:

- Blog posts under `source/_posts/` and changelogs under `source/changelogs/` (historical record).
- Real CLI commands such as `ha core …`, `ha os …`, `ha host …`, and `ha backups …`.
- The verbatim Android UI label `**HA: Assist**` in the voice control documentation.
- The `ZHA` integration name (it is the literal name of the integration).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
