### PR TITLE
Clarify Teleinfo prerequisites require historique TIC mode

### DIFF
--- a/source/_integrations/teleinfo.markdown
+++ b/source/_integrations/teleinfo.markdown
@@ -38,7 +38,7 @@ You can also manually configure any serial adapter connected to the meter's TIC 
 
 Before setting up this integration, make sure you have the following:
 
-1. A Linky meter (or compatible electronic meter) with the TIC output enabled.
+1. A Linky meter (or compatible electronic meter) with the TIC output enabled and set to historique mode. The newer standard mode is not supported. If your meter is in standard mode, you can ask Enedis to switch it back to historique mode.
 2. A Teleinfo USB adapter connected to the meter's TIC terminals (I1 and I2).
 3. The USB adapter plugged into your Home Assistant host.
 


### PR DESCRIPTION
## Summary

- Clarifies that the Linky meter must use _historique_ TIC mode, not standard mode, for the Teleinfo integration to work.
- Explains that users can contact Enedis to switch their meter back to historique mode if needed.

Fixes #45509

## Test plan

- [ ] Verify the prerequisite wording on the Teleinfo integration page reads clearly and accurately describes the mode requirement.