### PR TITLE
Add FRITZ!Box 6690 Cable to supported device list

### DIFF
--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -36,6 +36,7 @@ The **FRITZ!SmartHome** {% term integration %} for Home Assistant allows you to 
   - [FRITZ!Box 5590 Fiber][fritzbox_5590_fiber]
   - FRITZ!Box 6490 Cable
   - FRITZ!Box 6591 Cable
+  - [FRITZ!Box 6690 Cable][fritzbox_6690_cable]
   - FRITZ!Box 7590
   - FRITZ!Box 7490
   - FRITZ!Box 7430
@@ -153,6 +154,7 @@ The availability of these {% term sensor %} and {% term binary_sensor "binary se
 - Temperature
 
 [fritzbox_5590_fiber]: https://fritz.com/en/products/fritz-box-5590-fiber-20002981
+[fritzbox_6690_cable]: https://fritz.com/en/products/fritz-box-6690-cable-20002965
 [fritzbox_7590_ax]: https://fritz.com/en/products/fritz-box-7590-ax-20002998
 [fritzbox_7530_ax]: https://fritz.com/en/products/fritz-box-7530-ax-20002930
 [fritzdect_200]: https://fritz.com/en/products/fritz-dect-200-20002572


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
SSIA.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #43986

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
