### PR TITLE
Add Standing Fan to SwitchBot integration docs

### DIFF
--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -193,6 +193,7 @@ For instructions on how to obtain the encryption key, see README in [PySwitchbot
 ### Fans
 
 - [Circulator Fan](https://www.switch-bot.com/products/switchbot-battery-circulator-fan)
+- [Standing Fan](https://www.switch-bot.com/products/switchbot-tower-fan)
 
 ### Vacuums
 - [K10+](https://www.switch-bot.com/products/switchbot-mini-robot-vacuum-k10)
@@ -802,7 +803,7 @@ Features:
 
 ### Fans
 
-Fan entities are added for Battery Circulator Fan/Circulator Fan
+Fan entities are added for Battery Circulator Fan/Circulator Fan and Standing Fan.
 
 #### Battery Circulator Fan/Circulator Fan
 
@@ -813,6 +814,19 @@ Features:
 - set mode
 - oscillate left and right
 - get battery level (Battery Circulator Fan only)
+
+#### Standing Fan
+
+Features:
+
+- turn on
+- turn off
+- set speed
+- set mode (Normal, Natural, Sleep, Baby, Custom Natural)
+- oscillate horizontally and vertically (separate switches)
+- set horizontal and vertical oscillation angle (30°, 60°, or 90°)
+- set night light level (Off, Level 1, or Level 2)
+- get battery level
 
 ### Air Purifiers
 


### PR DESCRIPTION
## Proposed change

Document the newly added Standing Fan support in the SwitchBot integration.

The Standing Fan is added under the supported devices list and gets its own subsection under **Fans**, describing the fan entity (with five preset modes), the horizontal and vertical oscillation switches, the oscillation angle selects (30°, 60°, 90°), the night light select (Off, Level 1, Level 2), and the battery level sensor.


## Note from SwitchBot team

This change is developed by the **official SwitchBot team**. The implementation has been verified with real hardware testing on physical devices.

If you have any questions or need clarification, please reach out:
- Discord: @7eaves
- GitHub: @fankai777
## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/172109
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
