### PR TITLE
Lock: document triggers & conditions (Labs feature)

### DIFF
--- a/source/_actions/lock.lock.markdown
+++ b/source/_actions/lock.lock.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Lock"
+title: "Lock lock"
 action: lock.lock
 domain: lock
 description: "Locks one or more locks."

--- a/source/_actions/lock.lock.markdown
+++ b/source/_actions/lock.lock.markdown
@@ -1,0 +1,137 @@
+---
+title: "Lock"
+action: lock.lock
+domain: lock
+description: "Locks one or more locks."
+related_actions:
+  - lock.unlock
+---
+
+The **Lock** action lets you secure a door from an automation or script. Use it when you want Home Assistant to lock a door after a routine, like when everyone leaves, or after a door has been left unlocked for too long.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+6. From the actions shown for that target, select **Lock**.
+7. _Optional_: Enter **Code** if your lock requires one.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Code:
+  description: The code to use when locking the door, if your lock requires one.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `lock.lock`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: lock.lock
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This locks `lock.front_door`.
+
+If your lock requires a code, include it in the `data` section:
+
+{% example %}
+action: |
+  action: lock.lock
+  target:
+    entity_id: lock.front_door
+  data:
+    code: "1234"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+code:
+  description: >
+    The code to use when locking the door, if your lock requires one.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- Some locks require a code, and others do not.
+- A lock may already have a default code configured by its integration.
+- To do the opposite action, use [Unlock](/actions/lock.unlock/).
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: lock the front door every night
+
+If you want a simple nightly routine, lock the front door at the same time each evening. This automation locks the door at 11 PM.
+
+- **Trigger**: Time: 23:00
+- **Action**: Lock
+- **Target**: Front door lock
+
+{% details "YAML example for locking the front door every night" %}
+
+{% example %}
+automation: |
+  alias: "Lock the front door every night"
+  triggers:
+    - trigger: time
+      at: "23:00:00"
+  actions:
+    - action: lock.lock
+      target:
+        entity_id: lock.front_door
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: lock the back door after it stays unlocked for 10 minutes
+
+If a back door is often left unlocked, you can have Home Assistant secure it for you. This automation locks the back door after it has stayed unlocked for 10 minutes.
+
+- **Trigger**: Lock unlocked
+- **Target**: Back door lock
+- **Trigger when**: Each
+- **For at least**: 00:10:00
+- **Action**: Lock
+
+{% details "YAML example for locking a door after it stays unlocked" %}
+
+{% example %}
+automation: |
+  alias: "Lock the back door after 10 minutes"
+  triggers:
+    - trigger: lock.unlocked
+      target:
+        entity_id: lock.back_door
+      options:
+        behavior: any
+        for: "00:10:00"
+  actions:
+    - action: lock.lock
+      target:
+        entity_id: lock.back_door
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/lock.lock.markdown
+++ b/source/_actions/lock.lock.markdown
@@ -7,7 +7,7 @@ related_actions:
   - lock.unlock
 ---
 
-The **Lock** action lets you secure a door from an automation or script. Use it when you want Home Assistant to lock a door after a routine, like when everyone leaves, or after a door has been left unlocked for too long.
+The **Lock lock** action lets you secure a door from an automation or script. Use it when you want Home Assistant to lock a door after a routine, like when everyone leaves, or after a door has been left unlocked for too long.
 
 {% include actions/ui_header.md %}
 
@@ -18,7 +18,7 @@ To use this action in an automation or script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
-6. From the actions shown for that target, select **Lock**.
+6. From the actions shown for that target, select **Lock lock**.
 7. _Optional_: Enter **Code** if your lock requires one.
 8. Select **Save**.
 

--- a/source/_actions/lock.lock.markdown
+++ b/source/_actions/lock.lock.markdown
@@ -9,8 +9,6 @@ related_actions:
 
 The **Lock** action lets you secure a door from an automation or script. Use it when you want Home Assistant to lock a door after a routine, like when everyone leaves, or after a door has been left unlocked for too long.
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include actions/ui_header.md %}
 
 To use this action in an automation or script:

--- a/source/_actions/lock.lock.markdown
+++ b/source/_actions/lock.lock.markdown
@@ -81,7 +81,7 @@ code:
 If you want a simple nightly routine, lock the front door at the same time each evening. This automation locks the door at 11 PM.
 
 - **Trigger**: Time: 23:00
-- **Action**: Lock
+- **Action**: Lock lock
 - **Target**: Front door lock
 
 {% details "YAML example for locking the front door every night" %}
@@ -108,7 +108,7 @@ If a back door is often left unlocked, you can have Home Assistant secure it for
 - **Target**: Back door lock
 - **Trigger when**: Each
 - **For at least**: 00:10:00
-- **Action**: Lock
+- **Action**: Lock lock
 
 {% details "YAML example for locking a door after it stays unlocked" %}
 

--- a/source/_actions/lock.open.markdown
+++ b/source/_actions/lock.open.markdown
@@ -10,6 +10,7 @@ related_actions:
 The **Open lock** action lets you unlatch a supported lock from an automation or script. Use it when you want Home Assistant to open a door for a short, specific moment, like letting someone in after you verify who is there.
 
 The difference between **Open lock** and [Unlock lock](/actions/lock.unlock/) is that **Open** unlatches the door on locks that support that feature, while **Unlock** only changes the lock to the unlocked state. If you want the door ready to push open right away, use **Open**. If you only want to unlock the door, use [Unlock](/actions/lock.unlock/).
+The difference between **Open lock** and [Unlock lock](/actions/lock.unlock/) is that **Open lock** unlatches the door on locks that support that feature, while **Unlock lock** only changes the lock to the unlocked state. If you want the door ready to push open right away, use **Open lock**. If you only want to unlock the door, use [Unlock lock](/actions/lock.unlock/).
 
 {% include actions/ui_header.md %}
 
@@ -20,7 +21,7 @@ To use this action in an automation or script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
-6. From the actions shown for that target, select **Open**.
+6. From the actions shown for that target, select **Open lock**.
 7. _Optional_: Enter **Code** if your lock requires one.
 8. Select **Save**.
 
@@ -83,7 +84,7 @@ code:
 If you have a lockable gate that supports opening, Home Assistant can unlatch it when you arrive. This automation opens the front gate when your person entity changes to home.
 
 - **Trigger**: Person changes to home
-- **Action**: Open
+- **Action**: Open lock
 - **Target**: Front gate lock
 
 {% details "YAML example for opening the front gate on arrival" %}
@@ -108,7 +109,7 @@ automation: |
 If you use a user-created {% term helper %} to expose a dashboard button, you can use that helper to open a supported door. This automation opens the building door when the helper is turned on. Create the helper separately before using this example.
 
 - **Trigger**: User-created helper turns on
-- **Action**: Open
+- **Action**: Open lock
 - **Target**: Building door lock
 
 {% details "YAML example for opening a door from a helper" %}

--- a/source/_actions/lock.open.markdown
+++ b/source/_actions/lock.open.markdown
@@ -1,0 +1,138 @@
+---
+title: "Open"
+action: lock.open
+domain: lock
+description: "Unlatches one or more locks that support opening."
+related_actions:
+  - lock.unlock
+---
+
+The **Open** action lets you unlatch a supported lock from an automation or script. Use it when you want Home Assistant to open a door for a short, specific moment, like letting someone in after you verify who is there.
+
+The difference between **Open** and [Unlock](/actions/lock.unlock/) is that **Open** unlatches the door on locks that support that feature, while **Unlock** only changes the lock to the unlocked state. If you want the door ready to push open right away, use **Open**. If you only want to remove the lock, use [Unlock](/actions/lock.unlock/).
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+6. From the actions shown for that target, select **Open**.
+7. _Optional_: Enter **Code** if your lock requires one.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Code:
+  description: The code to use when opening the lock, if your lock requires one.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `lock.open`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: lock.open
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This unlatches `lock.front_door`.
+
+If your lock requires a code, include it in the `data` section:
+
+{% example %}
+action: |
+  action: lock.open
+  target:
+    entity_id: lock.front_door
+  data:
+    code: "1234"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+code:
+  description: >
+    The code to use when opening the lock, if your lock requires one.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action is available only for locks that support opening or unlatching.
+- Some locks require a code, and others do not.
+- A lock may already have a default code configured by its integration.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: open the front gate when a person arrives home
+
+If you have a lockable gate that supports opening, Home Assistant can unlatch it when you arrive. This automation opens the front gate when your person entity changes to home.
+
+- **Trigger**: Person changes to home
+- **Action**: Open
+- **Target**: Front gate lock
+
+{% details "YAML example for opening the front gate on arrival" %}
+
+{% example %}
+automation: |
+  alias: "Open the front gate on arrival"
+  triggers:
+    - trigger: state
+      entity_id: person.alex
+      to: home
+  actions:
+    - action: lock.open
+      target:
+        entity_id: lock.front_gate
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: open the building door after a button press
+
+If you use a user-created {% term helper %} to expose a dashboard button, you can use that helper to open a supported door. This automation opens the building door when the helper is turned on. Create the helper separately before using this example.
+
+- **Trigger**: User-created helper turns on
+- **Action**: Open
+- **Target**: Building door lock
+
+{% details "YAML example for opening a door from a helper" %}
+
+{% example %}
+automation: |
+  alias: "Open the building door from a helper"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.open_building_door
+      to: "on"
+  actions:
+    - action: lock.open
+      target:
+        entity_id: lock.building_door
+    - action: input_boolean.turn_off
+      target:
+        entity_id: input_boolean.open_building_door
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/lock.open.markdown
+++ b/source/_actions/lock.open.markdown
@@ -80,7 +80,7 @@ code:
 
 {% include actions/more_examples.md %}
 
-### Automation: open the front gate when a person arrives home
+### Automation: open the front gate when you arrive home
 
 If you have a lockable gate that supports opening, Home Assistant can unlatch it when you arrive. This automation opens the front gate when your person entity changes to home.
 

--- a/source/_actions/lock.open.markdown
+++ b/source/_actions/lock.open.markdown
@@ -11,8 +11,6 @@ The **Open** action lets you unlatch a supported lock from an automation or scri
 
 The difference between **Open** and [Unlock](/actions/lock.unlock/) is that **Open** unlatches the door on locks that support that feature, while **Unlock** only changes the lock to the unlocked state. If you want the door ready to push open right away, use **Open**. If you only want to unlock the door, use [Unlock](/actions/lock.unlock/).
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include actions/ui_header.md %}
 
 To use this action in an automation or script:

--- a/source/_actions/lock.open.markdown
+++ b/source/_actions/lock.open.markdown
@@ -9,7 +9,7 @@ related_actions:
 
 The **Open** action lets you unlatch a supported lock from an automation or script. Use it when you want Home Assistant to open a door for a short, specific moment, like letting someone in after you verify who is there.
 
-The difference between **Open** and [Unlock](/actions/lock.unlock/) is that **Open** unlatches the door on locks that support that feature, while **Unlock** only changes the lock to the unlocked state. If you want the door ready to push open right away, use **Open**. If you only want to remove the lock, use [Unlock](/actions/lock.unlock/).
+The difference between **Open** and [Unlock](/actions/lock.unlock/) is that **Open** unlatches the door on locks that support that feature, while **Unlock** only changes the lock to the unlocked state. If you want the door ready to push open right away, use **Open**. If you only want to unlock the door, use [Unlock](/actions/lock.unlock/).
 
 {% include integrations/labs_entity_triggers_note.md %}
 

--- a/source/_actions/lock.open.markdown
+++ b/source/_actions/lock.open.markdown
@@ -7,9 +7,9 @@ related_actions:
   - lock.unlock
 ---
 
-The **Open** action lets you unlatch a supported lock from an automation or script. Use it when you want Home Assistant to open a door for a short, specific moment, like letting someone in after you verify who is there.
+The **Open lock** action lets you unlatch a supported lock from an automation or script. Use it when you want Home Assistant to open a door for a short, specific moment, like letting someone in after you verify who is there.
 
-The difference between **Open** and [Unlock](/actions/lock.unlock/) is that **Open** unlatches the door on locks that support that feature, while **Unlock** only changes the lock to the unlocked state. If you want the door ready to push open right away, use **Open**. If you only want to unlock the door, use [Unlock](/actions/lock.unlock/).
+The difference between **Open lock** and [Unlock lock](/actions/lock.unlock/) is that **Open** unlatches the door on locks that support that feature, while **Unlock** only changes the lock to the unlocked state. If you want the door ready to push open right away, use **Open**. If you only want to unlock the door, use [Unlock](/actions/lock.unlock/).
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/lock.open.markdown
+++ b/source/_actions/lock.open.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Open"
+title: "Open lock"
 action: lock.open
 domain: lock
 description: "Unlatches one or more locks that support opening."

--- a/source/_actions/lock.unlock.markdown
+++ b/source/_actions/lock.unlock.markdown
@@ -1,0 +1,136 @@
+---
+title: "Unlock"
+action: lock.unlock
+domain: lock
+description: "Unlocks one or more locks."
+related_actions:
+  - lock.lock
+  - lock.open
+---
+
+The **Unlock** action lets you release a lock from an automation or script. Use it when you want Home Assistant to let someone in, prepare for an arrival, or remove one step from an emergency exit path.
+
+The difference between **Unlock** and [Open](/actions/lock.open/) is that **Unlock** only changes the lock to the unlocked state, while **Open** unlatches the door on locks that support that feature. If you want to remove the lock but not unlatch the door, use **Unlock**. If you want the door ready to push open right away, use [Open](/actions/lock.open/).
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+6. From the actions shown for that target, select **Unlock**.
+7. _Optional_: Enter **Code** if your lock requires one.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Code:
+  description: The code to use when unlocking the door, if your lock requires one.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `lock.unlock`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: lock.unlock
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This unlocks `lock.front_door`.
+
+If your lock requires a code, include it in the `data` section:
+
+{% example %}
+action: |
+  action: lock.unlock
+  target:
+    entity_id: lock.front_door
+  data:
+    code: "1234"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+code:
+  description: >
+    The code to use when unlocking the door, if your lock requires one.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- Some locks require a code, and others do not.
+- A lock may already have a default code configured by its integration.
+- To release a latch on a supported lock instead of only unlocking it, use [Open](/actions/lock.open/).
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: unlock the front door when you arrive home
+
+If you want a smoother arrival, Home Assistant can unlock the front door when you get home. This automation unlocks the door when your person entity changes to home.
+
+- **Trigger**: Person changes to home
+- **Action**: Unlock
+- **Target**: Front door lock
+
+{% details "YAML example for unlocking the front door on arrival" %}
+
+{% example %}
+automation: |
+  alias: "Unlock the front door on arrival"
+  triggers:
+    - trigger: state
+      entity_id: person.alex
+      to: home
+  actions:
+    - action: lock.unlock
+      target:
+        entity_id: lock.front_door
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: unlock the front door during a smoke alarm
+
+If you want to remove one step during an emergency, Home Assistant can unlock the front door when smoke is detected. This automation unlocks the door as soon as a smoke sensor reports smoke.
+
+- **Trigger**: Smoke detected
+- **Action**: Unlock
+- **Target**: Front door lock
+
+{% details "YAML example for unlocking a door during a smoke alarm" %}
+
+{% example %}
+automation: |
+  alias: "Unlock the front door when smoke is detected"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hall_smoke
+      to: "on"
+  actions:
+    - action: lock.unlock
+      target:
+        entity_id: lock.front_door
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/lock.unlock.markdown
+++ b/source/_actions/lock.unlock.markdown
@@ -10,7 +10,7 @@ related_actions:
 
 The **Unlock** action lets you release a lock from an automation or script. Use it when you want Home Assistant to let someone in, prepare for an arrival, or remove one step from an emergency exit path.
 
-The difference between **Unlock** and [Open](/actions/lock.open/) is that **Unlock** only changes the lock to the unlocked state, while **Open** unlatches the door on locks that support that feature. If you want to remove the lock but not unlatch the door, use **Unlock**. If you want the door ready to push open right away, use [Open](/actions/lock.open/).
+The difference between **Unlock** and [Open](/actions/lock.open/) is that **Unlock** only changes the lock to the unlocked state, while **Open** unlatches the door on locks that support that feature. If you want to unlock the door but not unlatch it, use **Unlock**. If you want the door ready to push open right away, use [Open](/actions/lock.open/).
 
 {% include integrations/labs_entity_triggers_note.md %}
 

--- a/source/_actions/lock.unlock.markdown
+++ b/source/_actions/lock.unlock.markdown
@@ -12,8 +12,6 @@ The **Unlock** action lets you release a lock from an automation or script. Use 
 
 The difference between **Unlock** and [Open](/actions/lock.open/) is that **Unlock** only changes the lock to the unlocked state, while **Open** unlatches the door on locks that support that feature. If you want to unlock the door but not unlatch it, use **Unlock**. If you want the door ready to push open right away, use [Open](/actions/lock.open/).
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include actions/ui_header.md %}
 
 To use this action in an automation or script:

--- a/source/_actions/lock.unlock.markdown
+++ b/source/_actions/lock.unlock.markdown
@@ -8,7 +8,7 @@ related_actions:
   - lock.open
 ---
 
-The **Unlock** action lets you release a lock from an automation or script. Use it when you want Home Assistant to let someone in, prepare for an arrival, or remove one step from an emergency exit path.
+The **Unlock lock** action lets you release a lock from an automation or script. Use it when you want Home Assistant to let someone in, prepare for an arrival, or remove one step from an emergency exit path.
 
 The difference between **Unlock** and [Open](/actions/lock.open/) is that **Unlock** only changes the lock to the unlocked state, while **Open** unlatches the door on locks that support that feature. If you want to unlock the door but not unlatch it, use **Unlock**. If you want the door ready to push open right away, use [Open](/actions/lock.open/).
 

--- a/source/_actions/lock.unlock.markdown
+++ b/source/_actions/lock.unlock.markdown
@@ -10,7 +10,7 @@ related_actions:
 
 The **Unlock lock** action lets you release a lock from an automation or script. Use it when you want Home Assistant to let someone in, prepare for an arrival, or remove one step from an emergency exit path.
 
-The difference between **Unlock** and [Open](/actions/lock.open/) is that **Unlock** only changes the lock to the unlocked state, while **Open** unlatches the door on locks that support that feature. If you want to unlock the door but not unlatch it, use **Unlock**. If you want the door ready to push open right away, use [Open](/actions/lock.open/).
+The difference between **Unlock lock** and [Open lock](/actions/lock.open/) is that **Unlock lock** only changes the lock to the unlocked state, while **Open lock** unlatches the door on locks that support that feature. If you want to unlock the door but not unlatch it, use **Unlock lock**. If you want the door ready to push open right away, use [Open lock](/actions/lock.open/).
 
 {% include actions/ui_header.md %}
 
@@ -21,7 +21,7 @@ To use this action in an automation or script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
-6. From the actions shown for that target, select **Unlock**.
+6. From the actions shown for that target, select **Unlock lock**.
 7. _Optional_: Enter **Code** if your lock requires one.
 8. Select **Save**.
 
@@ -84,7 +84,7 @@ code:
 If you want a smoother arrival, Home Assistant can unlock the front door when you get home. This automation unlocks the door when your person entity changes to home.
 
 - **Trigger**: Person changes to home
-- **Action**: Unlock
+- **Action**: Unlock lock
 - **Target**: Front door lock
 
 {% details "YAML example for unlocking the front door on arrival" %}
@@ -109,7 +109,7 @@ automation: |
 If you want to remove one step during an emergency, Home Assistant can unlock the front door when smoke is detected. This automation unlocks the door as soon as a smoke sensor reports smoke.
 
 - **Trigger**: Smoke detected
-- **Action**: Unlock
+- **Action**: Unlock lock
 - **Target**: Front door lock
 
 {% details "YAML example for unlocking a door during a smoke alarm" %}

--- a/source/_actions/lock.unlock.markdown
+++ b/source/_actions/lock.unlock.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Unlock"
+title: "Unlock lock"
 action: lock.unlock
 domain: lock
 description: "Unlocks one or more locks."

--- a/source/_conditions/lock.is_jammed.markdown
+++ b/source/_conditions/lock.is_jammed.markdown
@@ -110,7 +110,9 @@ automation: |
         behavior: any
         for: "00:01:00"
   actions:
-    - action: notify.mobile_app_phone
+    - action: notify.send_message
+      target:
+        entity_id: notify.mobile_app_phone
       data:
         title: "Front door lock still jammed"
         message: "Check the front door lock and clear the obstruction."

--- a/source/_conditions/lock.is_jammed.markdown
+++ b/source/_conditions/lock.is_jammed.markdown
@@ -90,7 +90,7 @@ If a first alert was missed, a follow-up reminder can help you fix the problem b
 - **Target**: Front door lock
 - **Condition passes if**: Any
 - **For at least**: 00:01:00
-- **Action**: Send a mobile notification
+- **Action**: Send a notification via mobile_app_phone
 
 {% details "YAML example for repeated jammed lock reminders" %}
 

--- a/source/_conditions/lock.is_jammed.markdown
+++ b/source/_conditions/lock.is_jammed.markdown
@@ -32,7 +32,7 @@ Condition passes if:
   required: true
 For at least:
   description: How long the lock must stay jammed before the condition passes.
-  required: true
+  required: false
 {% endoptions_ui %}
 
 {% include conditions/yaml_header.md %}
@@ -64,8 +64,8 @@ for:
   description: >
     How long the lock must stay jammed before the condition passes. Accepts a
     duration like `00:01:00` for one minute.
-  required: true
-  type: string
+  required: false
+  type: time
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_conditions/lock.is_jammed.markdown
+++ b/source/_conditions/lock.is_jammed.markdown
@@ -1,0 +1,158 @@
+---
+title: "Lock is jammed"
+condition: lock.is_jammed
+domain: lock
+description: "Tests if one or more locks are jammed."
+related_conditions:
+  - lock.is_locked
+---
+
+The **Lock is jammed** condition helps you check whether a lock is currently stuck. Use it when you want an automation to react only while the problem is still present, like sending repeated reminders or turning on more light at the door.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+5. From the conditions shown for that target, select **Lock is jammed**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All** to control how the check behaves when multiple locks are targeted.
+7. Under **For at least**, set how long the lock must stay jammed before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple locks are targeted, controls how results combine. Pick **Any** to pass if at least one targeted lock is jammed, or **All** to pass only when every targeted lock is jammed.
+  required: true
+For at least:
+  description: How long the lock must stay jammed before the condition passes.
+  required: true
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `lock.is_jammed`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: lock.is_jammed
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This passes when `lock.front_door` is currently jammed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple locks are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the lock must stay jammed before the condition passes. Accepts a
+    duration like `00:01:00` for one minute.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Locks that are `unavailable` or `unknown` are ignored for this condition. Home Assistant evaluates the remaining targeted locks.
+- Use **For at least** if you want to wait for a lasting problem instead of a brief status report.
+- To check for the normal secure state instead, use [Lock is locked](/conditions/lock.is_locked/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: send a reminder if the front door lock is still jammed
+
+If a first alert was missed, a follow-up reminder can help you fix the problem before leaving the house unsecured. This automation checks every 10 minutes and sends a reminder while the front door lock is still jammed.
+
+- **Trigger**: Time pattern: Every 10 minutes
+- **Condition**: Lock is jammed
+- **Target**: Front door lock
+- **Condition passes if**: Any
+- **For at least**: 00:01:00
+- **Action**: Send a mobile notification
+
+{% details "YAML example for repeated jammed lock reminders" %}
+
+{% example %}
+automation: |
+  alias: "Remind me that the front door lock is jammed"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/10"
+  conditions:
+    - condition: lock.is_jammed
+      target:
+        entity_id: lock.front_door
+      options:
+        behavior: any
+        for: "00:01:00"
+  actions:
+    - action: notify.mobile_app_phone
+      data:
+        title: "Front door lock still jammed"
+        message: "Check the front door lock and clear the obstruction."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on the porch light while any outside door lock is jammed
+
+Extra light can make it easier to see why a lock is stuck. This automation runs after sunset and turns on the porch light if any targeted outside lock has been jammed for at least 15 seconds.
+
+- **Trigger**: Time pattern: Every 1 minute
+- **Condition**: Lock is jammed
+- **Target**: Outside door locks (by label)
+- **Condition passes if**: Any
+- **For at least**: 00:00:15
+- **Condition**: Sun is below the horizon
+- **Action**: Turn on
+
+{% details "YAML example for lighting an area while a lock is jammed" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the porch light while a lock is jammed"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/1"
+  conditions:
+    - condition: lock.is_jammed
+      target:
+        label_id: outside_locks
+      options:
+        behavior: any
+        for: "00:00:15"
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.porch
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/lock.is_jammed.markdown
+++ b/source/_conditions/lock.is_jammed.markdown
@@ -75,7 +75,9 @@ for:
 
 ## Good to know
 
-- Locks that are `unavailable` or `unknown` are ignored for this condition. Home Assistant evaluates the remaining targeted locks.
+- Locks in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted lock is jammed.
+- With **All**, the condition passes only if every available targeted lock is jammed. If every targeted lock is `unavailable` or `unknown`, **All** passes and **Any** fails.
 - Use **For at least** if you want to wait for a lasting problem instead of a brief status report.
 - To check for the normal secure state instead, use [Lock is locked](/conditions/lock.is_locked/).
 

--- a/source/_conditions/lock.is_jammed.markdown
+++ b/source/_conditions/lock.is_jammed.markdown
@@ -57,7 +57,7 @@ behavior:
   description: >
     When multiple locks are targeted, controls how results combine. Accepts
     `all` or `any`.
-  required: true
+  required: false
   type: string
   default: any
 for:

--- a/source/_conditions/lock.is_jammed.markdown
+++ b/source/_conditions/lock.is_jammed.markdown
@@ -9,6 +9,8 @@ related_conditions:
 
 The **Lock is jammed** condition helps you check whether a lock is currently stuck. Use it when you want an automation to react only while the problem is still present, like sending repeated reminders or turning on more light at the door.
 
+{% include integrations/labs_entity_triggers_note.md %}
+
 {% include conditions/ui_header.md %}
 
 To use this condition in an automation:

--- a/source/_conditions/lock.is_jammed.markdown
+++ b/source/_conditions/lock.is_jammed.markdown
@@ -29,7 +29,7 @@ To use this condition in an automation:
 {% options_ui %}
 Condition passes if:
   description: When multiple locks are targeted, controls how results combine. Pick **Any** to pass if at least one targeted lock is jammed, or **All** to pass only when every targeted lock is jammed.
-  required: true
+  required: false
 For at least:
   description: How long the lock must stay jammed before the condition passes.
   required: false

--- a/source/_conditions/lock.is_jammed.markdown
+++ b/source/_conditions/lock.is_jammed.markdown
@@ -76,8 +76,6 @@ for:
 ## Good to know
 
 - Locks in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
-- With **Any**, the condition passes if at least one available targeted lock is jammed.
-- With **All**, the condition passes only if every available targeted lock is jammed. If every targeted lock is `unavailable` or `unknown`, **All** passes and **Any** fails.
 - Use **For at least** if you want to wait for a lasting problem instead of a brief status report.
 - To check for the normal secure state instead, use [Lock is locked](/conditions/lock.is_locked/).
 

--- a/source/_conditions/lock.is_locked.markdown
+++ b/source/_conditions/lock.is_locked.markdown
@@ -32,7 +32,7 @@ Condition passes if:
   required: true
 For at least:
   description: How long the lock must stay locked before the condition passes.
-  required: true
+  required: false
 {% endoptions_ui %}
 
 {% include conditions/yaml_header.md %}
@@ -64,8 +64,8 @@ for:
   description: >
     How long the lock must stay locked before the condition passes. Accepts a
     duration like `00:05:00` for five minutes.
-  required: true
-  type: string
+  required: false
+  type: time
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_conditions/lock.is_locked.markdown
+++ b/source/_conditions/lock.is_locked.markdown
@@ -75,7 +75,9 @@ for:
 
 ## Good to know
 
-- Locks that are `unavailable` or `unknown` are ignored for this condition. Home Assistant evaluates the remaining targeted locks.
+- Locks in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted lock is locked.
+- With **All**, the condition passes only if every available targeted lock is locked. If every targeted lock is `unavailable` or `unknown`, **All** passes and **Any** fails.
 - Use **For at least** when you want to avoid acting on a short state change.
 - To check whether a door is not secured, use [Lock is unlocked](/conditions/lock.is_unlocked/).
 

--- a/source/_conditions/lock.is_locked.markdown
+++ b/source/_conditions/lock.is_locked.markdown
@@ -76,8 +76,6 @@ for:
 ## Good to know
 
 - Locks in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
-- With **Any**, the condition passes if at least one available targeted lock is locked.
-- With **All**, the condition passes only if every available targeted lock is locked. If every targeted lock is `unavailable` or `unknown`, **All** passes and **Any** fails.
 - Use **For at least** when you want to avoid acting on a short state change.
 - To check whether a door is not secured, use [Lock is unlocked](/conditions/lock.is_unlocked/).
 

--- a/source/_conditions/lock.is_locked.markdown
+++ b/source/_conditions/lock.is_locked.markdown
@@ -9,6 +9,8 @@ related_conditions:
 
 The **Lock is locked** condition helps you check whether a lock is currently secure. Use it when an automation should continue only after a door has been locked, like arming an alarm or turning off devices near an entry.
 
+{% include integrations/labs_entity_triggers_note.md %}
+
 {% include conditions/ui_header.md %}
 
 To use this condition in an automation:

--- a/source/_conditions/lock.is_locked.markdown
+++ b/source/_conditions/lock.is_locked.markdown
@@ -1,0 +1,157 @@
+---
+title: "Lock is locked"
+condition: lock.is_locked
+domain: lock
+description: "Tests if one or more locks are locked."
+related_conditions:
+  - lock.is_unlocked
+---
+
+The **Lock is locked** condition helps you check whether a lock is currently secure. Use it when an automation should continue only after a door has been locked, like arming an alarm or turning off devices near an entry.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+5. From the conditions shown for that target, select **Lock is locked**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All** to control how the check behaves when multiple locks are targeted.
+7. Under **For at least**, set how long the lock must stay locked before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple locks are targeted, controls how results combine. Pick **Any** to pass if at least one targeted lock is locked, or **All** to pass only when every targeted lock is locked.
+  required: true
+For at least:
+  description: How long the lock must stay locked before the condition passes.
+  required: true
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `lock.is_locked`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: lock.is_locked
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This passes when `lock.front_door` is currently locked.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple locks are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the lock must stay locked before the condition passes. Accepts a
+    duration like `00:05:00` for five minutes.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Locks that are `unavailable` or `unknown` are ignored for this condition. Home Assistant evaluates the remaining targeted locks.
+- Use **For at least** when you want to avoid acting on a short state change.
+- To check whether a door is not secured, use [Lock is unlocked](/conditions/lock.is_unlocked/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: arm the alarm only if all the outside door locks are locked
+
+Before arming the house for the night, you may want one final check that every outside door is secure. This automation runs at bedtime and arms the alarm only if all targeted locks are locked.
+
+- **Trigger**: Time: 23:00
+- **Condition**: Lock is locked
+- **Target**: Outside door locks (by label)
+- **Condition passes if**: All
+- **For at least**: 00:00:00
+- **Action**: Arm alarm away
+
+{% details "YAML example for checking all outside locks" %}
+
+{% example %}
+automation: |
+  alias: "Arm the alarm only when all locks are locked"
+  triggers:
+    - trigger: time
+      at: "23:00:00"
+  conditions:
+    - condition: lock.is_locked
+      target:
+        label_id: outside_locks
+      options:
+        behavior: all
+        for: "00:00:00"
+  actions:
+    - action: alarm_control_panel.alarm_arm_away
+      target:
+        entity_id: alarm_control_panel.home_alarm
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn off the porch light if the front door has been locked for 5 minutes
+
+Once the front door has stayed locked for a while, you may not need the porch light anymore. This automation checks every evening and turns the light off after the door has remained locked for 5 minutes.
+
+- **Trigger**: Time pattern: Every 5 minutes
+- **Condition**: Lock is locked
+- **Target**: Front door lock
+- **Condition passes if**: Any
+- **For at least**: 00:05:00
+- **Condition**: Sun is below the horizon
+- **Action**: Turn off
+
+{% details "YAML example for turning off the porch light" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the porch light after the door stays locked"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/5"
+  conditions:
+    - condition: lock.is_locked
+      target:
+        entity_id: lock.front_door
+      options:
+        behavior: any
+        for: "00:05:00"
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.porch
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/lock.is_locked.markdown
+++ b/source/_conditions/lock.is_locked.markdown
@@ -29,7 +29,7 @@ To use this condition in an automation:
 {% options_ui %}
 Condition passes if:
   description: When multiple locks are targeted, controls how results combine. Pick **Any** to pass if at least one targeted lock is locked, or **All** to pass only when every targeted lock is locked.
-  required: true
+  required: false
 For at least:
   description: How long the lock must stay locked before the condition passes.
   required: false
@@ -57,7 +57,7 @@ behavior:
   description: >
     When multiple locks are targeted, controls how results combine. Accepts
     `all` or `any`.
-  required: true
+  required: false
   type: string
   default: any
 for:

--- a/source/_conditions/lock.is_open.markdown
+++ b/source/_conditions/lock.is_open.markdown
@@ -1,0 +1,155 @@
+---
+title: "Lock is open"
+condition: lock.is_open
+domain: lock
+description: "Tests if one or more locks are open."
+related_conditions:
+  - lock.is_locked
+---
+
+The **Lock is open** condition helps you check whether a lock is currently open. Use it when an automation should continue only while a door is still open, like leaving a light on or delaying another action until the door is closed again.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+5. From the conditions shown for that target, select **Lock is open**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All** to control how the check behaves when multiple locks are targeted.
+7. Under **For at least**, set how long the lock must stay open before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple locks are targeted, controls how results combine. Pick **Any** to pass if at least one targeted lock is open, or **All** to pass only when every targeted lock is open.
+  required: true
+For at least:
+  description: How long the lock must stay open before the condition passes.
+  required: true
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `lock.is_open`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: lock.is_open
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This passes when `lock.front_door` is currently open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple locks are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the lock must stay open before the condition passes. Accepts a
+    duration like `00:01:00` for one minute.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Locks that are `unavailable` or `unknown` are ignored for this condition. Home Assistant evaluates the remaining targeted locks.
+- Not every lock reports an open state. Use this condition only with locks that support open-state reporting.
+- To check for the secure state instead, use [Lock is locked](/conditions/lock.is_locked/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: keep the hallway light on while the front door is open
+
+If the front door stays open while you carry things inside, it helps to keep the hallway lit. This automation checks every minute and turns the light on while the door remains open.
+
+- **Trigger**: Time pattern: Every 1 minute
+- **Condition**: Lock is open
+- **Target**: Front door lock
+- **Condition passes if**: Any
+- **For at least**: 00:00:10
+- **Action**: Turn on
+
+{% details "YAML example for keeping a light on while the door is open" %}
+
+{% example %}
+automation: |
+  alias: "Keep the hallway light on while the door is open"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/1"
+  conditions:
+    - condition: lock.is_open
+      target:
+        entity_id: lock.front_door
+      options:
+        behavior: any
+        for: "00:00:10"
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.hallway
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a reminder if any patio door lock stays open
+
+If you want a simple reminder before bed, check whether any patio door is still open. This automation runs at night and sends a message if any targeted patio lock has stayed open for 2 minutes.
+
+- **Trigger**: Time: 22:30
+- **Condition**: Lock is open
+- **Target**: Patio door locks (by label)
+- **Condition passes if**: Any
+- **For at least**: 00:02:00
+- **Action**: Send a mobile notification
+
+{% details "YAML example for a patio door reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me if a patio door is still open"
+  triggers:
+    - trigger: time
+      at: "22:30:00"
+  conditions:
+    - condition: lock.is_open
+      target:
+        label_id: patio_locks
+      options:
+        behavior: any
+        for: "00:02:00"
+  actions:
+    - action: notify.mobile_app_phone
+      data:
+        title: "Patio door still open"
+        message: "A patio door has remained open for at least 2 minutes."
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/lock.is_open.markdown
+++ b/source/_conditions/lock.is_open.markdown
@@ -76,8 +76,6 @@ for:
 ## Good to know
 
 - Locks in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
-- With **Any**, the condition passes if at least one available targeted lock is open.
-- With **All**, the condition passes only if every available targeted lock is open. If every targeted lock is `unavailable` or `unknown`, **All** passes and **Any** fails.
 - Not every lock reports an open state. Use this condition only with locks that support open-state reporting.
 - To check for the secure state instead, use [Lock is locked](/conditions/lock.is_locked/).
 

--- a/source/_conditions/lock.is_open.markdown
+++ b/source/_conditions/lock.is_open.markdown
@@ -124,7 +124,7 @@ If you want a simple reminder before bed, check whether any patio door is still 
 - **Target**: Patio door locks (by label)
 - **Condition passes if**: Any
 - **For at least**: 00:02:00
-- **Action**: Send a mobile notification
+- **Action**: Send a notification via mobile_app_phone
 
 {% details "YAML example for a patio door reminder" %}
 

--- a/source/_conditions/lock.is_open.markdown
+++ b/source/_conditions/lock.is_open.markdown
@@ -9,6 +9,8 @@ related_conditions:
 
 The **Lock is open** condition helps you check whether a lock is currently open. Use it when an automation should continue only while a door is still open, like leaving a light on or delaying another action until the door is closed again.
 
+{% include integrations/labs_entity_triggers_note.md %}
+
 {% include conditions/ui_header.md %}
 
 To use this condition in an automation:

--- a/source/_conditions/lock.is_open.markdown
+++ b/source/_conditions/lock.is_open.markdown
@@ -32,7 +32,7 @@ Condition passes if:
   required: true
 For at least:
   description: How long the lock must stay open before the condition passes.
-  required: true
+  required: false
 {% endoptions_ui %}
 
 {% include conditions/yaml_header.md %}
@@ -64,8 +64,8 @@ for:
   description: >
     How long the lock must stay open before the condition passes. Accepts a
     duration like `00:01:00` for one minute.
-  required: true
-  type: string
+  required: false
+  type: time
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_conditions/lock.is_open.markdown
+++ b/source/_conditions/lock.is_open.markdown
@@ -29,7 +29,7 @@ To use this condition in an automation:
 {% options_ui %}
 Condition passes if:
   description: When multiple locks are targeted, controls how results combine. Pick **Any** to pass if at least one targeted lock is open, or **All** to pass only when every targeted lock is open.
-  required: true
+  required: false
 For at least:
   description: How long the lock must stay open before the condition passes.
   required: false
@@ -57,7 +57,7 @@ behavior:
   description: >
     When multiple locks are targeted, controls how results combine. Accepts
     `all` or `any`.
-  required: true
+  required: false
   type: string
   default: any
 for:

--- a/source/_conditions/lock.is_open.markdown
+++ b/source/_conditions/lock.is_open.markdown
@@ -75,7 +75,9 @@ for:
 
 ## Good to know
 
-- Locks that are `unavailable` or `unknown` are ignored for this condition. Home Assistant evaluates the remaining targeted locks.
+- Locks in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted lock is open.
+- With **All**, the condition passes only if every available targeted lock is open. If every targeted lock is `unavailable` or `unknown`, **All** passes and **Any** fails.
 - Not every lock reports an open state. Use this condition only with locks that support open-state reporting.
 - To check for the secure state instead, use [Lock is locked](/conditions/lock.is_locked/).
 

--- a/source/_conditions/lock.is_unlocked.markdown
+++ b/source/_conditions/lock.is_unlocked.markdown
@@ -76,8 +76,6 @@ for:
 ## Good to know
 
 - Locks in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
-- With **Any**, the condition passes if at least one available targeted lock is unlocked.
-- With **All**, the condition passes only if every available targeted lock is unlocked. If every targeted lock is `unavailable` or `unknown`, **All** passes and **Any** fails.
 - Use **For at least** if you want to ignore a short unlock before the door is secured again.
 - To check for the secure state instead, use [Lock is locked](/conditions/lock.is_locked/).
 

--- a/source/_conditions/lock.is_unlocked.markdown
+++ b/source/_conditions/lock.is_unlocked.markdown
@@ -75,7 +75,9 @@ for:
 
 ## Good to know
 
-- Locks that are `unavailable` or `unknown` are ignored for this condition. Home Assistant evaluates the remaining targeted locks.
+- Locks in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted lock is unlocked.
+- With **All**, the condition passes only if every available targeted lock is unlocked. If every targeted lock is `unavailable` or `unknown`, **All** passes and **Any** fails.
 - Use **For at least** if you want to ignore a short unlock before the door is secured again.
 - To check for the secure state instead, use [Lock is locked](/conditions/lock.is_locked/).
 

--- a/source/_conditions/lock.is_unlocked.markdown
+++ b/source/_conditions/lock.is_unlocked.markdown
@@ -29,7 +29,7 @@ To use this condition in an automation:
 {% options_ui %}
 Condition passes if:
   description: When multiple locks are targeted, controls how results combine. Pick **Any** to pass if at least one targeted lock is unlocked, or **All** to pass only when every targeted lock is unlocked.
-  required: true
+  required: false
 For at least:
   description: How long the lock must stay unlocked before the condition passes.
   required: false
@@ -57,7 +57,7 @@ behavior:
   description: >
     When multiple locks are targeted, controls how results combine. Accepts
     `all` or `any`.
-  required: true
+  required: false
   type: string
   default: any
 for:

--- a/source/_conditions/lock.is_unlocked.markdown
+++ b/source/_conditions/lock.is_unlocked.markdown
@@ -90,7 +90,7 @@ If you sometimes forget to lock the door before bed, a gentle reminder can help.
 - **Target**: Front door lock
 - **Condition passes if**: Any
 - **For at least**: 00:10:00
-- **Action**: Send a mobile notification
+- **Action**: Send a notification via mobile_app_phone
 
 {% details "YAML example for a bedtime lock reminder" %}
 

--- a/source/_conditions/lock.is_unlocked.markdown
+++ b/source/_conditions/lock.is_unlocked.markdown
@@ -32,7 +32,7 @@ Condition passes if:
   required: true
 For at least:
   description: How long the lock must stay unlocked before the condition passes.
-  required: true
+  required: false
 {% endoptions_ui %}
 
 {% include conditions/yaml_header.md %}
@@ -64,8 +64,8 @@ for:
   description: >
     How long the lock must stay unlocked before the condition passes. Accepts
     a duration like `00:10:00` for 10 minutes.
-  required: true
-  type: string
+  required: false
+  type: time
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_conditions/lock.is_unlocked.markdown
+++ b/source/_conditions/lock.is_unlocked.markdown
@@ -1,0 +1,158 @@
+---
+title: "Lock is unlocked"
+condition: lock.is_unlocked
+domain: lock
+description: "Tests if one or more locks are unlocked."
+related_conditions:
+  - lock.is_locked
+---
+
+The **Lock is unlocked** condition helps you check whether a lock is currently unlocked. Use it when an automation should continue only while a door is not secured, like reminding you to lock up before bed.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+5. From the conditions shown for that target, select **Lock is unlocked**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All** to control how the check behaves when multiple locks are targeted.
+7. Under **For at least**, set how long the lock must stay unlocked before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple locks are targeted, controls how results combine. Pick **Any** to pass if at least one targeted lock is unlocked, or **All** to pass only when every targeted lock is unlocked.
+  required: true
+For at least:
+  description: How long the lock must stay unlocked before the condition passes.
+  required: true
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `lock.is_unlocked`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: lock.is_unlocked
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This passes when `lock.front_door` is currently unlocked.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple locks are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the lock must stay unlocked before the condition passes. Accepts
+    a duration like `00:10:00` for 10 minutes.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Locks that are `unavailable` or `unknown` are ignored for this condition. Home Assistant evaluates the remaining targeted locks.
+- Use **For at least** if you want to ignore a short unlock before the door is secured again.
+- To check for the secure state instead, use [Lock is locked](/conditions/lock.is_locked/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: send a bedtime reminder if the front door is still unlocked
+
+If you sometimes forget to lock the door before bed, a gentle reminder can help. This automation runs at night and sends a phone notification if the front door has stayed unlocked for 10 minutes.
+
+- **Trigger**: Time: 22:00
+- **Condition**: Lock is unlocked
+- **Target**: Front door lock
+- **Condition passes if**: Any
+- **For at least**: 00:10:00
+- **Action**: Send a mobile notification
+
+{% details "YAML example for a bedtime lock reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me if the front door is unlocked at night"
+  triggers:
+    - trigger: time
+      at: "22:00:00"
+  conditions:
+    - condition: lock.is_unlocked
+      target:
+        entity_id: lock.front_door
+      options:
+        behavior: any
+        for: "00:10:00"
+  actions:
+    - action: notify.mobile_app_phone
+      data:
+        title: "Front door still unlocked"
+        message: "The front door has stayed unlocked for 10 minutes."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on a lamp if any outside door lock stays unlocked after sunset
+
+If an outside door stays unlocked after dark, a visible reminder can help. This automation checks every 5 minutes and turns on a lamp when any targeted outside lock remains unlocked.
+
+- **Trigger**: Time pattern: Every 5 minutes
+- **Condition**: Lock is unlocked
+- **Target**: Outside door locks (by label)
+- **Condition passes if**: Any
+- **For at least**: 00:05:00
+- **Condition**: Sun is below the horizon
+- **Action**: Turn on
+
+{% details "YAML example for a visual unlocked reminder" %}
+
+{% example %}
+automation: |
+  alias: "Turn on a lamp when an outside lock stays unlocked"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/5"
+  conditions:
+    - condition: lock.is_unlocked
+      target:
+        label_id: outside_locks
+      options:
+        behavior: any
+        for: "00:05:00"
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room_lamp
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/lock.is_unlocked.markdown
+++ b/source/_conditions/lock.is_unlocked.markdown
@@ -9,6 +9,8 @@ related_conditions:
 
 The **Lock is unlocked** condition helps you check whether a lock is currently unlocked. Use it when an automation should continue only while a door is not secured, like reminding you to lock up before bed.
 
+{% include integrations/labs_entity_triggers_note.md %}
+
 {% include conditions/ui_header.md %}
 
 To use this condition in an automation:

--- a/source/_integrations/lock.markdown
+++ b/source/_integrations/lock.markdown
@@ -14,7 +14,7 @@ ha_integration_type: entity
 Keeps track which locks are in your environment, their state and allows you to control them.
 
 - Maintains a state per lock and a combined state `all_locks`.
-- Registers actions `lock.lock`, `lock.unlock`, and `lock.open` (unlatch) to control locks.
+- Lets you use lock states in automations with built-in triggers, conditions, and actions.
 
 {% include integrations/building_block_integration.md %}
 
@@ -32,70 +32,76 @@ A lock entity can have the following states:
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
 
-## Actions
+{% include integrations/triggers_conditions_actions.md %}
 
-A lock integration provides the following actions:
+## Lock automation examples
 
-### Action: Lock
+The real power of the **Lock** integration is using your locks in automations.
+Here are a few ideas to get you started.
 
-The `lock.lock` action locks your door.
+{% include docs/paste_yaml_tip.md %}
 
-| Data attribute | Optional | Description                  |
-| -------------- | -------- | ---------------------------- |
-| `entity_id`    | no       | Entity of the relevant lock. |
-| `code`         | yes      | Code used to lock the lock.  |
+### Automation: turn on the hallway light when the front door unlocks
 
-#### Example
+If you often arrive home with your hands full, it helps when the light is already on. This automation turns on the hallway light when the front door unlocks.
 
-```yaml
-actions:
-  - action: lock.lock
-    target:
-      entity_id: lock.my_place
-    data:
-      code: "1234"
-```
+- **Trigger**: Lock unlocked
+- **Target**: Front door lock
+- **Trigger when**: Each
+- **For at least**: 00:00:00
+- **Action**: Turn on
 
-### Action: Unlock
+{% details "YAML example for turning on the hallway light" %}
 
-The `lock.unlock` action unlocks your door.
+{% example %}
+automation: |
+  alias: "Turn on the hallway light when the front door unlocks"
+  triggers:
+    - trigger: lock.unlocked
+      target:
+        entity_id: lock.front_door
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.hallway
+{% endexample %}
 
-| Data attribute | Optional | Description                   |
-| -------------- | -------- | ----------------------------- |
-| `entity_id`    | no       | Entity of the relevant lock.  |
-| `code`         | yes      | Code used to unlock the lock. |
+{% enddetails %}
 
-#### Example
+### Automation: send a bedtime reminder if the front door is still unlocked
 
-```yaml
-actions:
-  - action: lock.unlock
-    target:
-      entity_id: lock.my_place
-    data:
-      code: "1234"
-```
+If you sometimes forget to lock the door before bed, a gentle reminder can help. This automation runs at night and sends a phone notification if the front door has stayed unlocked for 10 minutes.
 
-### Action: Open
+- **Trigger**: Time: 22:00
+- **Condition**: Lock is unlocked
+- **Target**: Front door lock
+- **Condition passes if**: Any
+- **For at least**: 00:10:00
+- **Action**: Send a mobile notification
 
-The `lock.open` action opens (unlatches) a lock.
+{% details "YAML example for a bedtime lock reminder" %}
 
-| Data attribute | Optional | Description                   |
-| -------------- | -------- | ----------------------------- |
-| `entity_id`    | no       | Entity of the relevant lock.  |
-| `code`         | yes      | Code used to open the lock. |
+{% example %}
+automation: |
+  alias: "Remind me if the front door is unlocked at night"
+  triggers:
+    - trigger: time
+      at: "22:00:00"
+  conditions:
+    - condition: lock.is_unlocked
+      target:
+        entity_id: lock.front_door
+      options:
+        behavior: any
+        for: "00:10:00"
+  actions:
+    - action: notify.mobile_app_phone
+      data:
+        title: "Front door still unlocked"
+        message: "The front door has stayed unlocked for 10 minutes."
+{% endexample %}
 
-#### Example
-
-```yaml
-actions:
-  - action: lock.open
-    target:
-      entity_id: lock.my_place
-    data:
-      code: "1234"
-```
-
-## Use the actions
-
-Go to {% my developer_services title="**Settings** > **Developer tools** > **Actions**" %}, and choose `lock.lock`, `lock.unlock`, or `lock.open` from the list of available actions. Fill in the required data and select **Perform action**.
+{% enddetails %}

--- a/source/_integrations/lock.markdown
+++ b/source/_integrations/lock.markdown
@@ -11,7 +11,7 @@ ha_codeowners:
 ha_integration_type: entity
 ---
 
-Keeps track which locks are in your environment, their state and allows you to control them.
+Keeps track of the locks in your environment, their state, and lets you control them.
 
 - Maintains a state per lock and a combined state `all_locks`.
 - Lets you use lock states in automations with built-in triggers, conditions, and actions.

--- a/source/_integrations/lock.markdown
+++ b/source/_integrations/lock.markdown
@@ -80,7 +80,7 @@ If you sometimes forget to lock the door before bed, a gentle reminder can help.
 - **Target**: Front door lock
 - **Condition passes if**: Any
 - **For at least**: 00:10:00
-- **Action**: Send a mobile notification
+- **Action**: Send a notification via mobile_app_phone
 
 {% details "YAML example for a bedtime lock reminder" %}
 

--- a/source/_triggers/lock.jammed.markdown
+++ b/source/_triggers/lock.jammed.markdown
@@ -29,7 +29,7 @@ To use this trigger in an automation:
 {% options_ui %}
 Trigger when:
   description: When multiple locks are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted lock jams, **First** to fire only when the first targeted lock jams, or **All** to fire only after every targeted lock is jammed.
-  required: true
+  required: false
 For at least:
   description: How long the lock must stay jammed before the trigger fires. Set to zero to fire immediately.
   required: false
@@ -57,7 +57,7 @@ behavior:
   description: >
     When multiple locks are targeted, controls when the trigger fires.
     Accepts `any`, `first`, or `last`.
-  required: true
+  required: false
   type: string
   default: any
 for:

--- a/source/_triggers/lock.jammed.markdown
+++ b/source/_triggers/lock.jammed.markdown
@@ -9,6 +9,8 @@ related_triggers:
 
 The **Lock jammed** trigger helps you react when a lock cannot finish its movement. Use it when you want Home Assistant to warn you about a problem at the door, like a misaligned bolt or something blocking the lock.
 
+{% include integrations/labs_entity_triggers_note.md %}
+
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:

--- a/source/_triggers/lock.jammed.markdown
+++ b/source/_triggers/lock.jammed.markdown
@@ -1,0 +1,151 @@
+---
+title: "Lock jammed"
+trigger: lock.jammed
+domain: lock
+description: "Triggers after one or more locks jam."
+related_triggers:
+  - lock.locked
+---
+
+The **Lock jammed** trigger helps you react when a lock cannot finish its movement. Use it when you want Home Assistant to warn you about a problem at the door, like a misaligned bolt or something blocking the lock.
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+5. From the triggers shown for that target, select **Lock jammed**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All** to control how the trigger behaves when multiple locks are targeted.
+7. Under **For at least**, set how long the lock must stay jammed before the trigger fires. Leave it at zero to fire immediately.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple locks are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted lock jams, **First** to fire only when the first targeted lock jams, or **All** to fire only after every targeted lock is jammed.
+  required: true
+For at least:
+  description: How long the lock must stay jammed before the trigger fires. Set to zero to fire immediately.
+  required: true
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lock.jammed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lock.jammed
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This fires when `lock.front_door` enters the jammed state.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple locks are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the lock must stay jammed before the trigger fires. Accepts a
+    duration like `00:01:00` for one minute.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger fires only when a lock changes into the jammed state from a known state. If a lock comes back from `unavailable` or `unknown`, that recovery does not fire this trigger.
+- A jammed lock often needs attention right away, so keep **For at least** short unless you want to ignore brief reports.
+- To confirm that the lock later reaches its normal state, use [Lock locked](/triggers/lock.locked/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: notify you when the front door lock jams
+
+If the front door lock jams while someone is leaving, you want to know right away so the door is not left unsecured. This automation sends a phone notification as soon as the lock reports a jam.
+
+- **Trigger**: Lock jammed
+- **Target**: Front door lock
+- **Trigger when**: Each
+- **For at least**: 00:00:00
+- **Action**: Send a mobile notification
+
+{% details "YAML example for a jammed lock alert" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the front door lock jams"
+  triggers:
+    - trigger: lock.jammed
+      target:
+        entity_id: lock.front_door
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: notify.mobile_app_phone
+      data:
+        title: "Front door lock jammed"
+        message: "Check the front door lock. It may be blocked."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on the porch light if any outside door lock jams at night
+
+If a lock at an outside entry jams after dark, extra light can help you see what is wrong. This automation turns on the porch light when any targeted outside lock stays jammed for 10 seconds.
+
+- **Trigger**: Lock jammed
+- **Target**: Outside door locks (by label)
+- **Trigger when**: Each
+- **For at least**: 00:00:10
+- **Condition**: Sun is below the horizon
+- **Action**: Turn on
+
+{% details "YAML example for lighting the entry when a lock jams" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the porch light for a jammed lock"
+  triggers:
+    - trigger: lock.jammed
+      target:
+        label_id: outside_locks
+      options:
+        behavior: any
+        for: "00:00:10"
+  conditions:
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.porch
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/lock.jammed.markdown
+++ b/source/_triggers/lock.jammed.markdown
@@ -32,7 +32,7 @@ Trigger when:
   required: true
 For at least:
   description: How long the lock must stay jammed before the trigger fires. Set to zero to fire immediately.
-  required: true
+  required: false
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
@@ -64,8 +64,8 @@ for:
   description: >
     How long the lock must stay jammed before the trigger fires. Accepts a
     duration like `00:01:00` for one minute.
-  required: true
-  type: string
+  required: false
+  type: time
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_triggers/lock.jammed.markdown
+++ b/source/_triggers/lock.jammed.markdown
@@ -89,7 +89,7 @@ If the front door lock jams while someone is leaving, you want to know right awa
 - **Target**: Front door lock
 - **Trigger when**: Each
 - **For at least**: 00:00:00
-- **Action**: Send a mobile notification
+- **Action**: Send a notification via mobile_app_phone
 
 {% details "YAML example for a jammed lock alert" %}
 

--- a/source/_triggers/lock.locked.markdown
+++ b/source/_triggers/lock.locked.markdown
@@ -32,7 +32,7 @@ Trigger when:
   required: true
 For at least:
   description: How long the lock must stay locked before the trigger fires. Set to zero to fire immediately.
-  required: true
+  required: false
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
@@ -64,8 +64,8 @@ for:
   description: >
     How long the lock must stay locked before the trigger fires. Accepts a
     duration like `00:05:00` for five minutes.
-  required: true
-  type: string
+  required: false
+  type: time
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_triggers/lock.locked.markdown
+++ b/source/_triggers/lock.locked.markdown
@@ -9,6 +9,8 @@ related_triggers:
 
 The **Lock locked** trigger helps you react when a lock reaches the locked state. Use it when you want Home Assistant to confirm that a door is secured before turning off lights, arming an alarm, or sending a status update.
 
+{% include integrations/labs_entity_triggers_note.md %}
+
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:

--- a/source/_triggers/lock.locked.markdown
+++ b/source/_triggers/lock.locked.markdown
@@ -1,0 +1,146 @@
+---
+title: "Lock locked"
+trigger: lock.locked
+domain: lock
+description: "Triggers after one or more locks lock."
+related_triggers:
+  - lock.unlocked
+---
+
+The **Lock locked** trigger helps you react when a lock reaches the locked state. Use it when you want Home Assistant to confirm that a door is secured before turning off lights, arming an alarm, or sending a status update.
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+5. From the triggers shown for that target, select **Lock locked**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All** to control how the trigger behaves when multiple locks are targeted.
+7. Under **For at least**, set how long the lock must stay locked before the trigger fires. Leave it at zero to fire immediately.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple locks are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted lock locks, **First** to fire only when the first targeted lock locks, or **All** to fire only after every targeted lock is locked.
+  required: true
+For at least:
+  description: How long the lock must stay locked before the trigger fires. Set to zero to fire immediately.
+  required: true
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lock.locked`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lock.locked
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This fires when `lock.front_door` changes to the locked state.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple locks are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the lock must stay locked before the trigger fires. Accepts a
+    duration like `00:05:00` for five minutes.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger fires only when a lock changes into the locked state from a known state. If a lock comes back from `unavailable` or `unknown`, that recovery does not fire this trigger.
+- Use **For at least** if you want to wait until the lock has stayed secure for a while before acting.
+- To react when a door is no longer secured, use [Lock unlocked](/triggers/lock.unlocked/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off the entry light after the front door locks
+
+When you lock the front door after coming in, you may not need the bright entry light anymore. This automation waits 30 seconds after the door locks, then turns the light off.
+
+- **Trigger**: Lock locked
+- **Target**: Front door lock
+- **Trigger when**: Each
+- **For at least**: 00:00:30
+- **Action**: Turn off
+
+{% details "YAML example for turning off the entry light" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the entry light after locking"
+  triggers:
+    - trigger: lock.locked
+      target:
+        entity_id: lock.front_door
+      options:
+        behavior: any
+        for: "00:00:30"
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.entry
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: arm the alarm when all the outside doors are locked
+
+If you want one final check before arming the house, wait until every outside door lock reports locked. This automation arms the alarm only after all targeted locks are secure.
+
+- **Trigger**: Lock locked
+- **Target**: Outside door locks (by label)
+- **Trigger when**: All
+- **For at least**: 00:00:00
+- **Action**: Arm alarm away
+
+{% details "YAML example for arming the alarm after all locks are secure" %}
+
+{% example %}
+automation: |
+  alias: "Arm the alarm after all locks are locked"
+  triggers:
+    - trigger: lock.locked
+      target:
+        label_id: outside_locks
+      options:
+        behavior: last
+        for: "00:00:00"
+  actions:
+    - action: alarm_control_panel.alarm_arm_away
+      target:
+        entity_id: alarm_control_panel.home_alarm
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/lock.locked.markdown
+++ b/source/_triggers/lock.locked.markdown
@@ -29,7 +29,7 @@ To use this trigger in an automation:
 {% options_ui %}
 Trigger when:
   description: When multiple locks are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted lock locks, **First** to fire only when the first targeted lock locks, or **All** to fire only after every targeted lock is locked.
-  required: true
+  required: false
 For at least:
   description: How long the lock must stay locked before the trigger fires. Set to zero to fire immediately.
   required: false
@@ -57,7 +57,7 @@ behavior:
   description: >
     When multiple locks are targeted, controls when the trigger fires.
     Accepts `any`, `first`, or `last`.
-  required: true
+  required: false
   type: string
   default: any
 for:

--- a/source/_triggers/lock.opened.markdown
+++ b/source/_triggers/lock.opened.markdown
@@ -9,6 +9,8 @@ related_triggers:
 
 The **Lock opened** trigger helps you react when a lock reports that it is open. Use it when you want Home Assistant to respond to a door that has been opened, like turning on lights, pausing an alarm workflow, or sending a message that an entry point is no longer closed.
 
+{% include integrations/labs_entity_triggers_note.md %}
+
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:

--- a/source/_triggers/lock.opened.markdown
+++ b/source/_triggers/lock.opened.markdown
@@ -32,7 +32,7 @@ Trigger when:
   required: true
 For at least:
   description: How long the lock must stay open before the trigger fires. Set to zero to fire immediately.
-  required: true
+  required: false
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
@@ -64,8 +64,8 @@ for:
   description: >
     How long the lock must stay open before the trigger fires. Accepts a
     duration like `00:00:30` for 30 seconds.
-  required: true
-  type: string
+  required: false
+  type: time
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_triggers/lock.opened.markdown
+++ b/source/_triggers/lock.opened.markdown
@@ -29,7 +29,7 @@ To use this trigger in an automation:
 {% options_ui %}
 Trigger when:
   description: When multiple locks are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted lock opens, **First** to fire only when the first targeted lock opens, or **All** to fire only after every targeted lock is open.
-  required: true
+  required: false
 For at least:
   description: How long the lock must stay open before the trigger fires. Set to zero to fire immediately.
   required: false
@@ -57,7 +57,7 @@ behavior:
   description: >
     When multiple locks are targeted, controls when the trigger fires.
     Accepts `any`, `first`, or `last`.
-  required: true
+  required: false
   type: string
   default: any
 for:

--- a/source/_triggers/lock.opened.markdown
+++ b/source/_triggers/lock.opened.markdown
@@ -117,13 +117,13 @@ automation: |
 
 ### Automation: pause the alarm countdown when the patio door opens
 
-If you use a user-created script to handle alarm entry steps, opening the patio door can start a different response. This automation runs that script when the patio door lock reports open.
+If you have created a script to handle alarm entry steps, opening the patio door can start a different response. This automation runs that script when the patio door lock reports open.
 
 - **Trigger**: Lock opened
 - **Target**: Patio door lock
 - **Trigger when**: Each
 - **For at least**: 00:00:00
-- **Action**: Run a user-created entry script
+- **Action**: Script: Turn on script
 
 {% details "YAML example for running a user-created script" %}
 

--- a/source/_triggers/lock.opened.markdown
+++ b/source/_triggers/lock.opened.markdown
@@ -1,0 +1,148 @@
+---
+title: "Lock opened"
+trigger: lock.opened
+domain: lock
+description: "Triggers after one or more locks open."
+related_triggers:
+  - lock.locked
+---
+
+The **Lock opened** trigger helps you react when a lock reports that it is open. Use it when you want Home Assistant to respond to a door that has been opened, like turning on lights, pausing an alarm workflow, or sending a message that an entry point is no longer closed.
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+5. From the triggers shown for that target, select **Lock opened**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All** to control how the trigger behaves when multiple locks are targeted.
+7. Under **For at least**, set how long the lock must stay open before the trigger fires. Leave it at zero to fire immediately.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple locks are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted lock opens, **First** to fire only when the first targeted lock opens, or **All** to fire only after every targeted lock is open.
+  required: true
+For at least:
+  description: How long the lock must stay open before the trigger fires. Set to zero to fire immediately.
+  required: true
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lock.opened`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lock.opened
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This fires when `lock.front_door` changes to the open state.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple locks are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the lock must stay open before the trigger fires. Accepts a
+    duration like `00:00:30` for 30 seconds.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger fires only when a lock changes into the open state from a known state. If a lock comes back from `unavailable` or `unknown`, that recovery does not fire this trigger.
+- Not every lock reports an open state. Use this trigger only with locks that support open-state reporting.
+- To react when the same door becomes secure again, use [Lock locked](/triggers/lock.locked/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the hall light when the front door opens at night
+
+When you arrive home after dark, it helps if the hallway is already lit. This automation turns on the hall light when the front door lock reports open after sunset.
+
+- **Trigger**: Lock opened
+- **Target**: Front door lock
+- **Trigger when**: Each
+- **For at least**: 00:00:00
+- **Condition**: Sun is below the horizon
+- **Action**: Turn on
+
+{% details "YAML example for lighting the hall when the door opens" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the hall light when the front door opens"
+  triggers:
+    - trigger: lock.opened
+      target:
+        entity_id: lock.front_door
+      options:
+        behavior: any
+        for: "00:00:00"
+  conditions:
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.hall
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: pause the alarm countdown when the patio door opens
+
+If you use a user-created script to handle alarm entry steps, opening the patio door can start a different response. This automation runs that script when the patio door lock reports open.
+
+- **Trigger**: Lock opened
+- **Target**: Patio door lock
+- **Trigger when**: Each
+- **For at least**: 00:00:00
+- **Action**: Run a user-created entry script
+
+{% details "YAML example for running a user-created script" %}
+
+{% example %}
+automation: |
+  alias: "Run the patio entry script when the door opens"
+  triggers:
+    - trigger: lock.opened
+      target:
+        entity_id: lock.patio_door
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: script.patio_entry_sequence
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/lock.unlocked.markdown
+++ b/source/_triggers/lock.unlocked.markdown
@@ -119,7 +119,7 @@ If several storage areas use smart locks, you may want a quick record when one o
 - **Target**: Storage locks (by label)
 - **Trigger when**: Each
 - **For at least**: 00:00:00
-- **Action**: Send a mobile notification
+- **Action**: Send a notification via mobile_app_phone
 
 {% details "YAML example for a storage lock notification" %}
 

--- a/source/_triggers/lock.unlocked.markdown
+++ b/source/_triggers/lock.unlocked.markdown
@@ -29,7 +29,7 @@ To use this trigger in an automation:
 {% options_ui %}
 Trigger when:
   description: When multiple locks are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted lock unlocks, **First** to fire only when the first targeted lock unlocks, or **All** to fire only after every targeted lock is unlocked.
-  required: true
+  required: false
 For at least:
   description: How long the lock must stay unlocked before the trigger fires. Set to zero to fire immediately.
   required: false
@@ -57,7 +57,7 @@ behavior:
   description: >
     When multiple locks are targeted, controls when the trigger fires.
     Accepts `any`, `first`, or `last`.
-  required: true
+  required: false
   type: string
   default: any
 for:

--- a/source/_triggers/lock.unlocked.markdown
+++ b/source/_triggers/lock.unlocked.markdown
@@ -32,7 +32,7 @@ Trigger when:
   required: true
 For at least:
   description: How long the lock must stay unlocked before the trigger fires. Set to zero to fire immediately.
-  required: true
+  required: false
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
@@ -64,8 +64,8 @@ for:
   description: >
     How long the lock must stay unlocked before the trigger fires. Accepts a
     duration like `00:00:10` for 10 seconds.
-  required: true
-  type: string
+  required: false
+  type: time
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_triggers/lock.unlocked.markdown
+++ b/source/_triggers/lock.unlocked.markdown
@@ -1,0 +1,147 @@
+---
+title: "Lock unlocked"
+trigger: lock.unlocked
+domain: lock
+description: "Triggers after one or more locks unlock."
+related_triggers:
+  - lock.locked
+---
+
+The **Lock unlocked** trigger helps you react when a lock reaches the unlocked state. Use it when you want Home Assistant to welcome someone home, keep track of entry events, or adjust security devices after a door is no longer locked.
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your lock is in, like your front door or garage entry. You can also select a floor, a device, a specific entity, or a label.
+5. From the triggers shown for that target, select **Lock unlocked**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All** to control how the trigger behaves when multiple locks are targeted.
+7. Under **For at least**, set how long the lock must stay unlocked before the trigger fires. Leave it at zero to fire immediately.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple locks are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted lock unlocks, **First** to fire only when the first targeted lock unlocks, or **All** to fire only after every targeted lock is unlocked.
+  required: true
+For at least:
+  description: How long the lock must stay unlocked before the trigger fires. Set to zero to fire immediately.
+  required: true
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lock.unlocked`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lock.unlocked
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This fires when `lock.front_door` changes to the unlocked state.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple locks are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the lock must stay unlocked before the trigger fires. Accepts a
+    duration like `00:00:10` for 10 seconds.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger fires only when a lock changes into the unlocked state from a known state. If a lock comes back from `unavailable` or `unknown`, that recovery does not fire this trigger.
+- Use **For at least** if you want to ignore very brief unlock events.
+- To react when the door is secured again, use [Lock locked](/triggers/lock.locked/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the hallway light when the front door unlocks
+
+If you often arrive home with your hands full, it helps when the light is already on. This automation turns on the hallway light when the front door unlocks.
+
+- **Trigger**: Lock unlocked
+- **Target**: Front door lock
+- **Trigger when**: Each
+- **For at least**: 00:00:00
+- **Action**: Turn on
+
+{% details "YAML example for turning on the hallway light" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the hallway light when the front door unlocks"
+  triggers:
+    - trigger: lock.unlocked
+      target:
+        entity_id: lock.front_door
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.hallway
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a message when any storage door lock unlocks
+
+If several storage areas use smart locks, you may want a quick record when one of them is unlocked. This automation sends a phone notification when any targeted storage lock unlocks.
+
+- **Trigger**: Lock unlocked
+- **Target**: Storage locks (by label)
+- **Trigger when**: Each
+- **For at least**: 00:00:00
+- **Action**: Send a mobile notification
+
+{% details "YAML example for a storage lock notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when a storage lock unlocks"
+  triggers:
+    - trigger: lock.unlocked
+      target:
+        label_id: storage_locks
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: notify.mobile_app_phone
+      data:
+        title: "Storage door unlocked"
+        message: "One of the storage door locks has been unlocked."
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/lock.unlocked.markdown
+++ b/source/_triggers/lock.unlocked.markdown
@@ -9,6 +9,8 @@ related_triggers:
 
 The **Lock unlocked** trigger helps you react when a lock reaches the unlocked state. Use it when you want Home Assistant to welcome someone home, keep track of entry events, or adjust security devices after a door is no longer locked.
 
+{% include integrations/labs_entity_triggers_note.md %}
+
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:


### PR DESCRIPTION
## Proposed change

Document new triggers and conditions, and migrate actions for [Lock](https://www.home-assistant.io/integrations/lock/), to follow current style.

Previews:

- [Lock](https://deploy-preview-45216--home-assistant-docs.netlify.app/integrations/lock/)
- Triggers:
  - [Lock jammed](https://deploy-preview-45216--home-assistant-docs.netlify.app/triggers/lock.jammed/)
  - [Lock locked](https://deploy-preview-45216--home-assistant-docs.netlify.app/triggers/lock.locked/)
  - [Lock opened](https://deploy-preview-45216--home-assistant-docs.netlify.app/triggers/lock.opened/)
  - [Lock unlocked](https://deploy-preview-45216--home-assistant-docs.netlify.app/triggers/lock.unlocked/)
- Conditions:
  - [Lock is jammed](https://deploy-preview-45216--home-assistant-docs.netlify.app/conditions/lock.is_jammed/)
  - [Lock is locked](https://deploy-preview-45216--home-assistant-docs.netlify.app/conditions/lock.is_locked/)
  - [Lock is open](https://deploy-preview-45216--home-assistant-docs.netlify.app/conditions/lock.is_open/)
  - [Lock is unlocked](https://deploy-preview-45216--home-assistant-docs.netlify.app/conditions/lock.is_unlocked/)
- Actions:
  - [Lock](https://deploy-preview-45216--home-assistant-docs.netlify.app/actions/lock.lock/)
  - [Open](https://deploy-preview-45216--home-assistant-docs.netlify.app/actions/lock.open/)
  - [Unlock](https://deploy-preview-45216--home-assistant-docs.netlify.app/actions/lock.unlock/)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/44922

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
