### PR TITLE
water_heater: document triggers (Labs feature)

### DIFF
--- a/source/_triggers/water_heater.operation_mode_changed.markdown
+++ b/source/_triggers/water_heater.operation_mode_changed.markdown
@@ -157,7 +157,7 @@ When the first targeted water heater changes to **Eco** mode, reduce the recircu
   - **Operation mode**: eco
   - **Trigger when**: First
   - **For at least**: 00:05:00
-- **Action**: Turn on
+- **Action**: Turn on switch
 
 {% details "YAML example for lowering pump speed in Eco mode" %}
 

--- a/source/_triggers/water_heater.operation_mode_changed.markdown
+++ b/source/_triggers/water_heater.operation_mode_changed.markdown
@@ -1,0 +1,185 @@
+---
+title: "Water heater operation mode changed"
+trigger: water_heater.operation_mode_changed
+domain: water_heater
+description: "Triggers after the operation mode of one or more water heaters changes to a specific mode."
+related_triggers:
+  - water_heater.turned_on
+  - water_heater.turned_off
+---
+
+The **Water heater operation mode changed** trigger fires when a water heater {% term entity %} changes to one of the operation modes you select. Use it when you want an automation to react to a specific mode, like switching related devices to an energy-saving setup when the water heater changes to **Eco** mode.
+
+When you target more than one water heater, the **Trigger when** option controls whether the automation runs for each matching change, only for the first one, or only after all targeted water heaters reach the selected mode.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Water heater operation mode changed** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your water heater is in, or select a device, a specific entity, a floor, or a label.
+5. From the triggers shown for that target, select **Water heater operation mode changed**.
+6. Under **Operation mode**, select one or more modes to watch for. Only modes supported by the targeted water heater are shown.
+7. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+8. Under **For at least**, enter how long the water heater must stay in the selected mode before the trigger fires.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Operation mode:
+  description: The operation mode or modes that should fire the trigger. Only modes supported by the targeted water heater are shown.
+Trigger when:
+  description: |
+    When multiple water heaters are targeted, controls when the trigger fires:
+
+    - **Each** (`any` in YAML): Fire every time any targeted water heater changes to one of the selected modes.
+    - **First** (`first` in YAML): Fire only when the first targeted water heater changes to one of the selected modes.
+    - **All** (`last` in YAML): Fire only after all targeted water heaters have changed to one of the selected modes.
+For at least:
+  description: How long the water heater must stay in the selected mode before the trigger fires.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, **Water heater operation mode changed** is referred to as `water_heater.operation_mode_changed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: water_heater.operation_mode_changed
+  target:
+    entity_id: water_heater.utility_room
+  options:
+    operation_mode: eco
+{% endexample %}
+
+This fires when `water_heater.utility_room` changes to `eco` mode.
+
+To watch for more than one mode:
+
+{% example %}
+trigger: |
+  trigger: water_heater.operation_mode_changed
+  target:
+    entity_id: water_heater.utility_room
+  options:
+    operation_mode:
+      - eco
+      - heat_pump
+    behavior: first
+    for: "00:05:00"
+{% endexample %}
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+operation_mode:
+  description: >
+    The operation mode or modes that should fire the trigger. Accepts a single mode string or a list of mode strings. Only modes supported by the targeted water heater are valid.
+  required: true
+  type: string
+behavior:
+  description: |
+    When multiple water heaters are targeted, controls when the trigger fires:
+
+    - `any` (**Each** in the UI): Fires every time any targeted water heater changes to one of the selected modes.
+    - `first` (**First** in the UI): Fires only when the first targeted water heater changes to one of the selected modes.
+    - `last` (**All** in the UI): Fires only after all targeted water heaters have changed to one of the selected modes.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the water heater must stay in the selected mode before the trigger fires. Accepts a duration string in `HH:MM:SS` format. For example, `00:05:00` waits 5 minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The available operation modes depend on the water heater. Home Assistant only shows modes that the targeted entity supports.
+- This trigger fires when the mode changes _to_ one of the selected modes. It does not fire when the water heater leaves that mode.
+- `unavailable` and `unknown` are not offered as selectable modes.
+- To react when the water heater simply turns on or off, use [Water heater turned on](/triggers/water_heater.turned_on/) or [Water heater turned off](/triggers/water_heater.turned_off/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: send a notification when the water heater enters boost mode
+
+When the water heater changes to a high-demand or boost-style mode, send a notification so you know hot water recovery is being prioritized.
+
+- **Trigger**: Water heater operation mode changed
+  - **Target**: Utility room water heater
+  - **Operation mode**: performance
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a boost mode notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when water heater enters performance mode"
+  triggers:
+    - trigger: water_heater.operation_mode_changed
+      target:
+        entity_id: water_heater.utility_room
+      options:
+        operation_mode: performance
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The water heater switched to performance mode."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: lower the recirculation pump when the first water heater enters Eco mode
+
+When the first targeted water heater changes to **Eco** mode, reduce the recirculation pump speed to save energy.
+
+- **Trigger**: Water heater operation mode changed
+  - **Target**: Water heaters with the energy label
+  - **Operation mode**: eco
+  - **Trigger when**: First
+  - **For at least**: 00:05:00
+- **Action**: Turn on
+
+{% details "YAML example for lowering pump speed in Eco mode" %}
+
+{% example %}
+automation: |
+  alias: "Lower recirculation pump in Eco mode"
+  triggers:
+    - trigger: water_heater.operation_mode_changed
+      target:
+        label_id: energy_water_heaters
+      options:
+        operation_mode: eco
+        behavior: first
+        for: "00:05:00"
+  actions:
+    - action: switch.turn_on
+      target:
+        entity_id: switch.recirculation_pump_low_speed
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/water_heater.operation_mode_changed.markdown
+++ b/source/_triggers/water_heater.operation_mode_changed.markdown
@@ -37,11 +37,11 @@ Trigger when:
   description: |
     When multiple water heaters are targeted, controls when the trigger fires:
 
-    - **Each** (`any` in YAML): Fire every time any targeted water heater changes to one of the selected modes.
-    - **First** (`first` in YAML): Fire only when the first targeted water heater changes to one of the selected modes.
-    - **All** (`last` in YAML): Fire only after all targeted water heaters have changed to one of the selected modes.
+    - **Each** (default): Fire every time any targeted water heater changes to one of the selected modes.
+    - **First**: Fire only when the first targeted water heater changes to one of the selected modes.
+    - **All**: Fire only after all targeted water heaters have changed to one of the selected modes.
 For at least:
-  description: How long the water heater must stay in the selected mode before the trigger fires.
+  description: How long the water heater must stay in the selected mode before the trigger fires. Default is `0` (fires immediately).
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}

--- a/source/_triggers/water_heater.target_temperature_changed.markdown
+++ b/source/_triggers/water_heater.target_temperature_changed.markdown
@@ -161,7 +161,7 @@ When the target temperature is changed back into your normal range, switch the w
 - **Trigger**: Water heater target temperature changed
   - **Target**: Utility room water heater
   - **Threshold type**: In range (50-52°C)
-- **Action**: Set operation mode
+- **Action**: Set water heater operation mode
 
 {% details "YAML example for returning to Eco mode" %}
 

--- a/source/_triggers/water_heater.target_temperature_changed.markdown
+++ b/source/_triggers/water_heater.target_temperature_changed.markdown
@@ -1,0 +1,196 @@
+---
+title: "Water heater target temperature changed"
+trigger: water_heater.target_temperature_changed
+domain: water_heater
+description: "Triggers after the temperature setpoint of one or more water heaters changes."
+related_triggers:
+  - water_heater.target_temperature_crossed_threshold
+  - water_heater.operation_mode_changed
+---
+
+The **Water heater target temperature changed** trigger fires when the target temperature setting of a water heater {% term entity %} changes. The target temperature is the setpoint you want the water heater to maintain, not the current measured water temperature. Use this trigger when you want to react to any meaningful setpoint change, like sending an alert when someone raises the target temperature higher than usual.
+
+Use the threshold type to decide which changes matter. You can fire on any change, only when the new setpoint is above or below a value, or only when it lands inside or outside a range.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Water heater target temperature changed** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your water heater is in, or select a device, a specific entity, a floor, or a label.
+5. From the triggers shown for that target, select **Water heater target temperature changed**.
+6. Under **Threshold type**, choose which kind of setpoint change should fire the trigger:
+   - Select **Any change** to fire on any setpoint change.
+   - Select **Above** or **Below** to fire only when the new setpoint lands above or below a value.
+   - Select **In range** or **Outside range** to fire only when the new setpoint lands inside or outside a range.
+   - You can use a fixed number or select a temperature sensor, a temperature number entity, or a [number helper](/integrations/input_number/) as the threshold.
+   - If you need a helper, create the {% term helper %} separately before using it here.
+7. Under **Unit**, select the temperature unit to use for the comparison when you enter a number.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Threshold type:
+  description: |
+    Controls which setpoint changes fire the trigger:
+
+    - **Any change**: Fires on any setpoint change.
+    - **Above** or **Below** (exclusive): Fires only when the new setpoint is strictly above or below the threshold. A setpoint equal to the threshold does not fire the trigger.
+    - **In range** (exclusive): Fires only when the new setpoint is strictly between the two bounds. A setpoint equal to either bound does not fire the trigger.
+    - **Outside range** (inclusive): Fires when the new setpoint is at or below the lower bound, or at or above the upper bound. A setpoint equal to either bound fires the trigger.
+
+    You can use a fixed number or select a temperature sensor, a temperature number entity, or a [number helper](/integrations/input_number/) as the threshold.
+Unit:
+  description: The temperature unit to use for threshold comparison. Accepts `°C` or `°F` when you use a fixed number.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, **Water heater target temperature changed** is referred to as `water_heater.target_temperature_changed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: water_heater.target_temperature_changed
+  target:
+    entity_id: water_heater.utility_room
+  options:
+    threshold:
+      type: above
+      value:
+        number: 55
+        unit_of_measurement: "°C"
+{% endexample %}
+
+This fires when the target temperature of `water_heater.utility_room` changes to a value above 55°C.
+
+To fire when the setpoint lands outside a preferred range:
+
+{% example %}
+trigger: |
+  trigger: water_heater.target_temperature_changed
+  target:
+    entity_id: water_heater.utility_room
+  options:
+    threshold:
+      type: outside
+      value_min:
+        entity: input_number.water_heater_min_target
+      value_max:
+        entity: input_number.water_heater_max_target
+{% endexample %}
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+threshold:
+  description: |
+    A mapping that defines which setpoint changes fire the trigger:
+
+    - `type: any`: Fires on any target temperature change.
+    - `type: above` (exclusive): Fires when the new setpoint lands strictly above `value`. A setpoint equal to `value` does not fire the trigger.
+    - `type: below` (exclusive): Fires when the new setpoint lands strictly below `value`. A setpoint equal to `value` does not fire the trigger.
+    - `type: between` (exclusive): Fires when the new setpoint lands strictly between `value_min` and `value_max`. A setpoint equal to either bound does not fire the trigger.
+    - `type: outside` (inclusive): Fires when the new setpoint is at or below `value_min`, or at or above `value_max`. A setpoint equal to either bound fires the trigger.
+
+    For `type: above` and `type: below`, use `value` with either `number` and `unit_of_measurement`, or `entity`. For `type: between` and `type: outside`, use `value_min` and `value_max`, each with either `number` and `unit_of_measurement`, or `entity`.
+
+    The `entity` value can reference an `input_number`, `sensor`, or `number` entity. When you use a helper, create the {% term helper %} separately before using it here.
+  required: true
+  type: map
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+## Good to know
+
+- This trigger watches the target temperature setpoint, not the current measured water temperature.
+- To react only when the setpoint crosses a threshold boundary, use [Water heater target temperature crossed threshold](/triggers/water_heater.target_temperature_crossed_threshold/).
+- When you use an entity as the threshold, Home Assistant uses that entity's current value when the setpoint changes.
+- The threshold entities must provide temperature values. Supported threshold sources are temperature sensors, temperature number entities, and `input_number` helpers.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: notify when the target temperature is raised above a safe routine
+
+When someone raises the water heater target temperature above your usual daily setting, send a notification so you can double-check the change.
+
+- **Trigger**: Water heater target temperature changed
+  - **Target**: Utility room water heater
+  - **Threshold type**: Above (55°C)
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a high setpoint notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the water heater target temperature is raised"
+  triggers:
+    - trigger: water_heater.target_temperature_changed
+      target:
+        entity_id: water_heater.utility_room
+      options:
+        threshold:
+          type: above
+          value:
+            number: 55
+            unit_of_measurement: "°C"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The water heater target temperature is now above 55°C."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: switch to Eco mode when the setpoint returns to the normal range
+
+When the target temperature is changed back into your normal range, switch the water heater back to an energy-saving mode.
+
+- **Trigger**: Water heater target temperature changed
+  - **Target**: Utility room water heater
+  - **Threshold type**: In range (50-52°C)
+- **Action**: Set operation mode
+
+{% details "YAML example for returning to Eco mode" %}
+
+{% example %}
+automation: |
+  alias: "Return water heater to Eco mode"
+  triggers:
+    - trigger: water_heater.target_temperature_changed
+      target:
+        entity_id: water_heater.utility_room
+      options:
+        threshold:
+          type: between
+          value_min:
+            number: 50
+            unit_of_measurement: "°C"
+          value_max:
+            number: 52
+            unit_of_measurement: "°C"
+  actions:
+    - action: water_heater.set_operation_mode
+      target:
+        entity_id: water_heater.utility_room
+      data:
+        operation_mode: eco
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/water_heater.target_temperature_changed.markdown
+++ b/source/_triggers/water_heater.target_temperature_changed.markdown
@@ -46,7 +46,7 @@ Threshold type:
 
     You can use a fixed number or select a temperature sensor, a temperature number entity, or a [number helper](/integrations/input_number/) as the threshold.
 Unit:
-  description: The temperature unit to use for threshold comparison. Accepts `°C` or `°F` when you use a fixed number.
+  description: The temperature unit to use for threshold comparison. Accepts `°C` or `°F`. Required when using numerical thresholds (not required when using entity references). Default is `°C`.
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}

--- a/source/_triggers/water_heater.target_temperature_crossed_threshold.markdown
+++ b/source/_triggers/water_heater.target_temperature_crossed_threshold.markdown
@@ -1,0 +1,218 @@
+---
+title: "Water heater target temperature crossed threshold"
+trigger: water_heater.target_temperature_crossed_threshold
+domain: water_heater
+description: "Triggers after the temperature setpoint of one or more water heaters crosses a threshold."
+related_triggers:
+  - water_heater.target_temperature_changed
+  - water_heater.operation_mode_changed
+---
+
+The **Water heater target temperature crossed threshold** trigger fires when a water heater {% term entity %}'s target temperature crosses a threshold. Unlike [Water heater target temperature changed](/triggers/water_heater.target_temperature_changed/), which reacts to any matching landing value, this trigger reacts only at the moment the setpoint crosses into, out of, above, or below a threshold.
+
+Use it when you want to react to the crossing itself, like turning on a recirculation pump once the target temperature is raised past a certain point.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Water heater target temperature crossed threshold** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your water heater is in, or select a device, a specific entity, a floor, or a label.
+5. From the triggers shown for that target, select **Water heater target temperature crossed threshold**.
+6. Under **Threshold type**, choose how the setpoint must cross the threshold.
+7. If needed, select a fixed number or a supported temperature entity for the threshold.
+8. Under **Unit**, select the temperature unit to use for the comparison when you enter a number.
+9. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+10. Under **For at least**, enter how long the water heater must stay beyond the threshold before the trigger fires.
+11. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Threshold type:
+  description: |
+    Controls which threshold crossings fire the trigger:
+
+    - **Above** (exclusive): Fires when the setpoint crosses to strictly above the threshold. A setpoint equal to the threshold does not trigger a crossing.
+    - **Below** (exclusive): Fires when the setpoint crosses to strictly below the threshold. A setpoint equal to the threshold does not trigger a crossing.
+    - **In range** (exclusive): Fires when the setpoint crosses into the range. A setpoint equal to either bound is not considered inside the range.
+    - **Outside range** (inclusive): Fires when the setpoint crosses out of the range. A setpoint equal to either bound is considered outside the range.
+
+    You can use a fixed number or select a temperature sensor, a temperature number entity, or a [number helper](/integrations/input_number/) as the threshold.
+Unit:
+  description: The temperature unit to use for threshold comparison. Accepts `°C` or `°F` when you use a fixed number.
+Trigger when:
+  description: |
+    When multiple water heaters are targeted, controls when the trigger fires:
+
+    - **Each** (`any` in YAML): Fire every time any targeted water heater crosses the threshold.
+    - **First** (`first` in YAML): Fire only on the first threshold crossing.
+    - **All** (`last` in YAML): Fire only after all targeted water heaters cross the threshold.
+For at least:
+  description: How long the setpoint must stay beyond the threshold before the trigger fires.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, **Water heater target temperature crossed threshold** is referred to as `water_heater.target_temperature_crossed_threshold`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: water_heater.target_temperature_crossed_threshold
+  target:
+    entity_id: water_heater.utility_room
+  options:
+    threshold:
+      type: above
+      value:
+        number: 55
+        unit_of_measurement: "°C"
+{% endexample %}
+
+This fires when the target temperature of `water_heater.utility_room` crosses above 55°C.
+
+To wait for a sustained change across multiple water heaters:
+
+{% example %}
+trigger: |
+  trigger: water_heater.target_temperature_crossed_threshold
+  target:
+    label_id: upstairs_water_heaters
+  options:
+    threshold:
+      type: below
+      value:
+        number: 48
+        unit_of_measurement: "°C"
+    behavior: last
+    for: "00:10:00"
+{% endexample %}
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+threshold:
+  description: |
+    A mapping that defines when the trigger should fire:
+
+    - `type: above`: Fires when the setpoint crosses to strictly above `value`.
+    - `type: below`: Fires when the setpoint crosses to strictly below `value`.
+    - `type: between`: Fires when the setpoint crosses into the range between `value_min` and `value_max`.
+    - `type: outside`: Fires when the setpoint crosses out of the range and reaches `value_min` or below, or `value_max` or above.
+
+    For `type: above` and `type: below`, use `value` with either `number` and `unit_of_measurement`, or `entity`. For `type: between` and `type: outside`, use `value_min` and `value_max`, each with either `number` and `unit_of_measurement`, or `entity`.
+  required: true
+  type: map
+behavior:
+  description: |
+    When multiple water heaters are targeted, controls when the trigger fires:
+
+    - `any` (**Each** in the UI): Fires every time any targeted water heater crosses the threshold.
+    - `first` (**First** in the UI): Fires only on the first threshold crossing.
+    - `last` (**All** in the UI): Fires only after all targeted water heaters cross the threshold.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the setpoint must stay beyond the threshold before the trigger fires. Accepts a duration string in `HH:MM:SS` format. For example, `00:10:00` waits 10 minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger watches the target temperature setpoint, not the current measured water temperature.
+- It fires only when the setpoint crosses the threshold boundary. It does not keep firing while the setpoint stays beyond the threshold.
+- To react to any setpoint change that lands above, below, inside, or outside a range, use [Water heater target temperature changed](/triggers/water_heater.target_temperature_changed/).
+- When you use an entity as the threshold, Home Assistant uses that entity's current value when the crossing happens.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: start recirculation when the setpoint crosses above 55°C
+
+When the target temperature is raised above 55°C, start the recirculation pump so hot water is available more quickly.
+
+- **Trigger**: Water heater target temperature crossed threshold
+  - **Target**: Utility room water heater
+  - **Threshold type**: Above (55°C)
+- **Action**: Turn on
+
+{% details "YAML example for starting recirculation" %}
+
+{% example %}
+automation: |
+  alias: "Start recirculation after a higher setpoint"
+  triggers:
+    - trigger: water_heater.target_temperature_crossed_threshold
+      target:
+        entity_id: water_heater.utility_room
+      options:
+        threshold:
+          type: above
+          value:
+            number: 55
+            unit_of_measurement: "°C"
+  actions:
+    - action: switch.turn_on
+      target:
+        entity_id: switch.hot_water_recirculation
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify when all targeted water heaters stay below the minimum setpoint
+
+When every targeted water heater has a target temperature below your minimum comfort setting for 10 minutes, send a notification.
+
+- **Trigger**: Water heater target temperature crossed threshold
+  - **Target**: Upstairs water heaters
+  - **Threshold type**: Below (48°C)
+  - **Trigger when**: All
+  - **For at least**: 00:10:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a low setpoint warning" %}
+
+{% example %}
+automation: |
+  alias: "Warn when all water heaters are set too low"
+  triggers:
+    - trigger: water_heater.target_temperature_crossed_threshold
+      target:
+        label_id: upstairs_water_heaters
+      options:
+        threshold:
+          type: below
+          value:
+            number: 48
+            unit_of_measurement: "°C"
+        behavior: last
+        for: "00:10:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "All targeted water heaters have stayed below 48°C for 10 minutes."
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/water_heater.target_temperature_crossed_threshold.markdown
+++ b/source/_triggers/water_heater.target_temperature_crossed_threshold.markdown
@@ -149,7 +149,7 @@ When the target temperature is raised above 55°C, start the recirculation pump 
 - **Trigger**: Water heater target temperature crossed threshold
   - **Target**: Utility room water heater
   - **Threshold type**: Above (55°C)
-- **Action**: Turn on
+- **Action**: Turn on switch
 
 {% details "YAML example for starting recirculation" %}
 

--- a/source/_triggers/water_heater.target_temperature_crossed_threshold.markdown
+++ b/source/_triggers/water_heater.target_temperature_crossed_threshold.markdown
@@ -44,7 +44,7 @@ Threshold type:
 
     You can use a fixed number or select a temperature sensor, a temperature number entity, or a [number helper](/integrations/input_number/) as the threshold.
 Unit:
-  description: The temperature unit to use for threshold comparison. Accepts `°C` or `°F` when you use a fixed number.
+  description: The temperature unit to use for threshold comparison. Accepts `°C` or `°F`. Required when using numerical thresholds (not required when using entity references). Default is `°C`.
 Trigger when:
   description: |
     When multiple water heaters are targeted, controls when the trigger fires:

--- a/source/_triggers/water_heater.target_temperature_crossed_threshold.markdown
+++ b/source/_triggers/water_heater.target_temperature_crossed_threshold.markdown
@@ -49,11 +49,11 @@ Trigger when:
   description: |
     When multiple water heaters are targeted, controls when the trigger fires:
 
-    - **Each** (`any` in YAML): Fire every time any targeted water heater crosses the threshold.
-    - **First** (`first` in YAML): Fire only on the first threshold crossing.
-    - **All** (`last` in YAML): Fire only after all targeted water heaters cross the threshold.
+    - **Each** (default): Fire every time any targeted water heater crosses the threshold.
+    - **First**: Fire only on the first threshold crossing.
+    - **All**: Fire only after all targeted water heaters cross the threshold.
 For at least:
-  description: How long the setpoint must stay beyond the threshold before the trigger fires.
+  description: How long the setpoint must stay beyond the threshold before the trigger fires. Default is `0` (fires immediately).
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}

--- a/source/_triggers/water_heater.turned_off.markdown
+++ b/source/_triggers/water_heater.turned_off.markdown
@@ -1,0 +1,166 @@
+---
+title: "Water heater turned off"
+trigger: water_heater.turned_off
+domain: water_heater
+description: "Triggers after one or more water heaters turn off."
+related_triggers:
+  - water_heater.turned_on
+  - water_heater.operation_mode_changed
+---
+
+The **Water heater turned off** trigger fires when a water heater {% term entity %} changes to the off state. Use it when you want to react as soon as hot water heating is stopped, like pausing a recirculation pump or sending a notification if the water heater turns off unexpectedly.
+
+When you target more than one water heater, the **Trigger when** option controls whether the automation runs for each water heater that turns off, only for the first one, or only after all targeted water heaters are off.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Water heater turned off** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your water heater is in, or select a device, a specific entity, a floor, or a label.
+5. From the triggers shown for that target, select **Water heater turned off**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the water heater must stay off before the trigger fires.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: |
+    When multiple water heaters are targeted, controls when the trigger fires:
+
+    - **Each** (`any` in YAML): Fire every time any targeted water heater turns off.
+    - **First** (`first` in YAML): Fire only when the first targeted water heater turns off.
+    - **All** (`last` in YAML): Fire only after all targeted water heaters are off.
+For at least:
+  description: How long the water heater must stay off before the trigger fires.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, **Water heater turned off** is referred to as `water_heater.turned_off`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: water_heater.turned_off
+  target:
+    entity_id: water_heater.utility_room
+{% endexample %}
+
+This fires when `water_heater.utility_room` turns off.
+
+To wait for all targeted water heaters to stay off:
+
+{% example %}
+trigger: |
+  trigger: water_heater.turned_off
+  target:
+    label_id: vacation_water_heaters
+  options:
+    behavior: last
+    for: "00:15:00"
+{% endexample %}
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple water heaters are targeted, controls when the trigger fires:
+
+    - `any` (**Each** in the UI): Fires every time any targeted water heater turns off.
+    - `first` (**First** in the UI): Fires only when the first targeted water heater turns off.
+    - `last` (**All** in the UI): Fires only after all targeted water heaters are off.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the water heater must stay off before the trigger fires. Accepts a duration string in `HH:MM:SS` format. For example, `00:15:00` waits 15 minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger fires when the water heater enters the off state. It does not fire for operation mode changes unless the new state is actually off.
+- `unavailable` and `unknown` do not count as off for this trigger.
+- To react when the water heater turns back on, use [Water heater turned on](/triggers/water_heater.turned_on/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off the recirculation pump when the water heater turns off
+
+When the water heater turns off, stop the recirculation pump so it does not keep running unnecessarily.
+
+- **Trigger**: Water heater turned off
+  - **Target**: Utility room water heater
+- **Action**: Turn off
+
+{% details "YAML example for stopping the recirculation pump" %}
+
+{% example %}
+automation: |
+  alias: "Stop recirculation when the water heater turns off"
+  triggers:
+    - trigger: water_heater.turned_off
+      target:
+        entity_id: water_heater.utility_room
+  actions:
+    - action: switch.turn_off
+      target:
+        entity_id: switch.hot_water_recirculation
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: alert if all vacation water heaters stay off
+
+When every targeted water heater stays off for 15 minutes, send a notification so you can confirm that the vacation setup is still intentional.
+
+- **Trigger**: Water heater turned off
+  - **Target**: Vacation water heaters
+  - **Trigger when**: All
+  - **For at least**: 00:15:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for an off-state alert" %}
+
+{% example %}
+automation: |
+  alias: "Alert when all vacation water heaters are off"
+  triggers:
+    - trigger: water_heater.turned_off
+      target:
+        label_id: vacation_water_heaters
+      options:
+        behavior: last
+        for: "00:15:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "All vacation water heaters have been off for 15 minutes."
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/water_heater.turned_off.markdown
+++ b/source/_triggers/water_heater.turned_off.markdown
@@ -109,7 +109,7 @@ When the water heater turns off, stop the recirculation pump so it does not keep
 
 - **Trigger**: Water heater turned off
   - **Target**: Utility room water heater
-- **Action**: Turn off
+- **Action**: Turn off switch
 
 {% details "YAML example for stopping the recirculation pump" %}
 

--- a/source/_triggers/water_heater.turned_off.markdown
+++ b/source/_triggers/water_heater.turned_off.markdown
@@ -34,11 +34,11 @@ Trigger when:
   description: |
     When multiple water heaters are targeted, controls when the trigger fires:
 
-    - **Each** (`any` in YAML): Fire every time any targeted water heater turns off.
-    - **First** (`first` in YAML): Fire only when the first targeted water heater turns off.
-    - **All** (`last` in YAML): Fire only after all targeted water heaters are off.
+    - **Each** (default): Fire every time any targeted water heater turns off.
+    - **First**: Fire only when the first targeted water heater turns off.
+    - **All**: Fire only after all targeted water heaters are off.
 For at least:
-  description: How long the water heater must stay off before the trigger fires.
+  description: How long the water heater must stay off before the trigger fires. Default is `0` (fires immediately).
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}

--- a/source/_triggers/water_heater.turned_on.markdown
+++ b/source/_triggers/water_heater.turned_on.markdown
@@ -8,7 +8,7 @@ related_triggers:
   - water_heater.operation_mode_changed
 ---
 
-The **Water heater turned on** trigger fires when a water heater {% term entity %} changes from off to on. It does not depend on which operation mode the water heater uses after turning on. Use it when you want to react as soon as hot water heating becomes active again, like starting a circulation pump or restoring a normal schedule.
+The **Water heater turned on** trigger fires when a water heater {% term entity %} changes from off to on. It does not depend on which operation mode the water heater uses after turning on. Use it when you want to react as soon as hot water heating becomes active again, like starting a recirculation pump or restoring a normal schedule.
 
 When you target more than one water heater, the **Trigger when** option controls whether the automation runs for each water heater that turns on, only for the first one, or only after all targeted water heaters are on.
 

--- a/source/_triggers/water_heater.turned_on.markdown
+++ b/source/_triggers/water_heater.turned_on.markdown
@@ -1,0 +1,165 @@
+---
+title: "Water heater turned on"
+trigger: water_heater.turned_on
+domain: water_heater
+description: "Triggers after one or more water heaters turn on, regardless of the operation mode."
+related_triggers:
+  - water_heater.turned_off
+  - water_heater.operation_mode_changed
+---
+
+The **Water heater turned on** trigger fires when a water heater {% term entity %} changes from off to on. It does not depend on which operation mode the water heater uses after turning on. Use it when you want to react as soon as hot water heating becomes active again, like starting a circulation pump or restoring a normal schedule.
+
+When you target more than one water heater, the **Trigger when** option controls whether the automation runs for each water heater that turns on, only for the first one, or only after all targeted water heaters are on.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Water heater turned on** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your water heater is in, or select a device, a specific entity, a floor, or a label.
+5. From the triggers shown for that target, select **Water heater turned on**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the water heater must stay on before the trigger fires.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: |
+    When multiple water heaters are targeted, controls when the trigger fires:
+
+    - **Each** (`any` in YAML): Fire every time any targeted water heater turns on.
+    - **First** (`first` in YAML): Fire only when the first targeted water heater turns on.
+    - **All** (`last` in YAML): Fire only after all targeted water heaters are on.
+For at least:
+  description: How long the water heater must stay on before the trigger fires.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, **Water heater turned on** is referred to as `water_heater.turned_on`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: water_heater.turned_on
+  target:
+    entity_id: water_heater.utility_room
+{% endexample %}
+
+This fires when `water_heater.utility_room` turns on.
+
+To wait until all targeted water heaters are on:
+
+{% example %}
+trigger: |
+  trigger: water_heater.turned_on
+  target:
+    label_id: basement_water_heaters
+  options:
+    behavior: last
+    for: "00:05:00"
+{% endexample %}
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple water heaters are targeted, controls when the trigger fires:
+
+    - `any` (**Each** in the UI): Fires every time any targeted water heater turns on.
+    - `first` (**First** in the UI): Fires only when the first targeted water heater turns on.
+    - `last` (**All** in the UI): Fires only after all targeted water heaters are on.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the water heater must stay on before the trigger fires. Accepts a duration string in `HH:MM:SS` format. For example, `00:05:00` waits 5 minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger fires when the water heater changes from off to on, regardless of whether it comes back in `eco`, `electric`, `heat_pump`, or another supported mode.
+- Use [Water heater operation mode changed](/triggers/water_heater.operation_mode_changed/) if you need to react only to a specific operating mode.
+- `unavailable` and `unknown` do not count as on for this trigger.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: start recirculation when the water heater turns on
+
+When the water heater turns on, start the recirculation pump so hot water is available sooner at nearby fixtures.
+
+- **Trigger**: Water heater turned on
+  - **Target**: Utility room water heater
+- **Action**: Turn on
+
+{% details "YAML example for starting the recirculation pump" %}
+
+{% example %}
+automation: |
+  alias: "Start recirculation when the water heater turns on"
+  triggers:
+    - trigger: water_heater.turned_on
+      target:
+        entity_id: water_heater.utility_room
+  actions:
+    - action: switch.turn_on
+      target:
+        entity_id: switch.hot_water_recirculation
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: restore the normal operating mode when all basement water heaters come back on
+
+When all targeted water heaters are back on for 5 minutes, switch them to your normal operating mode.
+
+- **Trigger**: Water heater turned on
+  - **Target**: Basement water heaters
+  - **Trigger when**: All
+  - **For at least**: 00:05:00
+- **Action**: Set operation mode
+
+{% details "YAML example for restoring the normal mode" %}
+
+{% example %}
+automation: |
+  alias: "Restore water heater mode after startup"
+  triggers:
+    - trigger: water_heater.turned_on
+      target:
+        label_id: basement_water_heaters
+      options:
+        behavior: last
+        for: "00:05:00"
+  actions:
+    - action: water_heater.set_operation_mode
+      target:
+        label_id: basement_water_heaters
+      data:
+        operation_mode: heat_pump
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/water_heater.turned_on.markdown
+++ b/source/_triggers/water_heater.turned_on.markdown
@@ -34,11 +34,11 @@ Trigger when:
   description: |
     When multiple water heaters are targeted, controls when the trigger fires:
 
-    - **Each** (`any` in YAML): Fire every time any targeted water heater turns on.
-    - **First** (`first` in YAML): Fire only when the first targeted water heater turns on.
-    - **All** (`last` in YAML): Fire only after all targeted water heaters are on.
+    - **Each** (default): Fire every time any targeted water heater turns on.
+    - **First**: Fire only when the first targeted water heater turns on.
+    - **All**: Fire only after all targeted water heaters are on.
 For at least:
-  description: How long the water heater must stay on before the trigger fires.
+  description: How long the water heater must stay on before the trigger fires. Default is `0` (fires immediately).
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}

--- a/source/_triggers/water_heater.turned_on.markdown
+++ b/source/_triggers/water_heater.turned_on.markdown
@@ -109,7 +109,7 @@ When the water heater turns on, start the recirculation pump so hot water is ava
 
 - **Trigger**: Water heater turned on
   - **Target**: Utility room water heater
-- **Action**: Turn on
+- **Action**: Turn on switch
 
 {% details "YAML example for starting the recirculation pump" %}
 
@@ -136,7 +136,7 @@ When all targeted water heaters are back on for 5 minutes, switch them to your n
   - **Target**: Basement water heaters
   - **Trigger when**: All
   - **For at least**: 00:05:00
-- **Action**: Set operation mode
+- **Action**: Set water heater operation mode
 
 {% details "YAML example for restoring the normal mode" %}
 


### PR DESCRIPTION
## Proposed change

- Add dedicated trigger pages for the `water_heater` integration Labs feature triggers.
- Document the UI flow and YAML options for operation mode, target temperature, and on/off triggers.
- Add automation examples that match the current split-page trigger template.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Related to issue: #44943

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
