### PR TITLE
Add SwitchBot Permanent Outdoor Light to supported devices

### DIFF
--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -153,6 +153,7 @@ For instructions on how to obtain the encryption key, see README in [PySwitchbot
 - [Floor Lamp](https://www.switch-bot.com/products/switchbot-floor-lamp)
 - [RGBICWW Strip Light](https://www.switch-bot.com/products/switchbot-rgbicww-strip-light)
 - [RGBICWW Floor Lamp](https://www.switch-bot.com/products/switchbot-rgbicww-floor-lamp)
+- [Permanent Outdoor Light](https://www.switch-bot.com/products/switchbot-permanent-outdoor-light)
 
 ### Locks
 


### PR DESCRIPTION
Documents the SwitchBot Permanent Outdoor Light, added to the SwitchBot Bluetooth integration in home-assistant/core PR for the corresponding feature.