### PR TITLE
Remove stale FAQ about Raspberry Pi 4 8GB support

### DIFF
--- a/source/_faq/rpi4_8gb.markdown
+++ b/source/_faq/rpi4_8gb.markdown
@@ -1,6 +1,0 @@
----
-title: "Is the Raspberry Pi 4 with 8GB RAM supported?"
-ha_category: Home Assistant
----
-
-The Raspberry Pi 4 with 8GB RAM is supported with Home Assistant OS 5.5 and later using the 32-bit and 64-bit image. The 64-bit is the better tested option at this point.


### PR DESCRIPTION
## Proposed change

Removes the FAQ page about Raspberry Pi 4 8GB support. Home Assistant OS 5.5 was released years ago, the 32-bit images are no longer relevant, and the Raspberry Pi 4 with 8GB RAM has been a routinely supported board for a long time. The page no longer provides useful guidance.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
