### PR TITLE
Rework the missing-documentation FAQ

### DIFF
--- a/source/_faq/missing-documentation.markdown
+++ b/source/_faq/missing-documentation.markdown
@@ -1,9 +1,13 @@
 ---
-title: "Missing Documentation"
-description: "The documentation is missing or outdated"
+title: "The documentation is missing or out of date"
+description: "Good documentation matters to us. We are actively investing in making it more approachable, complete, and helpful for every type of user, but the documentation is large and improving it takes time."
 ha_category: Documentation
 ---
 
-Home Assistant is a FAST moving open source project. This means occasionally the official documentation will not be 100% current or complete. Since this is an open source volunteer project, we would encourage anyone who finds gaps in the documentation to select the `EDIT` link at the bottom and submit any corrections/enhancements they may find useful. A step-by-step guide on how to contribute to the documentation can be found [here](https://community.home-assistant.io/t/9573).
+Good documentation matters to us. Home Assistant has well over a thousand {% term integrations %}, ships a new release every month, and is used by people with very different backgrounds. We are actively investing in making the documentation more approachable, more complete, and more useful for everyone, from someone setting up their very first smart home to a long-time enthusiast.
 
-In the absence of information, many users find it beneficial to look at other people's configurations to find examples of what they want to accomplish in their own configurations. The easiest way to find these configurations is through this [GitHub search](https://github.com/search?q=topic%3Ahome-assistant-config&type=Repositories).
+That said, the documentation is huge, and rewriting and modernizing all of it is not something that can be done in a day or two. You may still come across pages that are out of date, incomplete, or written more for developers than for end users. We are working through them.
+
+If you spot something that is wrong or unclear, please tell us. Every page has a **Provide feedback** button at the bottom. Selecting it lets you describe what is missing or wrong, and the page address and Home Assistant version are filled in for you. Even short notes help us a lot, because we cannot fix what we do not know about.
+
+If you would like to go a step further and propose the actual change yourself, every page also has an **Edit this page on GitHub** link at the bottom that opens the source of that page directly, so you can suggest a fix as a pull request. A step-by-step guide is available on the [Home Assistant community forum](https://community.home-assistant.io/t/9573).

--- a/source/_faq/missing-documentation.markdown
+++ b/source/_faq/missing-documentation.markdown
@@ -8,6 +8,6 @@ Good documentation matters to us. Home Assistant has well over a thousand {% ter
 
 That said, the documentation is huge, and rewriting and modernizing all of it is not something that can be done in a day or two. You may still come across pages that are out of date, incomplete, or written more for developers than for end users. We are working through them.
 
-If you spot something that is wrong or unclear, please tell us. Every page has a **Provide feedback** button at the bottom. Selecting it lets you describe what is missing or wrong, and the page address and Home Assistant version are filled in for you. Even short notes help us a lot, because we cannot fix what we do not know about.
+If you spot something that is wrong or unclear, please tell us. Most documentation pages have a **Provide feedback** button at the bottom. Selecting it lets you describe what is missing or wrong, and the page address and Home Assistant version are filled in for you. Even short notes help us a lot, because we cannot fix what we do not know about.
 
-If you would like to go a step further and propose the actual change yourself, every page also has an **Edit this page on GitHub** link at the bottom that opens the source of that page directly, so you can suggest a fix as a pull request. A step-by-step guide is available on the [Home Assistant community forum](https://community.home-assistant.io/t/9573).
+If you would like to go a step further and propose the actual change yourself, every page also has an **Edit** link at the bottom that opens the source of that page directly on GitHub, so you can suggest a fix as a pull request. A step-by-step guide is available on the [Home Assistant community forum](https://community.home-assistant.io/t/9573).


### PR DESCRIPTION
## Proposed change

Rewrites the "Missing documentation" FAQ to better reflect how the documentation is maintained today and how readers can actually help.

The previous version was a short, slightly defensive note about Home Assistant being a "FAST moving" project, with a single link to a community forum guide for contributors and a tip to search GitHub for other people's configurations. It did not mention the in-page feedback or edit links that every documentation page now has, which are by far the easiest way for readers to flag issues.

The new version:

- Acknowledges the scale of the documentation (over a thousand integrations, monthly releases, very mixed audience) and that improving all of it takes time.
- Points readers to the **Provide feedback** button at the bottom of every page as the primary, low-effort way to report issues.
- Points readers who want to fix things directly at the **Edit this page on GitHub** link, with the existing community guide as a follow-up.
- Drops the "search GitHub for other people's configs" tip, which no longer fits how most users build their setup.

The page title and description are also updated to match the question users actually ask and to give a more useful meta description for search results.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
