### PR TITLE
siren: document triggers & conditions (Labs feature)

### DIFF
--- a/source/_conditions/siren.is_off.markdown
+++ b/source/_conditions/siren.is_off.markdown
@@ -88,7 +88,6 @@ After you disarm an alarm, you may want a quick confirmation that the siren has 
 - **Trigger**: State changed: Home alarm to disarmed
 - **Condition**: Siren is off
   - **Target**: Entry siren
-  - **Condition passes if**: Any
   - **For at least**: 00:00:30
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
@@ -107,7 +106,6 @@ automation: |
       target:
         entity_id: siren.entry
       options:
-        behavior: any
         for: "00:00:30"
   actions:
     - action: notify.send_message
@@ -130,7 +128,6 @@ Testing a siren is useful, but not if a real alarm is already active. This autom
 - **Condition**: Siren is off
   - **Target**: All sirens (by label)
   - **Condition passes if**: All
-  - **For at least**: 00:00:00
 - **Action**: Turn on siren
 
 {% details "YAML example for a siren test" %}
@@ -147,7 +144,6 @@ automation: |
         label_id: house_sirens
       options:
         behavior: all
-        for: "00:00:00"
   actions:
     - action: siren.turn_on
       target:

--- a/source/_conditions/siren.is_off.markdown
+++ b/source/_conditions/siren.is_off.markdown
@@ -55,14 +55,14 @@ behavior:
   description: >
     When multiple sirens are targeted, controls how results combine.
     Accepts `all` or `any`.
-  required: true
+  required: false
   type: string
   default: any
 for:
   description: >
     How long the siren must stay off before the condition passes.
     Accepts a duration string like `00:05:00`.
-  required: true
+  required: false
   type: string
   default: "00:00:00"
 {% endoptions_yaml %}

--- a/source/_conditions/siren.is_off.markdown
+++ b/source/_conditions/siren.is_off.markdown
@@ -1,0 +1,163 @@
+---
+title: "Siren is off"
+condition: siren.is_off
+domain: siren
+description: "Tests if one or more sirens are off."
+related_conditions:
+  - siren.is_on
+---
+
+The **Siren is off** condition is useful when an automation should continue only when a siren is quiet. You can use it to confirm a reset is complete, avoid starting a test during a real alarm, or make sure another action runs only after the siren has stopped.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your siren is in. You can also select a floor, a device, a specific entity, or a label.
+5. From the conditions shown for that target, select **Siren is off**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All** to control how the check behaves when multiple sirens are targeted.
+7. Under **For at least**, set how long the siren must stay off before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple sirens are targeted, controls how results combine. Pick **Any** to pass if at least one targeted siren is off, or **All** to pass only when every targeted siren is off.
+For at least:
+  description: How long the siren must stay off before the condition passes.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `siren.is_off`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: siren.is_off
+  target:
+    entity_id: siren.entry
+{% endexample %}
+
+This passes when `siren.entry` is currently off.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple sirens are targeted, controls how results combine.
+    Accepts `all` or `any`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the siren must stay off before the condition passes.
+    Accepts a duration string like `00:05:00`.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Sirens in the `unavailable` or `unknown` state do not count as being off.
+- With **All** behavior, the condition passes only if every targeted siren is off for the selected time.
+- To check whether a siren is sounding, use [Siren is on](/conditions/siren.is_on/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: confirm the alarm has reset after the siren stays off
+
+After you disarm an alarm, you may want a quick confirmation that the siren has really stopped. This automation waits for the entry siren to stay off for 30 seconds, then sends a message that the reset is complete.
+
+- **Trigger**: State changed: Home alarm to disarmed
+- **Condition**: Siren is off
+  - **Target**: Entry siren
+  - **Condition passes if**: Any
+  - **For at least**: 00:00:30
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a siren reset confirmation" %}
+
+{% example %}
+automation: |
+  alias: "Confirm the siren has stopped"
+  triggers:
+    - trigger: state
+      entity_id: alarm_control_panel.home_alarm
+      to: disarmed
+  conditions:
+    - condition: siren.is_off
+      target:
+        entity_id: siren.entry
+      options:
+        behavior: any
+        for: "00:00:30"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Alarm reset complete"
+        message: >
+          The entry siren has been off for
+          30 seconds.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: run a siren test only when every siren is off
+
+Testing a siren is useful, but not if a real alarm is already active. This automation runs a short siren test at noon only when every targeted siren is already off.
+
+- **Trigger**: Time: 12:00
+- **Condition**: Siren is off
+  - **Target**: All sirens (by label)
+  - **Condition passes if**: All
+  - **For at least**: 00:00:00
+- **Action**: Turn on siren
+
+{% details "YAML example for a siren test" %}
+
+{% example %}
+automation: |
+  alias: "Siren test at noon"
+  triggers:
+    - trigger: time
+      at: "12:00:00"
+  conditions:
+    - condition: siren.is_off
+      target:
+        label_id: house_sirens
+      options:
+        behavior: all
+        for: "00:00:00"
+  actions:
+    - action: siren.turn_on
+      target:
+        entity_id: siren.entry
+      data:
+        duration: 3
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/siren.is_on.markdown
+++ b/source/_conditions/siren.is_on.markdown
@@ -88,7 +88,6 @@ If a siren keeps sounding, it is easy to miss the first alert and forget to chec
 - **Trigger**: Time pattern: Every minute
 - **Condition**: Siren is on
   - **Target**: Patio siren
-  - **Condition passes if**: Any
   - **For at least**: 00:05:00
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
@@ -106,7 +105,6 @@ automation: |
       target:
         entity_id: siren.patio
       options:
-        behavior: any
         for: "00:05:00"
   actions:
     - action: notify.send_message
@@ -128,8 +126,6 @@ When you disarm your alarm, you usually want the noise to stop too. This automat
 - **Trigger**: State changed: Home alarm to disarmed
 - **Condition**: Siren is on
   - **Target**: Entry siren
-  - **Condition passes if**: Any
-  - **For at least**: 00:00:00
 - **Action**: Turn off siren
 
 {% details "YAML example for silencing the siren after disarming" %}
@@ -145,9 +141,6 @@ automation: |
     - condition: siren.is_on
       target:
         entity_id: siren.entry
-      options:
-        behavior: any
-        for: "00:00:00"
   actions:
     - action: siren.turn_off
       target:

--- a/source/_conditions/siren.is_on.markdown
+++ b/source/_conditions/siren.is_on.markdown
@@ -1,0 +1,161 @@
+---
+title: "Siren is on"
+condition: siren.is_on
+domain: siren
+description: "Tests if one or more sirens are on."
+related_conditions:
+  - siren.is_off
+---
+
+The **Siren is on** condition is useful when an automation should continue only while a siren is sounding. You can use it to send repeated reminders, stop a siren after a set time, or make sure a follow-up action only runs while the siren is still on.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your siren is in. You can also select a floor, a device, a specific entity, or a label.
+5. From the conditions shown for that target, select **Siren is on**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All** to control how the check behaves when multiple sirens are targeted.
+7. Under **For at least**, set how long the siren must stay on before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple sirens are targeted, controls how results combine. Pick **Any** to pass if at least one targeted siren is on, or **All** to pass only when every targeted siren is on.
+For at least:
+  description: How long the siren must stay on before the condition passes.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `siren.is_on`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: siren.is_on
+  target:
+    entity_id: siren.patio
+{% endexample %}
+
+This passes when `siren.patio` is currently on.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple sirens are targeted, controls how results combine.
+    Accepts `all` or `any`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the siren must stay on before the condition passes.
+    Accepts a duration string like `00:05:00`.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Sirens in the `unavailable` or `unknown` state do not count as being on.
+- With **All** behavior, the condition passes only if every targeted siren is on for the selected time.
+- To check whether a siren is not sounding, use [Siren is off](/conditions/siren.is_off/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: send a reminder while the siren is still on
+
+If a siren keeps sounding, it is easy to miss the first alert and forget to check again. This automation runs every minute and sends a reminder only if the patio siren has stayed on for at least 5 minutes.
+
+- **Trigger**: Time pattern: Every minute
+- **Condition**: Siren is on
+  - **Target**: Patio siren
+  - **Condition passes if**: Any
+  - **For at least**: 00:05:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a siren reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me while the patio siren is on"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/1"
+  conditions:
+    - condition: siren.is_on
+      target:
+        entity_id: siren.patio
+      options:
+        behavior: any
+        for: "00:05:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Siren still on"
+        message: >
+          The patio siren has been on for
+          at least 5 minutes.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn off the siren when the alarm is disarmed
+
+When you disarm your alarm, you usually want the noise to stop too. This automation turns off the entry siren only if it is still on when the alarm control panel changes to the disarmed state.
+
+- **Trigger**: State changed: Home alarm to disarmed
+- **Condition**: Siren is on
+  - **Target**: Entry siren
+  - **Condition passes if**: Any
+  - **For at least**: 00:00:00
+- **Action**: Turn off siren
+
+{% details "YAML example for silencing the siren after disarming" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the siren when the alarm is disarmed"
+  triggers:
+    - trigger: state
+      entity_id: alarm_control_panel.home_alarm
+      to: disarmed
+  conditions:
+    - condition: siren.is_on
+      target:
+        entity_id: siren.entry
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: siren.turn_off
+      target:
+        entity_id: siren.entry
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/siren.is_on.markdown
+++ b/source/_conditions/siren.is_on.markdown
@@ -55,14 +55,14 @@ behavior:
   description: >
     When multiple sirens are targeted, controls how results combine.
     Accepts `all` or `any`.
-  required: true
+  required: false
   type: string
   default: any
 for:
   description: >
     How long the siren must stay on before the condition passes.
     Accepts a duration string like `00:05:00`.
-  required: true
+  required: false
   type: string
   default: "00:00:00"
 {% endoptions_yaml %}

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -79,8 +79,6 @@ If a siren turns on while you are in another part of the building, you may want 
 
 - **Trigger**: Siren turned on
   - **Target**: Entry siren
-  - **Trigger when**: Each
-  - **For at least**: 00:00:00
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
 
@@ -93,9 +91,6 @@ automation: |
     - trigger: siren.turned_on
       target:
         entity_id: siren.entry
-      options:
-        behavior: any
-        for: "00:00:00"
   actions:
     - action: notify.send_message
       target:
@@ -115,7 +110,6 @@ If you want a siren to stop after a set time, you can check whether it is still 
 - **Trigger**: Time pattern: Every minute
 - **Condition**: Siren is on
   - **Target**: Patio siren
-  - **Condition passes if**: Any
   - **For at least**: 00:05:00
 - **Action**: Turn off siren
 
@@ -132,7 +126,6 @@ automation: |
       target:
         entity_id: siren.patio
       options:
-        behavior: any
         for: "00:05:00"
   actions:
     - action: siren.turn_off

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -12,7 +12,7 @@ ha_codeowners:
 ha_integration_type: entity
 ---
 
-The **Siren** {% term integration %} is built for the controlling and monitoring of siren/chime devices.
+The **Siren** {% term integration %} lets you control siren and chime devices and build automations around when they turn on or off.
 
 {% include integrations/building_block_integration.md %}
 
@@ -24,6 +24,10 @@ In addition, the entity can have the following states:
 
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
+
+{% include integrations/triggers.md %}
+
+{% include integrations/conditions.md %}
 
 ## Actions
 
@@ -62,3 +66,78 @@ The `siren.toggle` action toggles the siren on or off.
 | Data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of sirens to control.
+
+## Siren automation examples
+
+You can use siren triggers and conditions in automations to stay informed, light a path, or silence a siren at the right time.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: get a phone alert when the siren starts
+
+If a siren turns on while you are in another part of the building, you may want a notification right away. This automation sends a message to your phone as soon as the entry siren starts.
+
+- **Trigger**: Siren turned on
+  - **Target**: Entry siren
+  - **Trigger when**: Each
+  - **For at least**: 00:00:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a siren start notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the siren turns on"
+  triggers:
+    - trigger: siren.turned_on
+      target:
+        entity_id: siren.entry
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Siren started"
+        message: >
+          The entry siren just turned on.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn off a siren after it has been on for 5 minutes
+
+If you want a siren to stop after a set time, you can check whether it is still on before turning it off. This automation checks every minute and turns off the patio siren after it has stayed on for 5 minutes.
+
+- **Trigger**: Time pattern: Every minute
+- **Condition**: Siren is on
+  - **Target**: Patio siren
+  - **Condition passes if**: Any
+  - **For at least**: 00:05:00
+- **Action**: Turn off siren
+
+{% details "YAML example for turning off a siren after 5 minutes" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the patio siren after 5 minutes"
+  triggers:
+    - trigger: time_pattern
+      minutes: "/1"
+  conditions:
+    - condition: siren.is_on
+      target:
+        entity_id: siren.patio
+      options:
+        behavior: any
+        for: "00:05:00"
+  actions:
+    - action: siren.turn_off
+      target:
+        entity_id: siren.patio
+{% endexample %}
+
+{% enddetails %}

--- a/source/_triggers/siren.turned_off.markdown
+++ b/source/_triggers/siren.turned_off.markdown
@@ -87,8 +87,6 @@ When a siren stops, you may want to know the alarm state has settled down. This 
 
 - **Trigger**: Siren turned off
   - **Target**: Entry siren
-  - **Trigger when**: Each
-  - **For at least**: 00:00:00
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
 
@@ -101,9 +99,6 @@ automation: |
     - trigger: siren.turned_off
       target:
         entity_id: siren.entry
-      options:
-        behavior: any
-        for: "00:00:00"
   actions:
     - action: notify.send_message
       target:
@@ -122,7 +117,6 @@ If you turn on extra lights while a siren is active, you can also turn them off 
 
 - **Trigger**: Siren turned off
   - **Target**: Outdoor siren
-  - **Trigger when**: Each
   - **For at least**: 00:00:30
 - **Action**: Turn off light
 
@@ -136,7 +130,6 @@ automation: |
       target:
         entity_id: siren.outdoor
       options:
-        behavior: any
         for: "00:00:30"
   actions:
     - action: light.turn_off

--- a/source/_triggers/siren.turned_off.markdown
+++ b/source/_triggers/siren.turned_off.markdown
@@ -55,14 +55,14 @@ behavior:
   description: >
     When multiple sirens are targeted, controls when the trigger fires.
     Accepts `any`, `first`, or `last`.
-  required: true
+  required: false
   type: string
   default: any
 for:
   description: >
     How long the siren must stay off before the trigger fires.
     Accepts a duration string like `00:05:00`.
-  required: true
+  required: false
   type: string
   default: "00:00:00"
 {% endoptions_yaml %}

--- a/source/_triggers/siren.turned_off.markdown
+++ b/source/_triggers/siren.turned_off.markdown
@@ -1,0 +1,151 @@
+---
+title: "Siren turned off"
+trigger: siren.turned_off
+domain: siren
+description: "Triggers after one or more sirens turn off."
+related_triggers:
+  - siren.turned_on
+---
+
+The **Siren turned off** trigger is useful when you want Home Assistant to react when a siren stops sounding. You can use it to send an all-clear message, turn off temporary lighting, or reset other parts of an alarm flow after the noise ends.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your siren is in. You can also select a floor, a device, a specific entity, or a label.
+5. From the triggers shown for that target, select **Siren turned off**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All** to control how the trigger behaves when multiple sirens are targeted.
+7. Under **For at least**, set how long the siren must stay off before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple sirens are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted siren turns off, **First** to fire only when the first targeted siren turns off, or **All** to fire only after every targeted siren has turned off.
+For at least:
+  description: How long the siren must stay off before the trigger fires. Set to zero to fire right away.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `siren.turned_off`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: siren.turned_off
+  target:
+    entity_id: siren.entry
+{% endexample %}
+
+This fires every time `siren.entry` turns off.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple sirens are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the siren must stay off before the trigger fires.
+    Accepts a duration string like `00:05:00`.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger only fires when a siren changes from a known on state to off.
+- If a siren returns from `unavailable` or `unknown`, that recovery does not fire the trigger.
+- To react when a siren starts, use [Siren turned on](/triggers/siren.turned_on/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: send an all-clear notification when the siren stops
+
+When a siren stops, you may want to know the alarm state has settled down. This automation sends a phone notification as soon as the entry siren turns off.
+
+- **Trigger**: Siren turned off
+  - **Target**: Entry siren
+  - **Trigger when**: Each
+  - **For at least**: 00:00:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for an all-clear notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the siren turns off"
+  triggers:
+    - trigger: siren.turned_off
+      target:
+        entity_id: siren.entry
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Siren stopped"
+        message: >
+          The entry siren has turned off.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn off the porch lights after the siren stops
+
+If you turn on extra lights while a siren is active, you can also turn them off when the situation is over. This automation switches off the porch lights after the outdoor siren has been off for 30 seconds.
+
+- **Trigger**: Siren turned off
+  - **Target**: Outdoor siren
+  - **Trigger when**: Each
+  - **For at least**: 00:00:30
+- **Action**: Turn off light
+
+{% details "YAML example for turning off the porch lights" %}
+
+{% example %}
+automation: |
+  alias: "Turn off porch lights after the siren stops"
+  triggers:
+    - trigger: siren.turned_off
+      target:
+        entity_id: siren.outdoor
+      options:
+        behavior: any
+        for: "00:00:30"
+  actions:
+    - action: light.turn_off
+      target:
+        area_id: porch
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/siren.turned_on.markdown
+++ b/source/_triggers/siren.turned_on.markdown
@@ -1,0 +1,151 @@
+---
+title: "Siren turned on"
+trigger: siren.turned_on
+domain: siren
+description: "Triggers after one or more sirens turn on."
+related_triggers:
+  - siren.turned_off
+---
+
+The **Siren turned on** trigger is useful when you want Home Assistant to react as soon as a siren starts sounding. You can use it to send an alert, turn on lights, or start another automation the moment a siren changes from off to on.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your siren is in. You can also select a floor, a device, a specific entity, or a label.
+5. From the triggers shown for that target, select **Siren turned on**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All** to control how the trigger behaves when multiple sirens are targeted.
+7. Under **For at least**, set how long the siren must stay on before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple sirens are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted siren turns on, **First** to fire only when the first targeted siren turns on, or **All** to fire only after every targeted siren has turned on.
+For at least:
+  description: How long the siren must stay on before the trigger fires. Set to zero to fire right away.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `siren.turned_on`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: siren.turned_on
+  target:
+    entity_id: siren.entry
+{% endexample %}
+
+This fires every time `siren.entry` turns on.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple sirens are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: true
+  type: string
+  default: any
+for:
+  description: >
+    How long the siren must stay on before the trigger fires.
+    Accepts a duration string like `00:05:00`.
+  required: true
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger only fires when a siren changes from a known off state to on.
+- If a siren returns from `unavailable` or `unknown`, that recovery does not fire the trigger.
+- To react when a siren stops, use [Siren turned off](/triggers/siren.turned_off/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: send a phone alert when the siren starts
+
+If a siren turns on while you are outside or in another room, a phone alert helps you notice it right away. This automation sends a notification as soon as the entry siren starts.
+
+- **Trigger**: Siren turned on
+  - **Target**: Entry siren
+  - **Trigger when**: Each
+  - **For at least**: 00:00:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a siren start notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the siren turns on"
+  triggers:
+    - trigger: siren.turned_on
+      target:
+        entity_id: siren.entry
+      options:
+        behavior: any
+        for: "00:00:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Siren started"
+        message: >
+          The entry siren just turned on.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on the porch lights when the siren starts
+
+At night, a siren can be easier to deal with if the area around your home is lit. This automation turns on the porch lights when the outdoor siren starts, making it easier to check what is happening.
+
+- **Trigger**: Siren turned on
+  - **Target**: Outdoor siren
+  - **Trigger when**: Each
+  - **For at least**: 00:00:05
+- **Action**: Turn on light
+
+{% details "YAML example for lighting the porch when the siren starts" %}
+
+{% example %}
+automation: |
+  alias: "Turn on porch lights when the siren starts"
+  triggers:
+    - trigger: siren.turned_on
+      target:
+        entity_id: siren.outdoor
+      options:
+        behavior: any
+        for: "00:00:05"
+  actions:
+    - action: light.turn_on
+      target:
+        area_id: porch
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/siren.turned_on.markdown
+++ b/source/_triggers/siren.turned_on.markdown
@@ -55,14 +55,14 @@ behavior:
   description: >
     When multiple sirens are targeted, controls when the trigger fires.
     Accepts `any`, `first`, or `last`.
-  required: true
+  required: false
   type: string
   default: any
 for:
   description: >
     How long the siren must stay on before the trigger fires.
     Accepts a duration string like `00:05:00`.
-  required: true
+  required: false
   type: string
   default: "00:00:00"
 {% endoptions_yaml %}

--- a/source/_triggers/siren.turned_on.markdown
+++ b/source/_triggers/siren.turned_on.markdown
@@ -87,8 +87,6 @@ If a siren turns on while you are outside or in another room, a phone alert help
 
 - **Trigger**: Siren turned on
   - **Target**: Entry siren
-  - **Trigger when**: Each
-  - **For at least**: 00:00:00
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
 
@@ -101,9 +99,6 @@ automation: |
     - trigger: siren.turned_on
       target:
         entity_id: siren.entry
-      options:
-        behavior: any
-        for: "00:00:00"
   actions:
     - action: notify.send_message
       target:
@@ -122,7 +117,6 @@ At night, a siren can be easier to deal with if the area around your home is lit
 
 - **Trigger**: Siren turned on
   - **Target**: Outdoor siren
-  - **Trigger when**: Each
   - **For at least**: 00:00:05
 - **Action**: Turn on light
 
@@ -136,7 +130,6 @@ automation: |
       target:
         entity_id: siren.outdoor
       options:
-        behavior: any
         for: "00:00:05"
   actions:
     - action: light.turn_on


### PR DESCRIPTION
## Proposed change

Migrate the siren integration docs to the split-page format for Labs triggers and conditions.

This PR:
- adds split trigger pages for `siren.turned_on` and `siren.turned_off`
- adds split condition pages for `siren.is_on` and `siren.is_off`
- updates the siren integration page to include trigger and condition listings
- preserves the existing inline action documentation and adds integration-level automation examples

Previews:

- [Siren](https://deploy-preview-45522--home-assistant-docs.netlify.app/integrations/siren)
- Triggers:
  - [Siren turned off](https://deploy-preview-45522--home-assistant-docs.netlify.app/triggers/siren.turned_off)
  - [Siren turned on](https://deploy-preview-45522--home-assistant-docs.netlify.app/triggers/siren.turned_on)
- Conditions:
  - [Siren is off](https://deploy-preview-45522--home-assistant-docs.netlify.app/conditions/siren.is_off)
  - [Siren is on](https://deploy-preview-45522--home-assistant-docs.netlify.app/conditions/siren.is_on)

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #44934

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
