### PR TITLE
Clarify Duco fan behavior and examples

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -156,7 +156,7 @@ Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in
 
 ## Examples
 
-The example entity IDs below use the default naming that Home Assistant assigns on a clean install. Replace them with the entity IDs from your own system.
+The example entity IDs below use the default naming that Home Assistant assigns on a new Home Assistant installation. Replace them with the entity IDs from your own system.
 
 ### Activate high ventilation while cooking
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -82,14 +82,14 @@ The Duco system consists of multiple nodes. Each node appears as a separate devi
 
 The fan entity lets you control the ventilation speed of a node. You can set the speed as a percentage or switch back to automatic mode.
 
-The fan is always on. Setting the speed to 0% returns control to Duco (automatic mode), after which the firmware automatically resumes ventilation.
+The fan is always on. Turning off the fan is not supported.
 
-The following actions are available:
+Setting a speed percentage to 33%, 66%, or 100% activates a continuous override with no time limit. Setting it to 0% clears the override and hands control back to Duco:
 
-- **Speed 0%**: Hands control back to Duco (automatic mode).
-- **Speed 33%**: Low speed manual override.
-- **Speed 66%**: Medium speed manual override.
-- **Speed 100%**: High speed manual override.
+- **Speed 0%**: Clears the override and returns to automatic mode.
+- **Speed 33%**: Continuous low speed override.
+- **Speed 66%**: Continuous medium speed override.
+- **Speed 100%**: Continuous high speed override.
 - **Auto preset**: Same as speed 0%; hands control back to Duco.
 
 When a connected wall unit (such as a UCCO2) triggers a timed speed override on the Duco box, Home Assistant reflects the current ventilation level as a percentage. These timed states cannot be set from Home Assistant; writing a speed always uses the permanent manual mode (a continuous override with no time limit).
@@ -156,6 +156,8 @@ Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in
 
 ## Examples
 
+The example entity IDs below use the default naming that Home Assistant assigns on a clean install. Replace them with the entity IDs from your own system.
+
 ### Activate high ventilation while cooking
 
 This automation switches the ventilation to high speed when the kitchen hood is turned on, and returns it to automatic mode five minutes after the hood is switched off.
@@ -169,7 +171,7 @@ This automation switches the ventilation to high speed when the kitchen hood is 
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.node_1
       data:
         percentage: 100
 
@@ -182,7 +184,7 @@ This automation switches the ventilation to high speed when the kitchen hood is 
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.node_1
       data:
         percentage: 0
 ```
@@ -200,7 +202,7 @@ When the last person leaves home, the ventilation hands control back to Duco (au
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.node_1
       data:
         percentage: 0
 
@@ -212,37 +214,67 @@ When the last person leaves home, the ventilation hands control back to Duco (au
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.node_1
       data:
         percentage: 66
 ```
 
 ### Boost ventilation when CO₂ is high
 
-This automation switches to high speed when the CO₂ level in the office rises above 1000 ppm, and returns to automatic mode when it drops back below 800 ppm.
+This automation switches to high speed when the CO₂ level rises above 1000 ppm on a UCCO2 sensor module, and returns to automatic mode when it drops back below 800 ppm.
 
 ```yaml
 - alias: "Boost ventilation on high CO2"
   triggers:
     - trigger: numeric_state
-      entity_id: sensor.office_co2_carbon_dioxide
+      entity_id: sensor.node_2_carbon_dioxide
       above: 1000
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.node_1
       data:
         percentage: 100
 
 - alias: "Return to auto when CO2 is low"
   triggers:
     - trigger: numeric_state
-      entity_id: sensor.office_co2_carbon_dioxide
+      entity_id: sensor.node_2_carbon_dioxide
       below: 800
   actions:
     - action: fan.set_percentage
       target:
-        entity_id: fan.living_ventilation
+        entity_id: fan.node_1
+      data:
+        percentage: 0
+```
+
+### Boost ventilation when humidity is high
+
+This automation switches to medium speed when relative humidity rises above 70% on a UCRH or BSRH sensor module, and returns to automatic mode when it drops back below 60%.
+
+```yaml
+- alias: "Boost ventilation on high humidity"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.node_113_humidity
+      above: 70
+  actions:
+    - action: fan.set_percentage
+      target:
+        entity_id: fan.node_1
+      data:
+        percentage: 66
+
+- alias: "Return to auto when humidity is normal"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.node_113_humidity
+      below: 60
+  actions:
+    - action: fan.set_percentage
+      target:
+        entity_id: fan.node_1
       data:
         percentage: 0
 ```

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -90,7 +90,7 @@ Setting a speed percentage to 33%, 66%, or 100% activates a continuous override 
 - **Speed 33%**: Continuous low speed override.
 - **Speed 66%**: Continuous medium speed override.
 - **Speed 100%**: Continuous high speed override.
-- **Auto preset**: Same as speed 0%; hands control back to Duco.
+- **Auto preset**: Same as speed 0%. Clears the override and returns to automatic mode.
 
 When a connected wall unit (such as a UCCO2) triggers a timed speed override on the Duco box, Home Assistant reflects the current ventilation level as a percentage. These timed states cannot be set from Home Assistant; writing a speed always uses the permanent manual mode (a continuous override with no time limit).
 


### PR DESCRIPTION
> [!NOTE]
> These changes were originally submitted against the `next` branch in https://github.com/home-assistant/home-assistant.io/pull/45170, because the `current` branch did not yet exist at the time of submission. Now that `current` is available, the same changes are being applied here as well. We would appreciate it if these could be merged into `current` as soon as possible.

## Proposed change

Clarify a few documentation details for the initial Duco integration release.

- Clarify that the fan is always on and cannot be turned off from Home Assistant.
- Clarify that setting the speed to `0%` clears the override and returns control to Duco.
- Clarify that `33%`, `66%`, and `100%` represent continuous overrides.
- Update the examples to use the default entity naming from a clean install.
- Update the CO2 example to use a Duco sensor module entity.
- Add a humidity-based automation example.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167220
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards