### PR TITLE
Fix Denon RS232 spelling to RS-232

### DIFF
--- a/source/_integrations/denon_rs232.markdown
+++ b/source/_integrations/denon_rs232.markdown
@@ -1,6 +1,6 @@
 ---
-title: Denon RS232
-description: Instructions on how to integrate Denon receivers via their RS232 serial port into Home Assistant.
+title: Denon RS-232
+description: Instructions on how to integrate Denon receivers via their RS-232 serial port into Home Assistant.
 ha_category:
   - Media player
 ha_iot_class: Local Push
@@ -15,11 +15,11 @@ ha_integration_type: hub
 ha_quality_scale: bronze
 ---
 
-The **Denon RS232** {% term integration %} lets you control Denon receivers by connecting to their RS232 serial port. By connecting the receiver to your Home Assistant server using a serial (RS232) cable or a USB-to-serial adapter, you get local control with push-based state updates.
+The **Denon RS-232** {% term integration %} lets you control Denon receivers by connecting to their RS-232 serial port. By connecting the receiver to your Home Assistant server using a serial (RS-232) cable or a USB-to-serial adapter, you get local control with push-based state updates.
 
 ## Prerequisites
 
-- A Denon receiver that supports control over its RS232 serial port.
+- A Denon receiver that supports control over its RS-232 serial port.
 - A physical serial connection between your receiver and the system running Home Assistant, or ESPHome-based serial proxy.
 
 {% include integrations/config_flow.md %}

--- a/source/_posts/2026-05-06-release-20265.markdown
+++ b/source/_posts/2026-05-06-release-20265.markdown
@@ -125,7 +125,7 @@ This work is part of [an Open Home Foundation roadmap opportunity](https://githu
 
 We have a bit of a theme going on. Last release, [infrared became a first-class citizen of Home Assistant](/blog/2026/04/01/release-20264/#infrared-becoming-a-first-class-citizen-of-home-assistant). This release, [radio frequency joined the party](#radio-frequency-joins-infrared-as-a-first-class-citizen). And now, there's _another_ way you can put an ESPHome device somewhere in your home and let Home Assistant talk to things through it: **serial ports**. 🔌
 
-If you've ever set up a [Bluetooth proxy](/integrations/bluetooth/), the idea will feel familiar. Plenty of smart home gear talks over a serial connection, like energy meters with a P1 port, or that classic Denon receiver with the [new Denon RS232 integration](#new-integrations) shipping in this release. Until now, the device producing those serial signals had to be physically plugged into the same machine running Home Assistant, or wired up over a long, unwieldy cable. Not anymore. ✨
+If you've ever set up a [Bluetooth proxy](/integrations/bluetooth/), the idea will feel familiar. Plenty of smart home gear talks over a serial connection, like energy meters with a P1 port, or that classic Denon receiver with the [new Denon RS-232 integration](#new-integrations) shipping in this release. Until now, the device producing those serial signals had to be physically plugged into the same machine running Home Assistant, or wired up over a long, unwieldy cable. Not anymore. ✨
 
 With the new [serial proxy](https://esphome.io/components/serial_proxy/) support in [ESPHome](https://esphome.io), any serial port plugged into (or built into) an ESPHome device can now be exposed over your network and used by Home Assistant as if it were sitting right next to it. Drop an ESP somewhere convenient, plug your serial device into it, and Home Assistant takes care of the rest. 🪄
 
@@ -146,7 +146,7 @@ Behind the scenes, this release rewires Home Assistant's serial-port handling to
 
 - All of Home Assistant has been migrated to a modern, async-first serial driver called **serialx**, replacing the older `pyserial` library that Home Assistant has used for years. It's designed for the way Home Assistant works today and adds support for new connection types, including ESPHome serial proxies, transparently.
 - Integrations that need a serial port now get a new, polished serial port selector in the UI. It lists local USB serial ports _and_ remote ESPHome serial proxies side by side, with friendly names. The list even updates live, so a USB device you plug in while the dropdown is open shows up right away.
-- Common integrations that talk over serial pick up serial proxies for free. The new [Denon RS232] integration uses it from day one, and the existing [Russound RIO](/integrations/russound_rio/) integration has been migrated to serialx as well, so it can now talk to your multi-room audio gear over an ESPHome serial proxy too.
+- Common integrations that talk over serial pick up serial proxies for free. The new [Denon RS-232] integration uses it from day one, and the existing [Russound RIO](/integrations/russound_rio/) integration has been migrated to serialx as well, so it can now talk to your multi-room audio gear over an ESPHome serial proxy too.
 
 If you're an integration developer (or maintain a custom component) talking over serial, head over to the [migrating from pyserial to serialx](https://developers.home-assistant.io/blog/2026/04/27/pyserial-to-serialx) developer blog post to read all about how to take advantage of this. 🛠️
 
@@ -280,8 +280,8 @@ Thanks to our community for keeping pace with the new {% term integrations %} an
 
 We welcome the following new integrations in this release:
 
-- **[Denon RS232]**, added by [@balloob]  
-  Control your Denon receiver locally over its RS232 serial port. Connect your receiver using a serial cable or a USB-to-serial adapter for push-based state updates, without depending on the network or the cloud.
+- **[Denon RS-232]**, added by [@balloob]  
+  Control your Denon receiver locally over its RS-232 serial port. Connect your receiver using a serial cable or a USB-to-serial adapter for push-based state updates, without depending on the network or the cloud.
 
 - **[Duco]**, added by [@ronaldvdmeer] — launching at 🏆 platinum quality  
   Monitor and control your [Duco](https://www.duco.eu/) demand-controlled ventilation system locally from Home Assistant. Track CO₂, humidity, and other sensor data, and adjust ventilation, all over your local network.
@@ -326,7 +326,7 @@ We welcome the following new integrations in this release:
 [@rikroe]: https://github.com/rikroe
 [@ronaldvdmeer]: https://github.com/ronaldvdmeer
 [@tomer-w]: https://github.com/tomer-w
-[Denon RS232]: /integrations/denon_rs232
+[Denon RS-232]: /integrations/denon_rs232
 [Duco]: /integrations/duco
 [EARN-E P1 Meter]: /integrations/earn_e_p1
 [Eurotronic Comet Blue]: /integrations/eurotronic_cometblue


### PR DESCRIPTION
## Proposed change

Correct the spelling of "RS232" to "RS-232" (the proper way of writing the standard) in the Denon RS-232 integration documentation and the 2026.5 release blog post. The integration's domain and filename (`denon_rs232`) are intentionally left unchanged.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


---
_Generated by [Claude Code](https://claude.ai/code/session_01VXtd4NSS5NNUEw15QKSuoq)_