### PR TITLE
Add docs for Apple TV setup error

### DIFF
--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -311,3 +311,7 @@ logger:
 
 By providing logs directly when creating the issue, you will likely get help
 much faster.
+
+## "No devices found on the network" error during setup even when connecting by IP
+
+Ensure AirPlay is enabled. See Apple's docs [here](https://support.apple.com/guide/tv/adjust-settings-for-airplay-and-apple-home-atvb0342111f/tvos).

--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -314,4 +314,4 @@ much faster.
 
 ## "No devices found on the network" error during setup even when connecting by IP
 
-Ensure AirPlay is enabled. See Apple's docs [here](https://support.apple.com/guide/tv/adjust-settings-for-airplay-and-apple-home-atvb0342111f/tvos).
+Ensure AirPlay is enabled and configured properly. See [this FAQ entry](#when-adding-a-new-device-a-pin-code-is-requested-but-none-is-shown-on-the-screen).

--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -297,6 +297,10 @@ TV or soundbar directly.
 The Apple TV is quite picky when it comes to which formats it plays. The best bet is MP4. If it doesn't
 work, it's likely because of the media format.
 
+### "No devices found on the network" error during setup even when connecting by IP
+
+Ensure AirPlay is enabled and configured properly. See [this FAQ entry](#when-adding-a-new-device-a-pin-code-is-requested-but-none-is-shown-on-the-screen).
+
 ## Debugging
 
 If you have any problems and intend to write an issue, make sure you have the
@@ -311,7 +315,3 @@ logger:
 
 By providing logs directly when creating the issue, you will likely get help
 much faster.
-
-## "No devices found on the network" error during setup even when connecting by IP
-
-Ensure AirPlay is enabled and configured properly. See [this FAQ entry](#when-adding-a-new-device-a-pin-code-is-requested-but-none-is-shown-on-the-screen).


### PR DESCRIPTION
## Proposed change

Apple TV setup can return "No devices found on the network" when Airplay is disabled. Documenting the solution from [here](https://community.home-assistant.io/t/apple-tv-no-devices-found-despite-using-an-ip-address-which-is-reachable-from-ha/337279/5). Verified this solution works.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
