### PR TITLE
docs(dashboards): fix views caption claiming 3 layouts

### DIFF
--- a/source/dashboards/views.markdown
+++ b/source/dashboards/views.markdown
@@ -28,8 +28,8 @@ A view is a tab inside a dashboard. For example, the screenshot below shows a se
 Views control the layout.
 
 <p class='img'>
-    <img src='/images/dashboards/layout-types.png' alt='The three basic view layouts: Panel, sidebar, and masonry'>
-    The three basic view layouts: panel, sidebar, and masonry
+    <img src='/images/dashboards/layout-types.png' alt='Three of the four view types: Panel, Sidebar, and Masonry'>
+    Three of the four view types are shown: Panel, Sidebar, and Masonry. The default Sections view is not pictured.
 </p>
 
 There are four different view types:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

The image caption and alt text on [/dashboards/views/](https://www.home-assistant.io/dashboards/views/) said "three basic view layouts: panel, sidebar, and masonry," but the body text directly below correctly states there are four view types (Sections, Masonry, Panel, Sidebar). The `layout-types.png` image predates the Sections view, which became the default in 2024.3, so it shows only three of the four.

This is a text-only fix: the caption now says it shows three of the four view types and notes the default Sections view is not pictured, so it no longer contradicts the text below it. The image itself is unchanged — happy to regenerate it with all four view types in a follow-up PR if maintainers prefer that.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards