### PR TITLE
Elk-M1 integration: add switch_output_turn_on_for action

### DIFF
--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -531,7 +531,7 @@ The `sensor_zone_trigger` action creates a virtual momentary open condition on t
 | Data attribute | Required | Description |
 | -------------- | -------- | ----------- |
 | `entity_id`    | No       | Elk-M1 output to turn on |
-| `duration`     | Yes      | Duration in integer seconds (0-65535). Use `0` to keep the output on until you turn it off. |
+| `duration`     | Yes      | Duration in integer seconds (1-65535). |
 
 ### System actions
 

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -522,6 +522,17 @@ The only mechanism ElkM1 offers to clear zone bypass is to clear all bypassed zo
 The `sensor_zone_trigger` action creates a virtual momentary open condition on the zone as if the EOL hardwired loop had been physically opened.
 {% endnote %}
 
+### Switch actions
+
+#### Elk-M1 Output control
+
+- `elkm1.switch_output_turn_on_for` - Turn on the output for a specified duration
+
+| Data attribute | Required | Description              |
+| -------------- | -------- | ------------------------ |
+| `entity_id`    | No       | Elk-M1 output to turn on |
+| `duration`     | Yes      | Duration in seconds to keep the output on, as an ElkM1 integer value from 0 to 65535; 0 turns on until changed again  |
+
 ### System actions
 
 #### Time synchronization

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -528,10 +528,10 @@ The `sensor_zone_trigger` action creates a virtual momentary open condition on t
 
 - `elkm1.switch_output_turn_on_for` - Turn on the output for a specified duration
 
-| Data attribute | Required | Description              |
-| -------------- | -------- | ------------------------ |
+| Data attribute | Required | Description |
+| -------------- | -------- | ----------- |
 | `entity_id`    | No       | Elk-M1 output to turn on |
-| `duration`     | Yes      | Duration in seconds to keep the output on, as an ElkM1 integer value from 0 to 65535; 0 turns on until changed again  |
+| `duration`     | Yes      | Duration in integer seconds (0-65535). Use `0` to keep the output on until you turn it off. |
 
 ### System actions
 


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Elk-M1 integration add switch_output_turn_on_for action.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/170128
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
