### PR TITLE
Document Duco board 2.0 and valve sensor support

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -31,7 +31,7 @@ To set up the integration, your Duco system must expose the DUCO Connectivity Bo
 Hardware revisions:
 
 - **DUCO Connectivity Board 1.0**: Supported
-- **DUCO Connectivity Board 2.0**: Not tested
+- **DUCO Connectivity Board 2.0**: Supported
 
 Validated DucoBox models:
 
@@ -49,14 +49,17 @@ The following sensor module types are supported:
 - **UCCO2**: Wall-mounted CO₂ sensor unit; provides CO₂ concentration and CO₂ air quality index.
 - **BSRH**: Humidity sensor module installed in the duct inlet of the DucoBox, wired directly to the PCB via cable; provides relative humidity and humidity air quality index.
 - **UCRH**: Wireless humidity sensor module; provides relative humidity and humidity air quality index.
+- **VLVCO2**: Valve actuator with a built-in CO₂ sensor; provides CO₂ concentration and CO₂ air quality index.
+- **VLVRH**: Valve actuator with a built-in humidity sensor; provides relative humidity and humidity air quality index.
+- **VLVCO2RH**: Valve actuator with built-in CO₂ and humidity sensors; provides CO₂ concentration, CO₂ air quality index, relative humidity, and humidity air quality index.
 
-### Unsupported sensor modules
+### Unsupported node types
 
-The following sensor module types are discovered but not yet supported:
+The following node types are discovered but not yet supported:
 
 - **UC**: Universal control unit (no sensor data exposed)
 - **UCBAT**: Battery-powered sensor module
-- **VLV**: Valve actuator
+- **VLV**: Valve actuator without exposed sensor data
 
 When Home Assistant discovers a node with an unsupported type, it logs a warning and skips that node. All other nodes continue to work normally.
 
@@ -73,12 +76,7 @@ Host:
 
 ## Supported functionality
 
-The Duco system consists of multiple nodes. Each node appears as a separate device in Home Assistant, connected to the main ventilation box:
-
-- **BOX**: The main DucoBox (fan control, ventilation state, target flow level, mode end time)
-- **UCCO2**: A wall-mounted control unit with a built-in CO₂ sensor
-- **BSRH**: A humidity sensor module installed in the duct inlet of the DucoBox
-- **UCRH**: A wireless humidity sensor module
+Each supported node appears as a separate device in Home Assistant, connected to the main ventilation box. The sections below describe which entities Home Assistant creates for those supported node types.
 
 ### Fan
 
@@ -132,15 +130,15 @@ Available for the main ventilation box (BOX). Shows the time at which the curren
 
 #### CO₂ concentration
 
-Available for CO₂ sensor modules. Shows the current CO₂ concentration in parts per million (ppm).
+Available for CO₂ sensor modules and valve actuators with a built-in CO₂ sensor. Shows the current CO₂ concentration in parts per million (ppm).
 
 #### Humidity
 
-Available for humidity sensor modules (BSRH, UCRH). Shows the current relative humidity in percent.
+Available for humidity sensor modules and valve actuators with a built-in humidity sensor (BSRH, UCRH, VLVRH, VLVCO2RH). Shows the current relative humidity in percent.
 
 #### CO₂ air quality index
 
-Available for CO₂ sensor modules. Shows the CO₂ air quality score as a percentage (0–100%). This entity is disabled by default.
+Available for CO₂ sensor modules and valve actuators with a built-in CO₂ sensor. Shows the CO₂ air quality score as a percentage (0–100%). This entity is disabled by default.
 
 Indoor air quality ranges for CO₂:
 
@@ -151,7 +149,7 @@ Indoor air quality ranges for CO₂:
 
 #### Humidity air quality index
 
-Available for humidity sensor modules (BSRH, UCRH). Shows the humidity air quality score as a percentage (0–100%). This entity is disabled by default.
+Available for humidity sensor modules and valve actuators with a built-in humidity sensor (BSRH, UCRH, VLVRH, VLVCO2RH). Shows the humidity air quality score as a percentage (0–100%). This entity is disabled by default.
 
 Indoor air quality ranges for humidity:
 


### PR DESCRIPTION
## Proposed change
This updates the Duco integration page to document that DUCO Connectivity Board 2.0 is supported, and that valve sensor node types with built-in CO₂ and/or humidity sensors are also supported.

It also cleans up the Duco page structure a bit by removing a duplicated node-type list and by clarifying that plain `VLV` nodes without exposed sensor data are still not supported.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #45574

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
