### PR TITLE
Remove Duco temperature sensor documentation

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -42,10 +42,10 @@ Compatible DucoBox models:
 
 The following sensor module types are supported:
 
-- **BOX**: The main ventilation box; provides fan control, ventilation state, target flow level, mode end time, Wi-Fi signal strength, and temperature (measured inside the housing; disabled by default).
-- **UCCO2**: Wall-mounted CO₂ sensor unit; provides CO₂ concentration, CO₂ air quality index, and temperature.
-- **BSRH**: Humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity, humidity air quality index, and temperature.
-- **UCRH**: Wireless humidity sensor module; provides relative humidity, humidity air quality index, and temperature.
+- **BOX**: The main ventilation box; provides fan control, ventilation state, target flow level, mode end time, and Wi-Fi signal strength.
+- **UCCO2**: Wall-mounted CO₂ sensor unit; provides CO₂ concentration and CO₂ air quality index.
+- **BSRH**: Humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity and humidity air quality index.
+- **UCRH**: Wireless humidity sensor module; provides relative humidity and humidity air quality index.
 
 ### Unsupported sensor modules
 
@@ -147,12 +147,6 @@ Indoor air quality ranges for humidity:
 - 35–50%: Temporarily acceptable
 - 5–20%: Poor
 
-#### Temperature
-
-Available for the external sensor modules (UCCO2, BSRH, and UCRH). Shows the current air temperature in degrees Celsius measured by the sensor module.
-
-The main ventilation box (BOX) also provides a temperature reading. This entity is disabled by default because it reflects the temperature inside the box housing, which is typically not representative of the room temperature.
-
 #### Wi-Fi signal strength
 
 Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in dBm. This entity is disabled by default.
@@ -163,7 +157,6 @@ Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in
 - Return to auto mode when everyone leaves home using a presence-based automation.
 - Monitor ventilation activity over time via the logbook.
 - Trigger automations based on CO₂ levels or humidity reported by connected Duco modules.
-- Use temperature readings from sensor modules to detect rooms that are too hot or too cold and adjust ventilation accordingly.
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

Remove the temperature sensor documentation from the Duco integration page. The temperature entities exposed by the BOX, UCCO2, BSRH, and UCRH node types are removed in the corresponding core PR (home-assistant/core#170237) because the readings are not reliable enough to present as room temperatures. The physical sensor position can skew the measurements, for example when a sensor sits close to a heat-producing component or is mounted in a wall that affects the reading.

This PR removes:
- All references to temperature in the "Supported sensor modules" section.
- The "Temperature" subsection from the "Sensors" section.
- The temperature-based use case bullet point.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#170237
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards