### PR TITLE
Update Duco current docs for 2026.5.2

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -34,19 +34,15 @@ Hardware revisions:
 Compatible DucoBox models:
 
 - DucoBox Silent Connect
-- DucoBox Focus (from firmware version 17xxxx)
-- DucoBox Hygro Plus
-- DucoBox Energy Comfort / Energy Comfort Plus
-- DucoBox Energy Premium
 
 ### Supported sensor modules
 
 The following sensor module types are supported:
 
-- **BOX**: The main ventilation box; provides fan control, ventilation state, Wi-Fi signal strength, and temperature (measured inside the housing; disabled by default).
-- **UCCO2**: Wall-mounted CO₂ sensor unit; provides CO₂ concentration, CO₂ air quality index, and temperature.
-- **BSRH**: Humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity, humidity air quality index, and temperature.
-- **UCRH**: Wireless humidity sensor module; provides relative humidity, humidity air quality index, and temperature.
+- **BOX**: The main ventilation box; provides fan control, ventilation state, and Wi-Fi signal strength.
+- **UCCO2**: Wall-mounted CO₂ sensor unit; provides CO₂ concentration and CO₂ air quality index.
+- **BSRH**: Humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity and humidity air quality index.
+- **UCRH**: Wireless humidity sensor module; provides relative humidity and humidity air quality index.
 
 ### Unsupported sensor modules
 
@@ -136,12 +132,6 @@ Indoor air quality ranges for humidity:
 - 35–50%: Temporarily acceptable
 - 5–20%: Poor
 
-#### Temperature
-
-Available for the external sensor modules (UCCO2, BSRH, and UCRH). Shows the current air temperature in degrees Celsius measured by the sensor module.
-
-The main ventilation box (BOX) also provides a temperature reading. This entity is disabled by default because it reflects the temperature inside the box housing, which is typically not representative of the room temperature.
-
 #### Wi-Fi signal strength
 
 Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in dBm. This entity is disabled by default.
@@ -152,7 +142,6 @@ Available for the main ventilation box (BOX). Shows the Wi-Fi signal strength in
 - Return to auto mode when everyone leaves home using a presence-based automation.
 - Monitor ventilation activity over time via the logbook.
 - Trigger automations based on CO₂ levels or humidity reported by connected Duco modules.
-- Use temperature readings from sensor modules to detect rooms that are too hot or too cold and adjust ventilation accordingly.
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

> [!WARNING]
> Update the existing Duco documentation on the `current` branch so it matches the early production release of home-assistant/core#170237 in milestone/patch 2026.5.2.
>
> This documentation change is therefore time-sensitive.
>
> This is a current-branch port of home-assistant/home-assistant.io#45286, but with the supported hardware scope narrowed for now:

This PR:
- Removes the temperature sensor documentation that no longer matches the integration behavior
- Limits the listed compatible DucoBox models to **DucoBox Silent Connect** for now
- Keeps the change scoped to the existing `current` documentation page

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#170237
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards