### PR TITLE
Polish Duco node type wording in docs

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -41,9 +41,9 @@ Older Duco systems using the Communication Board V1 are not supported because th
 
 Other Duco systems that expose public API version 2.1 or newer can be set up, but some model-specific functionality may still be limited until it has been validated and implemented.
 
-### Supported sensor modules
+### Supported node types
 
-The following sensor module types are supported:
+The following node types are supported:
 
 - **BOX**: The main ventilation box; provides fan control, ventilation state, target flow level, mode end time, and Wi-Fi signal strength.
 - **UCCO2**: Wall-mounted CO₂ sensor unit; provides CO₂ concentration and CO₂ air quality index.
@@ -134,7 +134,7 @@ Available for CO₂ sensor modules and valve actuators with a built-in CO₂ sen
 
 #### Humidity
 
-Available for humidity sensor modules and valve actuators with a built-in humidity sensor (BSRH, UCRH, VLVRH, VLVCO2RH). Shows the current relative humidity in percent.
+Available for humidity sensor modules and valve actuators with a built-in humidity sensor. Shows the current relative humidity in percent.
 
 #### CO₂ air quality index
 
@@ -149,7 +149,7 @@ Indoor air quality ranges for CO₂:
 
 #### Humidity air quality index
 
-Available for humidity sensor modules and valve actuators with a built-in humidity sensor (BSRH, UCRH, VLVRH, VLVCO2RH). Shows the humidity air quality score as a percentage (0–100%). This entity is disabled by default.
+Available for humidity sensor modules and valve actuators with a built-in humidity sensor. Shows the humidity air quality score as a percentage (0–100%). This entity is disabled by default.
 
 Indoor air quality ranges for humidity:
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -134,7 +134,7 @@ Available for CO₂ sensor modules and valve actuators with a built-in CO₂ sen
 
 #### Humidity
 
-Available for humidity sensor modules and valve actuators with a built-in humidity sensor. Shows the current relative humidity in percent.
+Available for the supported node types with a built-in humidity sensor listed in [Supported node types](#supported-node-types). Shows the current relative humidity in percent.
 
 #### CO₂ air quality index
 
@@ -149,7 +149,7 @@ Indoor air quality ranges for CO₂:
 
 #### Humidity air quality index
 
-Available for humidity sensor modules and valve actuators with a built-in humidity sensor. Shows the humidity air quality score as a percentage (0–100%). This entity is disabled by default.
+Available for the supported node types with a built-in humidity sensor listed in [Supported node types](#supported-node-types). Shows the humidity air quality score as a percentage (0–100%). This entity is disabled by default.
 
 Indoor air quality ranges for humidity:
 


### PR DESCRIPTION
## Proposed change
This is a small follow-up to #45606.

That PR merged before the remaining Copilot wording comments were triaged. This PR picks up the two valid documentation cleanups from that review:

- Rename the Duco section from supported sensor modules to supported node types, because the list also includes valve actuator node types.
- Remove duplicated humidity type-code lists from the entity descriptions so the page has a single source of truth.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
