### PR TITLE
Update related links that pointed to the old frontend docs page

### DIFF
--- a/source/_dashboards/clock.markdown
+++ b/source/_dashboards/clock.markdown
@@ -4,8 +4,8 @@ title: "Clock card"
 sidebar_label: Clock
 description: "The Clock card shows the current time in a variety of formats and sizes."
 related:
-  - docs: /docs/frontend/#user--or-browser-dependent-settings
-    title: Setup your time format and timezone
+  - docs: /docs/configuration/basic/
+    title: Set your time zone
 ---
 
 The Clock card shows the current time in a variety of formats, sizes and time zones.

--- a/source/_docs/frontend/icons.markdown
+++ b/source/_docs/frontend/icons.markdown
@@ -2,8 +2,6 @@
 title: "Icons"
 description: "Material Design Icons in the Home Assistant frontend"
 related:
-  - docs: /docs/frontend/
-    title: Frontend
   - docs: /dashboards/cards/
     title: Dashboard cards
   - docs: /docs/configuration/customizing-devices/


### PR DESCRIPTION
## Proposed change

Follow-up to the earlier rework of the frontend documentation page. Two related-link entries still pointed at sections of `/docs/frontend/` that no longer match how the page is organized:

- `source/_dashboards/clock.markdown` — Replaces the broken deep link to "user or browser-dependent settings" with a link to `/docs/configuration/basic/`, which is where the time zone is actually configured today.
- `source/_docs/frontend/icons.markdown` — Removes the "Frontend" related link, since the page is no longer a useful jumping-off point for icon documentation.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
