### PR TITLE
Document raw Duco ventilation state values

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -110,7 +110,7 @@ Available for the main ventilation box (BOX). Shows the actual airflow target as
 
 #### Ventilation state
 
-Available for the main ventilation box (BOX). Shows the raw ventilation state code reported by the Duco API.
+Available for the main ventilation box (BOX). Shows the ventilation state using the Duco state codes shown by the device and app, instead of friendly labels with fixed meanings.
 
 Common values include:
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -120,7 +120,11 @@ Common values include:
 - `MAN1`, `MAN2`, `MAN3`: Timed manual low, medium, or high speed override
 - `EMPT`: Empty house mode
 
-`CNT` states are continuous overrides. `MAN` states are timed overrides, but the timer duration is configured on the Duco system and is not encoded in the raw state value itself. Some systems may also report compatibility values like `MAN1x2` or `MAN1x3` for timed manual modes. To see when a timed mode ends, use the **Mode end time** sensor.
+`CNT` states are continuous overrides.
+
+`MAN` states are timed overrides, but the timer duration is configured on the Duco system and is not encoded in the raw state value itself. Some systems may also report compatibility values like `MAN1x2` or `MAN1x3` for timed manual modes.
+
+To see when a timed mode ends, use the [Mode end time](#mode-end-time) sensor.
 
 #### Mode end time
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -114,11 +114,11 @@ Available for the main ventilation box (BOX). Shows the ventilation state using 
 
 Common values include:
 
-- `AUTO`: Automatic mode
-- `AUT1`, `AUT2`, `AUT3`: Automatic mode currently running at low, medium, or high airflow
-- `CNT1`, `CNT2`, `CNT3`: Continuous low, medium, or high speed override
-- `MAN1`, `MAN2`, `MAN3`: Timed manual low, medium, or high speed override
-- `EMPT`: Empty house mode
+- `AUTO`: Automatic mode.
+- `AUT1`, `AUT2`, `AUT3`: Automatic mode currently running at low, medium, or high airflow.
+- `CNT1`, `CNT2`, `CNT3`: Continuous low, medium, or high speed override.
+- `MAN1`, `MAN2`, `MAN3`: Timed manual low, medium, or high speed override.
+- `EMPT`: Empty house mode.
 
 `CNT` states are continuous overrides.
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -117,10 +117,10 @@ Common values include:
 - `AUTO`: Automatic mode
 - `AUT1`, `AUT2`, `AUT3`: Automatic mode currently running at low, medium, or high airflow
 - `CNT1`, `CNT2`, `CNT3`: Continuous low, medium, or high speed override
-- `MAN1`, `MAN2`, `MAN3`: Manual low, medium, or high speed override
+- `MAN1`, `MAN2`, `MAN3`: Timed manual low, medium, or high speed override
 - `EMPT`: Empty house mode
 
-Some systems may also report compatibility values like `MAN1x2` or `MAN1x3`. These indicate a timed manual override, but the timer duration is not encoded in the raw state value itself. To see when a timed mode ends, use the **Mode end time** sensor.
+`CNT` states are continuous overrides. `MAN` states are timed overrides, but the timer duration is configured on the Duco system and is not encoded in the raw state value itself. Some systems may also report compatibility values like `MAN1x2` or `MAN1x3` for timed manual modes. To see when a timed mode ends, use the **Mode end time** sensor.
 
 #### Mode end time
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -110,11 +110,17 @@ Available for the main ventilation box (BOX). Shows the actual airflow target as
 
 #### Ventilation state
 
-Available for the main ventilation box (BOX). Shows the current ventilation state, for example:
+Available for the main ventilation box (BOX). Shows the raw ventilation state code reported by the Duco API.
 
-- Automatic
-- Continuous high speed
-- Manual low speed (15 min)
+Common values include:
+
+- `AUTO`: Automatic mode
+- `AUT1`, `AUT2`, `AUT3`: Automatic mode currently running at low, medium, or high airflow
+- `CNT1`, `CNT2`, `CNT3`: Continuous low, medium, or high speed override
+- `MAN1`, `MAN2`, `MAN3`: Manual low, medium, or high speed override
+- `EMPT`: Empty house mode
+
+Some systems may also report compatibility values like `MAN1x2` or `MAN1x3`. These indicate a timed manual override, but the timer duration is not encoded in the raw state value itself. To see when a timed mode ends, use the **Mode end time** sensor.
 
 #### Mode end time
 


### PR DESCRIPTION
## Proposed change
This updates the Duco integration page to describe the ventilation state sensor as the raw state code reported by the Duco API instead of friendly labels with fixed meanings.

The previous wording suggested fixed manual durations such as 15 minutes, but those durations are configurable on the Duco system and can change based on installation-specific configuration. The updated page now explains the raw values, clarifies that `CNT` states are continuous overrides, and notes that `MAN` states are timed overrides without claiming a fixed duration.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/172314
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards