### PR TITLE
Lawn mower: document conditions + edit main page

### DIFF
--- a/source/_conditions/lawn_mower.is_docked.markdown
+++ b/source/_conditions/lawn_mower.is_docked.markdown
@@ -62,7 +62,7 @@ for:
     How long the mower must stay docked before the condition passes. Accepts a
     duration like `00:10:00` for 10 minutes.
   required: false
-  type: time
+  type: string
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_conditions/lawn_mower.is_docked.markdown
+++ b/source/_conditions/lawn_mower.is_docked.markdown
@@ -1,0 +1,151 @@
+---
+title: "Lawn mower is docked"
+condition: lawn_mower.is_docked
+domain: lawn_mower
+description: "Tests if one or more lawn mowers are docked."
+---
+
+The **Lawn mower is docked** condition passes when one or more targeted mowers are currently docked.
+Use it when you only want an automation to continue after the mower is safely back at the dock, like before turning off a yard light or sending a completion summary.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Lawn mower is docked**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, set how long the mower must stay docked before the condition passes. Leave it at zero to check the current state only.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple lawn mowers are targeted, controls how results combine. Pick **Any** to pass if at least one targeted mower is docked, or **All** to pass only when every targeted mower is docked.
+For at least:
+  description: How long the mower must stay docked before the condition passes. Leave it at zero to check the current state only.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `lawn_mower.is_docked`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: lawn_mower.is_docked
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This passes when `lawn_mower.backyard` is currently docked.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls how results combine.
+    Accepts `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay docked before the condition passes. Accepts a
+    duration like `00:10:00` for 10 minutes.
+  required: false
+  type: time
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Mowers in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- Use **For at least** if you want to wait until the mower has stayed docked for a while before the condition passes.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: Turn off the yard light once the mower is docked
+
+At the end of the evening, you might want the light near the dock to stay on until the mower is fully back in place.
+
+- **Trigger**: Time: 22:30
+- **Condition**: Lawn mower is docked
+  - **Target**: Backyard mower
+  - **For at least**: 00:05:00
+- **Action**: Turn off light
+
+{% details "YAML example for turning off the yard light" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the yard light after docking"
+  triggers:
+    - trigger: time
+      at: "22:30:00"
+  conditions:
+    - condition: lawn_mower.is_docked
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:05:00"
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.garden_path
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Send a summary only after the mower has stayed docked
+
+If you want to avoid a message during a brief stop, wait 10 minutes before sending the completion notification.
+
+- **Trigger**: Time: 21:00
+- **Condition**: Lawn mower is docked
+  - **Target**: Backyard mower
+  - **For at least**: 00:10:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a docked-status summary" %}
+
+{% example %}
+automation: |
+  alias: "Send a docked summary"
+  triggers:
+    - trigger: time
+      at: "21:00:00"
+  conditions:
+    - condition: lawn_mower.is_docked
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:10:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The backyard mower has been docked for 10 minutes."
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/lawn_mower.is_encountering_an_error.markdown
+++ b/source/_conditions/lawn_mower.is_encountering_an_error.markdown
@@ -62,7 +62,7 @@ for:
     How long the mower must stay in the error state before the condition
     passes. Accepts a duration like `00:05:00` for five minutes.
   required: false
-  type: time
+  type: string
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_conditions/lawn_mower.is_encountering_an_error.markdown
+++ b/source/_conditions/lawn_mower.is_encountering_an_error.markdown
@@ -1,0 +1,156 @@
+---
+title: "Lawn mower is encountering an error"
+condition: lawn_mower.is_encountering_an_error
+domain: lawn_mower
+description: "Tests if one or more lawn mowers are encountering an error."
+---
+
+The **Lawn mower is encountering an error** condition passes when one or more targeted mowers are currently in an error state.
+Use it when you want an automation to continue only while the problem is still active, like when you send repeated reminders or keep a warning light on.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Lawn mower is encountering an error**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, set how long the mower must stay in the error state before the condition passes. Leave it at zero to check the current state only.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple lawn mowers are targeted, controls how results combine. Pick **Any** to pass if at least one targeted mower is in an error state, or **All** to pass only when every targeted mower is in an error state.
+For at least:
+  description: How long the mower must stay in the error state before the condition passes. Leave it at zero to check the current state only.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `lawn_mower.is_encountering_an_error`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: lawn_mower.is_encountering_an_error
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This passes when `lawn_mower.backyard` is currently in the error state.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls how results combine.
+    Accepts `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay in the error state before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: time
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Mowers in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- Use **For at least** if you want to avoid acting on a short error that clears by itself.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: Send a reminder every 15 minutes while the error remains
+
+If the mower is still stuck after the first alert, send a follow-up reminder so the problem does not get forgotten.
+
+- **Trigger**: Time pattern: Every 15 minutes
+- **Condition**: Lawn mower is encountering an error
+  - **Target**: Backyard mower
+  - **For at least**: 00:05:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for repeated error reminders" %}
+
+{% example %}
+automation: |
+  alias: "Repeat the mower error reminder"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/15"
+  conditions:
+    - condition: lawn_mower.is_encountering_an_error
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:05:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          The backyard mower is still reporting an
+          error.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Keep the porch light on while the error is active
+
+If you are checking the mower after dark, this automation keeps the porch light on while the mower is still reporting a problem.
+
+- **Trigger**: Time pattern: Every 10 minutes
+- **Condition**: Lawn mower is encountering an error
+  - **Target**: Backyard mower
+  - **For at least**: 00:00:30
+- **Condition**: Sun: after sunset
+- **Action**: Turn on light
+
+{% details "YAML example for keeping the porch light on" %}
+
+{% example %}
+automation: |
+  alias: "Keep the porch light on during mower errors"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/10"
+  conditions:
+    - condition: lawn_mower.is_encountering_an_error
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:00:30"
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.porch
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/lawn_mower.is_mowing.markdown
+++ b/source/_conditions/lawn_mower.is_mowing.markdown
@@ -62,7 +62,7 @@ for:
     How long the mower must stay in the mowing state before the condition
     passes. Accepts a duration like `00:02:00` for two minutes.
   required: false
-  type: time
+  type: string
   default: "00:00:00"
 {% endoptions_yaml %}
 
@@ -117,7 +117,7 @@ If guests are about to arrive in the backyard, only pause the mower if it is act
 - **Condition**: Lawn mower is mowing
   - **Target**: Backyard mower
   - **For at least**: 00:02:00
-- **Action**: Pause
+- **Action**: Pause lawn mower
 
 {% details "YAML example for pausing the mower for guests" %}
 

--- a/source/_conditions/lawn_mower.is_mowing.markdown
+++ b/source/_conditions/lawn_mower.is_mowing.markdown
@@ -86,7 +86,7 @@ If rain starts while the mower is active, check that it is really mowing before 
 - **Trigger**: State: Rain sensor turned on
 - **Condition**: Lawn mower is mowing
   - **Target**: Backyard mower
-- **Action**: Return to dock
+- **Action**: Return lawn mower to dock
 
 {% details "YAML example for docking the mower in rain" %}
 

--- a/source/_conditions/lawn_mower.is_mowing.markdown
+++ b/source/_conditions/lawn_mower.is_mowing.markdown
@@ -1,0 +1,147 @@
+---
+title: "Lawn mower is mowing"
+condition: lawn_mower.is_mowing
+domain: lawn_mower
+description: "Tests if one or more lawn mowers are mowing."
+---
+
+The **Lawn mower is mowing** condition passes when one or more targeted mowers are actively mowing.
+Use it when an automation should continue only while the mower is out in the yard, like before delaying sprinklers or sending the mower back because of rain.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Lawn mower is mowing**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, set how long the mower must stay in the mowing state before the condition passes. Leave it at zero to check the current state only.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple lawn mowers are targeted, controls how results combine. Pick **Any** to pass if at least one targeted mower is mowing, or **All** to pass only when every targeted mower is mowing.
+For at least:
+  description: How long the mower must stay in the mowing state before the condition passes. Leave it at zero to check the current state only.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `lawn_mower.is_mowing`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: lawn_mower.is_mowing
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This passes when `lawn_mower.backyard` is currently mowing.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls how results combine.
+    Accepts `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay in the mowing state before the condition
+    passes. Accepts a duration like `00:02:00` for two minutes.
+  required: false
+  type: time
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Mowers in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- Use **For at least** if you want to make sure the mowing run is really under way before the condition passes.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: Return the mower to dock when rain starts
+
+If rain starts while the mower is active, check that it is really mowing before sending it back to the dock.
+
+- **Trigger**: State: Rain sensor turned on
+- **Condition**: Lawn mower is mowing
+  - **Target**: Backyard mower
+- **Action**: Return to dock
+
+{% details "YAML example for docking the mower in rain" %}
+
+{% example %}
+automation: |
+  alias: "Dock the mower when it starts raining"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.rain_detected
+      to: "on"
+  conditions:
+    - condition: lawn_mower.is_mowing
+      target:
+        entity_id: lawn_mower.backyard
+  actions:
+    - action: lawn_mower.dock
+      target:
+        entity_id: lawn_mower.backyard
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Pause the mower before guests enter the yard
+
+If guests are about to arrive in the backyard, only pause the mower if it is actually mowing at that moment.
+
+- **Trigger**: State: Gate opened
+- **Condition**: Lawn mower is mowing
+  - **Target**: Backyard mower
+  - **For at least**: 00:02:00
+- **Action**: Pause
+
+{% details "YAML example for pausing the mower for guests" %}
+
+{% example %}
+automation: |
+  alias: "Pause the mower when the gate opens"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.back_gate
+      to: "on"
+  conditions:
+    - condition: lawn_mower.is_mowing
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:02:00"
+  actions:
+    - action: lawn_mower.pause
+      target:
+        entity_id: lawn_mower.backyard
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/lawn_mower.is_paused.markdown
+++ b/source/_conditions/lawn_mower.is_paused.markdown
@@ -1,0 +1,151 @@
+---
+title: "Lawn mower is paused"
+condition: lawn_mower.is_paused
+domain: lawn_mower
+description: "Tests if one or more lawn mowers are paused."
+---
+
+The **Lawn mower is paused** condition passes when one or more targeted mowers are paused.
+Use it when an automation should continue only while the mower is stopped in the yard, like sending reminders, waiting before a restart, or holding back another task until you decide what to do next.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Lawn mower is paused**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, set how long the mower must stay paused before the condition passes. Leave it at zero to check the current state only.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple lawn mowers are targeted, controls how results combine. Pick **Any** to pass if at least one targeted mower is paused, or **All** to pass only when every targeted mower is paused.
+For at least:
+  description: How long the mower must stay paused before the condition passes. Leave it at zero to check the current state only.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `lawn_mower.is_paused`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: lawn_mower.is_paused
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This passes when `lawn_mower.backyard` is currently paused.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls how results combine.
+    Accepts `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay paused before the condition passes. Accepts a
+    duration like `00:10:00` for 10 minutes.
+  required: false
+  type: time
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Mowers in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- Use **For at least** if you want the condition to pass only after a longer pause.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: Send a reminder if the mower is still paused
+
+If you paused the mower for a short interruption, this automation can remind you to resume or dock it later.
+
+- **Trigger**: Time pattern: Every 30 minutes
+- **Condition**: Lawn mower is paused
+  - **Target**: Backyard mower
+  - **For at least**: 00:10:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a paused-mower reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me that the mower is paused"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/30"
+  conditions:
+    - condition: lawn_mower.is_paused
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:10:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The backyard mower is still paused."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Keep the gate automation off while the mower is paused
+
+If the mower is paused in the yard, you might want to keep another outdoor automation from running until the path is clear again.
+
+- **Trigger**: Time pattern: Every 10 minutes
+- **Condition**: Lawn mower is paused
+  - **Target**: Backyard mower
+  - **For at least**: 00:05:00
+- **Action**: Turn off automation
+
+{% details "YAML example for pausing another outdoor automation" %}
+
+{% example %}
+automation: |
+  alias: "Hold the gate routine while the mower is paused"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/10"
+  conditions:
+    - condition: lawn_mower.is_paused
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:05:00"
+  actions:
+    - action: automation.turn_off
+      target:
+        entity_id: automation.open_back_gate_for_delivery
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/lawn_mower.is_paused.markdown
+++ b/source/_conditions/lawn_mower.is_paused.markdown
@@ -62,7 +62,7 @@ for:
     How long the mower must stay paused before the condition passes. Accepts a
     duration like `00:10:00` for 10 minutes.
   required: false
-  type: time
+  type: string
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_conditions/lawn_mower.is_returning.markdown
+++ b/source/_conditions/lawn_mower.is_returning.markdown
@@ -62,7 +62,7 @@ for:
     How long the mower must stay in the returning state before the condition
     passes. Accepts a duration like `00:01:00` for one minute.
   required: false
-  type: time
+  type: string
   default: "00:00:00"
 {% endoptions_yaml %}
 

--- a/source/_conditions/lawn_mower.is_returning.markdown
+++ b/source/_conditions/lawn_mower.is_returning.markdown
@@ -122,7 +122,7 @@ If you use a gate during the mowing run, only lock it after the mower is returni
 - **Condition**: Lawn mower is returning
   - **Target**: Backyard mower
   - **For at least**: 00:01:00
-- **Action**: Lock
+- **Action**: Lock lock
 
 {% details "YAML example for locking the side gate" %}
 

--- a/source/_conditions/lawn_mower.is_returning.markdown
+++ b/source/_conditions/lawn_mower.is_returning.markdown
@@ -1,0 +1,151 @@
+---
+title: "Lawn mower is returning"
+condition: lawn_mower.is_returning
+domain: lawn_mower
+description: "Tests if one or more lawn mowers are returning to the dock."
+---
+
+The **Lawn mower is returning** condition passes when one or more targeted mowers are on their way back to the dock.
+Use it when an automation should continue only during the return trip, like keeping a path light on or waiting to start another yard task.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Lawn mower is returning**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, set how long the mower must stay in the returning state before the condition passes. Leave it at zero to check the current state only.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple lawn mowers are targeted, controls how results combine. Pick **Any** to pass if at least one targeted mower is returning, or **All** to pass only when every targeted mower is returning.
+For at least:
+  description: How long the mower must stay in the returning state before the condition passes. Leave it at zero to check the current state only.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `lawn_mower.is_returning`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: lawn_mower.is_returning
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This passes when `lawn_mower.backyard` is currently returning to the dock.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls how results combine.
+    Accepts `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay in the returning state before the condition
+    passes. Accepts a duration like `00:01:00` for one minute.
+  required: false
+  type: time
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Mowers in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- Use **For at least** if you want the condition to pass only after the mower has been returning for a short time.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: Keep the path light on while the mower returns
+
+If the dock is in a darker part of the yard, this automation checks whether the mower is returning before it turns on the path light.
+
+- **Trigger**: Time pattern: Every 5 minutes
+- **Condition**: Lawn mower is returning
+  - **Target**: Backyard mower
+  - **For at least**: 00:00:30
+- **Condition**: Sun: after sunset
+- **Action**: Turn on light
+
+{% details "YAML example for keeping the path lit" %}
+
+{% example %}
+automation: |
+  alias: "Keep the path lit while the mower returns"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/5"
+  conditions:
+    - condition: lawn_mower.is_returning
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:00:30"
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.garden_path
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Wait to lock the side gate until the mower is on its way home
+
+If you use a gate during the mowing run, only lock it after the mower is returning and the yard work is almost done.
+
+- **Trigger**: Time: 20:30
+- **Condition**: Lawn mower is returning
+  - **Target**: Backyard mower
+  - **For at least**: 00:01:00
+- **Action**: Lock
+
+{% details "YAML example for locking the side gate" %}
+
+{% example %}
+automation: |
+  alias: "Lock the side gate when the mower returns"
+  triggers:
+    - trigger: time
+      at: "20:30:00"
+  conditions:
+    - condition: lawn_mower.is_returning
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:01:00"
+  actions:
+    - action: lock.lock
+      target:
+        entity_id: lock.side_gate
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_integrations/lawn_mower.markdown
+++ b/source/_integrations/lawn_mower.markdown
@@ -11,7 +11,8 @@ ha_codeowners:
 ha_integration_type: entity
 ---
 
-The **Lawn mower** {% term integration %} allows the control of robotic lawn mowers to be reflected within Home Assistant.
+The **Lawn mower** {% term integration %} lets you bring compatible robotic lawn mowers into Home Assistant.
+Use it to monitor whether your mower is mowing, paused, returning to dock, docked, or reporting an error, and build automations around those states.
 
 {% include integrations/building_block_integration.md %}
 
@@ -26,6 +27,10 @@ A lawn mower entity can have the following states:
 - **Error**: The lawn mower encountered an error while active and needs assistance.
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
+
+{% include integrations/triggers.md %}
+
+{% include integrations/conditions.md %}
 
 ## Actions
 
@@ -56,3 +61,68 @@ The `lawn_mower.dock` action tells the lawn mower to return to its dock.
 | Data attribute | Optional | Description                                                          |
 | -------------- | -------- | -------------------------------------------------------------------- |
 | `entity_id`    | yes      | Only act on specific lawn_mower. Use `entity_id: all` to target all. |
+
+## Lawn mower automation examples
+
+You can use lawn mower triggers and conditions to react when mowing starts, pauses, or finishes.
+You can also combine them with weather, time, and notifications to keep your yard routine simple.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: Send a notification when mowing is done
+
+When the mower returns to dock, send a message so you know the job is finished without checking the app.
+
+- **Trigger**: Lawn mower returned to dock
+  - **Target**: Backyard mower
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for notifying when mowing is done" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the mower is done"
+  triggers:
+    - trigger: lawn_mower.docked
+      target:
+        entity_id: lawn_mower.backyard
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The backyard mower is back at the dock."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Return the mower to dock when rain starts
+
+If rain starts while the mower is active, you can stop the run early and send it back to the dock.
+
+- **Trigger**: State: Rain sensor turned on
+- **Condition**: Lawn mower is mowing
+  - **Target**: Backyard mower
+- **Action**: Return to dock
+
+{% details "YAML example for docking the mower when rain starts" %}
+
+{% example %}
+automation: |
+  alias: "Dock the mower when it starts raining"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.rain_detected
+      to: "on"
+  conditions:
+    - condition: lawn_mower.is_mowing
+      target:
+        entity_id: lawn_mower.backyard
+  actions:
+    - action: lawn_mower.dock
+      target:
+        entity_id: lawn_mower.backyard
+{% endexample %}
+
+{% enddetails %}

--- a/source/_integrations/lawn_mower.markdown
+++ b/source/_integrations/lawn_mower.markdown
@@ -104,7 +104,7 @@ If rain starts while the mower is active, you can stop the run early and send it
 - **Trigger**: State: Rain sensor turned on
 - **Condition**: Lawn mower is mowing
   - **Target**: Backyard mower
-- **Action**: Return to dock
+- **Action**: Return lawn mower to dock
 
 {% details "YAML example for docking the mower when rain starts" %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document new conditions for the [lawn mower](https://www.home-assistant.io/integrations/lawn_mower) integration and edit main integration page.

Triggers are edited in https://github.com/home-assistant/home-assistant.io/pull/45473.

Previews:

- Lawn mower
- Conditions:
  - [Lawn mower is docked](https://deploy-preview-45474--home-assistant-docs.netlify.app/conditions/lawn_mower.is_docked/)
  - [Lawn mower is encountering an error](https://deploy-preview-45474--home-assistant-docs.netlify.app/conditions/lawn_mower.is_encountering_an_error/)
  - [Lawn mower is mowing](https://deploy-preview-45474--home-assistant-docs.netlify.app/conditions/lawn_mower.is_mowing/)
  - [Lawn mower is paused](https://deploy-preview-45474--home-assistant-docs.netlify.app/conditions/lawn_mower.is_paused/)
  - [Lawn mower is returning](https://deploy-preview-45474--home-assistant-docs.netlify.app/conditions/lawn_mower.is_returning/)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/44919

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
