### PR TITLE
update: document triggers & conditions (Labs feature)

### DIFF
--- a/source/_conditions/update.is_available.markdown
+++ b/source/_conditions/update.is_available.markdown
@@ -8,7 +8,7 @@ related_conditions:
 ---
 
 The **Update is available** condition passes when one or more targeted update
-entities are currently available. Use it when an automation should continue
+entities currently have an update available. Use it when an automation should continue
 only if a device or service still has an update ready to install.
 
 This condition is useful for scheduled maintenance automations, reminders, and

--- a/source/_conditions/update.is_available.markdown
+++ b/source/_conditions/update.is_available.markdown
@@ -1,0 +1,167 @@
+---
+title: "Update is available"
+condition: update.is_available
+domain: update
+description: "Tests if one or more updates are available."
+related_conditions:
+  - update.is_not_available
+---
+
+The **Update is available** condition passes when one or more targeted update
+entities are currently available. Use it when an automation should continue
+only if a device or service still has an update ready to install.
+
+This condition is useful for scheduled maintenance automations, reminders, and
+checks you want to run before installing an update.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** >
+   **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Update is available**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)),
+   pick the device, area, floor, label, or specific update entity you want to
+   evaluate.
+6. Under **Condition passes if** (see
+   [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the update must have stayed available
+   before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple update entities are targeted, controls how results combine. Pick **Any** to pass if at least one targeted update is available, or **All** to pass only when every targeted update is available.
+For at least:
+  description: How long the update must have stayed available before the condition passes.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `update.is_available`. A basic example
+looks like this:
+
+{% example %}
+condition: |
+  condition: update.is_available
+  target:
+    entity_id: update.office_router_firmware
+{% endexample %}
+
+This passes when `update.office_router_firmware` is currently available.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are
+not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple update entities are targeted, controls how results combine.
+    Accepts `any` or `all`.
+  required: false
+  type: string
+for:
+  description: >
+    How long the update must have stayed available before the condition passes.
+    Use the `HH:MM:SS` format, like `00:10:00` for 10 minutes.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition checks update entities whose state is `on`, which means an
+  update is available.
+- Entities in the `unavailable` or `unknown` state are ignored.
+- With **All**, the condition passes only if every available targeted update is
+  available. If every targeted entity is `unavailable` or `unknown`, **All**
+  passes and **Any** fails.
+- If you use `for`, each matching update must stay available for the full time
+  you set.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: install an update during the evening if it is still available
+
+If you prefer to install updates at a quieter time, this automation checks each
+evening whether an update is still available and starts the installation.
+
+- **Trigger**: Time: 21:00
+- **Condition**: Update is available
+  - **Target**: Office router update
+- **Action**: Install update
+
+{% details "YAML example for installing an update in the evening" %}
+
+{% example %}
+automation: |
+  alias: "Install an update during the evening if it is still available"
+  triggers:
+    - trigger: time
+      at: "21:00:00"
+  conditions:
+    - condition: update.is_available
+      target:
+        entity_id: update.office_router_firmware
+  actions:
+    - action: update.install
+      target:
+        entity_id: update.office_router_firmware
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: remind yourself every morning about a pending update
+
+If you want a simple daily reminder, this automation checks every morning
+whether your media player still has an update available and sends a message if
+it does.
+
+- **Trigger**: Time: 08:00
+- **Condition**: Update is available
+  - **Target**: Living room media player update
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for reminding you about a pending update" %}
+
+{% example %}
+automation: |
+  alias: "Remind me every morning about a pending update"
+  triggers:
+    - trigger: time
+      at: "08:00:00"
+  conditions:
+    - condition: update.is_available
+      target:
+        entity_id: update.living_room_media_player_firmware
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Update still available"
+        message: >
+          The living room media player still has an update waiting.
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/update.is_available.markdown
+++ b/source/_conditions/update.is_available.markdown
@@ -98,7 +98,7 @@ for:
 
 {% include conditions/more_examples.md %}
 
-### Automation: install an update during the evening if it is still available
+### Automation: install an update in the evening if it is still available
 
 If you prefer to install updates at a quieter time, this automation checks each
 evening whether an update is still available and starts the installation.

--- a/source/_conditions/update.is_available.markdown
+++ b/source/_conditions/update.is_available.markdown
@@ -38,9 +38,9 @@ To use this condition in an automation:
 
 {% options_ui %}
 Condition passes if:
-  description: When multiple update entities are targeted, controls how results combine. Pick **Any** to pass if at least one targeted update is available, or **All** to pass only when every targeted update is available.
+  description: When multiple update entities are targeted, controls how results combine. Pick **Any** to pass if at least one targeted update is available, or **All** to pass only when every targeted update is available. The default is **Any**.
 For at least:
-  description: How long the update must have stayed available before the condition passes.
+  description: How long the update must have stayed available before the condition passes. The default is `00:00:00`.
 {% endoptions_ui %}
 
 {% include conditions/yaml_header.md %}
@@ -69,12 +69,14 @@ behavior:
     Accepts `any` or `all`.
   required: false
   type: string
+  default: any
 for:
   description: >
     How long the update must have stayed available before the condition passes.
     Use the `HH:MM:SS` format, like `00:10:00` for 10 minutes.
   required: false
   type: string
+  default: "00:00:00"
 {% endoptions_yaml %}
 
 {% include conditions/targets.md %}

--- a/source/_conditions/update.is_not_available.markdown
+++ b/source/_conditions/update.is_not_available.markdown
@@ -38,9 +38,9 @@ To use this condition in an automation:
 
 {% options_ui %}
 Condition passes if:
-  description: When multiple update entities are targeted, controls how results combine. Pick **Any** to pass if at least one targeted update is up to date, or **All** to pass only when every targeted update is up to date.
+  description: When multiple update entities are targeted, controls how results combine. Pick **Any** to pass if at least one targeted update is up to date, or **All** to pass only when every targeted update is up to date. The default is **Any**.
 For at least:
-  description: How long the update must have stayed up to date before the condition passes.
+  description: How long the update must have stayed up to date before the condition passes. The default is `00:00:00`.
 {% endoptions_ui %}
 
 {% include conditions/yaml_header.md %}
@@ -69,12 +69,14 @@ behavior:
     Accepts `any` or `all`.
   required: false
   type: string
+  default: any
 for:
   description: >
     How long the update must have stayed up to date before the condition
     passes. Use the `HH:MM:SS` format, like `00:10:00` for 10 minutes.
   required: false
   type: string
+  default: "00:00:00"
 {% endoptions_yaml %}
 
 {% include conditions/targets.md %}

--- a/source/_conditions/update.is_not_available.markdown
+++ b/source/_conditions/update.is_not_available.markdown
@@ -1,0 +1,163 @@
+---
+title: "Update is not available"
+condition: update.is_not_available
+domain: update
+description: "Tests if one or more updates are not available."
+related_conditions:
+  - update.is_available
+---
+
+The **Update is not available** condition passes when one or more targeted
+update entities are currently up to date. Use it when an automation should
+continue only if a device or service does not have an update waiting.
+
+This condition is useful for clean-up automations, status checks, and routines
+that should run only after everything you target is already up to date.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** >
+   **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Update is not available**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)),
+   pick the device, area, floor, label, or specific update entity you want to
+   evaluate.
+6. Under **Condition passes if** (see
+   [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the update must have stayed up to
+   date before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple update entities are targeted, controls how results combine. Pick **Any** to pass if at least one targeted update is up to date, or **All** to pass only when every targeted update is up to date.
+For at least:
+  description: How long the update must have stayed up to date before the condition passes.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `update.is_not_available`. A basic example
+looks like this:
+
+{% example %}
+condition: |
+  condition: update.is_not_available
+  target:
+    entity_id: update.office_router_firmware
+{% endexample %}
+
+This passes when `update.office_router_firmware` is currently up to date.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are
+not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple update entities are targeted, controls how results combine.
+    Accepts `any` or `all`.
+  required: false
+  type: string
+for:
+  description: >
+    How long the update must have stayed up to date before the condition
+    passes. Use the `HH:MM:SS` format, like `00:10:00` for 10 minutes.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition checks update entities whose state is `off`, which means no
+  update is available.
+- Entities in the `unavailable` or `unknown` state are ignored.
+- With **All**, the condition passes only if every available targeted update is
+  up to date. If every targeted entity is `unavailable` or `unknown`, **All**
+  passes and **Any** fails.
+- If you use `for`, each matching update must stay up to date for the full time
+  you set.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: turn off a reminder light after the update has been installed
+
+If you use a light as a reminder for pending updates, this automation turns it
+off once the update is no longer available.
+
+- **Trigger**: Time: 21:30
+- **Condition**: Update is not available
+  - **Target**: Guest room speaker update
+- **Action**: Turn off light
+
+{% details "YAML example for turning off an update reminder light" %}
+
+{% example %}
+automation: |
+  alias: "Turn off a reminder light after the update has been installed"
+  triggers:
+    - trigger: time
+      at: "21:30:00"
+  conditions:
+    - condition: update.is_not_available
+      target:
+        entity_id: update.guest_room_speaker_firmware
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.hallway_lamp
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: run a script only after all selected devices are up to date
+
+If you have created a script for a routine that should run only after updates
+are done, this automation can wait until every targeted update entity is back
+to up to date.
+
+- **Trigger**: Time: 22:00
+- **Condition**: Update is not available
+  - **Target**: Upstairs update label
+  - **Condition passes if**: All
+- **Action**: Run script
+
+{% details "YAML example for waiting until updates are done" %}
+
+{% example %}
+automation: |
+  alias: "Run a script only after all selected devices are up to date"
+  triggers:
+    - trigger: time
+      at: "22:00:00"
+  conditions:
+    - condition: update.is_not_available
+      target:
+        label_id: upstairs_updates
+      options:
+        behavior: all
+  actions:
+    - action: script.evening_shutdown
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_integrations/update.markdown
+++ b/source/_integrations/update.markdown
@@ -65,7 +65,7 @@ The following device classes are supported for update entities:
 ## Actions
 
 The update {% term entity %} exposes three actions that can be used to install,
-skip, or restore an offered software update.
+skip, or restore (clear previously skipped) an offered software update.
 
 ### Action: Install
 

--- a/source/_integrations/update.markdown
+++ b/source/_integrations/update.markdown
@@ -58,10 +58,14 @@ The following device classes are supported for update entities:
   to be set.
 - **`firmware`**: This update {% term integration %} provides firmwares.
 
+{% include integrations/triggers.md %}
+
+{% include integrations/conditions.md %}
+
 ## Actions
 
-The update {% term entity %} exposes two actions that can be used to install or skip
-an offered software update.
+The update {% term entity %} exposes three actions that can be used to install,
+skip, or restore an offered software update.
 
 ### Action: Install
 
@@ -131,26 +135,71 @@ target:
 This can be helpful to, for example, in an automation that weekly unskips
 all updates you have previously marked as skipped; as a reminder to update.
 
-## Example: Sending update available notifications
+## Update automation examples
 
-A common use case for using update entities is to notify you if an update
-has become available for installation. Using the update entities,
-this is fairly straightforward to do.
+Update entities are useful when you want to stay informed about available
+updates or take action at the right time. Here are a few examples to help you
+get started.
 
-This is a YAML example for an automation that sends out a notification when
-the update for a light bulb becomes available.
+{% include docs/paste_yaml_tip.md %}
 
-```yaml
-automation:
-  - alias: "Send notification when update available"
-    triggers:
-      - trigger: state
-        entity_id: update.my_light_bulb
-        to: "on"
-    actions:
-      - alias: "Send notification to my phone about the update"
-        action: notify.iphone
-        data:
-          title: "New update available"
-          message: "New update available for my_light_bulb!"
-```
+### Automation: send a notification when an update becomes available
+
+If an update for a device or service becomes available, this automation sends a
+notification to your phone right away.
+
+- **Trigger**: Update became available
+  - **Target**: Office router update
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for notifying you about a new update" %}
+
+{% example %}
+automation: |
+  alias: "Send a notification when an update becomes available"
+  triggers:
+    - trigger: update.update_became_available
+      target:
+        entity_id: update.office_router_firmware
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Update available"
+        message: >
+          A new update is available for the office router.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: install an update during the evening if it is still available
+
+If you prefer to install updates at a quieter time, this automation checks each
+evening whether an update is still available and starts the installation.
+
+- **Trigger**: Time: 21:00
+- **Condition**: Update is available
+  - **Target**: Office router update
+- **Action**: Install update
+
+{% details "YAML example for installing an update in the evening" %}
+
+{% example %}
+automation: |
+  alias: "Install an update during the evening if it is still available"
+  triggers:
+    - trigger: time
+      at: "21:00:00"
+  conditions:
+    - condition: update.is_available
+      target:
+        entity_id: update.office_router_firmware
+  actions:
+    - action: update.install
+      target:
+        entity_id: update.office_router_firmware
+{% endexample %}
+
+{% enddetails %}

--- a/source/_triggers/update.update_became_available.markdown
+++ b/source/_triggers/update.update_became_available.markdown
@@ -36,9 +36,9 @@ To use this trigger in an automation:
 
 {% options_ui %}
 Trigger when:
-  description: When multiple update entities are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted update becomes available, **First** to fire only when the first targeted update becomes available, or **All** to fire only after every targeted update is available.
+  description: When multiple update entities are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted update becomes available, **First** to fire only when the first targeted update becomes available, or **All** to fire only after every targeted update is available. The default is **Each**.
 For at least:
-  description: How long the update must stay available before the trigger fires. Set it to zero to fire immediately.
+  description: How long the update must stay available before the trigger fires. Set it to zero to fire immediately. The default is `00:00:00`.
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
@@ -67,12 +67,14 @@ behavior:
     fires. Accepts `any`, `first`, or `last`.
   required: false
   type: string
+  default: any
 for:
   description: >
     How long the update must stay available before the trigger fires. Use the
     `HH:MM:SS` format, like `00:10:00` for 10 minutes.
   required: false
   type: string
+  default: "00:00:00"
 {% endoptions_yaml %}
 
 {% include triggers/targets.md %}

--- a/source/_triggers/update.update_became_available.markdown
+++ b/source/_triggers/update.update_became_available.markdown
@@ -1,0 +1,156 @@
+---
+title: "Update became available"
+trigger: update.update_became_available
+domain: update
+description: "Triggers after one or more updates become available."
+---
+
+The **Update became available** trigger fires when a targeted update entity
+changes to available. Use it when you want Home Assistant to respond as soon as
+there is a new update ready for a device or service.
+
+This trigger is useful for sending a notification, starting a reminder, or
+waiting a little while before taking action on an available update.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** >
+   **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Update became available**.
+5. Select what you want to monitor. Under **By target** (see
+   [Targets](#targets)), pick the device, area, floor, label, or specific
+   update entity you want to watch.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)),
+   pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the update must stay available before
+   the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple update entities are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted update becomes available, **First** to fire only when the first targeted update becomes available, or **All** to fire only after every targeted update is available.
+For at least:
+  description: How long the update must stay available before the trigger fires. Set it to zero to fire immediately.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `update.update_became_available`. A basic
+example looks like this:
+
+{% example %}
+trigger: |
+  trigger: update.update_became_available
+  target:
+    entity_id: update.office_router_firmware
+{% endexample %}
+
+This fires when `update.office_router_firmware` becomes available.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are
+not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple update entities are targeted, controls when the trigger
+    fires. Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+for:
+  description: >
+    How long the update must stay available before the trigger fires. Use the
+    `HH:MM:SS` format, like `00:10:00` for 10 minutes.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger watches update entities whose state changes to `on`, which means
+  an update is available.
+- If an entity returns from `unavailable` or `unknown` to `on`, that recovery
+  does not fire this trigger.
+- If you use `for`, the update must stay available for the full time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: send a notification when an update becomes available
+
+If an update for a device or service becomes available, this automation sends a
+notification to your phone right away.
+
+- **Trigger**: Update became available
+  - **Target**: Office router update
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for notifying you about a new update" %}
+
+{% example %}
+automation: |
+  alias: "Send a notification when an update becomes available"
+  triggers:
+    - trigger: update.update_became_available
+      target:
+        entity_id: update.office_router_firmware
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Update available"
+        message: >
+          A new update is available for the office router.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on a reminder light if an update stays available for a week
+
+If you want a visual reminder for updates you have been putting off, this
+automation turns on a light after an update has stayed available for 7 days.
+
+- **Trigger**: Update became available
+  - **Target**: Guest room speaker update
+- **For at least**: 168:00:00
+- **Action**: Turn on light
+
+{% details "YAML example for turning on an update reminder light" %}
+
+{% example %}
+automation: |
+  alias: "Turn on a reminder light if an update stays available for a week"
+  triggers:
+    - trigger: update.update_became_available
+      target:
+        entity_id: update.guest_room_speaker_firmware
+      options:
+        for: "168:00:00"
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.hallway_lamp
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}


### PR DESCRIPTION
## Proposed change

- add Labs trigger documentation for `update.update_became_available`
- add Labs condition documentation for `update.is_available` and `update.is_not_available`
- update the `update` integration page to include trigger and condition lists plus UI-first automation examples while keeping existing action docs inline

Previews:

- [Update](https://deploy-preview-45592--home-assistant-docs.netlify.app/integrations/update)
- Trigger: [Update became available](https://deploy-preview-45592--home-assistant-docs.netlify.app/triggers/update.update_became_available/)
- Conditions:
  - [Update is available](https://deploy-preview-45592--home-assistant-docs.netlify.app/conditions/update.is_available/)
  - [Update is not available](https://deploy-preview-45592--home-assistant-docs.netlify.app/conditions/update.is_not_available/)

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #44940

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards