### PR TITLE
Change DHCP to Zeroconf in indevolt integration

### DIFF
--- a/source/_integrations/indevolt.markdown
+++ b/source/_integrations/indevolt.markdown
@@ -18,7 +18,7 @@ ha_platforms:
   - switch
 ha_domain: indevolt
 ha_integration_type: device
-ha_dhcp: true
+ha_zeroconf: true
 ha_quality_scale: bronze
 ha_config_flow: true
 ---

--- a/source/_integrations/indevolt.markdown
+++ b/source/_integrations/indevolt.markdown
@@ -18,6 +18,7 @@ ha_platforms:
   - switch
 ha_domain: indevolt
 ha_integration_type: device
+ha_dhcp: true
 ha_zeroconf: true
 ha_quality_scale: bronze
 ha_config_flow: true


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Recently DHCP discovery was added to the Indevolt integration, but since a recent firmware update the device now advertises itself via mDNS as IGEN_FW._http._tcp.local (confirmed in Wireshark) This PR switches from DHCP-based to zeroconf-based discovery, which is preferred in HA.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/172093
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
