### PR TITLE
Update ViCare integration docs for OAuth2 migration

### DIFF
--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -36,17 +36,15 @@ You will need to sign in on the [Viessmann developer portal](https://app.develop
 Create a new API client by selecting **Add** in the **Clients** section on the developer dashboard with the following settings:
    - Name: `HomeAssistant`
    - Google reCAPTCHA: `disabled`
-   - Redirect URIs: `vicare://oauth-callback/everest`
+   - Redirect URIs: `https://my.home-assistant.io/redirect/oauth`
 
 Copy the **Client ID** in the **Clients** section on the developer dashboard for the setup in Home Assistant.
-
-{% important %}
-You have to set up the {% term integration %} from your device (phone) where you have the ViCare app installed. Otherwise, your device does not know how to handle the `vicare://` redirect URL, and you will receive an **Invalid credentials** notification and the setup procedure will fail.
-{% endimportant %}
 
 {% note %}
 It may take up to an hour for your new client to become active and usable. Otherwise, you will not receive any devices in Home Assistant.
 {% endnote %}
+
+When Home Assistant prompts for application credentials during setup, enter the **Client ID** from the Viessmann developer portal. The **Client Secret** field is not used by the integration (ViCare uses PKCE), so you can enter any value.
 
 ### API limits
 


### PR DESCRIPTION
## Proposed change

Update the ViCare integration documentation for the OAuth2 with Application Credentials migration shipping in 2026.6.

- Update the redirect URI from `vicare://oauth-callback/everest` (mobile-app deep link, used by the old password-grant flow) to `https://my.home-assistant.io/redirect/oauth` (Home Assistant's standard OAuth callback).
- Remove the note requiring setup from the device with the ViCare app installed, since the new redirect URI no longer depends on the mobile app.
- Add a brief note explaining that ViCare uses PKCE, so the **Client Secret** field in the Home Assistant application credentials prompt is not used.

This PR targets the \`next\` branch and needs to be cherry-picked to \`current\` for the 2026.6.0 release.

## Type of change

- [ ] Spelling, grammar or other readability improvements (\`current\` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (\`current\` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (\`next\` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (\`next\` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#165621
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the \`current\` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the \`next\` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards