### PR TITLE
Add receiver event entity to LG Infrared

### DIFF
--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -1,6 +1,6 @@
 ---
 title: LG Infrared
-description: Integration to control LG TVs using an infrared emitter, and to receive commands from an LG remote using an infrared receiver.
+description: Integration to control LG TVs using an infrared emitter and to receive commands from an LG remote using an infrared receiver.
 ha_category:
   - Event
   - Media player

--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -1,7 +1,8 @@
 ---
 title: LG Infrared
-description: Integration to control LG TVs using an infrared transmitter.
+description: Integration to control LG TVs using an infrared emitter, and to receive commands from an LG remote using an infrared receiver.
 ha_category:
+  - Event
   - Media player
 ha_release: 2026.4
 ha_iot_class: Assumed State
@@ -11,27 +12,32 @@ ha_domain: lg_infrared
 ha_config_flow: true
 ha_platforms:
   - button
+  - event
   - media_player
 ha_integration_type: device
 ha_quality_scale: silver
 ---
 
-The **LG Infrared** {% term integration %} lets you control an LG TV using any infrared transmitter previously configured in Home Assistant.
+The **LG Infrared** {% term integration %} lets you control an LG TV using any infrared emitter previously configured in Home Assistant. It can also receive commands from an LG remote when you have an infrared receiver set up, allowing you to use the remote to trigger automations in Home Assistant.
 
 Because the integration communicates over infrared, it operates in a one-way, fire-and-forget fashion: commands are sent to the TV but there is no feedback channel to confirm the current state of the TV. The integration therefore uses assumed states.
 
 ## Prerequisites
 
-Before setting up the LG Infrared integration, you need a working infrared transmitter set up in Home Assistant that exposes an [Infrared](/integrations/infrared/) entity. For example, you can use an ESPHome device with an IR LED pointed at your LG TV.
+Before setting up the LG Infrared integration, you need a working infrared emitter, an infrared receiver, or both, already set up in Home Assistant. Each must expose an [Infrared](/integrations/infrared/) entity. For example, you can use an ESPHome device with an IR LED pointed at your LG TV to send commands, and an IR receiver module to capture commands from your LG remote.
 
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}
 Device type:
   description: The type of LG device to control. Currently, only **TV** is supported.
-Infrared transmitter:
-  description: The infrared transmitter entity to use for sending commands. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR transmitter.
+Infrared emitter:
+  description: The infrared emitter entity to use for sending commands to your LG TV. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR emitter.
+Infrared receiver:
+  description: The infrared receiver entity to use for receiving commands from your LG remote. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR receiver.
 {% endconfiguration_basic %}
+
+At least one of **Infrared emitter** or **Infrared receiver** must be selected. Select both if you want to be able to send commands to the TV and react to commands from the remote.
 
 ## Supported devices
 
@@ -45,7 +51,7 @@ The **LG Infrared** integration provides the following entities.
 
 #### Buttons
 
-Button entities are created for common TV remote control functions. Each button sends the corresponding infrared command when pressed.
+Button entities are created when an infrared emitter is configured. Each button sends the corresponding infrared command to the TV when pressed.
 
 - **Power on**, **Power off**
 - **HDMI 1**, **HDMI 2**, **HDMI 3**, **HDMI 4**
@@ -55,7 +61,18 @@ Button entities are created for common TV remote control functions. Each button 
 - **Info**, **Guide**
 - **0** through **9**
 
+#### Events
+
+An event entity is created when an infrared receiver is configured. It fires an event each time an LG TV remote command is received, so you can use the remote to trigger automations in Home Assistant.
+
+- **Received command**
+  - **Description**: Fires when a command from an LG TV remote is decoded from the infrared receiver. The fired event type matches the button pressed on the remote.
+  - **Event types**: `aspect`, `back`, `blue`, `channel_down`, `channel_up`, `exit`, `ez_adjust`, `fast_forward`, `green`, `guide`, `hdmi_1`, `hdmi_2`, `hdmi_3`, `hdmi_4`, `home`, `info`, `input`, `in_start`, `list`, `menu`, `mute`, `nav_down`, `nav_left`, `nav_right`, `nav_up`, `num_0` through `num_9`, `ok`, `pause`, `play`, `power`, `power_off`, `power_on`, `red`, `rewind`, `sap`, `settings`, `stop`, `subtitle`, `text`, `volume_down`, `volume_up`, `yellow`, and `unknown` for any LG command that is not recognized.
+  - **Remarks**: Only commands using the LG infrared address are processed. Signals from other remotes are ignored.
+
 #### Media player
+
+A media player entity is created when an infrared emitter is configured.
 
 - **LG TV**
   - **Description**: Represents the LG TV and allows you to control it via IR commands.
@@ -63,7 +80,7 @@ Button entities are created for common TV remote control functions. Each button 
 
 ## Known limitations
 
-- The integration uses assumed state, meaning Home Assistant cannot read the actual state of the TV (for example, whether it is on or off, or what the current volume is).
+- The integration uses assumed state, meaning Home Assistant cannot read the actual state of the TV (for example, whether it is on or off, or what the current volume is). Commands received through the infrared receiver are exposed as events only; they do not update the state of the media player entity.
 - Turning on and turning off the TV both send the same IR power toggle command, as is standard with infrared remotes.
 - Volume control is step-based only; there is no way to set an absolute volume level.
 

--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -67,7 +67,16 @@ An event entity is created when an infrared receiver is configured. It fires an 
 
 - **Received command**
   - **Description**: Fires when a command from an LG TV remote is decoded from the infrared receiver. The fired event type matches the button pressed on the remote.
-  - **Event types**: `aspect`, `back`, `blue`, `channel_down`, `channel_up`, `exit`, `ez_adjust`, `fast_forward`, `green`, `guide`, `hdmi_1`, `hdmi_2`, `hdmi_3`, `hdmi_4`, `home`, `info`, `input`, `in_start`, `list`, `menu`, `mute`, `nav_down`, `nav_left`, `nav_right`, `nav_up`, `num_0` through `num_9`, `ok`, `pause`, `play`, `power`, `power_off`, `power_on`, `red`, `rewind`, `sap`, `settings`, `stop`, `subtitle`, `text`, `volume_down`, `volume_up`, `yellow`, and `unknown` for any LG command that is not recognized.
+  - **Event types**:
+    - Navigation: `back`, `exit`, `guide`, `home`, `info`, `list`, `menu`, `nav_down`, `nav_left`, `nav_right`, `nav_up`, `ok`, `settings`
+    - Inputs and channels: `channel_down`, `channel_up`, `hdmi_1`, `hdmi_2`, `hdmi_3`, `hdmi_4`, `input`
+    - Playback: `fast_forward`, `pause`, `play`, `rewind`, `stop`
+    - Volume and audio: `mute`, `sap`, `subtitle`, `text`, `volume_down`, `volume_up`
+    - Power: `power`, `power_off`, `power_on`
+    - Number keys: `num_0` through `num_9`
+    - Color buttons: `blue`, `green`, `red`, `yellow`
+    - Other LG commands: `aspect`, `ez_adjust`, `in_start`
+    - `unknown` for any LG command that is not recognized
   - **Remarks**: Only commands using the LG infrared address are processed. Signals from other remotes are ignored.
 
 #### Media player


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
SSIA.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/170529
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
