### PR TITLE
Add geo_location to Prometheus supported domains

### DIFF
--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -172,7 +172,7 @@ Replace `your.longlived.token` with a Home Assistant [generated token](https://d
 The format to configure the bearer token has changed in Prometheus 2.26, so if you have a newer version, you can use this configuration sample:
 
 ```yaml
-# Example Prometheus scrape_configs entry (For version 2.26+
+# Example Prometheus scrape_configs entry (For version 2.26+)
   - job_name: "hass"
     scrape_interval: 60s
     metrics_path: /api/prometheus
@@ -215,4 +215,4 @@ This use of `unless` (which can be slow to compute) is no longer necessary, but 
 
 Metrics are exported only for the following domains:
 
-`alarm_control_panel`, `automation`, `binary_sensor`, `climate`, `cover`, `counter`, `device_tracker`, `fan`, `humidifier`, `input_boolean`, `input_number`, `light`, `lock`, `number`, `person`, `sensor`, `switch`, `update`
+`alarm_control_panel`, `automation`, `binary_sensor`, `climate`, `cover`, `counter`, `device_tracker`, `fan`, `geo_location`, `humidifier`, `input_boolean`, `input_number`, `light`, `lock`, `number`, `person`, `sensor`, `switch`, `update`


### PR DESCRIPTION
## Proposed change

Add `geo_location` to the list of supported domains in the Prometheus integration docs, corresponding to the new handler added in https://github.com/home-assistant/core/pull/170721.

Also fixes a minor typo: unclosed parenthesis in a YAML comment on line 175 (`(For version 2.26+` → `(For version 2.26+)`).

**Note:** While reviewing, I noticed that `water_heater` and `zwave` are also handled by the Prometheus exporter in core but are missing from this supported domains list. These are pre-existing omissions and out of scope for this PR, but worth addressing separately.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/170721
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards