### PR TITLE
Refresh intros and meta descriptions across the main user-facing docs

### DIFF
--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -141,6 +141,20 @@
   link: /integrations/climate
   aliases:
     - climates
+- term: Cloud-independent
+  definition: >-
+    Home Assistant is cloud-independent, meaning it does not need an internet
+    connection or a vendor cloud account to keep your smart home running.
+    Devices that talk over local protocols such as Zigbee, Z-Wave, Matter,
+    Thread, and ESPHome continue to work even when the internet is down or a
+    manufacturer shuts down its cloud service. Optional cloud features, such as
+    [Home Assistant Cloud](https://www.nabucasa.com), can be added on top, but
+    the core of your smart home stays on your own hardware.
+  excerpt: >-
+    Cloud-independent means Home Assistant does not need an internet
+    connection or a vendor cloud account to keep your smart home running.
+  aliases:
+    - cloud independent
 - term: Commissioning
   definition: >-
     In the context of Matter devices, *commissioning* is the process of adding a
@@ -457,6 +471,19 @@
   link: /integrations/light
   aliases:
     - lights
+- term: Local control
+  definition: >-
+    Local control means Home Assistant talks to your devices directly over your
+    own network, without sending the commands through a vendor cloud first.
+    Local control makes your smart home faster, keeps your data on your own
+    hardware, and keeps things working when the internet is down. Many
+    integrations in Home Assistant use local control out of the box,
+    including those for Zigbee, Z-Wave, Matter, Thread, and ESPHome devices.
+  excerpt: >-
+    Local control means Home Assistant talks to your devices directly over your
+    own network, without going through a vendor cloud.
+  aliases:
+    - locally controlled
 - term: Matter
   definition: >-
     Matter is an open-source standard that defines how to control smart home

--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -1,13 +1,13 @@
 ---
 title: "Automating Home Assistant"
-description: "Steps to help you get automation setup in Home Assistant."
+description: "Build automations for your smart home with the visual editor, no coding required."
 ---
 
-Home Assistant contains information about all your {% term devices %} and {% term services %}. This information is available to you in the dashboard and it can be used to trigger {% term automations %}. And that's fun!
+Automations are how you make your home work for you. They let Home Assistant automatically respond to things that happen, such as turning the lights on at sunset or pausing the music when you receive a call.
 
-Automations in Home Assistant allow you to automatically respond to things that happen. You can turn the lights on at sunset or pause the music when you receive a call.
+You build automations in Home Assistant with the visual automation editor, so no coding is required. Home Assistant already knows about all your {% term devices %} and {% term services %}, so you can pick from them directly when you decide what should trigger an automation and what should happen as a result.
 
-If you are just starting out, we recommend that you start with blueprint automations. These are ready-made automations by the community that you only need to configure.
+If you are just starting out, we recommend that you start with blueprint automations. These are ready-made automations from the community that you only need to configure.
 
 ### [Learn about automation blueprints &raquo;](/docs/automation/using_blueprints/)
 

--- a/source/_docs/automation/editor.markdown
+++ b/source/_docs/automation/editor.markdown
@@ -1,12 +1,12 @@
 ---
 title: "Automation editor"
-description: "Instructions on how to use the automation editor."
+description: "Create and edit automations from the Home Assistant user interface. The visual editor walks you through choosing a trigger, conditions, and actions, no coding needed."
 related:
   - docs: /getting-started/automation/
     title: Automating Home Assistant
 ---
 
-The automation editor is an easy way of creating and editing automations from the UI.
+The automation editor lets you create and edit automations directly from the Home Assistant user interface, without writing any YAML. The editor walks you through choosing a trigger, optional conditions, and the actions to run.
 
 This tutorial uses the [Random sensor](/integrations/random#sensor) because it generates data (by default, values between 0 and 20). This enables us to walk through the example, even if you do not have any actual sensors connected yet. You could use any other sensor that outputs a numeric value.
 

--- a/source/_docs/automation/modes.markdown
+++ b/source/_docs/automation/modes.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Automation modes"
-description: "Choose how an automation behaves when it is triggered while a previous run is still going, with the single, restart, queued, and parallel modes."
+description: "Automation modes define how an automation behaves when it is triggered while still running from a previous trigger. Home Assistant has single, restart, queued, and parallel modes."
 ---
 
 Sometimes an automation gets triggered again before it has finished running from the previous time. The mode setting tells Home Assistant what to do in that situation: ignore the new trigger, start over, queue it up, or run another copy in parallel.

--- a/source/_docs/automation/modes.markdown
+++ b/source/_docs/automation/modes.markdown
@@ -1,11 +1,11 @@
 ---
 title: "Automation modes"
-description: "How to use and configure automation modes."
+description: "Choose how an automation behaves when it is triggered while a previous run is still going, with the single, restart, queued, and parallel modes."
 ---
 
-An {% term automation %} can be triggered while it is already running.
+Sometimes an automation gets triggered again before it has finished running from the previous time. The mode setting tells Home Assistant what to do in that situation: ignore the new trigger, start over, queue it up, or run another copy in parallel.
 
-The automation's `mode` configuration option controls what happens when the automation is triggered while the {% term actions %} are still running from a previous {% term trigger %}.
+Most of the time, the default `single` mode is exactly what you want. The other modes are there for special cases, like a notification automation that should run a fresh copy for every event, or a long-running sequence that should restart from the top whenever something changes.
 
 Mode | Description
 -|-

--- a/source/_docs/automation/services.markdown
+++ b/source/_docs/automation/services.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Automation actions"
-description: "How to use the various automation actions."
+description: "Reference for the actions you can call from an automation, including how to pass data, target a specific entity, and chain multiple actions together."
 ---
 
 The automation integration has actions to control automations, like turning automations on and off. This can be useful if you want to disable an automation from another automation.

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Automation Templates"
-description: "List all trigger variables available to templates."
+title: "Automation templates"
+description: "Use templates inside an automation to access trigger data, build dynamic messages, and pass calculated values to actions."
 ---
 
 Automations support the advanced features of [templating](/docs/templating/) in the same way as scripts do. In addition to the [Home Assistant template extensions](/docs/templating/) available to scripts, the `trigger` and `this` template variables are available for automations.

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -1,14 +1,14 @@
 ---
-title: "Automation Trigger"
-description: "All the different ways how automations can be triggered."
+title: "Automation triggers"
+description: "Triggers are the events that start an automation, such as a sensor changing state, a time of day, the sun setting, or a person arriving home."
 related:
   - docs: /voice_control/custom_sentences/#adding-a-custom-sentence-to-trigger-an-automation
     title: Adding a custom sentence to trigger an automation
 ---
 
-Triggers are what starts the processing of an {% term automation %} rule. When _any_ of the automation's triggers becomes true (trigger _fires_), Home Assistant will validate the [conditions](/docs/automation/condition/), if any, and call the [action](/docs/automation/action/).
+A trigger is what wakes an automation up. Until something triggers it, an automation just sits there quietly, waiting. The moment a trigger fires, Home Assistant checks any [conditions](/docs/automation/condition/) you set, and if they pass, it runs the [actions](/docs/automation/action/).
 
-An {% term automation %} can be triggered by an {% term event %}, a certain {% term entity %} {% term state %}, at a given time, and more. These can be specified directly or more flexible via templates. It is also possible to specify multiple triggers for one automation.
+Triggers can be almost anything that happens in your home or in Home Assistant itself. A motion sensor detecting movement. The sun going down. A specific time of day. A person arriving home. A button on a remote being pressed. Even a voice command spoken to {% term Assist %}. You can give a single automation more than one trigger, and the automation will start as soon as _any_ of them fires.
 
 - [Trigger ID](#trigger-id)
 - [Trigger variables](#trigger-variables)

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -8,7 +8,7 @@ related:
 
 A trigger is what wakes an automation up. Until something triggers it, an automation just sits there quietly, waiting. The moment a trigger fires, Home Assistant checks any [conditions](/docs/automation/condition/) you set, and if they pass, it runs the [actions](/docs/automation/action/).
 
-Triggers can be almost anything that happens in your home or in Home Assistant itself. A motion sensor detecting movement. The sun going down. A specific time of day. A person arriving home. A button on a remote being pressed. Even a voice command spoken to {% term Assist %}. You can give a single automation more than one trigger, and the automation will start as soon as _any_ of them fires.
+Triggers can be almost anything that happens in your home or in Home Assistant itself. A motion sensor detecting movement. The sun going down. A specific time of day. A person arriving home. A button on a remote being pressed. Even a voice command spoken to Assist. You can give a single automation more than one trigger, and the automation will start as soon as _any_ of them fires.
 
 - [Trigger ID](#trigger-id)
 - [Trigger variables](#trigger-variables)

--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -1,9 +1,11 @@
 ---
 title: "Troubleshooting automations"
-description: "Tips on how to troubleshoot your automations."
+description: "How to find out why an automation did not run, using the trace timeline, the logs, and the test buttons in the automation editor."
 ---
 
-Automations and {% term scripts %} can be debugged in a few different ways. You can [test run](#testing-your-automation) the full sequence of actions, or test each condition and action separately. [Traces](#traces) let you see details of every step after an automation is run. For complicated automations with {% term templates %}, see the section [testing templates](#testing-templates).
+Sometimes an automation does not do what you expect. Maybe it does not run at all, maybe it runs at the wrong moment, or maybe one of the actions in the middle quietly fails. Home Assistant has built-in tools to help you find out exactly what happened, without having to dig through log files.
+
+The most useful tool is the **trace**. Every time an automation runs, Home Assistant records a step-by-step timeline of what was triggered, which conditions were checked, and what each action did. You can also test parts of an automation directly from the editor, without waiting for a real trigger.
 
 ## Testing your automation
 

--- a/source/_docs/automation/using_blueprints.markdown
+++ b/source/_docs/automation/using_blueprints.markdown
@@ -1,9 +1,11 @@
 ---
 title: "Using automation blueprints"
-description: "How to create automations based off blueprints."
+description: "Blueprints are ready-made automations shared by the Home Assistant community. Install a blueprint and create your own automation by filling in a few fields, no YAML required."
 ---
 
-Automation blueprints are pre-made {% term automations %} that you can easily add to your Home Assistant instance. Each blueprint can be added as many times as you want.
+Blueprints are the easiest way to add an automation to your Home Assistant. They are ready-made automations shared by the Home Assistant community: someone else has already done the thinking and the writing, and you just plug in your own devices.
+
+You can find blueprints for almost any common use case, from "turn the lights on when motion is detected" to "announce the weather every morning at 7" to "notify me when the laundry is done". You install a blueprint once and can use it as many times as you like, with different devices and settings each time.
 
 Quick links:
 

--- a/source/_docs/automation/yaml.markdown
+++ b/source/_docs/automation/yaml.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Automation YAML"
-description: "How to use the automation integration with YAML."
+title: "Automations in YAML"
+description: "Power-user reference for writing automations directly in YAML, including the full structure, advanced options, and how to manage automations from configuration.yaml."
 ---
 
 Automations are created in Home Assistant via the UI, but are stored in a {% term YAML %} format. If you want to edit the {% term YAML %} of an {% term automation %}, select the automation, select the menu button in the top right then on **Edit in YAML**.

--- a/source/_docs/blueprint.markdown
+++ b/source/_docs/blueprint.markdown
@@ -1,6 +1,6 @@
 ---
 title: "About blueprints"
-description: "Introduction to blueprints."
+description: "Blueprints are ready-made automations, scripts, and template entities that you can install with a few clicks and customize for your own home, no coding required."
 related:
   - docs: /docs/blueprint/schema/
     title: About the blueprint schema
@@ -14,15 +14,19 @@ related:
     url: /get-blueprints
 ---
 
-This section gives a high-level introduction to blueprints. To view a description of the YAML-schema used to create a valid blueprint, refer to the section [About the blueprint schema](/docs/blueprint/schema/).
+Blueprints are the easiest way to add automations, scripts, or template entities to your Home Assistant. Someone in the community has already done the work of writing the configuration, and you fill in the bits that are specific to your home, like which sensor to watch and which light to control.
+
+You can find a blueprint for almost any common use case in the [community blueprint forum][blueprint-forums]: motion-activated lights, low-battery notifications, holiday lighting, presence-based heating, and many more.
+
+This page is a high-level introduction. If you want to create your own blueprint to share, see [About the blueprint schema](/docs/blueprint/schema/).
 
 ## What is a blueprint?
 
-A blueprint is a {% term script %}, {% term automation %} or [template entity](/integrations/template/) configuration with certain parts marked as configurable. This allows you to create different scripts, automations or template entities based on the same blueprint.
+A blueprint is a {% term script %}, {% term automation %}, or [template entity](/integrations/template/) configuration where some parts have been left blank, ready for you to fill in. That way, the same blueprint can be reused over and over with different devices and settings.
 
-Imagine you want to control lights based on motion. A blueprint provides the generic {% term automation %} framework, while letting you select one specific motion sensor as a {% term trigger %}, and the exact light to control. This blueprint makes it possible to create two automations. Each automation has their own configuration and act completely independently. Yet, they share some basic automation configuration so that you do not have to set this up every time.
+Imagine you want to turn on a light when motion is detected. A blueprint provides the generic automation, while letting you select _which_ motion sensor and _which_ light. You can use that same blueprint twice, once for the hallway and once for the bathroom, and end up with two completely independent automations that each behave the way you configured them.
 
-Automations inherit from blueprints, which means that changes made to a blueprint will be reflected in all automations based on that blueprint the next time the automations are reloaded. This occurs as part of Home Assistant starting. To manually reload the automations, go to {% my server_controls title="**Settings** > **Developer tools** > **YAML**" %} and reload the automations.
+Automations inherit from the blueprint they were built on, so if the blueprint is updated, all automations using it pick up the change the next time Home Assistant reloads them. To reload manually, go to {% my server_controls title="**Settings** > **Developer tools** > **YAML**" %} and reload the automations.
 
 Blueprints are shared by the community in the [blueprint community forum][blueprint-forums].
 

--- a/source/_docs/configuration.markdown
+++ b/source/_docs/configuration.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Configuration.yaml"
-description: "Configuring Home Assistant via text files."
+title: "The configuration.yaml file"
+description: "How the configuration.yaml file works in Home Assistant: when you need it, where to find it, and how to edit it safely."
 related:
   - docs: /docs/configuration/yaml/
     title: YAML syntax
@@ -16,9 +16,7 @@ related:
     title: Troubleshooting the configuration
 ---
 
-While you can configure most of Home Assistant from the user interface, for some integrations, you need to edit the `configuration.yaml` file.
-
-This file contains {% term integrations %} to be loaded along with their configurations. Throughout the documentation, you will find snippets that you can add to your configuration file to enable specific functionality.
+While you can configure most of Home Assistant from the user interface, a small number of integrations and power-user features still need a few lines in the `configuration.yaml` file. This page explains how that file works, so you can use it when you need to.
 
 <p class='img'>
 <img src='/images/docs/configuration/config-yaml_via-file-editor.png' alt='Screenshot of an example of a configuration.yaml file, accessed using the File editor app on a Home Assistant Operating System installation.'>

--- a/source/_docs/configuration/basic.markdown
+++ b/source/_docs/configuration/basic.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Setup basic information"
-description: "Setting up the basic info of Home Assistant."
+title: "Basic settings"
+description: "Set the basic information about your Home Assistant, such as your home's name, location, time zone, and units of measurement."
 related:
   - docs: /integrations/homeassistant/
   - docs: /docs/configuration/

--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Customizing entities"
-description: "Simple customization for entities."
+description: "Override the name, icon, or other properties of an entity in YAML, useful for entities that cannot be customized through the user interface."
 related:
   - docs: /integrations/homeassistant/
   - docs: /docs/configuration/

--- a/source/_docs/configuration/entities_domains.markdown
+++ b/source/_docs/configuration/entities_domains.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Entities and domains"
-description: "Describes what entities and domains are in Home Assistant."
+description: "Entities are the building blocks of Home Assistant: each device, sensor, or service appears as one or more entities, grouped by domain such as light, switch, or sensor."
 related:
   - docs: /docs/configuration/state_object/
     title: State object, entity state and attributes

--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Events"
-description: "Describes all there is to know about events in Home Assistant."
+description: "Events are how integrations and parts of Home Assistant tell each other that something has happened, and how you can trigger automations based on them."
 related:
   - docs: /docs/automation/trigger/#event-trigger
     title: Event triggers

--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Packages"
-description: "Bundle configurations from multiple integrations using configuration packages."
+title: "Configuration packages"
+description: "Configuration packages let you bundle related YAML configuration from multiple integrations into a single file, so you can keep large setups organized."
 ---
 
 Packages in Home Assistant provide a way to bundle configurations from multiple integrations. You can use packages to include multiple integrations, or parts of integrations, using any of the `!include` directives introduced in [splitting the configuration](/docs/configuration/splitting_configuration/).

--- a/source/_docs/configuration/platform_options.markdown
+++ b/source/_docs/configuration/platform_options.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Entity integration platform options"
-description: "Shows how to customize polling interval for any integration via configuration.yaml."
+description: "Configure shared entity options such as the polling interval for any integration through configuration.yaml."
 ---
 
 {% important %}

--- a/source/_docs/configuration/remote.markdown
+++ b/source/_docs/configuration/remote.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Remote access"
-description: "Setting up remote access for Home Assistant."
+description: "Reach your Home Assistant from outside your home network. The recommended option is Home Assistant Cloud, which works without exposing anything to the internet."
 related:
   - docs: /docs/configuration/securing/
     title: Securing your instance
@@ -8,17 +8,19 @@ related:
     title: Home Assistant Cloud - remote access
 ---
 
-If you're interested in logging in to Home Assistant while away, you'll have to make your instance remotely accessible. Below are a few options to do this.
+By default, your Home Assistant only listens on your local network, which keeps things private and secure. If you want to reach it from outside your home, for example to control your devices while you are at work or on holiday, you have a few options.
+
+The easiest and safest option for most people is [Home Assistant Cloud](/cloud/). Other options are listed further down for those who prefer to set things up themselves.
 
 {% tip %}
-Remember to follow the [securing checklist](/docs/configuration/securing/) before doing this.
+Before exposing Home Assistant to the internet, follow the [securing checklist](/docs/configuration/securing/).
 {% endtip %}
 
 ## Home Assistant Cloud
 
-Users of <a href="https://www.nabucasa.com">Home Assistant Cloud</a> can use the <a href="https://www.nabucasa.com/config/remote/">Home Assistant Cloud remote access</a> feature without requiring any configuration.
+[Home Assistant Cloud](https://www.nabucasa.com) gives you remote access to your Home Assistant from anywhere, without opening any ports on your router and without exposing your home network to the internet. Setup takes a single toggle in the user interface.
 
-A unique remote URL will be generated and given to you along with a certificate so all your traffic to Home Assistant is encrypted automatically.
+A unique remote URL is generated for you, and all traffic between your device and your home is encrypted automatically. Your Home Assistant Cloud subscription also helps fund the development of Home Assistant itself.
 
 ## VPN
 

--- a/source/_docs/configuration/secrets.markdown
+++ b/source/_docs/configuration/secrets.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Storing secrets"
-description: "Storing secrets outside of your configuration.yaml."
+description: "Keep passwords, API keys, and other sensitive values out of your configuration.yaml by storing them in a separate secrets.yaml file."
 related:
   - docs: /docs/configuration/
     title: configuration.yaml file

--- a/source/_docs/configuration/securing.markdown
+++ b/source/_docs/configuration/securing.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Securing"
-description: "Instructions on how to secure your Home Assistant installation."
+title: "Securing your Home Assistant"
+description: "Recommended settings and best practices for keeping your Home Assistant secure, from strong passwords to safe remote access."
 
 related:
   - docs: /docs/configuration/
@@ -12,15 +12,15 @@ related:
     title: Nabu Casa
 ---
 
-One major advantage of Home Assistant is that it is not dependent on cloud services. Even if you are only using Home Assistant on a local network, you should take steps to secure your instance.
+Home Assistant runs on your own hardware and does not depend on any cloud service to work, which already removes a large category of risks that come with internet-connected smart home platforms. Even so, there are a few simple steps you should take to keep your Home Assistant secure, especially if you plan to access it from outside your home network.
 
 ## Checklist
 
-Here's the summary of what you *must* do to secure your Home Assistant system:
+The most important things to do to keep your Home Assistant secure:
 
-- Centralize sensitive data in [secrets](/docs/configuration/secrets/) (but do remember to back them up).
+- Centralize sensitive data in [secrets](/docs/configuration/secrets/) (and remember to back them up).
   - **Note**: Storing secrets in `secrets.yaml` does not encrypt them.
-- Regularly keep the system up to date.
+- Keep your system up to date with each monthly release.
 
 ## Remote access
 

--- a/source/_docs/configuration/splitting_configuration.markdown
+++ b/source/_docs/configuration/splitting_configuration.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Splitting up the configuration"
-description: "Splitting the configuration.yaml into several files."
+description: "Keep your configuration.yaml manageable by splitting it into smaller, focused files using the !include directive."
 related:
   - docs: /docs/configuration/
     title: configuration.yaml file

--- a/source/_docs/configuration/state_object.markdown
+++ b/source/_docs/configuration/state_object.markdown
@@ -1,6 +1,6 @@
 ---
 title: "State and state object"
-description: "Describes all there is to know about state and the state object in Home Assistant."
+description: "Every entity in Home Assistant has a state, such as on, off, or a temperature reading. This page covers what the state object contains and how to use it."
 related:
   - docs: /docs/configuration/entities_domains/
     title: Entities and domains

--- a/source/_docs/configuration/troubleshooting.markdown
+++ b/source/_docs/configuration/troubleshooting.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Troubleshooting your configuration"
-description: "Common problems with tweaking your configuration and their solutions."
+description: "Common problems with your Home Assistant configuration and how to fix them, including how to read the logs and check your YAML before restarting."
 related:
   - docs: /docs/configuration/
   - docs: /docs/configuration/customizing-devices/

--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -1,6 +1,6 @@
 ---
 title: "YAML syntax"
-description: "Details about the YAML syntax used to configure Home Assistant."
+description: "How YAML works in Home Assistant: indentation, lists, and the small set of rules you need to know if you ever need to edit configuration.yaml by hand."
 related:
   - docs: /docs/configuration/
     title: configuration.yaml file
@@ -16,11 +16,11 @@ related:
     title: YAML Style Guide for Home Assistant developers
 ---
 
-Home Assistant uses the [YAML](https://yaml.org/) syntax for configuration. While most integrations can be configured through the UI, some integrations require you to edit your [`configuration.yaml`](/docs/configuration/) file to specify its settings.
+Most things in Home Assistant can be set up directly from the user interface, and you never need to touch a YAML file. A small number of advanced features and a few integrations still require entries in [`configuration.yaml`](/docs/configuration/), and this page explains the bit of YAML syntax you need for those cases.
 
-## YAML Style Guide
+## YAML style guide
 
-This page gives a high-level introduction to the YAML syntax used in Home Assistant. For a more detailed description and more examples, refer to the [YAML Style Guide for Home Assistant developers](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/).
+This page gives a high-level introduction to the YAML syntax used in Home Assistant. For a more detailed description and more examples, refer to the [YAML style guide for Home Assistant developers](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/).
 
 ## A first example
 

--- a/source/_docs/energy.markdown
+++ b/source/_docs/energy.markdown
@@ -1,16 +1,16 @@
 ---
-title: "Understanding Home Energy Management"
-description: "How to get started using home energy management in Home Assistant."
+title: "Home energy management"
+description: "Track and understand how energy is used in your home with Home Assistant. See where your power is going, get the most out of your solar panels, and save money on your bills."
 toc: false
 ---
 
-Home Assistant allows you to get on top of your energy use with its home energy management feature. Gain new insights, optimize your solar panel production, plan energy usage and save money.
+Home Assistant turns your home into a clear, easy-to-read picture of how energy flows in and out of it. You can see how much electricity you draw from the grid and when, how much your solar panels produced today, how full your home battery is, and which appliances are quietly costing you the most. With that information, you can plan when to run the dishwasher, charge the car when power is cheap or your panels are at their peak, and set automations that quietly save you money in the background.
 
 {% my energy badge %} {% my config_energy badge %}
 
-Home energy management helps you track and understand how energy is used in your home. It works with different types of utilities, such as electricity, gas, and water. For each utility, usage is grouped into three types: consumption, production, and storage/flow. You can start using it even if you just have one source connected to Home Assistant. Each source you add will complement the others, giving you even more insight into energy in your home.
+The energy dashboard works with electricity, gas, and water. For each one, your usage is grouped into three simple types: what you consume, what you produce, and what you store. You can start with a single source, even just your electricity meter, and add more as you go. Every source you add makes the picture more complete.
 
-Home Assistant is an open platform and so home energy management is not restricted to specific hardware. Any energy monitoring hardware that integrates with Home Assistant can be used as a data source. Check out the following sections for in-depth explanations and hardware recommendations.
+Home Assistant is open and works with hardware from many different brands, so you are not locked into one ecosystem. Any energy monitor, smart plug, solar inverter, or utility meter that integrates with Home Assistant can feed data into the energy dashboard.
 
 - [Integrate your energy use from the electricity grid](/docs/energy/electricity-grid/)
 - [Integrate your solar panels](/docs/energy/solar-panels/)

--- a/source/_docs/glossary.markdown
+++ b/source/_docs/glossary.markdown
@@ -1,9 +1,9 @@
 ---
 title: "Glossary"
-description: "Home Assistant's Glossary."
+description: "Definitions of the most common terms used in Home Assistant: integrations, entities, devices, automations, and more."
 ---
 
-The glossary covers terms which are used around Home Assistant.
+Home Assistant has a vocabulary of its own. Most of it comes up in everyday use: integrations, entities, devices, automations, dashboards. This page is a quick reference for what every term means and how the pieces fit together. Whenever you see a term you do not recognize in the documentation or in the user interface, you can come back here.
 
 {% assign entries = site.data.glossary | sort: 'term' %}
 {% assign current_letter = '' %}

--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -1,6 +1,6 @@
 ---
 title: "I'm locked out!"
-description: "Options for regaining access"
+description: "Options for regaining access to your Home Assistant when you are locked out, including resetting the owner password and recovering your data."
 related:
   - docs: /common-tasks/os/#listing-all-users-from-the-command-line
     title: Listing all usernames via command line

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -4,7 +4,7 @@ description: "How to write Home Assistant scripts in YAML: the available actions
 toc: true
 ---
 
-A script is a sequence of steps that Home Assistant runs from top to bottom whenever you call it. Think of it as a small recipe: "turn on the porch light, wait 30 seconds, then send me a notification". Once you have written a script, you can run it from a button on your dashboard, from {% term Assist %}, from inside an {% term automation %}, or from anywhere else that calls actions.
+A script is a sequence of steps that Home Assistant runs from top to bottom whenever you call it. Think of it as a small recipe: "turn on the porch light, wait 30 seconds, then send me a notification". Once you have written a script, you can run it from a button on your dashboard, from Assist, from inside an {% term automation %}, or from anywhere else that calls actions.
 
 Scripts and automations are very closely related. The only real difference is that an automation runs by itself when something triggers it, and a script runs when you call it.
 

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -1,12 +1,14 @@
 ---
-title: "Script Syntax"
-description: "Documentation for the Home Assistant Script Syntax."
+title: "Script syntax"
+description: "How to write Home Assistant scripts in YAML: the available actions, their structure, and how to use them inside automations."
 toc: true
 ---
 
-Scripts are a sequence of {% term actions %} that Home Assistant will execute. Scripts are available as an entity through the standalone [Script integration] but can also be embedded in {% term automations %} and [Alexa/Amazon Echo] configurations.
+A script is a sequence of steps that Home Assistant runs from top to bottom whenever you call it. Think of it as a small recipe: "turn on the porch light, wait 30 seconds, then send me a notification". Once you have written a script, you can run it from a button on your dashboard, from {% term Assist %}, from inside an {% term automation %}, or from anywhere else that calls actions.
 
-When the script is executed within an {% term automation %}, the `trigger` variable is available. See [Available-Trigger-Data](/docs/automation/templating/#available-trigger-data).
+Scripts and automations are very closely related. The only real difference is that an automation runs by itself when something triggers it, and a script runs when you call it.
+
+When the script runs as part of an {% term automation %}, the `trigger` variable is also available. See [Available-Trigger-Data](/docs/automation/templating/#available-trigger-data).
 
 ## Script syntax
 

--- a/source/_faq/usb_config.markdown
+++ b/source/_faq/usb_config.markdown
@@ -1,6 +1,7 @@
 ---
 title: "Do I need to leave the USB stick connected for Wi-Fi?"
+description: "No. The USB CONFIG stick is only used once to import a network profile, and can be removed afterwards."
 ha_category: Home Assistant
 ---
 
-No. The USB "CONFIG" stick is only used to import a network profile to `/etc/NetworkManager/system-connections/` and can be removed.
+No. The USB `CONFIG` stick is only used once, to import a network profile into `/etc/NetworkManager/system-connections/`. After that, you can safely remove it. Home Assistant remembers your Wi-Fi settings without the stick.

--- a/source/_includes/custom/getting-started.html
+++ b/source/_includes/custom/getting-started.html
@@ -1,22 +1,10 @@
 <section class="grid getting-started">
   <div class="grid__item one-whole">
     <h2 class="sub-title">Let's get started.</h2>
-    <p class="lead">A variety of options for pragmatists and tinkerers alike.</p>
+    <p class="lead">Pick the hardware that fits you. The easiest way to get started is with Home Assistant Green.</p>
   </div>
 
   <div class="getting-started-grid grid__item one-whole">
-
-    <div class="getting-started-device" id="Raspberry_Pi">
-      <div class="content">
-        <div class="badge">Easy</div>
-        <img src="/images/frontpage/raspberry-pi.png" alt="Raspberry Pi"/>
-        <div>
-          <h3>Raspberry Pi</h3>
-          <p>A low-cost DIY solution to get started with Home Assistant</p>
-        </div>
-        <a class="button" aria-label="Learn more about installing Home Assistant on Raspberry Pi" href="/installation/raspberrypi">Learn more</a>
-      </div>
-    </div>
 
     <div class="getting-started-device" id="HA_Green">
       <div class="content">
@@ -24,7 +12,7 @@
         <img src="/images/frontpage/ha-green.png" alt="Home Assistant Green"/>
         <div>
           <h3>Home Assistant Green</h3>
-          <p>The easiest way to get started with Home Assistant</p>
+          <p>A plug-and-play hub that is ready to use in about 15 minutes. Recommended for most people.</p>
         </div>
         <a class="button" aria-label="Learn more about Home Assistant Green" href="/green">Learn more</a>
       </div>
@@ -32,21 +20,33 @@
 
     <div class="getting-started-device" id="HA_Yellow">
       <div class="content">
-        <div class="badge">Intermediate</div>
+        <div class="badge">More powerful</div>
         <img src="/images/frontpage/ha-yellow.png" alt="Home Assistant Yellow"/>
         <div>
           <h3>Home Assistant Yellow</h3>
-          <p>The powerful way to run and customize Home Assistant to your needs</p>
+          <p>A more powerful and expandable hub for larger setups, with built-in Zigbee, Thread, and Matter support.</p>
         </div>
         <a class="button" aria-label="Learn more about Home Assistant Yellow" href="/yellow">Learn more</a>
+      </div>
+    </div>
+
+    <div class="getting-started-device" id="Raspberry_Pi">
+      <div class="content">
+        <div class="badge">Bring your own</div>
+        <img src="/images/frontpage/raspberry-pi.png" alt="Raspberry Pi"/>
+        <div>
+          <h3>Raspberry Pi</h3>
+          <p>Already have a Raspberry Pi? Install Home Assistant on it and be up and running in a few steps.</p>
+        </div>
+        <a class="button" aria-label="Learn more about installing Home Assistant on Raspberry Pi" href="/installation/raspberrypi">Learn more</a>
       </div>
     </div>
   </div>
 
   <div class="grid__item one-half palm-one-whole">
     <h2>Need more options?</h2>
-    <p>Home Assistant can repurpose and be installed on various hardware, such as an Odroid or a generic x86-64 machine.</p>
-    <p>The Home Assistant Operating System allows you to install Home Assistant on these devices even if you have little to no Linux experience.</p>
+    <p>Home Assistant also runs on other hardware, such as an ODROID, an Intel NUC, or any x86-64 machine.</p>
+    <p>The Home Assistant Operating System makes installing Home Assistant on these devices straightforward, even if you have little to no Linux experience.</p>
     <a class="button" href="/installation#install-on-other-hardware">Get started</a>
   </div>
 </section>

--- a/source/apps/index.html
+++ b/source/apps/index.html
@@ -30,7 +30,7 @@ regenerate: false
 </p>
 
 {% important %}
-Apps are only available if you used the Home Assistant Operating System <a href="/installation">installation method</a>. With other installation methods you can often achieve the same result manually; refer to the documentation provided by the application you would like to run.
+Apps are only available if you used the Home Assistant Operating System <a href="/installation">installation method</a>. With other installation methods, you can often achieve the same result manually. Refer to the documentation provided by the application you would like to run.
 {% endimportant %}
 
 <p>

--- a/source/apps/index.html
+++ b/source/apps/index.html
@@ -1,18 +1,19 @@
 ---
 title: "Home Assistant Apps"
-description: "Find apps to install with Home Assistant."
+description: "Apps extend Home Assistant with extra applications, from MQTT brokers to ad blockers, all installable in a few clicks from the built-in app store."
 regenerate: false
 ---
 
 <p>
-  Apps (formerly known as add-ons) allow you to extend the functionality around Home
-    Assistant by installing additional applications.
+  Apps (formerly known as add-ons) extend Home Assistant with additional
+  applications that run alongside it on your own hardware. You can install,
+  update, and configure them in a few clicks from the built-in {% my supervisor title="<b>Settings</b> > <b>Apps</b>" %} panel.
 </p>
 <p>
-  This can be running an application that Home Assistant can integrate with
-    (like an MQTT broker) or to share the configuration via Samba for easy editing
-    from other computers. Apps can be configured via the {% my supervisor title="Settings > Apps" %} panel in Home
-    Assistant.
+  Apps can run anything from an MQTT broker for your smart devices, to a network-wide
+  ad blocker, to a file-sharing service that lets you edit your configuration from another
+  computer. Whatever you install stays on your own hardware, alongside the rest of
+  your smart home.
 </p>
 
 <p class="img">
@@ -21,16 +22,15 @@ regenerate: false
 </p>
 
 <p>
-  To install apps, in Home Assistant, go to {% my supervisor title="Settings > Apps" %}, and select <b>Install app</b>. All apps, including their documentation, are available right from the store.
-    Some advanced apps will only be visible after you opt-in to "Advanced Mode" which can be changed on your user profile page.
-    Click on an app you are interested in, to read the documentation or to install the app.
+  To install an app, in Home Assistant, go to {% my supervisor title="<b>Settings</b> > <b>Apps</b>" %}, and select <b>Install app</b>. All apps, including their documentation, are available right from the store. Select an app you are interested in to read its documentation or to install it.
+</p>
+
+<p>
+  A few power-user apps are hidden by default. To see them, turn on <b>Advanced mode</b> on your user profile page.
 </p>
 
 {% important %}
-Apps are only available if you've used the Home Assistant Operating System <a href="/installation">installation</a> method. If you
-installed Home Assistant using any other method then you cannot use apps.
-Often you can achieve the same manually, refer to the documentation by the
-vendor of the application you'd like to install.
+Apps are only available if you used the Home Assistant Operating System <a href="/installation">installation method</a>. With other installation methods you can often achieve the same result manually; refer to the documentation provided by the application you would like to run.
 {% endimportant %}
 
 <p>

--- a/source/cloud/index.markdown
+++ b/source/cloud/index.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Home Assistant Cloud"
-description: "Enable the Home Assistant Cloud integration."
+description: "Home Assistant Cloud is an optional subscription from Nabu Casa that adds secure remote access, voice assistant integrations with Google and Alexa, and helps fund the project."
 sidebar: false
 ha_release: "0.60"
 ha_category: Voice
@@ -8,7 +8,11 @@ ha_iot_class: Cloud Push
 ha_domain: cloud
 ---
 
-Home Assistant Cloud is a subscription service provided by our partner Nabu Casa, Inc. Check out [their website](https://www.nabucasa.com) for more information on features, pricing, and [how to configure Home Assistant](https://www.nabucasa.com/config/).
+Home Assistant Cloud is an optional subscription service provided by our partner [Nabu Casa](https://www.nabucasa.com). It adds secure remote access to your Home Assistant from anywhere, integrations with Google Assistant and Amazon Alexa, and the text-to-speech and speech-to-text engines used by [Assist](/voice_control/). Subscriptions also help fund the development of Home Assistant itself.
+
+Home Assistant works fully without it. Home Assistant Cloud is there for the things that genuinely benefit from a cloud connection, such as remote access and the voice assistant integrations, while everything else continues to run locally on your own hardware.
+
+For full details on features, pricing, and setup instructions, see the [Nabu Casa website](https://www.nabucasa.com).
 
 <div style='max-width: 250px; margin: 0 auto'><a href='https://www.nabucasa.com'><img src='/images/blog/2018-09-thinking-big/logo-text.svg' style='border: 0; box-shadow: none' alt='Logo of Nabu Casa, Inc'></a>
 </div>

--- a/source/common-tasks/container.markdown
+++ b/source/common-tasks/container.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Common tasks - Container"
-description: "Common tasks for Home Assistant Container"
+title: "Common tasks - Home Assistant Container"
+description: "Tasks specific to Home Assistant Container installations, including updating the container image and managing the underlying Docker environment."
 installation: container
 ---
 

--- a/source/common-tasks/general.markdown
+++ b/source/common-tasks/general.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Common tasks - installation independent"
-description: "Common tasks"
+title: "Common tasks for every Home Assistant"
+description: "Tasks that work the same on every Home Assistant installation: managing users, creating backups, configuring access tokens, and similar housekeeping."
 installation_name: "Installation independent"
 ---
 This section provides tasks that do not depend on a specific Home Assistant installation type or a specific integration. They may be referenced in other procedures.

--- a/source/common-tasks/os.markdown
+++ b/source/common-tasks/os.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Common tasks - Operating System"
-description: "Common tasks for Home Assistant Operating System"
+title: "Common tasks - Home Assistant Operating System"
+description: "Tasks specific to Home Assistant Operating System installations, such as updating the OS, working with network storage, and accessing the underlying system."
 installation: os
 installation_name: "Operating System"
 related:

--- a/source/dashboards/actions.markdown
+++ b/source/dashboards/actions.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Actions"
-description: "Define what an object does when interacted with."
+title: "Dashboard actions"
+description: "Define what happens when you tap, hold, or double-tap a card on your dashboard, from toggling a device to opening another dashboard."
 related:
   - docs: /dashboards/button/
     title: Button card

--- a/source/dashboards/cards.markdown
+++ b/source/dashboards/cards.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Cards"
-description: "Introduction to the role of cards on the dashboard and how to add a card."
+title: "Dashboard cards"
+description: "Cards are the building blocks of a Home Assistant dashboard. Each card shows information from your home or lets you control a device, and you add them with a single tap."
 related:
   - docs: /dashboards/actions/
     title: Card tap actions

--- a/source/dashboards/dashboards.markdown
+++ b/source/dashboards/dashboards.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Multiple dashboards"
-description: "Multiple powerful and configurable dashboards in Home Assistant."
+description: "Create more than one dashboard in Home Assistant: a private overview for yourself, a simpler one for the rest of the household, and a tablet view in the kitchen."
 related:
   - docs: /integrations/logbook/
     title: Activity integration

--- a/source/dashboards/features.markdown
+++ b/source/dashboards/features.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Features for dashboard cards"
-description: "Decorate your dashboard cards with quick controls."
+title: "Card features"
+description: "Add quick controls to your dashboard cards, such as a brightness slider for a light, a fan speed selector, or a temperature setpoint."
 related:
   - docs: /dashboards/humidifier/
     title: Humidifier card

--- a/source/dashboards/header-footer.markdown
+++ b/source/dashboards/header-footer.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Headers & Footers for dashboard cards"
-description: "Decorate your dashboard cards with header and footer widgets."
+title: "Card headers and footers"
+description: "Add a header or footer to a dashboard card to show extra information such as a graph, a weather forecast, or a list of buttons."
 related:
   - docs: /integrations/entity/
     title: Entity

--- a/source/dashboards/index.markdown
+++ b/source/dashboards/index.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Dashboards"
-description: "Powerful and configurable dashboards for Home Assistant."
+description: "Build customizable dashboards for your smart home with drag and drop, no coding required."
 related:
   - docs: /integrations/entity/
     title: Dashboard themes
@@ -16,7 +16,9 @@ related:
     title: Community custom cards
 ---
 
-Home Assistant dashboards allow you to display information about your smart home. Dashboards are customizable and provide a powerful way to manage your home from your mobile or desktop.
+Your dashboard is what you and your family see when you open the Home Assistant app or website. It is the at-a-glance view of your home: which lights are on, what the temperature is in each room, who is home, and what is happening right now. From the same dashboard, a single tap dims the lights, starts your robot vacuum, or arms the alarm.
+
+Home Assistant comes with a dashboard out of the box, automatically generated from the devices you add. From there, you can build your own dashboards visually, with drag and drop, no coding required. Make a focused dashboard for the kitchen tablet, a simple one for guests, and a detailed one for yourself.
 
 You can customize your dashboard using various options:
 

--- a/source/dashboards/views.markdown
+++ b/source/dashboards/views.markdown
@@ -1,6 +1,6 @@
 ---
-title: "Views"
-description: "A view is a tab inside a dashboard."
+title: "Dashboard views"
+description: "A view is a tab inside a dashboard that groups related cards together, such as a tab for the living room or one for energy."
 related:
   - docs: /dashboards/masonry/
     title: Masonry view

--- a/source/docs/index.html
+++ b/source/docs/index.html
@@ -5,7 +5,7 @@ feedback: false
 no_toc: true
 ---
 
-<p>The documentation covers beginner to advanced topics around the installation, setup, configuration, and usage of Home Assistant.</p>
+<p>Home Assistant is the open smart home platform that runs on your own hardware and works with thousands of devices and brands. This documentation covers everything from your first install to advanced setups, and most of it can be done through the user interface without writing any code.</p>
 
 <p>
   To see what Home Assistant can do, take a look at the <a href="https://demo.home-assistant.io">demo page</a>.

--- a/source/getting-started/automation.markdown
+++ b/source/getting-started/automation.markdown
@@ -1,11 +1,11 @@
 ---
 title: "Automating Home Assistant"
-description: "A quick intro on getting your first automation going."
+description: "Build your first Home Assistant automations using the visual editor, no code required."
 ---
 
-Once your {% term devices %} are set up, it's time to put the cherry on the pie: {% term automation %}.
+Now that your devices are connected, you can put them to work. {% term Automations %} let your home react to things on its own: turn the lights on when the sun goes down, lower the heat when everyone leaves, or remind you to close the garage door at bedtime. You build them with the visual automation editor, so you can follow this tutorial without writing a single line of code.
 
-We're going to create two automations: One, to turn on the lights when the sun sets. And a second one to dim the light at a certain time in the evening before a workday.
+We are going to create two automations together: one that turns the lights on as the sun sets, and a second that dims them later in the evening on workdays.
 
 ## Turning on the lights before sunset
 

--- a/source/getting-started/concepts-terminology.markdown
+++ b/source/getting-started/concepts-terminology.markdown
@@ -1,8 +1,8 @@
 ---
 title: "Concepts and terminology"
-description: "Explaining some Home Assistant basics"
+description: "The core concepts behind Home Assistant: integrations, devices, entities, areas, and automations."
 ---
-Now you're in Home Assistant, let's look at the most important concepts.
+Now that you are in Home Assistant, let's look at the most important concepts. Home Assistant is built around a small set of building blocks: integrations, devices, entities, areas, and automations. Once you understand how they fit together, the rest of the platform falls into place.
 
 ## Integrations
 

--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Next steps"
-description: "Next steps in configuring your Home Assistant"
+description: "You have Home Assistant up and running. Here is what to look at next: adding the rest of your household, installing the mobile apps, setting up backups, and exploring voice control."
 related:
   - docs: configuration/basic/
     title: Changing basic settings
@@ -16,7 +16,7 @@ related:
     title: Home Assistant on Android and iOS
 ---
 
-The onboarding process takes you through the initial setup for Home Assistant, such as getting the system up and running, naming your home and selecting your location. This section points you to further documentation helping you with the next steps.
+Onboarding got you the basics: a working Home Assistant, your home's name and location, your first integrations. From here, your smart home is yours to shape. This page points you to a few of the next things most people do once they have Home Assistant running, so you can pick whichever one matters most to you and pace yourself.
 
 ## Adding other persons to Home Assistant
 

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -1,12 +1,14 @@
 ---
-title: "Getting started"
-description: "Getting started with Home Assistant"
+title: "Getting started with Home Assistant"
+description: "A step-by-step guide to setting up Home Assistant: installing on your hardware, completing the first-run onboarding, adding your devices, and creating your first automation."
 body_id: getting_started
 feedback: false
 show_title: true
 ---
 
-Thanks for choosing Home Assistant for your smart home. Here are the basic steps to get you started on the journey to a more private, powerful, and sustainable home.
+Welcome to Home Assistant. This guide walks you through everything you need to get up and running, from picking your hardware to creating your first automation. There are no servers in the cloud and no hidden subscriptions: Home Assistant runs on your own hardware, in your own home, and your data stays with you.
+
+You do not need to write code or edit configuration files to follow along. Almost everything is done from the user interface. The whole journey, from a fresh install to a working smart home, takes most people about an afternoon.
 
 <!-- textlint-disable -->
 {% include getting-started/next_step.html step="Installation" link="/installation/" icon="simple-icons:homeassistant" %}

--- a/source/getting-started/integration.markdown
+++ b/source/getting-started/integration.markdown
@@ -1,8 +1,10 @@
 ---
 title: "Adding integrations"
-description: "Instructions to add an integration."
+description: "Add your first integration to Home Assistant. Choose from over a thousand brands, with most setups handled by the user interface."
 ---
-Let's start by adding your first {% term integration %}. In this tutorial, we will use the **Workday** integration. It can be used to automate based on workdays, days off, or holidays. No smart device is needed for this tutorial.
+Let's start by adding your first {% term integration %}. Home Assistant works with devices and services from over a thousand brands, and most of them can be added through the user interface in just a few steps.
+
+In this tutorial, we will use the **Workday** integration. It can be used to automate based on workdays, days off, or holidays. No smart device is needed for this tutorial.
 
 ## Prerequisites
 

--- a/source/getting-started/join-the-community.markdown
+++ b/source/getting-started/join-the-community.markdown
@@ -1,19 +1,21 @@
 ---
-title: "Join the Community"
-description: "Part of the Home Assistant experience is the large world-wide community of tinkerers. Join us."
+title: "Join the community"
+description: "One of the best parts of Home Assistant is the people who use it. A worldwide community of enthusiasts, builders, and helpers - all sharing what they have learned."
 toc: false
 ---
 
-You made it here? Good job! You've been able to install Home Assistant and get a small taste of all the things that are possible.
+You made it. You have Home Assistant installed and you have had a first taste of what it can do. From here, the best resource you have is not the documentation, it is the people who use Home Assistant every day.
 
-Now that you've got that going, let's see what is next:
+A worldwide community of Home Assistant users hangs out on the forum and in the chat, all of them happy to help you figure things out, share what works in their homes, and trade automation ideas. Whatever you are trying to build, somebody has probably already done something close to it.
 
- - Learn about [next steps](/getting-started/configuration/) of the getting started guide, such as creating a backup or configuring network storage.
- - Join the community in [our forums] or [our chat].
- - Check out [video tutorials] on a wide range of Home Assistant related topics
+Here are some good places to start:
 
-You're now ready to be a part of our world-wide community of tinkerers. Welcome!
+ - Read up on the [next steps](/getting-started/configuration/) of the getting started guide, like creating a backup or setting up network storage.
+ - Join the conversation on [our forum] or in [our chat].
+ - Browse [video tutorials] for almost any Home Assistant topic you can think of.
 
-[our forums]: https://community.home-assistant.io/
+Welcome to the community.
+
+[our forum]: https://community.home-assistant.io/
 [our chat]: /join-chat/
 [video tutorials]: https://www.youtube.com/results?search_query=home+assistant

--- a/source/getting-started/onboarding.markdown
+++ b/source/getting-started/onboarding.markdown
@@ -4,7 +4,7 @@ description: "Set up Home Assistant for the first time. Create your account, res
 toc: false
 ---
 
-After Home Assistant has been [installed](/installation/) on your device, there are 5 steps to complete setting up Home Assistant. The whole onboarding takes only a few minutes and is done entirely in your browser, so no command line or coding is required.
+After Home Assistant has been [installed](/installation/) on your device, there are 5 steps to complete setting up Home Assistant. The entire onboarding takes only a few minutes and is done in your browser, so no command-line or coding is required.
 
 1. Enter the following URL into the browser's address bar: [http://homeassistant.local:8123/](http://homeassistant.local:8123/).
    - Result: You now see the **Preparing Home Assistant** page. Depending on your hardware and internet connection, preparation may take a while.

--- a/source/getting-started/onboarding.markdown
+++ b/source/getting-started/onboarding.markdown
@@ -1,14 +1,14 @@
 ---
 title: "Onboarding Home Assistant"
-description: "Instructions to get Home Assistant configured."
+description: "Set up Home Assistant for the first time. Create your account, restore from a backup, or pick up where you left off."
 toc: false
 ---
 
-After Home Assistant has been [installed](/installation/) on your device, there are 5 steps to complete setting up Home Assistant.
+After Home Assistant has been [installed](/installation/) on your device, there are 5 steps to complete setting up Home Assistant. The whole onboarding takes only a few minutes and is done entirely in your browser, so no command line or coding is required.
 
 1. Enter the following URL into the browser's address bar: [http://homeassistant.local:8123/](http://homeassistant.local:8123/).
    - Result: You now see the **Preparing Home Assistant** page. Depending on your hardware and internet connection, preparation may take a while.
-     - Home Assistant downloads the latest version of {% term "Home Assistant Core" %} (about 700&nbsp;MB).
+     - Home Assistant downloads the latest version of Home Assistant (about 700&nbsp;MB).
    - If you ran into issues with this step, refer to the [installation troubleshooting](/installation/troubleshooting/).
    - Once preparation is finished, the welcome screen is shown.
 

--- a/source/getting-started/onboarding_dashboard.markdown
+++ b/source/getting-started/onboarding_dashboard.markdown
@@ -1,9 +1,9 @@
 ---
 title: "Introduction to dashboards"
-description: "Dashboards overview and instructions on editing the dashboard for the first time"
+description: "Dashboards are how you see and control your smart home in Home Assistant. Build them visually, no coding required."
 ---
 
-Dashboards are customizable pages that display information about your smart home devices.
+Dashboards are how you see and control your smart home in Home Assistant. They are made up of cards and views, and you can build them visually with drag and drop, so no coding is required.
 
 ## Types of dashboards
 

--- a/source/getting-started/presence-detection.markdown
+++ b/source/getting-started/presence-detection.markdown
@@ -1,9 +1,9 @@
 ---
 title: "Setting up presence detection"
-description: "Instructions on how to set up zone presence detection within Home Assistant."
+description: "Set up presence detection in Home Assistant to trigger automations when people arrive home or leave."
 ---
 
-Zone presence detection detects if people are within a certain zone, which can be valuable input for automation. Knowing who is home or where they are opens a range of automation options:
+Presence detection tells Home Assistant who is at home and where they are. That is one of the most useful pieces of information you can give your smart home, because it lets your automations react to people arriving and leaving:
 
 - Send me a notification when my child arrives at school
 - Turn on the AC when I leave work

--- a/source/help/index.markdown
+++ b/source/help/index.markdown
@@ -1,9 +1,9 @@
 ---
-title: "Help"
-description: "If you need help or have a question..."
+title: "Get help with Home Assistant"
+description: "Get help with Home Assistant from the community forum, the Discord chat server, social channels, and the official issue trackers."
 ---
 
-There are various ways to get in touch with the Home Assistant community. It doesn't matter if you have a question, need help, want to request a feature, or just say 'Hi'.
+Home Assistant has one of the largest and most active smart home communities on the internet. Whether you have a question, need help with a setup, want to request a feature, or just want to say hi, there are plenty of places to get in touch.
 
 ## Communication channels
 
@@ -15,9 +15,9 @@ There are various ways to get in touch with the Home Assistant community. It doe
 - Join the [Facebook community][facebook]
 - Join the Reddit in [/r/homeassistant][reddit]
 
-## Bugs, Feature requests, and alike
+## Bugs and feature requests
 
-Have you found an issue in your Home Assistant installation? Please report it. Reporting it makes it easy to track and ensures that it gets fixed. For more details, please refer to the [Reporting issues](/help/reporting_issues/) page.
+Have you found an issue in your Home Assistant installation? Please report it. Reporting it makes it easy to track and ensures that it gets fixed. For more details, refer to the [Reporting issues](/help/reporting_issues/) page.
 
 - [Feature requests](https://github.com/orgs/home-assistant/discussions) (Don't post feature requests in the issue trackers. Thanks!)
 - [Issue tracker Home Assistant Core](https://github.com/home-assistant/core/issues)
@@ -28,7 +28,7 @@ Have you found an issue in your Home Assistant installation? Please report it. R
 - [Issue tracker Home Assistant iOS App](https://github.com/home-assistant/ios/issues)
 - [Issue tracker website & documentation](https://github.com/home-assistant/home-assistant.io/issues)
 
-## Videos, talks, workshops and alike
+## Videos, talks, and workshops
 
 - [PyconFR 2018 - Faire de la domotique libriste avec Python](https://www.youtube.com/watch?v=Eu6umBJ51I4) (French) ([Slides](https://hackmd.io/p/BJTSyDkqm)) - October 2018
 - [Automate your home with Home Assistant](https://www.youtube.com/watch?v=SSrgi4iHGbs) at [foss-north 2018](https://foss-north.se/2018/speakers-and-talks.html#jparadies) - March 2018

--- a/source/installation/index.html
+++ b/source/installation/index.html
@@ -8,9 +8,14 @@ toc: true
 
 <div class="intro">
   <p class="lead">
-    The first step to getting started with Home Assistant is to install it on a
-    device. There are many ways to run it for all kinds of scenarios and all
-    kinds of skill levels.
+    Home Assistant runs on your own hardware, so your smart home keeps
+    working even when the internet is down and your data stays at home with
+    you. The easiest way to get started is with
+    <a href="/green/">Home Assistant Green</a>, a plug-and-play hub that is
+    ready to use in about 15 minutes. If you would rather use hardware you
+    already own, Home Assistant runs on a Raspberry Pi, a mini PC, a
+    server, or in a virtual machine. Pick the option below that fits you
+    best.
   </p>
 </div>
 
@@ -65,11 +70,11 @@ toc: true
 
   <span class="label easy">Easy</span>
 
-  <h2>DIY with Raspberry Pi</h2>
+  <h2>Install on a Raspberry Pi</h2>
   <p>
-    Raspberry Pi, a mini low-cost computer, is one of the most popular platforms
-    for running Home Assistant. If you want to learn how to DIY, this is a good
-    way to start and gain experience.
+    The Raspberry Pi, a small and affordable computer, is one of the most popular
+    platforms for running Home Assistant. If you already have one or want to put
+    one to use, this is a great option to get started.
   </p>
 
   <div class="installations-card">
@@ -82,7 +87,7 @@ toc: true
         </div>
         <div class="content">
           <h3>Install Home Assistant on Raspberry Pi</h3>
-          <p>A low-cost DIY solution to get started with Home Assistant</p>
+          <p>A great option if you already have a Raspberry Pi or want to put one to use.</p>
           <div class="columns">
             <div>
               <b>SKILLS REQUIRED</b>

--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -1,6 +1,6 @@
 ---
-title: "Integrations"
-description: "List of the built-in integrations of Home Assistant."
+title: "Integrations - devices and services that work with Home Assistant"
+description: "Browse the list of devices and services Home Assistant works with. Home Assistant supports thousands of brands across more than a hundred categories, including Z-Wave, Zigbee, Matter, and Thread."
 sidebar: false
 is_homepage: true
 feedback: false

--- a/source/voice_control/best_practices.markdown
+++ b/source/voice_control/best_practices.markdown
@@ -1,5 +1,6 @@
 ---
 title: Best practices with Assist
+description: "Tips to get the most out of Assist: which devices to expose, how to name your areas and entities, and small tweaks that make voice commands feel natural."
 related:
   - docs: /voice_control/android
     title: Assist on Android devices
@@ -14,12 +15,9 @@ related:
   - url: https://support.nabucasa.com/hc/categories/24451727188125
     title: Voice Preview Edition
 ---
-There are a few things you should do to get the most out of the voice assistant experience.
+Voice control feels effortless when it is set up well, and frustrating when it is not. The good news is that getting Assist to feel natural mostly comes down to a few simple choices: which devices it can see, how things are named, and how your home is organized into areas. This page collects the small habits that make a big difference.
 
-Using Assist consists of saying supported commands while targeting exposed devices and entities. So essentially:
-
-- You control what data Assist has access to, and what it can control.
-- Every entity in Home Assistant can be exposed or not to Assist.
+In Home Assistant, you decide what Assist has access to. Every entity is opt-in: nothing is exposed to your voice assistant until you say so. That means you can give Assist exactly the devices and information you want it to handle, and nothing else.
 
 Some best practices we recommend to have an efficient setup are:
 

--- a/source/voice_control/index.markdown
+++ b/source/voice_control/index.markdown
@@ -1,5 +1,6 @@
 ---
-title: Talking with Home Assistant - get your system up & running
+title: "Assist - Talk to your smart home with Home Assistant"
+description: "Assist is the voice assistant built into Home Assistant. It can run fully on your own hardware, so your voice commands stay private."
 related:
   - docs: /voice_control/android/
     title: Assist on Android
@@ -15,18 +16,11 @@ related:
     title: Voice Preview Edition
 ---
 
-This section will help you set up Assist, which is Home Assistant's voice assistant.
+Assist is the voice assistant built into Home Assistant. It lets you control your smart home with natural language, and it can run fully on your own hardware, so your voice commands stay private. Assist works in the Home Assistant companion app, on dedicated voice hardware like the [Home Assistant Voice Preview Edition](/voice-pe/), and on devices you build yourself with [ESPHome](https://www.esphome.io/components/voice_assistant/).
 
-Assist allows you to control Home Assistant using natural language. It is built on top of an open voice foundation and powered by knowledge provided by our community.
+Look for the Assist icon <img src='/images/assist/assist-icon.svg' alt='Assist icon' style='height: 32px' class='no-shadow'> at the top right of your dashboard to try it out right away.
 
-The simplest way to try out Assist is inside our companion app. Look for the Assist icon <img src='/images/assist/assist-icon.svg' alt='Assist icon' style='height: 32px' class='no-shadow'> at the top right of your dashboard.
-
-The simplest way to get started with Assist is with our recommended voice assistant hardware, the [Home Assistant Voice Preview Edition](/voice-pe/).
-
-As for the rest of Home Assistant core functionalities, Assist can be personalized and extended to fit your needs.
-
-- It can work locally or leverage the greatest LLMs of the moment.
-- It can work on your phone or tablet or other custom voice devices.
+Assist is built on an open voice foundation and powered by knowledge contributed by our community. It can work locally or, if you prefer, use one of the latest large language models to handle more conversational requests.
 
 <lite-youtube videoid="XF53wUbeLxA" videotitle="Voice at Home Assistant"></lite-youtube>
 

--- a/source/voice_control/voice_remote_cloud_assistant.markdown
+++ b/source/voice_control/voice_remote_cloud_assistant.markdown
@@ -1,5 +1,6 @@
 ---
-title: "Getting Started - Home Assistant Cloud"
+title: "Set up a voice assistant with Home Assistant Cloud"
+description: "The fastest way to get Assist running well: use the high-quality speech-to-text and text-to-speech voices included with a Home Assistant Cloud subscription."
 related:
   - docs: /voice_control/best_practices/
     title: Best practices with Assist
@@ -13,12 +14,11 @@ related:
     title: Voice Preview Edition - Documentation
 ---
 
-Before being able to use Assist, you need to configure it.
+The fastest way to get a great-sounding voice assistant up and running is to use the speech-to-text and text-to-speech voices included with a [Home Assistant Cloud](https://www.nabucasa.com/config/) subscription. They handle the heavy parts (turning your speech into text and turning Home Assistant's reply into a natural-sounding voice) on Nabu Casa's servers, so you can use Assist without needing extra hardware.
 
-The simplest and most effective way to use Assist is to leverage the voice providers (for speech-to-text and text-to-speech) included in Home Assistant Cloud.
-This page will detail how to do just that.
+Only the audio is sent to the cloud for processing. Everything Assist actually does in your home, opening lights, locking doors, running automations, still happens on your own Home Assistant.
 
-If you are interested in setting up a fully local voice assistant, follow the [guide to creating a local voice assistant](/voice_control/voice_remote_local_assistant/) instead.
+If you would prefer to keep absolutely everything local, see the [fully local voice assistant guide](/voice_control/voice_remote_local_assistant/) instead.
 
 
 ## Setting up a cloud Assist pipeline

--- a/source/voice_control/voice_remote_local_assistant.markdown
+++ b/source/voice_control/voice_remote_local_assistant.markdown
@@ -1,5 +1,6 @@
 ---
-title: "Getting started - Local"
+title: "Set up a fully local voice assistant"
+description: "Run Assist completely on your own hardware: do speech recognition, intent processing, and text-to-speech locally, with no cloud involved."
 related:
   - docs: /voice_control/best_practices/
     title: Best practices with Assist
@@ -11,9 +12,9 @@ related:
     title: Voice Preview Edition - Documentation
 ---
 
-The simplest and most effective way to use Assist is to leverage the voice providers (for speech-to-text and text-to-speech) included in [Home Assistant Cloud](/voice_control/voice_remote_cloud_assistant/)
+Assist can run entirely on your own hardware. Your spoken commands never leave your home: a microphone hears you, a local speech-to-text engine turns your voice into text, Home Assistant figures out what you want, and a local text-to-speech engine speaks the answer back. This guide walks you through setting that up.
 
-If you are interested in setting up a fully local voice assistant, follow this setup:
+If you would rather not run all of that yourself, the simplest path is to use the speech-to-text and text-to-speech voices included with [Home Assistant Cloud](/voice_control/voice_remote_cloud_assistant/). Both options work well, and you can switch between them later.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Proposed change

A broad refresh of the introductions, page titles, and frontmatter descriptions across the main user-facing sections of the documentation. The goal is to make these pages read like they were written for the people actually arriving on them today: people who use Home Assistant from the user interface and the companion app, do not necessarily write code, and often land on a page directly from a search engine.

The changes are deliberately limited to introductions, titles, and descriptions. The reference content, examples, and YAML snippets further down each page are left alone.

This aims at improve SEO and LLMO for our website.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
