### PR TITLE
Vistapool: document select platform

### DIFF
--- a/source/_integrations/vistapool.markdown
+++ b/source/_integrations/vistapool.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Button
   - Light
   - Number
+  - Select
   - Sensor
 ha_release: 2026.6
 ha_iot_class: Cloud Push
@@ -18,6 +19,7 @@ ha_platforms:
   - button
   - light
   - number
+  - select
   - sensor
 ha_integration_type: hub
 ha_dhcp: true
@@ -195,6 +197,23 @@ The integration provides the following adjustable values, grouped by what they c
 - **Intel temperature**: target temperature used by INTEL filtration mode (5–40 °C).
 - **Heating minimum temperature**, **Heating maximum temperature**: lower and upper bounds of the HEAT mode temperature range (5–40 °C each). Available only if your controller supports HEAT mode.
 - **Smart minimum temperature**, **Smart maximum temperature**: lower and upper bounds of the SMART mode temperature range (5–40 °C each). Available only if your controller supports SMART mode.
+
+### Selects
+
+The integration provides the following select {% term entities %}, grouped by what they control. Each is exposed as a configuration {% term entity %}, so they appear under the **Configuration** section of the device page rather than in the main controls.
+
+#### Filtration mode and speed
+
+- **Pump mode**: how the filtration pump decides when to run. Options are `manual`, `auto`, `heat` (run while heating is active), `smart` (Smart filtration mode), and `intel` (Intel filtration mode).
+- **Pump speed**: speed used when the pump is running in manual mode. Options are `slow`, `medium`, and `high`.
+
+#### Timer speeds
+
+The controller has three independent timer slots. Each slot lets you choose the speed the pump should use when that slot is active.
+
+- **Filtration timer speed 1**: speed used for the first timer slot. Options are `slow`, `medium`, and `high`.
+- **Filtration timer speed 2**: same, for the second slot.
+- **Filtration timer speed 3**: same, for the third slot.
 
 ## Data updates
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the `select` platform added to the Vistapool integration in home-assistant/core#<CORE_SELECT_PR_NUMBER>. Follow-up to #44725 (sensor docs), and the in-flight binary_sensor / switch / number docs PRs.

Changes to `source/_integrations/vistapool.markdown`:

- Adds `Select` to `ha_category` and `select` to `ha_platforms`.
- Adds a `## Selects` section with H3 subheadings grouped by purpose:
  - **Filtration mode and speed** — `Pump mode` (`manual` / `auto` / `heat` / `smart` / `intel`) and `Pump speed` (`slow` / `medium` / `high`).
  - **Timer speeds** — three independent timer-slot speed pickers (`Filtration timer speed 1` / `2` / `3`).

Independent of the other in-flight Vistapool docs PRs; touches different sections of the same file and can merge in any order.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/172547
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards