### PR TITLE
Add SwitchBot Permanent Outdoor Light to SwitchBot Bluetooth integration

### DIFF
--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -153,6 +153,7 @@ For instructions on how to obtain the encryption key, see README in [PySwitchbot
 - [Floor Lamp](https://www.switch-bot.com/products/switchbot-floor-lamp)
 - [RGBICWW Strip Light](https://www.switch-bot.com/products/switchbot-rgbicww-strip-light)
 - [RGBICWW Floor Lamp](https://www.switch-bot.com/products/switchbot-rgbicww-floor-lamp)
+- Permanent Outdoor Light
 
 ### Locks
 
@@ -637,6 +638,18 @@ Features:
 - set effect
 
 #### RGBICWW Floor Lamp
+
+This is an encrypted device.
+
+Features:
+
+- turn on or off
+- change brightness
+- change color temperature
+- change color
+- set effect
+
+#### Permanent Outdoor Light
 
 This is an encrypted device.
 


### PR DESCRIPTION
## Proposed change

Documents the SwitchBot Permanent Outdoor Light, newly supported by the `switchbot` Bluetooth integration:

- Lists the device under **Supported devices > Lights**.
- Adds a **Permanent Outdoor Light** subsection under **Supported functionality > Lights** describing it as an encrypted device with on/off, brightness, color temperature, color, and effect support.

The device is exposed via `SwitchbotPermanentOutdoorLight` in `PySwitchbot` (already pinned at 2.2.0 in `home-assistant/core` `dev`).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#170463
- Link to parent pull request in the codebase with the changes for the supported devices: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made changes to existing documentation and used the `current` branch.
  - I made changes that only apply to a new/future version and used the `next` branch.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards