### PR TITLE
Refresh older FAQ entries with clearer titles, structure, and modern terminology

### DIFF
--- a/source/_faq/404.markdown
+++ b/source/_faq/404.markdown
@@ -1,13 +1,15 @@
 ---
 title: "404 Client Error: Not Found ('no such image: homeassistant/...)"
+description: "This error means an update or app could not be downloaded. It is almost always caused by not having enough free disk space, or by a temporary network problem."
 ha_category: Home Assistant
 ---
 
-This error indicates the image, whether for updating to Home Assistant or installing or updating an app, was not able to be pulled to your system. This is usually a situation where there is not enough space for the image to be downloaded. The first thing to check for is the available space on your system.
+This error means an update or {% term app %} could not be downloaded to your system. In almost every case, this is because there is not enough free disk space.
 
-Please note, if you are running the operating system as a virtual machine; the default VM image is only about 6GB. Many VM users run into this as they have not allocated enough storage. 32GB is the minimum recommended size.
+A few things to check:
 
-You will need to explore your own system to determine where space has gone.
-Using `df -h` in the SSH app console you can quickly check to see if you have space available.
+- **Free disk space**. Go to {% my system_dashboard title="**Settings** > **System**" %} and look at the storage information. If your system is nearly full, you will need to free up space, or move to larger storage.
+- **Virtual machine disk size**. The default Home Assistant virtual machine image is around 6 GB, which is fine to get started but quickly becomes too small. We recommend at least 32 GB.
+- **Network connection**. If your system has plenty of space, the download may have failed due to a temporary network problem. Wait a few minutes and try again.
 
-If there is plenty of space available then you might check to see if you are having network issues that are preventing images from being downloaded.
+If the issue keeps happening, share the full error from {% my logs title="**Settings** > **System** > **Logs**" %} when [asking for help](/help/).

--- a/source/_faq/addon_not_starting.markdown
+++ b/source/_faq/addon_not_starting.markdown
@@ -1,8 +1,9 @@
 ---
-title: "Why does the start button for an app flash red when I click it?"
+title: "Why does the start button for an app flash red when I select it?"
+description: "A red flash means the app failed to start or install. The reason is in the logs."
 ha_category: Home Assistant
 ---
 
-If you are looking for more information about apps, which won't start or install, go to {% my supervisor_logs title="**Settings** > **System** > **Logs**" %} in the UI and check the logs.
+A red flash on the start button means the {% term app %} failed to start or install. The reason is in the logs.
 
-The logs on this page are the same you would see using `su logs` in the custom CLI.
+Go to {% my supervisor_logs title="**Settings** > **System** > **Logs**" %} and select the relevant app from the dropdown to see why it failed to start. Common causes include a port that is already in use, missing configuration, or a hardware device that is not available.

--- a/source/_faq/after-upgrading.markdown
+++ b/source/_faq/after-upgrading.markdown
@@ -1,11 +1,9 @@
 ---
-title: "After upgrading, your browser login gets stuck"
-description: "After upgrading, your browser login gets stuck"
+title: "After updating, my browser login gets stuck"
+description: "In rare cases, an old browser cache can prevent the login page from loading after a Home Assistant update. Refreshing or clearing the cache fixes it."
 ha_category: Usage
 ---
 
-After upgrading to a new version, you may notice your browser gets stuck at the "loading data" login screen. Close the window/tab and go into your browser settings and delete all the cookies for your URL. You can then log back in and it should work.
+In rare cases, an old browser cache can prevent the login page from loading after a Home Assistant update. The fix is the same as for any other caching issue: refresh the page or clear the cache for Home Assistant.
 
-Android Chrome:
-
-chrome -> settings -> site settings -> storage -> search for your URL for Home Assistant-> "clear & reset"
+For step-by-step instructions, see [The Home Assistant user interface is acting weird](/faq/#the-home-assistant-user-interface-is-acting-weird).

--- a/source/_faq/browser.markdown
+++ b/source/_faq/browser.markdown
@@ -8,7 +8,7 @@ If buttons, cards, or whole pages start to look or behave strangely, it is almos
 
 This typically happens after:
 
-- Installing, updating, or removing a custom card or custom {% term dashboard %} element from outside the official integration store, such as through HACS.
+- Installing, updating, or removing a custom card or custom dashboard element from outside the official integration store, such as through HACS.
 - In rare cases, after a Home Assistant update.
 
 To fix it:

--- a/source/_faq/browser.markdown
+++ b/source/_faq/browser.markdown
@@ -1,7 +1,33 @@
 ---
-title: "Frontend is acting weird"
-description: "Frontend is acting weird"
+title: "The Home Assistant user interface is acting weird"
+description: "If buttons, cards, or whole pages start to look or behave strangely after an update, it is almost always a caching issue in your browser or app. Refreshing usually fixes it."
 ha_category: Usage
 ---
 
-Close the windows or tab and clear the cache. The frontend is aggressively caching and clearing the cache ensures that the frontend is reloaded when you access it the next time.
+If buttons, cards, or whole pages start to look or behave strangely, it is almost always a caching issue. The Home Assistant user interface caches a lot of things in your browser to make it fast, and sometimes that cache gets out of sync with what is actually running on your Home Assistant.
+
+This typically happens after:
+
+- Installing, updating, or removing a custom card or custom {% term dashboard %} element from outside the official integration store, such as through HACS.
+- In rare cases, after a Home Assistant update.
+
+To fix it:
+
+1. Close all browser tabs and Home Assistant app windows that have Home Assistant open.
+2. Open Home Assistant again. In most cases, this is enough.
+3. If the issue is still there, do a hard refresh of the page, or clear your browser cache for Home Assistant, and try again.
+
+A hard refresh reloads the page while bypassing the cache:
+
+- On Windows and Linux, press `Ctrl` + `F5` or `Ctrl` + `Shift` + `R`.
+- On macOS, press `Cmd` + `Shift` + `R`.
+- On the Home Assistant Companion app for Android or iOS, pull down on the page to refresh.
+
+If a hard refresh is not enough, you can clear the browser cache for Home Assistant specifically:
+
+- **Chrome, Edge, or Brave**: Open Home Assistant, then press `F12` to open the developer tools. Right-click the refresh button in the browser toolbar and select **Empty cache and hard reload**.
+- **Firefox**: Open the menu, go to **Settings** > **Privacy & Security** > **Cookies and Site Data** > **Manage Data**, search for your Home Assistant address, select it, and select **Remove Selected**.
+- **Safari**: Open **Safari** > **Settings** > **Privacy** > **Manage Website Data**, search for your Home Assistant address, select it, and select **Remove**.
+- **Home Assistant Companion app**: Go to **Settings** in the app and select **Reset frontend cache**.
+
+If a specific custom card is the cause, removing or updating that card will resolve it.

--- a/source/_faq/component.markdown
+++ b/source/_faq/component.markdown
@@ -1,12 +1,14 @@
 ---
 title: "My integration does not show up"
-description: "My integration does not show up"
+description: "If an integration you set up does not appear in Home Assistant, the reason is almost always in the logs."
 ha_category: Configuration
 ---
 
-When an integration does not show up, many different things can be the case. Before you try any of these steps, make sure to look at the [the logs](/integrations/logger/#viewing-logs) and see if there are any errors related to your integration you are trying to set up.
+If an {% term integration %} you set up does not appear in Home Assistant, the reason is almost always in the logs. Go to {% my logs title="**Settings** > **System** > **Logs**" %} and look for errors that mention the integration.
 
-If you have incorrect entries in your configuration files you can use the CLI script to check your configuration, each installation type has its own section in the common-tasks about this:
+If you configured the integration through {% term "`configuration.yaml`" %} and the YAML file has a mistake, Home Assistant will refuse to load the affected parts. You can check your configuration before restarting:
 
 - [Operating System](/common-tasks/os/#configuration-check)
 - [Container](/common-tasks/container/#configuration-check)
+
+Most integrations are set up through the user interface and do not require any YAML at all. See [Do I need to learn YAML to use Home Assistant?](/faq/#do-i-need-to-learn-yaml-to-use-home-assistant) for more on when YAML is and is not needed.

--- a/source/_faq/connection-error.markdown
+++ b/source/_faq/connection-error.markdown
@@ -1,13 +1,19 @@
 ---
 title: "Connection error"
-description: "Connection error"
+description: "A connection error in the logs almost always means a device, service, or network on your side is unreachable, not a bug in Home Assistant."
 ha_category: Usage
 ---
 
-It can happen that you get a traceback that notify you about connection issues while running Home Assistant. Eg.
+A connection error in the logs almost always means a device, service, or network on your side is unreachable, not a bug in Home Assistant. For example:
 
-```bash
+```text
 ConnectionRefusedError: [Errno 111] Connection refused
 ```
 
-The chance is very high that this is not a bug but an issue with the service/daemon itself. Check your network (DNS, DHCP, uplink, etc.) first and make sure that Home Assistant and the service are properly configured. Keep in mind that webservices can be down.
+A few things to check:
+
+- The device or service that the {% term integration %} talks to is powered on and reachable on your network.
+- Your network is healthy. Routers, DNS, or DHCP problems can take services offline.
+- For cloud services, check the provider's status page. The internet service may be temporarily down.
+
+If the error mentions a specific integration, the integration page often has a troubleshooting section with more focused advice.

--- a/source/_faq/documentation-tool.markdown
+++ b/source/_faq/documentation-tool.markdown
@@ -1,8 +1,9 @@
 ---
-title: "Documentation tools"
-description: "Tools for creating the documentation"
+title: "What tools do you use to build the documentation?"
+description: "The Home Assistant website is a Jekyll site written in Markdown, hosted on GitHub, and deployed by Netlify."
 ha_category: Documentation
 ---
 
+The Home Assistant website is a [Jekyll](https://jekyllrb.com/) site. The pages are written in Markdown with some Liquid templating, the source is hosted on [GitHub](https://github.com/home-assistant/home-assistant.io), and the site is built and deployed by [Netlify](https://www.netlify.com/).
 
-Why are you not using tools X for the documentation? Because the current solution works for us and we see no additional value in using a separate publishing platform.
+This setup works well for an open-source project: every page has an **Edit this page on GitHub** link, so anyone can suggest changes through a pull request without needing to learn a separate publishing platform.

--- a/source/_faq/ha-vs-hassio.markdown
+++ b/source/_faq/ha-vs-hassio.markdown
@@ -1,13 +1,19 @@
 ---
-title: "Home Assistant vs. Home Assistant Core"
-description: "Home Assistant vs. Home Assistant Core"
+title: "What is the difference between Home Assistant Operating System and Home Assistant Container?"
+description: "Home Assistant Operating System is the recommended, all-in-one installation method. Home Assistant Container is for people who already run Docker on their own Linux system and want to manage it themselves."
 ha_category: Installation
 ---
 
-Home Assistant Core is a Python program, in simple words. It can be run on various operating systems and provide the ability to track, control and automate your devices.
-When people talking about Home Assistant Core they usually refer to a standalone [installation type](/docs/installation/).
+Home Assistant offers two installation methods: {% term "Home Assistant Operating System" %} and {% term "Home Assistant Container" %}. Both run the same Home Assistant software, so the choice is mostly about how much of the underlying system you want to manage yourself.
 
-[Home Assistant](/hassio/) is a combination of Home Assistant Core and tools which allows one to run it easily on a Raspberry Pi and other platforms without setting up an operating system first.
-Home Assistant is an all-in one-solution and has a management user interface that can be used from the Home Assistant frontend. This interface is not present in a Home Assistant Core setup.
+[Home Assistant Operating System](/installation/#about-installation-methods) is the recommended installation method for almost everyone. It is an all-in-one solution that includes the operating system, Home Assistant itself, and a management user interface. It supports {% term apps %}, takes care of upgrading everything for you, and powers official hardware like [Home Assistant Green](/green/) and [Home Assistant Yellow](/yellow/).
 
-Be aware that apps are only available in regular Home Assistant installations.
+[Home Assistant Container](/installation/alternative/) runs Home Assistant as a Docker container on a Linux system you provide and maintain yourself. It is intended for people who already run Docker and want to integrate Home Assistant with their existing setup. Home Assistant Container does not support apps, and you are responsible for updates and the host operating system.
+
+You may still see references to "Home Assistant Core" or "Home Assistant Supervised" in older articles. These were earlier installation methods that are no longer offered or supported. Today's recommended path is Home Assistant Operating System.
+
+Learn more:
+
+- [About installation methods](/installation/#about-installation-methods)
+- [Home Assistant Green](/green/)
+- [Home Assistant Yellow](/yellow/)

--- a/source/_faq/unique_id.markdown
+++ b/source/_faq/unique_id.markdown
@@ -1,29 +1,29 @@
 ---
-title: "This entity does not have a unique ID?"
-description: "This entity does not have a unique ID?"
+title: "Why doesn't this entity have a unique ID?"
+description: "A unique ID is a permanent identifier (such as a serial number) that some entities don't have. Without one, you can't rename the entity from the UI."
 ha_category: Configuration
 ---
 
-If you try to access the configuration dialog for an entity in your Home Assistant, you might end up seeing this message:
+When you open the configuration dialog of an {% term entity %}, you may see this message:
 
 ![Screenshot of popup for no unique ID](/images/faq/faq_no_unique_id.jpg)
 
-This means that this entity does not have a unique identification, e.g., a serial number or another identifier that is guaranteed to be static and never changes. As a result, the normal editing process that allows you to change various settings through the user interface (such as the entity ID, icon, friendly name, etc.) is not possible here.
+A unique ID is a permanent identifier (for example, a serial number) that is guaranteed never to change. Without one, Home Assistant cannot safely let you rename the entity or change its settings from the user interface, because there would be no reliable way to track which entity you meant.
 
-Typically, you'll see this when you create entities manually using YAML, but it can also appear if the integration that provides this entity cannot determine a unique ID. This is not an error, but rather a limitation of the integration you use. A few selected integrations (such as [`template`](/integrations/template/) and [`mqtt`](/integrations/mqtt/)) allow you to define a unique ID.
+You will typically see this on entities you created manually in YAML, or on entities from an {% term integration %} that has no way to determine a unique ID for the underlying device. This is not an error, but a limitation of the integration. A few integrations (such as [`template`](/integrations/template/) and [`mqtt`](/integrations/mqtt/)) let you define a unique ID yourself in YAML.
 
-### Used where?
+### Where each ID is used
 
 **Unique ID:**
 
-- Only internally in Home Assistant.
+- Used only internally in Home Assistant.
 
 **Entity ID:**
 
-- Entity with a unique ID: Entity ID only used as a reference, e.g., in automations or dashboards.
-- Entity without a unique ID: Entity ID acts as the replacement for the non-existing unique ID plus as a reference, e.g., in automations or dashboards.
+- Entity with a unique ID: the entity ID is only used as a reference, for example in automations or dashboards.
+- Entity without a unique ID: the entity ID acts as the replacement for the missing unique ID, _and_ as the reference in automations or dashboards.
 
-### Can be changed?
+### Can the IDs be changed?
 
 **Unique ID:**
 
@@ -31,17 +31,13 @@ Typically, you'll see this when you create entities manually using YAML, but it 
 
 **Entity ID:**
 
-- Entity with a unique ID: Entity ID can be adjusted freely (as long as it follows the format `<domain>.<id>` and does not result in duplicates in your Home Assistant). Keep in mind that if you change the entity ID, you also need to update the references, e.g., in automations and dashboards.<br>
-- Entity without a unique ID: Entity ID is considered a fixed, static identifier and cannot be changed.
+- Entity with a unique ID: the entity ID can be changed freely, as long as it follows the format `<domain>.<id>` and does not collide with another entity. If you change the entity ID, remember to update the references in automations and dashboards.
+- Entity without a unique ID: the entity ID is treated as a fixed identifier and cannot be changed.
 
-In case your entity has no unique ID and therefore cannot be changed through the UI, there are some [manual customization options](/docs/configuration/customizing-devices) directly through YAML files.
+If your entity has no unique ID, you can still adjust some properties through the [manual customization options](/docs/configuration/customizing-devices) in YAML.
 
 ### Can I add a unique ID myself?
 
-No, as an end-user, you cannot add a unique ID to an entity that doesn't have one. Unique IDs are a feature that must be provided by the integration itself. This is because the unique ID needs to be persistent across restarts and should consistently identify the same physical device or service.
+No. As an end user, you cannot add a unique ID to an entity that does not have one. Unique IDs must come from the integration itself, because they need to consistently identify the same physical device or service across restarts.
 
-If an integration currently doesn't provide unique IDs for its entities, this means the integration could potentially be modernized to include this capability. However, providing unique IDs is not currently a mandatory requirement for all integrations.
-
-The Home Assistant project always welcomes code contributions to enhance integrations with this capability. If you're interested in improving an integration to provide unique IDs, you can contribute code to the Home Assistant project. For more information on contributing, please visit the [developer documentation](https://developers.home-assistant.io/docs/development_index).
-
-In case you want to read more about unique IDs, head over to this [developer documentation page](https://developers.home-assistant.io/docs/entity_registry_index/).
+If an integration does not provide unique IDs, it could potentially be improved to do so. Contributions are welcome. See the [developer documentation](https://developers.home-assistant.io/docs/development_index) to get started, and the [entity registry documentation](https://developers.home-assistant.io/docs/entity_registry_index/) for more on unique IDs.

--- a/source/_faq/usb_boot.markdown
+++ b/source/_faq/usb_boot.markdown
@@ -1,12 +1,19 @@
 ---
-title: "Is USB Boot for the Raspberry Pi 4 supported?"
+title: "Can I run Home Assistant from a USB drive on a Raspberry Pi 4?"
+description: "Yes, with caveats. The recommended option is to keep the SD card and offload your data to a USB drive using the data disk feature."
 ha_category: Home Assistant
 ---
 
-Home Assistant offers a data disk feature that offloads all data to an attached USB hard drive. The SD card is still in use but is only used to serve the Home Assistant OS. [Learn more about the data disk feature.](/common-tasks/os/#using-external-data-disk)
+Yes, but with caveats. There are two ways to use a USB drive with a Raspberry Pi 4.
 
-**Booting from USB**
+### Recommended: data disk on USB
 
-Due to the complexity of USB and the USB mass storage device class, booting from a USB device is delicate. When booting from a USB drive this process has to be done multiple times (firmware/boot loader and the operating system), and there is a high chance that it doesn't complete during one of these stages.
+{% term "Home Assistant Operating System" %} has a data disk feature that moves all your data to an attached USB drive (such as an SSD), while the SD card stays in place to boot the operating system. This gives you most of the speed and reliability benefits of an SSD without the complexity of booting from USB. See [using an external data disk](/common-tasks/os/#using-external-data-disk) for instructions.
 
-That said, booting Home Assistant OS completely from a USB drive (SSD or any other USB mass storage device) works with *some* USB devices. USB Devices that are known to work with Raspberry Pi OS (check the Raspberry Pi Forum) are more likely to work with Home Assistant OS. However, because Home Assistant OS also has U-Boot in the boot chain, there are devices which are known to work with Raspberry Pi OS but do *not* work with Home Assistant OS. Finding the right combination of hardware can require experimentation.
+### Booting fully from USB
+
+Booting Home Assistant Operating System completely from a USB drive (without an SD card) is possible with _some_ devices, but it is delicate. The boot process passes through firmware, U-Boot, and the operating system, each of which has to negotiate with the USB device, and there is a real chance of the boot failing at one of these stages.
+
+USB drives that are known to work with Raspberry Pi OS (see the Raspberry Pi forum) are more likely to work with Home Assistant Operating System. However, because Home Assistant Operating System has U-Boot in the boot chain, some drives that work fine on Raspberry Pi OS do _not_ work on Home Assistant Operating System. Finding the right combination of hardware can take some experimentation.
+
+If you simply want a more reliable storage setup than an SD card, the data disk option above is the safer route.


### PR DESCRIPTION
## Proposed change

Refreshes a batch of older FAQ entries so they read more like the rest of the site: sentence-style question titles, useful frontmatter descriptions for SEO and previews, list-based structure where it helps, and language that matches today's Home Assistant.

Highlights:

- **404 image not found** — Adds a description, restructured as a checklist (free disk space, virtual machine disk size, network), and points readers at the system storage page and logs through My links.
- **Add-on red start button** — Renamed from "click" to "select", added a description, and made it clearer that the reason is in the logs.
- **Browser login stuck after update** — Trimmed and pointed at the broader UI caching FAQ instead of duplicating the steps.
- **Frontend is acting weird** — Renamed to "The Home Assistant user interface is acting weird", explained the typical cause (custom cards from outside the integration store), and added concrete hard-refresh and cache-clear steps for Chrome/Edge/Brave, Firefox, Safari, and the companion app.
- **Integration does not show up** — Leads with the logs, links to the configuration check pages, and cross-links to the new "Do I need to learn YAML" FAQ.
- **Connection error** — Restructured into a checklist (device reachable, network healthy, vendor cloud status), and switched the code block hint from `bash` to `text`.
- **Documentation tools** — Replaces a dismissive "we see no value in tool X" answer with an actual description of the stack (Jekyll + Markdown + GitHub + Netlify).
- **Home Assistant vs. Home Assistant Core** — Reframed as "What is the difference between Home Assistant Operating System and Home Assistant Container?", since the previous "Core" framing referred to installation methods that are no longer offered. Notes that "Core" and "Supervised" still appear in older articles.
- **Unique ID** — Sentence-style title, plainer language, fewer "e.g." constructs, and tighter section headings.
- **USB boot on Raspberry Pi 4** — Renamed to "Can I run Home Assistant from a USB drive on a Raspberry Pi 4?", added a clear recommendation (data disk on USB) and a separate section on booting fully from USB with the existing caveats.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
