### PR TITLE
Fix integration search filter to use exact category match

### DIFF
--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -364,7 +364,7 @@ join: ',' | split: ',' -%}
           if (key === 'search') {
             if (
               integration[key].indexOf(query[key]) === -1
-              && integration.cat.find((c) => c.includes(query[key])) == undefined
+              && integration.cat.find((c) => c === query[key]) == undefined
             ) {
               return false;
             }


### PR DESCRIPTION
## Proposed change

This PR fixes a bug in the integration search filter where category matching was using `includes()` instead of an exact equality check. The previous implementation would incorrectly match partial strings within category names, leading to false positive search results.

For example, searching for a category would match any category name that contained the search query as a substring, rather than requiring an exact match.

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

This is a bug fix for the integration search functionality on the integrations index page.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.

https://claude.ai/code/session_01JS6dnFMH834q6ZMY2S9imB