### PR TITLE
lutron_caseta: document long_press trigger for HomeWorks QSX

### DIFF
--- a/source/_integrations/lutron_caseta.markdown
+++ b/source/_integrations/lutron_caseta.markdown
@@ -175,11 +175,18 @@ Radio RA3 and HomeWorks QSX systems can use these button entities to activate sc
 
 For more information on working with buttons in Home Assistant, see the [Buttons integration](/integrations/button/).
 
-## Pico and Shade Remotes
+## Keypads and remotes
 
-Pico and Shade remotes are supported on the Smart Bridge (L-BDG2-WH), Smart Bridge PRO (L-BDGPRO2-WH), and RA2 Select (RR-SEL-REP2-BL) models.
+Device triggers are available for every button on Pico remotes, Shade remotes, and keypads (Palladiom, SeeTouch, Sunnata, HomeOwner, etc.). Automations can be triggered on the following actions:
 
-Device triggers are implemented for `press` and `release` of each button on the remotes via watching for `lutron_caseta_button_event` events in the format:
+| Action | Description | Supported hardware |
+|---|---|---|
+| `press` | Button pressed | All |
+| `release` | Button released | All |
+| `multi_tap` | Button tapped multiple times in quick succession | All |
+| `long_press` | Button held for an extended duration | HomeWorks QSX processors only |
+
+These are exposed as device triggers in the automation editor, and also fire `lutron_caseta_button_event` events in the format:
 
 {% raw %}
 
@@ -195,3 +202,7 @@ Device triggers are implemented for `press` and `release` of each button on the 
 ```
 
 {% endraw %}
+
+{% note %}
+The `long_press` action relies on a native `LongHold` event sent by the Lutron LEAP protocol. It is currently only confirmed to work on **HomeWorks QSX** processors (e.g., HQP7). Caseta and RadioRA 3 bridges do not emit this event, so the `long_press` trigger will not appear in the automation editor for those systems.
+{% endnote %}

--- a/source/_integrations/lutron_caseta.markdown
+++ b/source/_integrations/lutron_caseta.markdown
@@ -202,5 +202,5 @@ These are exposed as device triggers in the automation editor, and also fire `lu
 {% endraw %}
 
 {% note %}
-The `long_press` action relies on a native `LongHold` event sent by the Lutron LEAP protocol. It is currently only confirmed to work on **HomeWorks QSX** processors (e.g., HQP7). Caseta and RadioRA 3 bridges do not emit this event, so the `long_press` trigger will not appear in the automation editor for those systems.
+The `long_press` action relies on a native `LongHold` event sent by the Lutron LEAP protocol. It is currently only confirmed to work on **HomeWorks QSX** processors (for example, HQP7). Caséta and RadioRA 3 bridges do not emit this event, so the `long_press` trigger will not appear in the automation editor for those systems.
 {% endnote %}

--- a/source/_integrations/lutron_caseta.markdown
+++ b/source/_integrations/lutron_caseta.markdown
@@ -179,12 +179,10 @@ For more information on working with buttons in Home Assistant, see the [Buttons
 
 Device triggers are available for every button on Pico remotes, Shade remotes, and keypads (Palladiom, SeeTouch, Sunnata, HomeOwner, etc.). Automations can be triggered on the following actions:
 
-| Action | Description | Supported hardware |
-|---|---|---|
-| `press` | Button pressed | All |
-| `release` | Button released | All |
-| `multi_tap` | Button tapped multiple times in quick succession | All |
-| `long_press` | Button held for an extended duration | HomeWorks QSX processors only |
+- `press`: Button pressed. Supported on all hardware.
+- `release`: Button released. Supported on all hardware.
+- `multi_tap`: Button tapped multiple times in quick succession. Supported on all hardware.
+- `long_press`: Button held for an extended duration. Supported on HomeWorks QSX processors only.
 
 These are exposed as device triggers in the automation editor, and also fire `lutron_caseta_button_event` events in the format:
 


### PR DESCRIPTION
## Proposed change

Documents the new `long_press` device trigger added to the `lutron_caseta` integration in home-assistant/core#172634.

Changes:
- Renamed section "Pico and Shade Remotes" → "Keypads and remotes" to better reflect all supported hardware (Palladiom, SeeTouch, Sunnata, HomeOwner keypads, plus Pico/Shade remotes)
- Added a table listing all 4 trigger actions (`press`, `release`, `multi_tap`, `long_press`) with their hardware support
- Added a note that `long_press` is confirmed only on HomeWorks QSX processors and will not appear in the automation editor for Caséta or RadioRA 3

## Type of change

- [ ] Spelling, grammar or other fixes
- [ ] Clarification of existing documentation
- [ ] Documentation of new features
- [x] Updated integration documentation

## Additional information

- Companion code PR: home-assistant/core#172634
- Tested on real HomeWorks QSX (HQP7) hardware

## Checklist

- [x] This PR fixes or closes issue: N/A
- [x] Link to documentation added in code PR