### PR TITLE
Document Yoto media browser

### DIFF
--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -73,7 +73,7 @@ The integration provides one media player entity per Yoto player. Each entity su
 
 Yoto players cannot be powered on remotely. Home Assistant reports the player as _off_ when it is offline but cannot wake it up.
 
-You can browse your Yoto card library from the **Media** panel or the more-info dialog of the player, then select a card, chapter, or track to start playback.
+To browse your Yoto card library, open the more-info dialog of the Yoto player and select the browse media button. From there, you can select a card, chapter, or track to start playback.
 
 To start playback from a script or automation, call the [`media_player.play_media`](/integrations/media_player/#action-media_playerplay_media) action with `media_content_type: music` and a `yoto://` URI:
 
@@ -81,7 +81,7 @@ To start playback from a script or automation, call the [`media_player.play_medi
 - `yoto://<card_id>/<chapter_key>` plays the chapter from its first track.
 - `yoto://<card_id>/<chapter_key>/<track_key>` plays the track from the start.
 
-You can get the URI for any card, chapter, or track by browsing your library in the **Media** panel and copying it from the selected item.
+The URI is case-sensitive. When picking a card in the media browser, the corresponding URI is the value passed to `media_content_id`.
 
 ```yaml
 action: media_player.play_media

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -16,7 +16,7 @@ ha_platforms:
 ha_integration_type: hub
 ---
 
-The **Yoto** {% term integration %} lets you control your [Yoto](https://yotoplay.com) audio players from Home Assistant. You can play and pause cards, change the volume, skip tracks, seek within a track, and see what is currently playing.
+The **Yoto** {% term integration %} lets you control your [Yoto](https://yotoplay.com) audio players from Home Assistant. You can play and pause cards, change the volume, skip tracks, seek within a track, see what is currently playing, and browse your card library to start a specific card, chapter, or track.
 
 The integration talks to the official Yoto cloud over OAuth2 and receives playback updates over MQTT, so changes that happen on the player show up in Home Assistant almost immediately. Online and offline detection still relies on the cloud API and can lag by up to 5 minutes.
 
@@ -57,6 +57,8 @@ For more details, see the [Yoto Developers documentation](https://yoto.dev/get-s
 
 During setup, Home Assistant asks for your Yoto **Client ID** and **Client secret** through the [Application Credentials](/integrations/application_credentials/) flow, then opens the Yoto authorization page so you can grant access. After you approve, Home Assistant creates one {% term device %} and one media player {% term entity %} for every Yoto player in your family.
 
+If a Yoto player is connected to your local network, Home Assistant detects it through DHCP and offers to start the setup flow automatically.
+
 ## Supported functionality
 
 The integration provides one media player entity per Yoto player. Each entity supports:
@@ -67,8 +69,26 @@ The integration provides one media player entity per Yoto player. Each entity su
 - Set the volume directly, or step up and down in the 16 hardware steps the player uses
 - Show the currently playing track title, the card title and author, and the card cover art as media artwork
 - Show the player as _off_ when it is asleep or disconnected from the Yoto cloud
+- Browse your Yoto card library and start playback of a card, chapter, or track
 
 Yoto players cannot be powered on remotely. Home Assistant reports the player as _off_ when it is offline but cannot wake it up.
+
+You can browse your Yoto card library from the **Media** panel or the more-info dialog of the player, then select a card, chapter, or track to start playback.
+
+To start playback from a script or automation, call the [`media_player.play_media`](/integrations/media_player/#action-media_playerplay_media) action with `media_content_type: music` and a `yoto://` URI:
+
+- `yoto://<card_id>` plays the card, honoring its own resume setting.
+- `yoto://<card_id>/<chapter_key>` plays the chapter from its first track.
+- `yoto://<card_id>/<chapter_key>/<track_key>` plays the track from the start.
+
+```yaml
+action: media_player.play_media
+target:
+  entity_id: media_player.yoto_player
+data:
+  media_content_type: music
+  media_content_id: "yoto://abc123/01/02"
+```
 
 ## Data updates
 
@@ -80,7 +100,6 @@ The player's online or offline state comes from the Yoto cloud REST API, which t
 
 - The online and offline state of a player can lag by up to 5 minutes because the Yoto cloud only exposes this through polling.
 - Yoto players cannot be powered on or off from Home Assistant.
-- Starting playback of a specific card from Home Assistant is not supported yet. You can control playback that is already running on the player, but you cannot tell the player which card to play.
 
 ## Removing the integration
 

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -77,9 +77,9 @@ To browse your Yoto card library, open the more-info dialog of the Yoto player a
 
 To start playback from a script or automation, call the [`media_player.play_media`](/integrations/media_player/#action-media_playerplay_media) action with `media_content_type: music` and a `yoto://` URI:
 
-- `yoto://<card_id>` plays the card, honoring its own resume setting.
-- `yoto://<card_id>/<chapter_key>` plays the chapter from its first track.
-- `yoto://<card_id>/<chapter_key>/<track_key>` plays the track from the start.
+- `yoto://card/<card_id>` plays the card, honoring its own resume setting.
+- `yoto://card/<card_id>/<chapter_key>` plays the chapter from its first track.
+- `yoto://card/<card_id>/<chapter_key>/<track_key>` plays the track from the start.
 
 The URI is case-sensitive. When picking a card in the media browser, the corresponding URI is the value passed to `media_content_id`.
 
@@ -89,7 +89,7 @@ target:
   entity_id: media_player.yoto_player
 data:
   media_content_type: "music"
-  media_content_id: "yoto://abc123/01/02"
+  media_content_id: "yoto://card/abc123/01/02"
 ```
 
 ## Data updates

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -57,8 +57,6 @@ For more details, see the [Yoto Developers documentation](https://yoto.dev/get-s
 
 During setup, Home Assistant asks for your Yoto **Client ID** and **Client secret** through the [Application Credentials](/integrations/application_credentials/) flow, then opens the Yoto authorization page so you can grant access. After you approve, Home Assistant creates one {% term device %} and one media player {% term entity %} for every Yoto player in your family.
 
-If a Yoto player is connected to your local network, Home Assistant detects it through <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> and offers to start the setup flow automatically.
-
 ## Supported functionality
 
 The integration provides one media player entity per Yoto player. Each entity supports:

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -57,7 +57,7 @@ For more details, see the [Yoto Developers documentation](https://yoto.dev/get-s
 
 During setup, Home Assistant asks for your Yoto **Client ID** and **Client secret** through the [Application Credentials](/integrations/application_credentials/) flow, then opens the Yoto authorization page so you can grant access. After you approve, Home Assistant creates one {% term device %} and one media player {% term entity %} for every Yoto player in your family.
 
-If a Yoto player is connected to your local network, Home Assistant detects it through DHCP and offers to start the setup flow automatically.
+If a Yoto player is connected to your local network, Home Assistant detects it through <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> and offers to start the setup flow automatically.
 
 ## Supported functionality
 
@@ -80,6 +80,8 @@ To start playback from a script or automation, call the [`media_player.play_medi
 - `yoto://<card_id>` plays the card, honoring its own resume setting.
 - `yoto://<card_id>/<chapter_key>` plays the chapter from its first track.
 - `yoto://<card_id>/<chapter_key>/<track_key>` plays the track from the start.
+
+You can get the URI for any card, chapter, or track by browsing your library in the **Media** panel and copying it from the selected item.
 
 ```yaml
 action: media_player.play_media

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -88,7 +88,7 @@ action: media_player.play_media
 target:
   entity_id: media_player.yoto_player
 data:
-  media_content_type: music
+  media_content_type: "music"
   media_content_id: "yoto://abc123/01/02"
 ```
 


### PR DESCRIPTION
## Proposed change

Add library browsing through the media browser (https://github.com/home-assistant/core/pull/172325).

Also drops the "Starting playback of a specific card is not supported yet" known limitation, since the media browser covers it.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/172325
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
