### PR TITLE
Document Wallbox resume schedule button

### DIFF
--- a/source/_integrations/wallbox.markdown
+++ b/source/_integrations/wallbox.markdown
@@ -76,7 +76,9 @@ The {% term integration %} adds a switch {% term entity %}, allowing you to paus
 
 ## Button
 
-The {% term integration %} adds a **Resume schedule** button {% term entity %}. Pressing it resumes the charger's programmed schedule and EcoSmart mode after a manual stop, mirroring the **Resume schedule** action available in the Wallbox mobile app. This requires a user with admin rights.
+The {% term integration %} adds a **Resume schedule** button {% term entity %}. Pressing it resumes the charger's programmed schedule and EcoSmart mode after a manual stop, mirroring the **Resume schedule** action available in the Wallbox mobile app.
+
+This action requires a user with admin rights. If the configured user lacks them, pressing the button fails with an error and a repair issue is raised. See [Insufficient Rights](#insufficient-rights) for details.
 
 ## Data updates
 

--- a/source/_integrations/wallbox.markdown
+++ b/source/_integrations/wallbox.markdown
@@ -7,6 +7,7 @@ ha_release: 2021.6
 ha_iot_class: Cloud Polling
 ha_domain: wallbox
 ha_platforms:
+  - button
   - lock
   - number
   - select
@@ -72,6 +73,10 @@ The {% term integration %} adds a select {% term entity %} to control solar char
 ## Switch
 
 The {% term integration %} adds a switch {% term entity %}, allowing you to pause/resume the charging process.
+
+## Button
+
+The {% term integration %} adds a **Resume schedule** button {% term entity %}. Pressing it resumes the charger's programmed schedule and EcoSmart mode after a manual stop, mirroring the **Resume schedule** action available in the Wallbox mobile app. This requires a user with admin rights.
 
 ## Data updates
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new **Resume schedule** button entity added to the Wallbox integration. The button resumes the charger's programmed schedule and EcoSmart mode after a manual stop, mirroring the **Resume schedule** action in the Wallbox mobile app. Adds a `## Button` section and lists `button` under `ha_platforms`.

Companion documentation for home-assistant/core#171847.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#171847
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
