### PR TITLE
Add default polling interval for Waze travel time

### DIFF
--- a/source/_integrations/waze_travel_time.markdown
+++ b/source/_integrations/waze_travel_time.markdown
@@ -25,6 +25,7 @@ Notes:
 - The `incl_filter`/`excl_filter` allow you to force the {% term integration %} to use a particular route or avoid a particular route in its time travel calculation. These inputs must be an exact match to the street name including casing, spaces, and special characters. Use the service [`waze_travel_time.get_travel_times`](#action-waze_travel_timeget_travel_times) to get the exact street names for each route.
 - When using the `Avoid Toll Roads?`, `Avoid Subscription Roads?` and `Avoid Ferries?` options, be aware that Waze will sometimes still route you over toll roads or ferries if a valid vignette/subscription is assumed. Default behavior is that Waze will route you over roads having subscription options. It is therefor best is to set both `Avoid Toll Roads?` and `Avoid Subscription Roads?` or `Avoid Ferries?` if needed and experiment to ensure the desired outcome.
 - When **Origin** or **Destination** is an address, Waze resolves it to coordinates. If the address matches multiple locations, Waze selects the result closest to the `base_coordinates`. By default, this is your home location.
+- By default, Waze is polled every five minutes for the travel time.  See below for how to poll using custom invervals.
 
 ## Action `waze_travel_time.get_travel_times`
 

--- a/source/_integrations/waze_travel_time.markdown
+++ b/source/_integrations/waze_travel_time.markdown
@@ -25,7 +25,7 @@ Notes:
 - The `incl_filter`/`excl_filter` allow you to force the {% term integration %} to use a particular route or avoid a particular route in its time travel calculation. These inputs must be an exact match to the street name including casing, spaces, and special characters. Use the service [`waze_travel_time.get_travel_times`](#action-waze_travel_timeget_travel_times) to get the exact street names for each route.
 - When using the `Avoid Toll Roads?`, `Avoid Subscription Roads?` and `Avoid Ferries?` options, be aware that Waze will sometimes still route you over toll roads or ferries if a valid vignette/subscription is assumed. Default behavior is that Waze will route you over roads having subscription options. It is therefor best is to set both `Avoid Toll Roads?` and `Avoid Subscription Roads?` or `Avoid Ferries?` if needed and experiment to ensure the desired outcome.
 - When **Origin** or **Destination** is an address, Waze resolves it to coordinates. If the address matches multiple locations, Waze selects the result closest to the `base_coordinates`. By default, this is your home location.
-- By default, Waze is polled every five minutes for the travel time.  See below for how to poll using custom invervals.
+- By default, Waze is polled every five minutes for the travel time. See below for how to poll using custom intervals.
 
 ## Action `waze_travel_time.get_travel_times`
 


### PR DESCRIPTION
Clarify the polling interval for Waze travel time.  Docs were missing this and it was only documented in the source code.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation fix; Waze integration did not document the default polling interval, but it did document how to change the default.  (Hmm, how would someone know if they wanted to customize the interval without knowing what the default was? 😊)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
