### PR TITLE
Lawn mower: document triggers

### DIFF
--- a/source/_triggers/lawn_mower.docked.markdown
+++ b/source/_triggers/lawn_mower.docked.markdown
@@ -62,7 +62,7 @@ for:
     How long the mower must stay docked before the trigger fires. Accepts a
     duration like `00:05:00` for five minutes.
   required: false
-  type: time
+  type: string
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_triggers/lawn_mower.docked.markdown
+++ b/source/_triggers/lawn_mower.docked.markdown
@@ -109,7 +109,7 @@ automation: |
 
 ### Automation: Turn off the patio light after the mower is back
 
-If the mower returns after sunset, you can leave the patio light on for the trip back, then turn it off once the mower has safely docked.
+If you turn on the patio light earlier in the mowing routine to help the mower reach the dock, this trigger is a good way to end that routine. Waiting 30 seconds after docking gives the mower time to settle before the automation runs.
 
 - **Trigger**: Lawn mower returned to dock
   - **Target**: Backyard mower

--- a/source/_triggers/lawn_mower.docked.markdown
+++ b/source/_triggers/lawn_mower.docked.markdown
@@ -1,0 +1,147 @@
+---
+title: "Lawn mower returned to dock"
+trigger: lawn_mower.docked
+domain: lawn_mower
+description: "Triggers after one or more lawn mowers have returned to dock."
+---
+
+The **Lawn mower returned to dock** trigger fires when a mower finishes its run and reaches its dock.
+Use it when you want Home Assistant to react the moment yard work is done, like sending a notification, turning off a patio light, or starting a follow-up task.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Lawn mower returned to dock**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, set how long the mower must stay docked before the trigger fires. Leave it at zero to fire immediately.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple lawn mowers are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted mower docks, **First** to fire only when the first targeted mower docks, or **All** to fire only after every targeted mower has docked.
+For at least:
+  description: How long the mower must stay docked before the trigger fires. Leave it at zero to fire immediately.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lawn_mower.docked`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lawn_mower.docked
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This fires when `lawn_mower.backyard` reaches the dock.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay docked before the trigger fires. Accepts a
+    duration like `00:05:00` for five minutes.
+  required: false
+  type: time
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger only fires when a mower changes into the docked state from a known state. If a mower comes back from `unavailable` or `unknown`, that recovery does not fire this trigger.
+- Use **For at least** if you want to wait until the mower has fully settled at the dock before the automation runs.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: Send a notification when mowing is finished
+
+If you want a simple heads-up when yard work is done, use this trigger to send a message as soon as the mower gets back to its dock.
+
+- **Trigger**: Lawn mower returned to dock
+  - **Target**: Backyard mower
+  - **Trigger when**: Each
+  - **For at least**: 00:00:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for notifying when the mower docks" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the mower docks"
+  triggers:
+    - trigger: lawn_mower.docked
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The backyard mower is back at the dock."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Turn off the patio light after the mower is back
+
+If the mower returns after sunset, you can leave the patio light on for the trip back, then turn it off once the mower has safely docked.
+
+- **Trigger**: Lawn mower returned to dock
+  - **Target**: Backyard mower
+  - **Trigger when**: Each
+  - **For at least**: 00:00:30
+- **Action**: Turn off light
+
+{% details "YAML example for turning off the patio light" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the patio light after docking"
+  triggers:
+    - trigger: lawn_mower.docked
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        behavior: any
+        for: "00:00:30"
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.patio
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/lawn_mower.docked.markdown
+++ b/source/_triggers/lawn_mower.docked.markdown
@@ -85,8 +85,6 @@ If you want a simple heads-up when yard work is done, use this trigger to send a
 
 - **Trigger**: Lawn mower returned to dock
   - **Target**: Backyard mower
-  - **Trigger when**: Each
-  - **For at least**: 00:00:00
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
 
@@ -99,9 +97,6 @@ automation: |
     - trigger: lawn_mower.docked
       target:
         entity_id: lawn_mower.backyard
-      options:
-        behavior: any
-        for: "00:00:00"
   actions:
     - action: notify.send_message
       target:
@@ -118,7 +113,6 @@ If the mower returns after sunset, you can leave the patio light on for the trip
 
 - **Trigger**: Lawn mower returned to dock
   - **Target**: Backyard mower
-  - **Trigger when**: Each
   - **For at least**: 00:00:30
 - **Action**: Turn off light
 
@@ -132,7 +126,6 @@ automation: |
       target:
         entity_id: lawn_mower.backyard
       options:
-        behavior: any
         for: "00:00:30"
   actions:
     - action: light.turn_off

--- a/source/_triggers/lawn_mower.errored.markdown
+++ b/source/_triggers/lawn_mower.errored.markdown
@@ -62,7 +62,7 @@ for:
     How long the mower must stay in the error state before the trigger fires.
     Accepts a duration like `00:01:00` for one minute.
   required: false
-  type: time
+  type: string
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_triggers/lawn_mower.errored.markdown
+++ b/source/_triggers/lawn_mower.errored.markdown
@@ -1,0 +1,154 @@
+---
+title: "Lawn mower encountered an error"
+trigger: lawn_mower.errored
+domain: lawn_mower
+description: "Triggers after one or more lawn mowers encounter an error."
+---
+
+The **Lawn mower encountered an error** trigger fires when a mower reports a problem while it is working.
+Use it to notify you quickly, pause related automations, or turn on a nearby light before you go outside to check what happened.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Lawn mower encountered an error**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, set how long the mower must stay in the error state before the trigger fires. Leave it at zero to fire immediately.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple lawn mowers are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted mower reports an error, **First** to fire only when the first targeted mower reports an error, or **All** to fire only after every targeted mower reports an error.
+For at least:
+  description: How long the mower must stay in the error state before the trigger fires. Leave it at zero to fire immediately.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lawn_mower.errored`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lawn_mower.errored
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This fires when `lawn_mower.backyard` enters the error state.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay in the error state before the trigger fires.
+    Accepts a duration like `00:01:00` for one minute.
+  required: false
+  type: time
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger only fires when a mower changes into the error state from a known state. If a mower comes back from `unavailable` or `unknown`, that recovery does not fire this trigger.
+- Use **For at least** if you want to ignore a brief status change while the mower recovers on its own.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: Send an urgent alert when the mower needs help
+
+If the mower gets stuck under a bush or reports another fault, send an alert right away so you can fix the problem before the schedule falls behind.
+
+- **Trigger**: Lawn mower encountered an error
+  - **Target**: Backyard mower
+  - **Trigger when**: Each
+  - **For at least**: 00:00:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for an error alert" %}
+
+{% example %}
+automation: |
+  alias: "Alert when the mower reports an error"
+  triggers:
+    - trigger: lawn_mower.errored
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Lawn mower needs attention"
+        message: >
+          The backyard mower reported an error.
+          Check it in the yard or in the app.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Turn on the porch light before you go outside
+
+If the mower reports an error after dark, turn on the porch light so you can see the yard before stepping outside.
+
+- **Trigger**: Lawn mower encountered an error
+  - **Target**: Backyard mower
+  - **Trigger when**: Each
+  - **For at least**: 00:00:15
+- **Condition**: Sun: after sunset
+- **Action**: Turn on light
+
+{% details "YAML example for lighting the yard on error" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the porch light when the mower errors"
+  triggers:
+    - trigger: lawn_mower.errored
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        behavior: any
+        for: "00:00:15"
+  conditions:
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.porch
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/lawn_mower.errored.markdown
+++ b/source/_triggers/lawn_mower.errored.markdown
@@ -85,8 +85,6 @@ If the mower gets stuck under a bush or reports another fault, send an alert rig
 
 - **Trigger**: Lawn mower encountered an error
   - **Target**: Backyard mower
-  - **Trigger when**: Each
-  - **For at least**: 00:00:00
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
 
@@ -99,9 +97,6 @@ automation: |
     - trigger: lawn_mower.errored
       target:
         entity_id: lawn_mower.backyard
-      options:
-        behavior: any
-        for: "00:00:00"
   actions:
     - action: notify.send_message
       target:
@@ -121,7 +116,6 @@ If the mower reports an error after dark, turn on the porch light so you can see
 
 - **Trigger**: Lawn mower encountered an error
   - **Target**: Backyard mower
-  - **Trigger when**: Each
   - **For at least**: 00:00:15
 - **Condition**: Sun: after sunset
 - **Action**: Turn on light
@@ -136,7 +130,6 @@ automation: |
       target:
         entity_id: lawn_mower.backyard
       options:
-        behavior: any
         for: "00:00:15"
   conditions:
     - condition: sun

--- a/source/_triggers/lawn_mower.paused_mowing.markdown
+++ b/source/_triggers/lawn_mower.paused_mowing.markdown
@@ -62,7 +62,7 @@ for:
     How long the mower must stay paused before the trigger fires. Accepts a
     duration like `00:10:00` for 10 minutes.
   required: false
-  type: time
+  type: string
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_triggers/lawn_mower.paused_mowing.markdown
+++ b/source/_triggers/lawn_mower.paused_mowing.markdown
@@ -85,7 +85,6 @@ If the mower has been paused for 15 minutes, send a reminder so you can decide w
 
 - **Trigger**: Lawn mower paused mowing
   - **Target**: Backyard mower
-  - **Trigger when**: Each
   - **For at least**: 00:15:00
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
@@ -100,7 +99,6 @@ automation: |
       target:
         entity_id: lawn_mower.backyard
       options:
-        behavior: any
         for: "00:15:00"
   actions:
     - action: notify.send_message
@@ -120,7 +118,6 @@ If the mower pauses because the yard is busy, you can also stop another outdoor 
 
 - **Trigger**: Lawn mower paused mowing
   - **Target**: Backyard mower
-  - **Trigger when**: Each
   - **For at least**: 00:05:00
 - **Action**: Turn off automation
 
@@ -134,7 +131,6 @@ automation: |
       target:
         entity_id: lawn_mower.backyard
       options:
-        behavior: any
         for: "00:05:00"
   actions:
     - action: automation.turn_off

--- a/source/_triggers/lawn_mower.paused_mowing.markdown
+++ b/source/_triggers/lawn_mower.paused_mowing.markdown
@@ -1,0 +1,149 @@
+---
+title: "Lawn mower paused mowing"
+trigger: lawn_mower.paused_mowing
+domain: lawn_mower
+description: "Triggers after one or more lawn mowers pause mowing."
+---
+
+The **Lawn mower paused mowing** trigger fires when a mower stops in the middle of a run without docking.
+Use it when you want to react to an interrupted job, like sending a reminder, pausing another yard task, or waiting before you restart the mower.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Lawn mower paused mowing**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, set how long the mower must stay paused before the trigger fires. Leave it at zero to fire immediately.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple lawn mowers are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted mower pauses, **First** to fire only when the first targeted mower pauses, or **All** to fire only after every targeted mower has paused.
+For at least:
+  description: How long the mower must stay paused before the trigger fires. Leave it at zero to fire immediately.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lawn_mower.paused_mowing`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lawn_mower.paused_mowing
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This fires when `lawn_mower.backyard` changes to the paused state.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay paused before the trigger fires. Accepts a
+    duration like `00:10:00` for 10 minutes.
+  required: false
+  type: time
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger only fires when a mower changes into the paused state from a known state. If a mower comes back from `unavailable` or `unknown`, that recovery does not fire this trigger.
+- Use **For at least** if you only want to react when the pause lasts longer than a quick stop.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: Remind yourself when the mower has been paused for a while
+
+If the mower has been paused for 15 minutes, send a reminder so you can decide whether to resume the run or bring it back to the dock.
+
+- **Trigger**: Lawn mower paused mowing
+  - **Target**: Backyard mower
+  - **Trigger when**: Each
+  - **For at least**: 00:15:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a paused-mowing reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me when the mower stays paused"
+  triggers:
+    - trigger: lawn_mower.paused_mowing
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        behavior: any
+        for: "00:15:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          The backyard mower has been paused for
+          15 minutes.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Turn off the sprinkler schedule while the mower is paused
+
+If the mower pauses because the yard is busy, you can also stop another outdoor routine until you decide what to do next.
+
+- **Trigger**: Lawn mower paused mowing
+  - **Target**: Backyard mower
+  - **Trigger when**: Each
+  - **For at least**: 00:05:00
+- **Action**: Turn off automation
+
+{% details "YAML example for turning off another automation" %}
+
+{% example %}
+automation: |
+  alias: "Pause sprinkler routine when mowing pauses"
+  triggers:
+    - trigger: lawn_mower.paused_mowing
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        behavior: any
+        for: "00:05:00"
+  actions:
+    - action: automation.turn_off
+      target:
+        entity_id: automation.water_the_backyard
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/lawn_mower.started_mowing.markdown
+++ b/source/_triggers/lawn_mower.started_mowing.markdown
@@ -85,8 +85,6 @@ If someone is about to let pets or children into the yard, a quick message can h
 
 - **Trigger**: Lawn mower started mowing
   - **Target**: Backyard mower
-  - **Trigger when**: Each
-  - **For at least**: 00:00:00
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
 
@@ -99,9 +97,6 @@ automation: |
     - trigger: lawn_mower.started_mowing
       target:
         entity_id: lawn_mower.backyard
-      options:
-        behavior: any
-        for: "00:00:00"
   actions:
     - action: notify.send_message
       target:
@@ -118,7 +113,6 @@ If the mower and sprinklers should never run at the same time, turn off the spri
 
 - **Trigger**: Lawn mower started mowing
   - **Target**: Backyard mower
-  - **Trigger when**: Each
   - **For at least**: 00:02:00
 - **Action**: Turn off automation
 
@@ -132,7 +126,6 @@ automation: |
       target:
         entity_id: lawn_mower.backyard
       options:
-        behavior: any
         for: "00:02:00"
   actions:
     - action: automation.turn_off

--- a/source/_triggers/lawn_mower.started_mowing.markdown
+++ b/source/_triggers/lawn_mower.started_mowing.markdown
@@ -1,0 +1,147 @@
+---
+title: "Lawn mower started mowing"
+trigger: lawn_mower.started_mowing
+domain: lawn_mower
+description: "Triggers after one or more lawn mowers start mowing."
+---
+
+The **Lawn mower started mowing** trigger fires when a mower begins a mowing run.
+Use it to react when yard work starts, like muting another routine, sending a confirmation, or turning on a light along the first part of the route.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Lawn mower started mowing**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, set how long the mower must stay in the mowing state before the trigger fires. Leave it at zero to fire immediately.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple lawn mowers are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted mower starts mowing, **First** to fire only when the first targeted mower starts mowing, or **All** to fire only after every targeted mower has started mowing.
+For at least:
+  description: How long the mower must stay in the mowing state before the trigger fires. Leave it at zero to fire immediately.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lawn_mower.started_mowing`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lawn_mower.started_mowing
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This fires when `lawn_mower.backyard` starts mowing.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay in the mowing state before the trigger fires.
+    Accepts a duration like `00:02:00` for two minutes.
+  required: false
+  type: time
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger only fires when a mower changes into the mowing state from a known state. If a mower comes back from `unavailable` or `unknown`, that recovery does not fire this trigger.
+- Use **For at least** if you want to ignore a short transition while the mower leaves the dock.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: Let your household know the mower has started
+
+If someone is about to let pets or children into the yard, a quick message can help them avoid the mowing area.
+
+- **Trigger**: Lawn mower started mowing
+  - **Target**: Backyard mower
+  - **Trigger when**: Each
+  - **For at least**: 00:00:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a mowing-start notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the mower starts"
+  triggers:
+    - trigger: lawn_mower.started_mowing
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The backyard mower has started mowing."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Turn off the sprinkler automation when mowing begins
+
+If the mower and sprinklers should never run at the same time, turn off the sprinkler automation as soon as the mowing run starts.
+
+- **Trigger**: Lawn mower started mowing
+  - **Target**: Backyard mower
+  - **Trigger when**: Each
+  - **For at least**: 00:02:00
+- **Action**: Turn off automation
+
+{% details "YAML example for pausing the sprinkler schedule" %}
+
+{% example %}
+automation: |
+  alias: "Turn off sprinklers when mowing starts"
+  triggers:
+    - trigger: lawn_mower.started_mowing
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        behavior: any
+        for: "00:02:00"
+  actions:
+    - action: automation.turn_off
+      target:
+        entity_id: automation.water_the_backyard
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/lawn_mower.started_mowing.markdown
+++ b/source/_triggers/lawn_mower.started_mowing.markdown
@@ -62,7 +62,7 @@ for:
     How long the mower must stay in the mowing state before the trigger fires.
     Accepts a duration like `00:02:00` for two minutes.
   required: false
-  type: time
+  type: string
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_triggers/lawn_mower.started_returning.markdown
+++ b/source/_triggers/lawn_mower.started_returning.markdown
@@ -5,7 +5,7 @@ domain: lawn_mower
 description: "Triggers after one or more lawn mowers start returning to dock."
 ---
 
-The **Lawn mower started returning to dock** trigger fires when a mower leaves the yard and starts heading back to its dock.
+The **Lawn mower started returning to dock** trigger fires when a mower stops mowing and starts returning to its dock.
 Use it when you want to react before the mower arrives, like turning on a path light, delaying another task, or sending a message that mowing is almost done.
 
 {% include integrations/labs_entity_triggers_note.md %}

--- a/source/_triggers/lawn_mower.started_returning.markdown
+++ b/source/_triggers/lawn_mower.started_returning.markdown
@@ -1,0 +1,151 @@
+---
+title: "Lawn mower started returning to dock"
+trigger: lawn_mower.started_returning
+domain: lawn_mower
+description: "Triggers after one or more lawn mowers start returning to dock."
+---
+
+The **Lawn mower started returning to dock** trigger fires when a mower leaves the yard and starts heading back to its dock.
+Use it when you want to react before the mower arrives, like turning on a path light, delaying another task, or sending a message that mowing is almost done.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Lawn mower started returning to dock**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, set how long the mower must stay in the returning state before the trigger fires. Leave it at zero to fire immediately.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple lawn mowers are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted mower starts returning, **First** to fire only when the first targeted mower starts returning, or **All** to fire only after every targeted mower has started returning.
+For at least:
+  description: How long the mower must stay in the returning state before the trigger fires. Leave it at zero to fire immediately.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lawn_mower.started_returning`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lawn_mower.started_returning
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This fires when `lawn_mower.backyard` starts heading back to the dock.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay in the returning state before the trigger
+    fires. Accepts a duration like `00:01:00` for one minute.
+  required: false
+  type: time
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger only fires when a mower changes into the returning state from a known state. If a mower comes back from `unavailable` or `unknown`, that recovery does not fire this trigger.
+- Use **For at least** if you only want to react after the mower has been returning for a short time.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: Turn on the path light while the mower heads home
+
+If the mower docks in a darker part of the yard, turn on a nearby light when it starts returning so the last part of its route stays visible.
+
+- **Trigger**: Lawn mower started returning to dock
+  - **Target**: Backyard mower
+  - **Trigger when**: Each
+  - **For at least**: 00:00:00
+- **Condition**: Sun: after sunset
+- **Action**: Turn on light
+
+{% details "YAML example for lighting the path to the dock" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the path light when the mower returns"
+  triggers:
+    - trigger: lawn_mower.started_returning
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        behavior: any
+        for: "00:00:00"
+  conditions:
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.garden_path
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Send a message that mowing is almost done
+
+If someone is waiting to use the yard, send a short message when the mower starts heading back so they know it is nearly finished.
+
+- **Trigger**: Lawn mower started returning to dock
+  - **Target**: Backyard mower
+  - **Trigger when**: Each
+  - **For at least**: 00:01:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a return-to-dock notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the mower starts returning"
+  triggers:
+    - trigger: lawn_mower.started_returning
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        behavior: any
+        for: "00:01:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The backyard mower is on its way back to the dock."
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/lawn_mower.started_returning.markdown
+++ b/source/_triggers/lawn_mower.started_returning.markdown
@@ -85,8 +85,6 @@ If the mower docks in a darker part of the yard, turn on a nearby light when it 
 
 - **Trigger**: Lawn mower started returning to dock
   - **Target**: Backyard mower
-  - **Trigger when**: Each
-  - **For at least**: 00:00:00
 - **Condition**: Sun: after sunset
 - **Action**: Turn on light
 
@@ -99,9 +97,6 @@ automation: |
     - trigger: lawn_mower.started_returning
       target:
         entity_id: lawn_mower.backyard
-      options:
-        behavior: any
-        for: "00:00:00"
   conditions:
     - condition: sun
       after: sunset
@@ -119,7 +114,6 @@ If someone is waiting to use the yard, send a short message when the mower start
 
 - **Trigger**: Lawn mower started returning to dock
   - **Target**: Backyard mower
-  - **Trigger when**: Each
   - **For at least**: 00:01:00
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
@@ -134,7 +128,6 @@ automation: |
       target:
         entity_id: lawn_mower.backyard
       options:
-        behavior: any
         for: "00:01:00"
   actions:
     - action: notify.send_message

--- a/source/_triggers/lawn_mower.started_returning.markdown
+++ b/source/_triggers/lawn_mower.started_returning.markdown
@@ -62,7 +62,7 @@ for:
     How long the mower must stay in the returning state before the trigger
     fires. Accepts a duration like `00:01:00` for one minute.
   required: false
-  type: time
+  type: string
   default: "00:00:00"
 {% endoptions_yaml %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document new triggers for the [lawn mower](https://www.home-assistant.io/integrations/lawn_mower) integration.

Conditions and the main page are edited in https://github.com/home-assistant/home-assistant.io/pull/45474.

Previews:

- [Lawn mower returned to dock](https://deploy-preview-45473--home-assistant-docs.netlify.app/triggers/lawn_mower.docked/)
- [Lawn mower encountered an error](https://deploy-preview-45473--home-assistant-docs.netlify.app/triggers/lawn_mower.errored/)
- [Lawn mower paused mowing](https://deploy-preview-45473--home-assistant-docs.netlify.app/triggers/lawn_mower.paused_mowing/)
- [Lawn mower started mowing](https://deploy-preview-45473--home-assistant-docs.netlify.app/triggers/lawn_mower.started_mowing/)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/44919

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
