### PR TITLE
Fix broken markdown link in updates FAQ

### DIFF
--- a/source/_faq/do-updates-break-things.markdown
+++ b/source/_faq/do-updates-break-things.markdown
@@ -10,7 +10,7 @@ A lot of the older articles and forum posts you may run into describe a time whe
 
 A new version of Home Assistant is released on the first Wednesday of every month, with smaller fix releases in between. A few things make the update process safe by default:
 
-- An [automatic {% term backup %}](/common-tasks/general/#backups) is taken before each update, so you can roll back if something does not work for you.
+- An [automatic backup](/common-tasks/general/#backups) is taken before each update, so you can roll back if something does not work for you.
 - Every release is preceded by a public beta period, so issues are usually found and fixed before the stable release.
 - Breaking changes are documented in advance in the [release notes](/blog/categories/core/), so you know what to look for.
 - The built-in [repair system](/integrations/repairs/) proactively flags any issues after an update and walks you through how to resolve them.


### PR DESCRIPTION
## Proposed change

In `source/_faq/do-updates-break-things.markdown`, the bullet about automatic backups wrapped a `{% term backup %}` glossary tooltip inside a markdown link:

```markdown
- An [automatic {% term backup %}](/common-tasks/general/#backups) is taken before each update, ...
```

The term tooltip expands to HTML that includes the glossary definition (which itself contains an `[installation types](/installation/#about-installation-types)` link) and a "Learn more" link. Because that HTML is nested inside another markdown link, the parser breaks and the rendered output leaks the inner link syntax into the page, producing text like:

> An automatic backupinstallation types. [Learn more] is taken before each update, so you can roll back if something does not work for you.

Removed the nested term tooltip and kept the existing markdown link to `/common-tasks/general/#backups`, so the sentence renders correctly.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


---
_Generated by [Claude Code](https://claude.ai/code/session_01B4cJWsi2LqRsjoRk25ev4J)_