### PR TITLE
Refresh HomematicIP Cloud integration page

### DIFF
--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -90,168 +90,154 @@ authtoken:
   type: string
 {% endconfiguration %}
 
-## Adding and removing devices and group via native HomematicIP APP
+## Adding and removing devices and groups via the Homematic IP app
 
-Devices and groups are instantly removed from Home Assistant when removed in the native HomematicIP APP.
-Groups are instantly created in Home Assistant when created in the native HomematicIP APP.
-Devices are created with a delay of 30 seconds in Home Assistant when created in the native HomematicIP APP.
-Within this delay the device registration should be completed in the App, otherwise the device name will be a default one based on the device type. This can easily be fixed in the Home Assistant entity registry afterwards.
+Devices and groups you add or remove in the Homematic IP app are mirrored into Home Assistant:
+
+- Groups appear and disappear immediately.
+- Devices appear with a delay of about 30 seconds, and disappear immediately. Within this delay, finish naming the device in the Homematic IP app; otherwise Home Assistant uses a default name based on the device type. You can rename the device later in the entity registry.
 
 ## Use HmIP-DLD Door Lock Drive in Home Assistant
 
-If you are unable to control the **HmIP-DLD** device via Home Assistant, you may need to allow the Home Assistant device to control the **HmIP-DLD** in the HomematicIP app.
+If you are unable to control the HmIP-DLD device via Home Assistant, you might need to allow the Home Assistant access point to control the lock in the Homematic IP app.
 
-To do this, navigate to the **Access Control** section in your HomematicIP app and enable the necessary permissions.
+To do this, navigate to **Access Control** in the Homematic IP app and enable the necessary permissions.
 
-Currently, the **HmIP-DLD** can only be used in Home Assistant without a PIN. Ensure that no PIN is set for the device in the HomematicIP app.
+Currently, you can only use the HmIP-DLD in Home Assistant without a PIN. Make sure no PIN is set for the device in the Homematic IP app.
 
-## Implemented and tested devices
+## Supported devices
 
-- homematicip_cloud.alarm_control_panel
-  - Combined Alarm Control Panal with INTERNAL and EXTERNAL Security zones (*HmIP-SecurityZone*)
+The list below shows which Home Assistant entities each supported Homematic IP device contributes. Devices are grouped by Home Assistant entity platform; a single physical device often contributes entities on more than one platform (for example, a wall thermostat appears under *Climate*, *Sensors*, and *Binary sensors* for the battery state). If your device isn't listed, see [My device isn't recognized](#my-device-isnt-recognized).
 
-- homematicip_cloud.binary_sensor
-  - Access Point Cloud Connection (*HmIP-HAP, HmIP-HAP-B1*)
-  - Acceleration Sensor (*HMIP-SAM*)
-  - Inclination and vibration Sensor (*HMIP-STV*)
-  - Window and door contact (*HmIP-SWDO, HmIP-SWDO-PL, HmIP-SWDO-I, HmIP-SWDM, HmIP-SWDM-B2*)
-  - Contact Interface flush-mount – 1x channel (*HmIP-FCI1*)
-  - Contact Interface flush-mount – 6x channels (*HmIP-FCI6*)
-  - Contact Interface (*HmIP-SCI*)
-  - Window Rotary Handle Sensor (*HmIP-SRH*)
-  - Smoke sensor and alarm (*HmIP-SWSD*)
-  - Motion Detector with Brightness Sensor - indoor (*HmIP-SMI*)
-  - Motion Detector with Brightness Sensor - outdoor (*HmIP-SMO*)
-  - Presence Sensor – indoor (*HmIP-SPI*)
-  - Rain Sensor (*HmIP-SRD*)
-  - Water Sensor (*HmIP-SWD*)
-  - Remote Control - 8x buttons (*HmIP-RC8*) (battery only)
-  - Wall-mount Remote Control - 2x buttons (*HmIP-WRC2*) (battery only)
-  - Wall-mount Remote Control - flat - 2x buttons (*HmIP-WRCC2*) (battery only)
-  - Wall-mount Remote Control - 6x buttons (*HmIP-WRC6*) (battery only)
-  - Key Ring Remote Control - 4x buttons (*HmIP-KRC4*) (battery only)
-  - Key Ring Remote Control - alarm  (*HmIP-KRCA*) (battery only)
-  - Alarm Siren (*HmIP-ASIR, -B1*) (battery only)
-  - Remote Control for brand switches – 2x buttons (*HmIP-BRC2*) (battery only)
-  - Pluggable Power Supply Monitoring (*HmIP-PMFS*)
-  - Wired Inbound module – 32x channels (*HMIPW-DRI32*)
+### Alarm control panel
 
-- homematicip_cloud.button
-  - Wall Mounted Garage Door Controller (*HmIP-WGC*)
+- Combined alarm control panel with internal and external security zones (`HmIP-SecurityZone`)
 
-- homematicip_cloud.climate
-  - Climate group (*HmIP-HeatingGroup*)
-  - This includes temperature/humidity measures for climate devices of a room delivered by:
-    - Wall-mounted thermostat (*HmIP-WTH, HmIP-WTH-2, HmIP-WTH-B, HmIP-WTH-1*)
-    - Brand Wall-mounted thermostat (*HmIP-BWTH, HmIP-BWTH-24*)
-    - Radiator thermostat (*HmIP-eTRV, HmIP-eTRV-2, HmIP-eTRV-C*) - should also work with (*HmIP-eTRV-2-UK, HmIP-eTRV-2-B, HmIP-eTRV-2-B1*)
-    - Temperature and humidity sensor (*HmIP-STH*)
-    - Temperature and humidity Sensor with display (*HmIP-STHD*)
-    - Alpha IP Wall Thermostat Display (*ALPHA-IP-RBG*)
-    - Alpha IP Wall Thermostat Display analog (*ALPHA-IP-RBGa*)
-  - There is no need to directly support the following devices by Home Assistant, because their integration is done by the required wall thermostats:
-    - Floor Heating Actuator – 6x channels, 230V (*HMIP-FAL230-C6*)
-    - Floor Heating Actuator – 10x channels, 230V (*HMIP-FAL230-C10*)
-    - Floor Heating Actuator – 6x channels, 24V (*HMIP-FAL24-C6*)
-    - Floor Heating Actuator – 10x channels, 24V (*HMIP-FAL24-C10*)
-    - Floor Heating Actuator – 12x channels, motorized (*HMIP-FALMOT-C12*)
+### Binary sensors
 
-- homematicip_cloud.cover
-  - Shutter actuator for brand-mount (*HmIP-BROLL*)
-  - Shutter actuator for flush-mount (*HmIP-FROLL*)
-  - Blind Actuator for brand switches (*HmIP-BBL*)
-  - Blind Actuator for DIN rail mount – 4x channels (*HMIP-DRBLI4*)
-  - Blind Actuator for flush-mount (*HmIP-FBL*)
-  - Garage door module for Tormatic (*HmIP-MOD_TM*)
-  - Module for Hoermann drives (*HMIP-MOD-HO*)
-  - Hunter Douglas & erfal window blinds (*HMIP-HDM1*)
+- Access point cloud connection (`HmIP-HAP`, `HmIP-HAP-B1`)
+- Window and door contacts, including the rotary handle sensor (`HmIP-SWDO`, `HmIP-SWDO-PL`, `HmIP-SWDO-I`, `HmIP-SWDM`, `HmIP-SWDM-B2`, `HmIP-SRH`)
+- Contact interfaces (`HmIP-FCI1`, `HmIP-FCI6`, `HmIP-SCI`)
+- Smoke detectors (`HmIP-SWSD`, `HmIP-SWSD-2`)
+- Motion and presence sensors (`HmIP-SMI`, `HmIP-SMI55`, `HmIP-SMO`, `HmIP-SMO-A`, `HmIP-SMO230`, `HmIP-SPI`)
+- Acceleration and tilt sensors (`HmIP-SAM`, `HmIP-STV`)
+- Rain sensor (`HmIP-SRD`)
+- Water sensor (`HmIP-SWD`)
+- Alarm sirens (`HmIP-ASIR`, `HmIP-ASIR-O`, `HmIP-ASIR-B1`)
+- Pluggable power supply monitoring (`HmIP-PMFS`)
+- Wired input module – 32 channels (`HmIPW-DRI32`)
+- Battery sensors on remote controls (`HmIP-RC8`, `HmIP-WRC2`, `HmIP-WRCC2`, `HmIP-WRC6`, `HmIP-WRC6-230`, `HmIPW-WRC6`, `HmIP-KRC4`, `HmIP-KRCA`, `HmIP-BRC2`, `HmIP-MOD-RC8`)
+- Full Flush Lock Controller glass-break and lock state sensors (`HmIP-FLC`)
 
-- homematicip_cloud.event
-  - Doorbell Event for devices *HmIP-DSD-PCB* and others where ChannelRole equals DOOR_BELL_INPUT 
+### Buttons
 
-- homematicip_cloud.light
-  - Switch actuator and meter for brand switches (*HmIP-BSM*)
-  - Dimming actuator for brand switches (*HmIP-BDT*)
-  - Dimming actuator flush-mount (*HmIP-FDT*)
-  - Pluggable Dimmer – trailing edge (*HmIP-PDT*)
-  - Switch Actuator for brand switches – with signal lamp (*HmIP-BSL*)
-  - Wired Dimmer module – 3x channels (*HMIPW-DRD3*)
+- Wall-mounted garage door controller (`HmIP-WGC`)
+- Full Flush Lock Controller door opener (`HmIP-FLC`)
 
-- homematicip_cloud.lock
-  - Door Lock Drive - currently, usage just without a pin is possible (*HmIP-DLD*)
+### Climate
 
-- homematicip_cloud.sensor
-  - Access Point Duty Cycle (*HmIP-HAP, HmIP-HAP-B1*)
-  - Wall Mounted Thermostat (*HmIP-WTH, HmIP-WTH2, HmIP-WTH-B*)
-  - Radiator thermostat (*HmIP-eTRV, HmIP-eTRV-2, HmIP-eTRV-C*) - should also work with (*HmIP-eTRV-2-UK, HmIP-eTRV-2-B, HmIP-eTRV-2-B1*)
-  - Temperature and Humidity Sensor without display - indoor (*HmIP-STH*)
-  - Temperature and Humidity Sensor with display - indoor (*HmIP-STHD*)
-  - Temperature and Humidity sensor - outdoor (*HmIP-STHO, -A*)
-  - Temperature sensor with external probes - 2-way (*HmIP-STE2-PCB*)
-  - Motion Detector with Brightness Sensor - indoor (*HmIP-SMI*)
-  - Motion Detector with Brightness Sensor - outdoor (*HmIP-SMO*)
-  - Presence Sensor – indoor (*HmIP-SPI*)
-  - Light Sensor - outdoor (*HmIP-SLO*)
-  - Passage Sensor with Direction Recognition (*HmIP-SPDR*) (delta counter)
-  - Alpha IP Wall Thermostat Display (*ALPHA-IP-RBG*)
-  - Alpha IP Wall Thermostat Display analog (*ALPHA-IP-RBGa*)
-  - Floor Heating Actuator – 12x channels, motorized - Valve positions (*HmIP-FALMOT-C12*)
+The integration creates one climate entity per room as a Homematic IP heating group (`HmIP-HeatingGroup`). The group reads temperature and humidity from any of the following devices in that room and drives the floor heating or radiator actuators behind it:
 
-- homematicip_cloud.switch
-  - Pluggable Switch (*HmIP-PS*)
-  - Pluggable Switch and Meter (*HmIP-PSM*) - should also work with (*HmIP-PSM-CH, HmIP-PSM-IT, HmIP-PSM-UK, HmIP-PSM-PE*)
-  - Switch Actuator and Meter – flush-mount (*HmIP-FSM, HmIP-FSM16*)
-  - Switch Actuator with Push-button Input – flush-mount (*HmIP-FSI16*)
-  - Open Collector Module Receiver - 8x channels (*HmIP-MOD-OC8*)
-  - Multi IO Box - 2x (*HmIP-MIOB*)
-  - Switch Circuit Board - 1x channels (*HmIP-PCBS*)
-  - Switch Circuit Board - 2x channels (*HmIP-PCBS2*)
-  - Printed Circuit Board Switch Battery (*HmIP-PCBS-BAT*)
-  - Switch Actuator for heating systems – 2x channels (*HmIP-WHS2*)
-  - Wired Switch Actuator – 8x channels (*HMIPW-DRS8*)
-  - Switch Actuator for DIN rail mount – 4x channels (*HMIP-DRSI4*)
-  - Switch Actuator for DIN rail mount – 1x channels (*HMIP-DRSI1*)
-  - Switch Actuator - 2x channels (*HmIP-BS2*)
+- Wall thermostats (`HmIP-WTH`, `HmIP-WTH-1`, `HmIP-WTH-2`, `HmIP-WTH-B`, `HmIP-BWTH`, `HmIP-BWTH-24`, `ALPHA-IP-RBG`, `ALPHA-IP-RBGa`)
+- Radiator thermostats (`HmIP-eTRV`, `HmIP-eTRV-2`, `HmIP-eTRV-2-UK`, `HmIP-eTRV-2-B`, `HmIP-eTRV-2-B1`, `HmIP-eTRV-C`, `HmIP-eTRV-E`)
+- Temperature and humidity sensors (`HmIP-STH`, `HmIP-STHD`)
 
-- homematicip_cloud.valve
-  - Smart Watering Actuator (*ELV-SH-WSM*)
+Floor heating actuators are operated through the climate group and don't need their own entity (`HMIP-FAL230-C6`, `HMIP-FAL230-C10`, `HMIP-FAL24-C6`, `HMIP-FAL24-C10`, `HMIP-FALMOT-C12`).
 
-- homematicip_cloud.weather
-  - Weather Sensor – basic (*HmIP-SWO-B*)
-  - Weather Sensor – plus (*HmIP-SWO-PL*)
-  - Weather Sensor – pro (*HmIP-SWO-PR*)
-  
-## What to do, if a device is missing in Home Assistant
+### Covers
 
-In order for a device to be integrated into Home Assistant, it must first be implemented in the upstream library. A dump of your configuration is required for this, which is then attached to a new issue in the [upstream lib's](https://github.com/hahn-th/homematicip-rest-api) GitHub repository.
+- Shutter actuators (`HmIP-BROLL`, `HmIP-FROLL`)
+- Blind actuators (`HmIP-BBL`, `HmIP-FBL`, `HMIP-DRBLI4`)
+- Garage door modules (`HmIP-MOD-TM`, `HMIP-MOD-HO`)
+- Hunter Douglas and Erfal window blinds (`HMIP-HDM1`)
 
-1. Create a dump of your access point configuration in Home Assistant:
-  {% my developer_call_service title="**Settings** > **Developer tools** > **Actions**" %} > Select `homematicip_cloud.dump_hap_config` > **Execute**. 
-  The default dump is anonymized and is written to your configuration directory (`hmip_config_XXXX.json`).
-2. Create a [new issue](https://github.com/hahn-th/homematicip-rest-api/issues/new) at this GitHub repository and attach the created dump file.
+### Events
 
-Please be patient, wait for the implementation and a new release of the upstream library.
-Afterward, this device can be implemented into Home Assistant.
-  
+- Doorbell events for devices that expose a `DOOR_BELL_INPUT` channel, like `HmIP-DSD-PCB`.
+
+### Lights
+
+- Dimming actuators (`HmIP-BDT`, `HmIP-FDT`, `HmIP-PDT`)
+- Switch actuators with signal lamp or meter (`HmIP-BSL`, `HmIP-BSM`)
+- Wired dimmer module – 3 channels (`HmIPW-DRD3`)
+
+### Locks
+
+- Door lock drive – currently usable without a PIN only (`HmIP-DLD`)
+- Full Flush Lock Controller (`HmIP-FLC`)
+
+### Sensors
+
+- Access point duty cycle (`HmIP-HAP`, `HmIP-HAP-B1`)
+- Wall thermostats (`HmIP-WTH`, `HmIP-WTH-1`, `HmIP-WTH-2`, `HmIP-WTH-B`, `ALPHA-IP-RBG`, `ALPHA-IP-RBGa`)
+- Radiator thermostats (`HmIP-eTRV`, `HmIP-eTRV-2`, `HmIP-eTRV-C`, `HmIP-eTRV-E`)
+- Temperature and humidity sensors (`HmIP-STH`, `HmIP-STHD`, `HmIP-STHO`, `HmIP-STHO-A`)
+- External temperature sensors with two probes (`HmIP-STE2-PCB`, `ELV-SH-PTI2`)
+- Light sensor – outdoor (`HmIP-SLO`)
+- Motion and presence sensors (`HmIP-SMI`, `HmIP-SMO`, `HmIP-SPI`)
+- Passage sensor with direction recognition (`HmIP-SPDR`)
+- Floor heating actuator – 12 channels, valve positions (`HMIP-FALMOT-C12`)
+- Fine dust sensor (`HmIP-SFD`)
+- Soil moisture sensor (`ELV-SH-SMSI`)
+- Door lock pad (`HmIP-DLP`)
+
+### Switches
+
+- Pluggable switches and meters (`HmIP-PS`, `HmIP-PSM`, `HmIP-PSM-CH`, `HmIP-PSM-IT`, `HmIP-PSM-UK`, `HmIP-PSM-PE`)
+- Flush-mount switch actuators and meters (`HmIP-FSM`, `HmIP-FSM16`)
+- Switch actuator with push-button input – flush-mount (`HmIP-FSI16`)
+- Open collector module receiver – 8 channels (`HmIP-MOD-OC8`)
+- Multi-IO box (`HmIP-MIOB`)
+- Switch circuit boards (`HmIP-PCBS`, `HmIP-PCBS2`, `HmIP-PCBS-BAT`)
+- Switch actuator for heating systems – 2 channels (`HmIP-WHS2`)
+- Wired switch actuator – 8 channels (`HmIPW-DRS8`)
+- DIN rail switch actuators (`HMIP-DRSI1`, `HMIP-DRSI4`)
+- Switch actuator – 2 channels (`HmIP-BS2`)
+- Switchable power supply – 25 W (`ELV-SH-SPS25`)
+
+### Valves
+
+- Smart watering actuator (`ELV-SH-WSM`)
+
+### Weather
+
+- Weather sensors – basic, plus, and pro (`HmIP-SWO-B`, `HmIP-SWO-PL`, `HmIP-SWO-PR`)
+
+## My device isn't recognized
+
+If your device shows up in the Homematic IP app but Home Assistant doesn't pick it up, the device family is most likely not yet implemented in the [Python library](https://github.com/hahn-th/homematicip-rest-api) that this integration uses. Each device family has to be added there first.
+
+Here is how you can help getting it added:
+
+1. **Download diagnostics for your access point.** Go to {% my integrations title="**Settings** > **Devices & services**" %}, open the **HomematicIP Cloud** integration, and select **Download diagnostics**. Home Assistant downloads an anonymized JSON file. Device IDs, labels, location, and the refresh token are replaced with placeholders, so you can share the file publicly without exposing your home layout.
+2. **Open an issue on the library repository.** File a [new issue](https://github.com/hahn-th/homematicip-rest-api/issues/new) describing what the device does (model number, what you use it for), and attach the diagnostics file.
+3. **Wait for the device to land.** Adding a new device runs through several steps: library pull request, library release on PyPI, Home Assistant integration update, and finally a Home Assistant release. Each step usually takes a few days to a few weeks. You can follow progress on the library issue and on the linked pull requests.
+
+While you wait, you can often expose the device through the Homematic IP app's own automations. The effects on devices that Home Assistant already supports will then show up there.
+
+
 ## Actions
 
-Executable by all users:
-- `homematicip_cloud.activate_eco_mode_with_duration`: Activate eco mode with duration.
-- `homematicip_cloud.activate_eco_mode_with_period`: Activate eco mode with period.
-- `homematicip_cloud.activate_vacation`: Activates the vacation mode until the given time.
-- `homematicip_cloud.deactivate_eco_mode`: Deactivates the eco mode immediately.
-- `homematicip_cloud.deactivate_vacation`: Deactivates the vacation mode immediately.
-- `homematicip_cloud.set_active_climate_profile`: Set the active climate profile index.
-- `homematicip_cloud.set_home_cooling_mode`: Enable or disable cooling for the home.
+The integration registers the following service actions. You can call them from automations or from {% my developer_call_service title="**Developer tools** > **Actions**" %}, which also shows the parameters for each action.
 
-Executable by administrators or within the context of an automation:
-- `homematicip_cloud.dump_hap_config`: Dump the configuration of the Homematic IP Access Point(s).
-- `homematicip_cloud.reset_energy_counter`: Reset energy counter of measuring actuators.
+All actions that operate on the access point accept an optional `accesspoint_id` parameter (the SGTIN). If your installation has only one access point, you can leave this out. With multiple access points, you can find the ID at the top of the integration page or printed on the back of the access point.
+
+### Climate and home modes
+
+- `homematicip_cloud.activate_eco_mode_with_duration` – Activate eco mode for a given number of minutes.
+- `homematicip_cloud.activate_eco_mode_with_period` – Activate eco mode until a given date and time.
+- `homematicip_cloud.deactivate_eco_mode` – Deactivate eco mode immediately.
+- `homematicip_cloud.activate_vacation` – Activate vacation mode until a given date and time, holding a target temperature.
+- `homematicip_cloud.deactivate_vacation` – Deactivate vacation mode immediately.
+- `homematicip_cloud.set_active_climate_profile` – Switch the active climate profile of a climate entity. The index is 1-based and matches the order shown in the Homematic IP app.
+- `homematicip_cloud.set_home_cooling_mode` – Switch the entire home between heating and cooling. *Administrator only.*
+
+### Energy and diagnostics
+
+- `homematicip_cloud.reset_energy_counter` – Reset the energy counter of a measuring actuator. *Administrator only.*
+- `homematicip_cloud.dump_hap_config` – Write a configuration dump to a file on disk. *Administrator only.* For sharing the dump publicly, prefer **Download diagnostics** from the integration page; it produces the same dump with stricter redaction.
 
 ### Action examples
-
-`accesspoint_id` (SGTIN) is optional for all actions and only relevant if you have multiple Homematic IP Accesspoints connected to Home Assistant. If empty, the action will be performed for all configured Homematic IP Access Points.
-The `accesspoint_id` (SGTIN) can be found on top of the integration page, or on the back of your Homematic IP Accesspoint.
 
 Activate eco mode with duration. 
 

--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -209,9 +209,12 @@ If your device shows up in the Homematic IP app but Home Assistant doesn't pick 
 
 Here is how you can help getting it added:
 
-1. **Download diagnostics for your access point.** Go to {% my integrations title="**Settings** > **Devices & services**" %}, open the **HomematicIP Cloud** integration, and select **Download diagnostics**. Home Assistant downloads an anonymized JSON file. Device IDs, labels, location, and the refresh token are replaced with placeholders, so you can share the file publicly without exposing your home layout.
-2. **Open an issue on the library repository.** File a [new issue](https://github.com/hahn-th/homematicip-rest-api/issues/new) describing what the device does (model number, what you use it for), and attach the diagnostics file.
-3. **Wait for the device to land.** Adding a new device runs through several steps: library pull request, library release on PyPI, Home Assistant integration update, and finally a Home Assistant release. Each step usually takes a few days to a few weeks. You can follow progress on the library issue and on the linked pull requests.
+1. Download diagnostics for your access point:
+    - Go to {% my integrations title="**Settings** > **Devices & services**" %}, open the **HomematicIP Cloud** integration, and select **Download diagnostics**.
+    - Result: Home Assistant downloads an anonymized JSON file.
+    - Device IDs, labels, location, and the refresh token are replaced with placeholders, so you can share the file publicly without exposing your home layout.
+2. Open an issue on the library repository. File a [new issue](https://github.com/hahn-th/homematicip-rest-api/issues/new) describing what the device does (model number, what you use it for), and attach the diagnostics file.
+3. Wait for the device to land. Adding a new device runs through several steps: library pull request, library release on PyPI, Home Assistant integration update, and finally a Home Assistant release. Each step usually takes a few days to a few weeks. You can follow progress on the library issue and on the linked pull requests.
 
 While you wait, you can often expose the device through the Homematic IP app's own automations. The effects on devices that Home Assistant already supports will then show up there.
 
@@ -224,18 +227,18 @@ All actions that operate on the access point accept an optional `accesspoint_id`
 
 ### Climate and home modes
 
-- `homematicip_cloud.activate_eco_mode_with_duration` – Activate eco mode for a given number of minutes.
-- `homematicip_cloud.activate_eco_mode_with_period` – Activate eco mode until a given date and time.
-- `homematicip_cloud.deactivate_eco_mode` – Deactivate eco mode immediately.
-- `homematicip_cloud.activate_vacation` – Activate vacation mode until a given date and time, holding a target temperature.
-- `homematicip_cloud.deactivate_vacation` – Deactivate vacation mode immediately.
-- `homematicip_cloud.set_active_climate_profile` – Switch the active climate profile of a climate entity. The index is 1-based and matches the order shown in the Homematic IP app.
-- `homematicip_cloud.set_home_cooling_mode` – Switch the entire home between heating and cooling. *Administrator only.*
+- `homematicip_cloud.activate_eco_mode_with_duration`: Activate eco mode for a given number of minutes.
+- `homematicip_cloud.activate_eco_mode_with_period`: Activate eco mode until a given date and time.
+- `homematicip_cloud.deactivate_eco_mode`: Deactivate eco mode immediately.
+- `homematicip_cloud.activate_vacation`: Activate vacation mode until a given date and time, holding a target temperature.
+- `homematicip_cloud.deactivate_vacation`: Deactivate vacation mode immediately.
+- `homematicip_cloud.set_active_climate_profile`: Switch the active climate profile of a climate entity. The index is 1-based and matches the order shown in the Homematic IP app.
+- `homematicip_cloud.set_home_cooling_mode`: Switch the entire home between heating and cooling. *Administrator only.*
 
 ### Energy and diagnostics
 
-- `homematicip_cloud.reset_energy_counter` – Reset the energy counter of a measuring actuator. *Administrator only.*
-- `homematicip_cloud.dump_hap_config` – Write a configuration dump to a file on disk. *Administrator only.* For sharing the dump publicly, prefer **Download diagnostics** from the integration page; it produces the same dump with stricter redaction.
+- `homematicip_cloud.reset_energy_counter`: Reset the energy counter of a measuring actuator. *Administrator only.*
+- `homematicip_cloud.dump_hap_config`: Write a configuration dump to a file on disk. *Administrator only.* For sharing the dump publicly, prefer **Download diagnostics** from the integration page; it produces the same dump with stricter redaction.
 
 ### Action examples
 


### PR DESCRIPTION
## Proposed change

Polish for the HomematicIP Cloud integration page, valid against the currently released integration. No new feature documentation.

- Restructures "Implemented and tested devices" into a "Supported devices" section with per-platform subsections (Alarm control panel, Binary sensors, Buttons, Climate, Covers, Events, Lights, Locks, Sensors, Switches, Valves, Weather). One entry per device family, with model variants grouped in backticks.
- Adds devices already supported but previously missing from the page: HmIP-FLC (binary sensor, button, lock), HmIP-SFD, HmIP-SWSD-2, HmIP-DLP, ELV-SH-SPS25, HmIP-SMO230, ELV-SH-PTI2, ELV-SH-SMSI.
- Rewords the Adding/Removing, HmIP-DLD permission, and "device not recognized" sections.
- Rewrites the Actions section: grouped by function (Climate and home modes vs Energy and diagnostics) instead of by permission level. Fixes set_home_cooling_mode classification (admin-only per source). Switches the device-not-recognized recommendation from the dump_hap_config service action to Download diagnostics on the integration page (same dump, stricter redaction).
- Replaces "HomematicIP APP" with "Homematic IP app" throughout to match the vendor brand.
- Adds @lackas as second codeowner in the frontmatter to mirror the Home Assistant Core CODEOWNERS file (updated 2026-02-10 via home-assistant/core#168169).

Split off from #45416 per reviewer request. #45416 now contains only the button event documentation for home-assistant/core#171065.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/168169
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards