### PR TITLE
Humidity: add cross-references

### DIFF
--- a/source/_conditions/humidity.is_value.markdown
+++ b/source/_conditions/humidity.is_value.markdown
@@ -35,7 +35,7 @@ Threshold type:
     The humidity level the entity has to meet for the condition to pass. You can enter a fixed percentage between 0 and 100 (select **Number**), or pick an entity as a dynamic threshold (select **Entity**). When you pick an `input_number` or `number` helper, you can change the threshold without editing the automation. When you pick a humidity sensor, its live reading becomes the threshold, which is useful for comparing two humidity values, for example indoor versus outdoor. In both cases, also pick whether the reading must be above, below, or within a range of that value.
   required: true
 Condition passes if:
-  description: When multiple entities are targeted, controls how results combine. Pick **Any** to pass if at least one targeted entity meets the threshold, or **All** to pass only when every targeted entity does.
+  description: When multiple entities are targeted, controls how results combine. Pick **Any** to pass if at least one targeted entity meets the threshold, or **All** to pass only when every targeted entity does. Default is **Any**.
   required: true
 {% endoptions_ui %}
 
@@ -114,6 +114,7 @@ behavior:
 - Humidity is expressed as a percentage. Indoor comfort is generally between 40% and 60%. Below 30% often feels dry and can irritate airways. Above 65% can encourage mold and dust mites.
 - This condition checks the entity's _current_ humidity reading, not its target setpoint. To check a humidifier's target setpoint instead, use the [Humidifier target humidity](/conditions/humidifier.is_target_humidity/) condition.
 - When you use a sensor as a dynamic threshold, its value is read at the moment the condition runs. The threshold is not continuously tracked; it is re-evaluated each time the automation fires.
+- Pair with [Relative humidity crossed threshold](/triggers/humidity.crossed_threshold/) as a matching trigger when you need the automation to run the moment humidity crosses a specific level.
 
 {% include conditions/try_it.md %}
 

--- a/source/_integrations/humidity.markdown
+++ b/source/_integrations/humidity.markdown
@@ -1,6 +1,6 @@
 ---
 title: Humidity
-description: This integration provides humidity automation triggers.
+description: This integration provides humidity automation triggers and conditions.
 ha_category:
   - Automation
 ha_release: 2026.4
@@ -9,6 +9,13 @@ ha_codeowners:
   - '@home-assistant/core'
 ha_domain: humidity
 ha_integration_type: system
+related:
+  - docs: /integrations/humidifier/
+    title: Humidifier
+  - docs: /integrations/climate/
+    title: Climate
+  - docs: /integrations/weather/
+    title: Weather
 ---
 
 This {% term integration %} provides automation triggers and conditions for climate, humidifier, and weather entities, as well as sensors with device class humidity. There are no configuration options for this integration.

--- a/source/_triggers/humidity.changed.markdown
+++ b/source/_triggers/humidity.changed.markdown
@@ -117,6 +117,7 @@ threshold:
 - The threshold type controls both the direction and the landing zone of the change. Use **Above** or **Below** to filter by direction, **In range** to fire only when the new value is inside a range, and **Outside range** to fire only when it escapes a range.
 - Use **Any change** to fire on every change regardless of direction or where the new value lands.
 - To react only when humidity first crosses a specific level, use [Relative humidity crossed threshold](/triggers/humidity.crossed_threshold/) instead.
+- Pair this trigger with [Relative humidity](/conditions/humidity.is_value/) in follow-up conditions to verify the reading meets a threshold before continuing the automation.
 - The trigger works with climate entities, humidifier entities, weather entities, and sensors with the humidity device class.
 
 {% include triggers/try_it.md %}

--- a/source/_triggers/humidity.crossed_threshold.markdown
+++ b/source/_triggers/humidity.crossed_threshold.markdown
@@ -138,6 +138,7 @@ for:
 - **In range** (`between`) fires when the reading moves from outside the bounds into the bounds. **Outside range** (`outside`) fires when the reading moves from inside the bounds past either bound.
 - A comfortable indoor humidity range is typically 40% to 60%. Use **Outside range** with those bounds to fire the moment conditions drift out of that comfort zone.
 - Pair this trigger with [Relative humidity changed](/triggers/humidity.changed/) if you also want to react to smaller fluctuations between crossings.
+- Pair this trigger with [Relative humidity](/conditions/humidity.is_value/) in follow-up conditions to double-check the final state.
 - The trigger works with climate entities, humidifier entities, weather entities, and sensors with the humidity device class.
 
 {% include triggers/try_it.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
