### PR TITLE
Remove MQTT entry from the docs sitemap aside

### DIFF
--- a/source/_includes/asides/docs_sitemap.html
+++ b/source/_includes/asides/docs_sitemap.html
@@ -281,21 +281,6 @@
 </li>
 
 <li>
-  {% icon "simple-icons:mqtt" %} {% active_link /integrations/mqtt MQTT %}
-  {% if doc == 'mqtt' or include.docs_index %}
-  <ul>
-    <li>{% active_link /integrations/mqtt/#broker-configuration Broker %}</li>
-    <li>{% active_link /integrations/mqtt/#advanced-broker-configuration Certificate %}</li>
-    <li>{% active_link /integrations/mqtt/#mqtt-discovery Discovery %}</li>
-    <li>{% active_link /integrations/mqtt/#publish--dump-actions Publish action %}</li>
-    <li>{% active_link /integrations/mqtt/#birth-and-last-will-messages Birth and last will messages %}</li>
-    <li>{% active_link /integrations/mqtt/#testing-your-setup Testing your setup %}</li>
-    <li>{% active_link /integrations/mqtt/#logging Logging %}</li>
-  </ul>
-  {% endif %}
-</li>
-
-<li>
   {% icon "bitcoin-icons:node-hardware-filled" %} Official hardware
   <ul>
     <li><a href="https://support.nabucasa.com/hc/categories/24638797677853">Home Assistant Green</a></li>


### PR DESCRIPTION
## Proposed change

Removes the top-level MQTT entry from the docs sitemap aside. MQTT is an integration and is already covered through the integrations index, so it does not need a dedicated entry alongside top-level documentation sections like the companion app or official hardware.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
