### PR TITLE
Vistapool: document number platform

### DIFF
--- a/source/_integrations/vistapool.markdown
+++ b/source/_integrations/vistapool.markdown
@@ -55,7 +55,7 @@ The integration provides the following sensors:
 
 ## Numbers
 
-The integration provides the following adjustable values, grouped by what they configure. All are stored in the configuration {% term entities %} category.
+The integration provides the following adjustable values, grouped by what they configure. Each is exposed as a configuration {% term entity %}, so they appear under the **Configuration** section of the device page rather than in the main controls.
 
 ### Chemical setpoints
 

--- a/source/_integrations/vistapool.markdown
+++ b/source/_integrations/vistapool.markdown
@@ -2,6 +2,7 @@
 title: Vistapool
 description: Monitor and control Hayward-branded pool controllers via the Hayward cloud API.
 ha_category:
+  - Number
   - Sensor
 ha_release: 2026.6
 ha_iot_class: Cloud Push
@@ -10,6 +11,7 @@ ha_codeowners:
   - "@fdebrus"
 ha_domain: vistapool
 ha_platforms:
+  - number
   - sensor
 ha_integration_type: hub
 ---
@@ -50,6 +52,23 @@ The integration provides the following sensors:
 - **Electrolysis / Hydrolysis**: current production level in gr/h
 - **Filtration intel time**: daily runtime in Intel mode
 - **Wi-Fi signal strength**: controller RSSI (diagnostic, disabled by default)
+
+## Numbers
+
+The integration provides the following adjustable values, grouped by what they configure. All are stored in the configuration {% term entities %} category.
+
+### Chemical setpoints
+
+- **Redox setpoint**: target redox potential in mV (500–800). Available if a redox module is installed.
+- **pH minimum**: lower bound of the pH target window (6.00–8.00). Available if a pH module is installed.
+- **pH maximum**: upper bound of the pH target window (6.00–8.00). Available if a pH module is installed.
+- **Electrolysis setpoint**: target cell production in g/h. The maximum value is read from the cell's hardware-reported maximum, so the slider adapts automatically to different cell sizes. Available if a hydrolysis or electrolysis module is installed.
+
+### Temperature targets
+
+- **Intel temperature**: target temperature used by INTEL filtration mode (5–40 °C).
+- **Heating minimum temperature**, **Heating maximum temperature**: lower and upper bounds of the HEAT mode temperature range (5–40 °C each). Available only if your controller supports HEAT mode.
+- **Smart minimum temperature**, **Smart maximum temperature**: lower and upper bounds of the SMART mode temperature range (5–40 °C each). Available only if your controller supports SMART mode.
 
 ## Known limitations
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the `number` platform added to the Vistapool integration in home-assistant/core#<CORE_NUMBER_PR_NUMBER>. Follow-up to #44725 (sensor docs), home-assistant.io#45582 (binary_sensor docs, in flight), and home-assistant.io#<SWITCH_DOCS_PR_NUMBER> (switch docs, in flight).

Changes to `source/_integrations/vistapool.markdown`:

- Adds `Number` to `ha_category` and `number` to `ha_platforms`.
- Adds a `## Numbers` section with H3 subheadings grouped by purpose:
  - **Chemical setpoints** — `Redox setpoint` (gated on `hasRX`), `pH minimum`/`pH maximum` (gated on `hasPH`), `Electrolysis setpoint` (gated on `hasHidro`, dynamic max).
  - **Temperature targets** — `Intel temperature` (always), `Heating minimum`/`maximum` (gated on `filtration.hasHeat`), `Smart minimum`/`maximum` (gated on `filtration.hasSmart`).

Independent of the binary_sensor docs PR (#45582) and the switch docs PR (#<SWITCH_DOCS_PR_NUMBER>); the three PRs touch different sections of the same file and can merge in any order.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/172542
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards