### PR TITLE
Teleinfo: document narrowed USB auto-discovery

### DIFF
--- a/source/_integrations/teleinfo.markdown
+++ b/source/_integrations/teleinfo.markdown
@@ -26,12 +26,18 @@ By connecting a Teleinfo USB adapter to your meter's TIC output, you can monitor
 
 ### USB adapters
 
-The integration auto-discovers the following USB adapters:
+Only the **Micro Teleinfo** USB dongle is auto-discovered. It uses an FTDI chip (USB VID:PID `0403:6015`) and exposes a distinctive USB serial number starting with `TINFO-`, which lets Home Assistant recognize it specifically.
 
-- **FTDI FT2232** (USB VID:PID `0403:6015`): GCE Electronics Teleinfo USB, Cartelectronic
-- **Silicon Labs CP2102** (USB VID:PID `10C4:EA60`): Various Teleinfo USB dongles
+All other adapters are **not** auto-discovered and must be added manually using the configuration flow:
 
-You can also manually configure any serial adapter connected to the meter's TIC output.
+- Cartelectronic dongles
+- Silicon Labs CP2102/CP2102N–based dongles
+- Generic FTDI adapters without a `TINFO-` serial number
+- GPIO/UART serial connections
+
+These adapters rely on generic USB-to-serial bridge chips that are also used by a wide range of unrelated hardware (for example, Zigbee and Z-Wave coordinators), so they cannot be reliably identified as Teleinfo devices. Home Assistant intentionally does not auto-discover them to avoid disturbing other integrations that own the same serial port.
+
+To add one of these adapters, start the integration setup manually and enter the serial port path connected to the meter's TIC output (for example, `/dev/ttyUSB0` or a `/dev/serial/by-id/` path).
 
 ## Prerequisites
 
@@ -218,7 +224,9 @@ This typically indicates corrupted data on the serial line. Check for electrical
 
 ### USB device not auto-detected
 
-Only FTDI FT2232 (`0403:6015`) and Silicon Labs CP2102 (`10C4:EA60`) adapters are auto-discovered. For other adapters, use the manual configuration flow and enter the serial port path directly.
+Only the **Micro Teleinfo** dongle (FTDI `0403:6015` with a USB serial number starting with `TINFO-`) is auto-discovered. All other adapters — including Cartelectronic, Silicon Labs CP2102/CP2102N, generic FTDI, and GPIO/UART connections — must be added manually: start the integration setup and enter the serial port path directly.
+
+Earlier releases also auto-discovered any FTDI `0403:6015` or Silicon Labs CP2102 (`10C4:EA60`) device. Because those USB IDs are shared with unrelated hardware such as Zigbee and Z-Wave coordinators, that broad discovery could open and disturb serial ports owned by other integrations, so it was narrowed to the Micro Teleinfo dongle only. Existing configured devices keep working and are not affected.
 
 ## Removing the integration
 

--- a/source/_integrations/teleinfo.markdown
+++ b/source/_integrations/teleinfo.markdown
@@ -224,7 +224,7 @@ This typically indicates corrupted data on the serial line. Check for electrical
 
 ### USB device not auto-detected
 
-Only the **Micro Teleinfo** dongle (FTDI `0403:6015` with a USB serial number starting with `TINFO-`) is auto-discovered. All other adapters — including Cartelectronic, Silicon Labs CP2102/CP2102N, generic FTDI, and GPIO/UART connections — must be added manually: start the integration setup and enter the serial port path directly.
+Only the **Micro Teleinfo** dongle (FTDI `0403:6015` with a USB serial number starting with `TINFO-`) is auto-discovered. All other adapters—including Cartelectronic, Silicon Labs CP2102/CP2102N, generic FTDI, and GPIO/UART connections—must be added manually: start the integration setup and enter the serial port path directly.
 
 Earlier releases also auto-discovered any FTDI `0403:6015` or Silicon Labs CP2102 (`10C4:EA60`) device. Because those USB IDs are shared with unrelated hardware such as Zigbee and Z-Wave coordinators, that broad discovery could open and disturb serial ports owned by other integrations, so it was narrowed to the Micro Teleinfo dongle only. Existing configured devices keep working and are not affected.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

The Teleinfo USB auto-discovery is being narrowed in core PR
home-assistant/core#170901. Previously the integration auto-discovered any
generic FTDI (`0403:6015`) or Silicon Labs CP2102 (`10C4:EA60`) device. Those
USB IDs are shared with a large range of unrelated hardware (Zigbee/Z-Wave
coordinators, ESP boards, …), so discovery opened and disturbed serial ports
owned by other integrations.

Discovery is now limited to the Micro Teleinfo dongle, which exposes a
distinctive `TINFO-*` USB serial number. CP2102/CP2102N, Cartelectronic,
generic-descriptor FTDI and GPIO/UART setups must now be added manually.

This PR updates the **Supported devices → USB adapters** section and the
**USB device not auto-detected** troubleshooting section accordingly, and
explains that existing configured devices keep working.

The core fix ships in a 2026.5.x patch release, so this documentation
targets the `current` branch.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#170901
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
