### PR TITLE
garage_door: document triggers & conditions (Labs feature)

### DIFF
--- a/source/_conditions/garage_door.is_closed.markdown
+++ b/source/_conditions/garage_door.is_closed.markdown
@@ -1,0 +1,152 @@
+---
+title: "Garage door is closed"
+condition: garage_door.is_closed
+domain: garage_door
+description: "Tests if one or more garage doors are closed."
+related_conditions:
+  - garage_door.is_open
+---
+
+The **Garage door is closed** condition passes when one or more targeted garage doors are currently closed. Use it when an automation should continue only after a garage door is shut.
+
+This condition is useful for security checks and routines that depend on a closed garage door, like arming an alarm or turning on climate control only after the opening is sealed.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Garage door is closed**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your garage door is in, like your garage or driveway. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the garage door must have stayed closed before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple garage doors are targeted, controls how results combine. Pick **Any** to pass if at least one targeted garage door is closed, or **All** to pass only when every targeted garage door is closed.
+For at least:
+  description: How long the garage door must have stayed closed before the condition passes.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `garage_door.is_closed`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: garage_door.is_closed
+  target:
+    entity_id: cover.garage_door
+{% endexample %}
+
+This passes when `cover.garage_door` is currently closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple garage doors are targeted, controls how results combine. Accepts `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the garage door must have stayed closed before the condition passes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works with garage door contact sensors that use the `garage_door` device class and garage door covers that use the `garage` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted garage door is closed.
+- With **All**, the condition passes only if every available targeted garage door is closed. If every targeted garage door is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: arm the garage alarm only when the garage door has been closed for 10 minutes
+
+If you have created a bedtime {% term helper %} separately, this automation waits for that helper to turn on, then checks that the garage door has stayed closed for 10 minutes before it arms the alarm.
+
+- **Trigger**: User-created bedtime helper turns on
+- **Condition**: Garage door is closed
+  - **Target**: Garage door
+  - **For at least**: 00:10:00
+- **Action**: Arm alarm away
+
+{% details "YAML example for arming the garage alarm after the door stays closed" %}
+
+{% example %}
+automation: |
+  alias: "Arm the garage alarm only when the garage door has been closed for 10 minutes"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.bedtime_mode
+      to: "on"
+  conditions:
+    - condition: garage_door.is_closed
+      target:
+        entity_id: cover.garage_door
+      options:
+        for: "00:10:00"
+  actions:
+    - action: alarm_control_panel.alarm_arm_away
+      target:
+        entity_id: alarm_control_panel.garage_alarm
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: start the garage fan only after the garage door has been closed for 5 minutes
+
+If you use a fan to clear heat or fumes from the garage, this automation waits until the garage door has been shut for 5 minutes before it starts the fan.
+
+- **Trigger**: Time
+- **Condition**: Garage door is closed
+  - **Target**: Garage door
+  - **For at least**: 00:05:00
+- **Action**: Turn on switch
+
+{% details "YAML example for starting the garage fan after the door closes" %}
+
+{% example %}
+automation: |
+  alias: "Start the garage fan after the garage door has been closed for 5 minutes"
+  triggers:
+    - trigger: time
+      at: "18:00:00"
+  conditions:
+    - condition: garage_door.is_closed
+      target:
+        entity_id: binary_sensor.garage_door_contact
+      options:
+        for: "00:05:00"
+  actions:
+    - action: switch.turn_on
+      target:
+        entity_id: switch.garage_fan
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/garage_door.is_open.markdown
+++ b/source/_conditions/garage_door.is_open.markdown
@@ -1,0 +1,156 @@
+---
+title: "Garage door is open"
+condition: garage_door.is_open
+domain: garage_door
+description: "Tests if one or more garage doors are open."
+related_conditions:
+  - garage_door.is_closed
+---
+
+The **Garage door is open** condition passes when one or more targeted garage doors are currently open. Use it when an automation should continue only if a garage door is still open at the moment the automation runs.
+
+This condition is useful for reminders, security checks, and routines that should warn you when a garage door has been left open.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Garage door is open**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your garage door is in, like your garage or driveway. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the garage door must have stayed open before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple garage doors are targeted, controls how results combine. Pick **Any** to pass if at least one targeted garage door is open, or **All** to pass only when every targeted garage door is open.
+For at least:
+  description: How long the garage door must have stayed open before the condition passes.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `garage_door.is_open`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: garage_door.is_open
+  target:
+    entity_id: cover.garage_door
+{% endexample %}
+
+This passes when `cover.garage_door` is currently open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple garage doors are targeted, controls how results combine. Accepts `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the garage door must have stayed open before the condition passes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works with garage door contact sensors that use the `garage_door` device class and garage door covers that use the `garage` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted garage door is open.
+- With **All**, the condition passes only if every available targeted garage door is open. If every targeted garage door is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: remind you at bedtime if the garage door is still open
+
+If you have created a {% term helper %} to mark bedtime, this automation can use it to check whether the garage door is still open before you settle in for the night.
+
+- **Trigger**: Bedtime helper turns on
+- **Condition**: Garage door is open
+  - **Target**: Garage door
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a bedtime garage door reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me at bedtime if the garage door is still open"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.bedtime_mode
+      to: "on"
+  conditions:
+    - condition: garage_door.is_open
+      target:
+        entity_id: cover.garage_door
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Garage door is open"
+        message: "The garage door is still open at bedtime."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: alert you if the garage door is still open after you leave home
+
+When the last person leaves home, this automation checks whether the garage door is still open. If it is, Home Assistant sends an alert so you can close it before getting too far away.
+
+- **Trigger**: Person leaves home zone
+- **Condition**: Garage door is open
+  - **Target**: Garage door
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for checking the garage door when leaving home" %}
+
+{% example %}
+automation: |
+  alias: "Alert me if the garage door is open when leaving home"
+  triggers:
+    - trigger: zone
+      entity_id: person.frenck
+      zone: zone.home
+      event: leave
+  conditions:
+    - condition: garage_door.is_open
+      target:
+        entity_id: binary_sensor.garage_door_contact
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Garage door is open"
+        message: "The garage door is still open, and you just left home."
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_integrations/garage_door.markdown
+++ b/source/_integrations/garage_door.markdown
@@ -11,7 +11,7 @@ ha_domain: garage_door
 ha_integration_type: system
 ---
 
-The **Garage door** {% term integration %} provides automation triggers and conditions for binary sensors with device class `garage_door` and covers with device class `garage`. There are no configuration options for this integration.
+The **Garage door** {% term integration %} provides automation triggers and conditions for binary sensors with device class `garage_door` and covers with device class `garage`.
 
 ## Supported entities
 

--- a/source/_integrations/garage_door.markdown
+++ b/source/_integrations/garage_door.markdown
@@ -1,6 +1,6 @@
 ---
 title: Garage door
-description: This integration provides garage door automation triggers.
+description: This integration provides garage door automation triggers and conditions.
 ha_category:
   - Automation
 ha_release: 2026.4
@@ -11,4 +11,92 @@ ha_domain: garage_door
 ha_integration_type: system
 ---
 
-The **Garage door** {% term integration %} provides automation triggers for binary sensors and covers with device class `garage_door`. There are no configuration options for this integration.
+The **Garage door** {% term integration %} provides automation triggers and conditions for binary sensors with device class `garage_door` and covers with device class `garage`. There are no configuration options for this integration.
+
+## Supported entities
+
+The **Garage door** integration supports the following entity types:
+
+- Binary sensors with device class `garage_door`
+- Covers with device class `garage`
+
+## Configuration
+
+The **Garage door** integration does not require any configuration.
+
+## Supported functionality
+
+The **Garage door** integration provides the following automation building blocks for supported garage door entities.
+
+{% include integrations/triggers.md %}
+
+{% include integrations/conditions.md %}
+
+## Garage door automation examples
+
+You can use these triggers and conditions to react when a garage door opens, confirm that it is closed before another automation continues, or remind yourself when it has been left open.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: turn on the garage entry light when the garage door opens after dark
+
+If you come home after sunset, this automation turns on the light near the garage entry as soon as the garage door opens.
+
+- **Trigger**: Garage door opened
+  - **Target**: Garage door
+- **Action**: Turn on light
+
+{% details "YAML example for turning on the garage entry light" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the garage entry light when the garage door opens after dark"
+  triggers:
+    - trigger: garage_door.opened
+      target:
+        entity_id: cover.garage_door
+  conditions:
+    - condition: numeric_state
+      entity_id: sun.sun
+      attribute: elevation
+      below: 0
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.garage_entry
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: arm the garage alarm only when the garage door has been closed for 10 minutes
+
+If you have created a bedtime {% term helper %} separately, this automation waits for that helper to turn on, then checks that the garage door has stayed closed for 10 minutes before it arms the alarm.
+
+- **Trigger**: User-created bedtime helper turns on
+- **Condition**: Garage door is closed
+  - **Target**: Garage door
+  - **For at least**: 00:10:00
+- **Action**: Arm alarm away
+
+{% details "YAML example for arming the garage alarm after the door stays closed" %}
+
+{% example %}
+automation: |
+  alias: "Arm the garage alarm only when the garage door has been closed for 10 minutes"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.bedtime_mode
+      to: "on"
+  conditions:
+    - condition: garage_door.is_closed
+      target:
+        entity_id: cover.garage_door
+      options:
+        for: "00:10:00"
+  actions:
+    - action: alarm_control_panel.alarm_arm_away
+      target:
+        entity_id: alarm_control_panel.garage_alarm
+{% endexample %}
+
+{% enddetails %}

--- a/source/_integrations/garage_door.markdown
+++ b/source/_integrations/garage_door.markdown
@@ -17,8 +17,8 @@ The **Garage door** {% term integration %} provides automation triggers and cond
 
 The **Garage door** integration supports the following entity types:
 
-- Binary sensors with device class `garage_door`
-- Covers with device class `garage`
+- Binary sensors with device class `garage_door`.
+- Covers with device class `garage`.
 
 ## Configuration
 

--- a/source/_triggers/garage_door.closed.markdown
+++ b/source/_triggers/garage_door.closed.markdown
@@ -95,7 +95,7 @@ After you finish unloading the car, this automation gives you a little time to w
 
 {% example %}
 automation: |
-  alias: "Turn off the garage lights after the garage door closes"
+  alias: "Turn off the garage lights after the garage door has been closed for 2 minutes"
   triggers:
     - trigger: garage_door.closed
       target:

--- a/source/_triggers/garage_door.closed.markdown
+++ b/source/_triggers/garage_door.closed.markdown
@@ -1,0 +1,140 @@
+---
+title: "Garage door closed"
+trigger: garage_door.closed
+domain: garage_door
+description: "Triggers after one or more garage doors close."
+related_triggers:
+  - garage_door.opened
+---
+
+The **Garage door closed** trigger fires when a targeted garage door changes to closed. Use it when you want an automation to wait for the garage door to finish closing before it continues.
+
+This trigger is useful for turning lights off after you park, resuming a security routine after the garage is shut, and confirming that a close cycle has finished.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Garage door closed**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your garage door is in, like your garage or driveway. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the garage door must stay closed before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple garage doors are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted garage door closes, **First** to fire only when the first targeted garage door closes, or **All** to fire only after every targeted garage door is closed.
+For at least:
+  description: How long the garage door must stay closed before the trigger fires. Set it to zero to fire immediately.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `garage_door.closed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: garage_door.closed
+  target:
+    entity_id: cover.garage_door
+{% endexample %}
+
+This fires when `cover.garage_door` closes.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple garage doors are targeted, controls when the trigger fires. Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the garage door must stay closed before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works with garage door contact sensors that use the `garage_door` device class and garage door covers that use the `garage` device class.
+- If an entity comes back from `unavailable` or `unknown`, that recovery does not count as the garage door closing.
+- The `for` option only fires the automation if the garage door stays closed for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off the garage lights after the garage door has been closed for 2 minutes
+
+After you finish unloading the car, this automation gives you a little time to walk inside before it turns off the garage lights.
+
+- **Trigger**: Garage door closed
+  - **Target**: Garage door
+  - **For at least**: 00:02:00
+- **Action**: Turn off light
+
+{% details "YAML example for turning off the garage lights" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the garage lights after the garage door closes"
+  triggers:
+    - trigger: garage_door.closed
+      target:
+        entity_id: cover.garage_door
+      options:
+        for: "00:02:00"
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.garage_lights
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: close the interior entry lock after the garage door closes
+
+If you use the garage as your main entrance, this automation can lock the interior entry door after the garage door finishes closing.
+
+- **Trigger**: Garage door closed
+  - **Target**: Garage door
+- **Action**: Lock lock
+
+{% details "YAML example for locking the interior entry door" %}
+
+{% example %}
+automation: |
+  alias: "Lock the interior entry door after the garage door closes"
+  triggers:
+    - trigger: garage_door.closed
+      target:
+        entity_id: binary_sensor.garage_door_contact
+  actions:
+    - action: lock.lock
+      target:
+        entity_id: lock.garage_entry_door
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/garage_door.opened.markdown
+++ b/source/_triggers/garage_door.opened.markdown
@@ -1,0 +1,153 @@
+---
+title: "Garage door opened"
+trigger: garage_door.opened
+domain: garage_door
+description: "Triggers after one or more garage doors open."
+related_triggers:
+  - garage_door.closed
+---
+
+The **Garage door opened** trigger fires when a targeted garage door changes to open. Use it when you want Home Assistant to respond as soon as a garage door starts to open or is detected as open.
+
+This trigger is useful for turning on lights when you arrive, sending alerts if the garage opens while nobody is home, and starting routines that depend on access to the garage.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Garage door opened**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your garage door is in, like your garage or driveway. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the garage door must stay open before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple garage doors are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted garage door opens, **First** to fire only when the first targeted garage door opens, or **All** to fire only after every targeted garage door is open.
+For at least:
+  description: How long the garage door must stay open before the trigger fires. Set it to zero to fire immediately.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `garage_door.opened`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: garage_door.opened
+  target:
+    entity_id: cover.garage_door
+{% endexample %}
+
+This fires when `cover.garage_door` opens.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple garage doors are targeted, controls when the trigger fires. Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the garage door must stay open before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works with garage door contact sensors that use the `garage_door` device class and garage door covers that use the `garage` device class.
+- If an entity comes back from `unavailable` or `unknown`, that recovery does not count as the garage door opening.
+- The `for` option only fires the automation if the garage door stays open for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the garage entry light when the garage door opens after dark
+
+If you come home after sunset, this automation turns on the light near the garage entry as soon as the garage door opens.
+
+- **Trigger**: Garage door opened
+  - **Target**: Garage door
+- **Action**: Turn on light
+
+{% details "YAML example for turning on the garage entry light" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the garage entry light when the garage door opens after dark"
+  triggers:
+    - trigger: garage_door.opened
+      target:
+        entity_id: cover.garage_door
+  conditions:
+    - condition: numeric_state
+      entity_id: sun.sun
+      attribute: elevation
+      below: 0
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.garage_entry
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the garage door opens while nobody is home
+
+If the garage door opens after everyone has left, this automation sends a notification right away so you can check what happened.
+
+- **Trigger**: Garage door opened
+  - **Target**: Garage door
+- **Condition**: Numeric state
+  - **Entity**: Home zone
+  - **Below**: 1
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for notifying you when the garage door opens away from home" %}
+
+{% example %}
+automation: |
+  alias: "Notify if the garage door opens while nobody is home"
+  triggers:
+    - trigger: garage_door.opened
+      target:
+        entity_id: binary_sensor.garage_door_contact
+  conditions:
+    - condition: numeric_state
+      entity_id: zone.home
+      below: 1
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Garage door opened"
+        message: "The garage door opened while nobody was home."
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}


### PR DESCRIPTION
## Proposed change

Migrate the Garage door integration docs to the split-page format for Labs triggers and conditions.

This updates the integration page, adds split trigger pages for garage_door.opened and garage_door.closed, and adds split condition pages for garage_door.is_open and garage_door.is_closed.

This leaves actions out of scope because Core does not implement garage_door services.

Previews:

- [Garage door](https://deploy-preview-45521--home-assistant-docs.netlify.app/integrations/garage_door)
- Triggers:
  - [Garage door closed](https://deploy-preview-45521--home-assistant-docs.netlify.app/triggers/garage_door.closed/)
  - [Garage door opened](https://deploy-preview-45521--home-assistant-docs.netlify.app/triggers/garage_door.opened/)
- Conditions:
  - [Garage door is closed](https://deploy-preview-45521--home-assistant-docs.netlify.app/conditions/garage_door.is_closed/)
  - [Garage door is open](https://deploy-preview-45521--home-assistant-docs.netlify.app/conditions/garage_door.is_open/)

## Type of change

- [ ] Spelling, grammar or other readability improvements (current branch).
- [x] Adjusted missing or incorrect information in the current documentation (current branch).
- [ ] Added documentation for a new integration I am adding to Home Assistant (next branch).
  - [ ] I have opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I am adding to Home Assistant (next branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #44913

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the current branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the next branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards