### PR TITLE
Document HomematicIP button events

### DIFF
--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -355,26 +355,26 @@ actions:
 
 ## Button events
 
-Devices with physical buttons expose an event entity per button channel. You can use these to trigger automations on a short press, a long press start, or a long press stop.
+Devices with physical buttons expose an event entity per button channel. You can use these to trigger automations on a short release, a long press, or a long release.
 
 {% important %}
 If a button is directly paired to an actuator inside the Homematic IP app (*Direct Device Connection*, called *Direktverknüpfung* in the German app), the cloud doesn't see the press, so Home Assistant can't react to it either. To use the button in Home Assistant, either remove the direct pairing in the Homematic IP app, or add an automation in the Homematic IP app that references the button. The cloud then forwards the press to Home Assistant.
 {% endimportant %}
 
 {% note %}
-The cloud doesn't deliver a dedicated double-press event. A double-press arrives as two consecutive `short_press` events, so double-press automations are built on top of the same event entity, as shown below.
+The cloud doesn't deliver a dedicated double-press event. A double-press arrives as two consecutive `short_release` events, so double-press automations are built on top of the same event entity, as shown below.
 {% endnote %}
 
-### Trigger an action on a short press
+### Trigger an action on a short release
 
 {% example %}
 automation:
-  - alias: "Toggle living room light on button 3 short press"
+  - alias: "Toggle living room light on button 3 short release"
     triggers:
       - trigger: state
         entity_id: event.wandtaster_6_fach_button_3
         attribute: event_type
-        to: short_press
+        to: short_release
     actions:
       - action: light.toggle
         target:
@@ -383,7 +383,7 @@ automation:
 
 ### Trigger an action on a double press
 
-The cloud delivers a double press as two consecutive `short_press` events. Use `wait_for_trigger` with a short timeout to detect the second press:
+The cloud delivers a double press as two consecutive `short_release` events. Use `wait_for_trigger` with a short timeout to detect the second press:
 
 {% example %}
 automation:
@@ -392,13 +392,13 @@ automation:
       - trigger: state
         entity_id: event.wandtaster_6_fach_button_3
         attribute: event_type
-        to: short_press
+        to: short_release
     actions:
       - wait_for_trigger:
           - trigger: state
             entity_id: event.wandtaster_6_fach_button_3
             attribute: event_type
-            to: short_press
+            to: short_release
         timeout: "00:00:00.500"
         continue_on_timeout: false
       - action: scene.turn_on
@@ -408,7 +408,7 @@ automation:
 
 ### Dim a light while holding a button
 
-The button reports `long_press_start` when held and `long_press_stop` when released. Use a `repeat` loop that keeps dimming until the release event fires:
+The button reports `long_press` when held and `long_release` when released. Use a `repeat` loop that keeps dimming until the release event fires:
 
 {% example %}
 automation:
@@ -417,7 +417,7 @@ automation:
       - trigger: state
         entity_id: event.wandtaster_6_fach_button_3
         attribute: event_type
-        to: long_press_start
+        to: long_press
     actions:
       - repeat:
           sequence:
@@ -431,5 +431,5 @@ automation:
             - condition: state
               entity_id: event.wandtaster_6_fach_button_3
               attribute: event_type
-              state: long_press_start
+              state: long_press
 {% endexample %}

--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -353,18 +353,83 @@ actions:
       accesspoint_id: 3014xxxxxxxxxxxxxxxxxxxx
 ```
 
-## Additional info
+## Button events
 
-Push button devices are only available with a battery sensor. This is due to a limitation of the vendor API (eq3).
-It's not possible to detect a key press event on these devices at the moment.
+Devices with physical buttons expose an event entity per button channel. You can use these to trigger automations on a short press, a long press start, or a long press stop.
 
-  - Remote Control - 8x buttons (*HmIP-RC8*)
-  - Wall-mount Remote Control for brand switches - 2x buttons (*HmIP-BRC2*)
-  - Motion Detector for 55mm frames - indoor (HmIP-SMI55)(Push button)
-  - Wall-mount Remote Control - 2x buttons (*HmIP-WRC2*)
-  - Wall-mount Remote Control - flat - 2x buttons (*HmIP-WRCC2*)
-  - Wall-mount Remote Control - 6x buttons (*HmIP-WRC6*)
-  - Key Ring Remote Control - 4x buttons (*HmIP-KRC4*)
-  - Key Ring Remote Control - alarm  (*HmIP-KRCA*)
-  - Wall-mount Remote Control – flat (*HmIP-WRCC2*)
-  - Rotary Button (*HmIP-WRCR*)
+{% important %}
+If a button is directly paired to an actuator inside the Homematic IP app (called *Direktverknüpfung* in the German app), the cloud doesn't see the press, so Home Assistant can't react to it either. To use the button in Home Assistant, either remove the direct pairing in the Homematic IP app, or add an automation in the Homematic IP app that references the button. The cloud then forwards the press to Home Assistant.
+{% endimportant %}
+
+{% note %}
+The cloud doesn't deliver a dedicated double-press event. A double-press arrives as two consecutive `short_press` events, so double-press automations are built on top of the same event entity, as shown below.
+{% endnote %}
+
+### Trigger an action on a short press
+
+```yaml
+automation:
+  - alias: "Toggle living room light on button 3 short press"
+    triggers:
+      - trigger: state
+        entity_id: event.wandtaster_6_fach_button_3
+        attribute: event_type
+        to: short_press
+    actions:
+      - action: light.toggle
+        target:
+          entity_id: light.living_room
+```
+
+### Trigger an action on a double press
+
+The cloud delivers a double press as two consecutive `short_press` events. Use `wait_for_trigger` with a short timeout to detect the second press:
+
+```yaml
+automation:
+  - alias: "Activate movie scene on button 3 double press"
+    triggers:
+      - trigger: state
+        entity_id: event.wandtaster_6_fach_button_3
+        attribute: event_type
+        to: short_press
+    actions:
+      - wait_for_trigger:
+          - trigger: state
+            entity_id: event.wandtaster_6_fach_button_3
+            attribute: event_type
+            to: short_press
+        timeout: "00:00:00.500"
+        continue_on_timeout: false
+      - action: scene.turn_on
+        target:
+          entity_id: scene.movie_night
+```
+
+### Dim a light while holding a button
+
+The button reports `long_press_start` when held and `long_press_stop` when released. Use a `repeat` loop that keeps dimming until the release event fires:
+
+```yaml
+automation:
+  - alias: "Dim living room while holding button 3"
+    triggers:
+      - trigger: state
+        entity_id: event.wandtaster_6_fach_button_3
+        attribute: event_type
+        to: long_press_start
+    actions:
+      - repeat:
+          sequence:
+            - action: light.turn_on
+              target:
+                entity_id: light.living_room
+              data:
+                brightness_step_pct: -5
+            - delay: "00:00:00.200"
+          while:
+            - condition: state
+              entity_id: event.wandtaster_6_fach_button_3
+              attribute: event_type
+              state: long_press_start
+```

--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -358,7 +358,7 @@ actions:
 Devices with physical buttons expose an event entity per button channel. You can use these to trigger automations on a short press, a long press start, or a long press stop.
 
 {% important %}
-If a button is directly paired to an actuator inside the Homematic IP app (called *Direktverknüpfung* in the German app), the cloud doesn't see the press, so Home Assistant can't react to it either. To use the button in Home Assistant, either remove the direct pairing in the Homematic IP app, or add an automation in the Homematic IP app that references the button. The cloud then forwards the press to Home Assistant.
+If a button is directly paired to an actuator inside the Homematic IP app (*Direct Device Connection*, called *Direktverknüpfung* in the German app), the cloud doesn't see the press, so Home Assistant can't react to it either. To use the button in Home Assistant, either remove the direct pairing in the Homematic IP app, or add an automation in the Homematic IP app that references the button. The cloud then forwards the press to Home Assistant.
 {% endimportant %}
 
 {% note %}
@@ -367,7 +367,7 @@ The cloud doesn't deliver a dedicated double-press event. A double-press arrives
 
 ### Trigger an action on a short press
 
-```yaml
+{% example %}
 automation:
   - alias: "Toggle living room light on button 3 short press"
     triggers:
@@ -379,13 +379,13 @@ automation:
       - action: light.toggle
         target:
           entity_id: light.living_room
-```
+{% endexample %}
 
 ### Trigger an action on a double press
 
 The cloud delivers a double press as two consecutive `short_press` events. Use `wait_for_trigger` with a short timeout to detect the second press:
 
-```yaml
+{% example %}
 automation:
   - alias: "Activate movie scene on button 3 double press"
     triggers:
@@ -404,13 +404,13 @@ automation:
       - action: scene.turn_on
         target:
           entity_id: scene.movie_night
-```
+{% endexample %}
 
 ### Dim a light while holding a button
 
 The button reports `long_press_start` when held and `long_press_stop` when released. Use a `repeat` loop that keeps dimming until the release event fires:
 
-```yaml
+{% example %}
 automation:
   - alias: "Dim living room while holding button 3"
     triggers:
@@ -432,4 +432,4 @@ automation:
               entity_id: event.wandtaster_6_fach_button_3
               attribute: event_type
               state: long_press_start
-```
+{% endexample %}


### PR DESCRIPTION
## Proposed change

Documents the new button event entities added in home-assistant/core#171065.

The previous "Additional info" section claimed key press events are not detectable. With #171065, devices with physical buttons expose an event entity per button channel (short_press, long_press_start, long_press_stop). This PR replaces that section with a new "Button events" section covering:

- The direct-pairing caveat: a button paired to an actuator inside the Homematic IP app is invisible to the cloud, so Home Assistant cannot react to it.
- Double-press handling: the cloud delivers a double press as two consecutive short_press events.
- Three automation examples: short press, double press via wait_for_trigger, and hold-to-dim via repeat/while.

The documentation refresh that was previously part of this PR (devices list restructure, Actions rewrite, brand normalization, codeowner addition) moved to a separate PR against current: home-assistant/home-assistant.io#45615 (merged 2026-05-28).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#171065
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards