### PR TITLE
Remove outdated ‘required firmware x and higher’ from HomeWizard documentation

### DIFF
--- a/source/_integrations/homewizard.markdown
+++ b/source/_integrations/homewizard.markdown
@@ -42,17 +42,17 @@ You have to enable the local API to allow Home Assistant to communicate with you
 {% tip %}
 You can skip this step if you are configuring one of the following devices:
 
-- Wi-Fi P1 Meter with firmware version 6 or higher
-- Wi-Fi kWh Meter with firmware version 5 or higher
+- P1 Meter
+- kWh Meter
 - Plug-In Battery
 
 These products use a different authentication method that doesn't require enabling the local API.
 {% endtip %}
 
-  1. Go to Settings (gear icon in the upper-right).
-  2. Go to 'Meters'.
+  1. Go to **Settings** (gear icon in the upper-right).
+  2. Go to **Meters**.
   3. Select your device.
-  4. Scroll down and turn on 'Local API'.
+  4. Scroll down and turn on **Local API**.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

"with firmware version x or higher” was added because not all devices were able to update. But at this time all devices had the change to update.

Also addresses https://github.com/home-assistant/home-assistant.io/pull/45513#discussion_r3288077670


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
