### PR TITLE
Vistapool: add use cases, examples, and data updates sections

### DIFF
--- a/source/_integrations/vistapool.markdown
+++ b/source/_integrations/vistapool.markdown
@@ -1,6 +1,6 @@
 ---
 title: Vistapool
-description: Monitor and control Hayward-branded pool controllers via the Hayward cloud API.
+description: Monitor and control Vistapool-compatible pool controllers via the Vistapool cloud API.
 ha_category:
   - Button
   - Sensor
@@ -16,9 +16,9 @@ ha_platforms:
 ha_integration_type: hub
 ---
 
-The **Vistapool** integration connects Home Assistant to **Hayward-branded pool controllers**, including AquaRite, Vistapool, Sugar Valley, Poolwatch, Kripsol, and Dagen devices.
+The **Vistapool** integration connects Home Assistant to **Vistapool-compatible pool controllers**, including AquaRite, Vistapool, Sugar Valley, Poolwatch, Kripsol, and Dagen devices.
 
-It communicates with the official Hayward cloud API using real-time push updates (no polling), giving you instant visibility and control over your pool equipment.
+It communicates with the official Vistapool cloud API using real-time push updates (no polling), giving you instant visibility and control over your pool equipment.
 
 ### Use case
 
@@ -33,15 +33,15 @@ Vistapool turns your pool controller into a live source of data and a remote tha
 
 ## Prerequisites
 
-- A supported Hayward-compatible pool controller
+- A supported Vistapool-compatible pool controller
 - A Wi-Fi module connected to the internet
-- The controller must already be linked to your Hayward cloud account
+- The controller must already be linked to your Vistapool cloud account
 
 ## Supported devices
 
-Any pool controller compatible with the Hayward / AquaRite cloud platform, including:
+Any pool controller compatible with the Vistapool cloud platform, including:
 
-- Hayward AquaRite
+- AquaRite
 - Vistapool
 - Sugar Valley
 - Poolwatch
@@ -125,20 +125,20 @@ automation: |
 
 ## Data updates
 
-Vistapool uses real-time **cloud push**. Home Assistant subscribes to the Hayward cloud once and the controller streams every change as it happens, so dashboards and automations react within a second or two of the physical event, with no fixed polling interval.
+Vistapool uses real-time **cloud push**. Home Assistant subscribes to the Vistapool cloud once and the controller streams every change as it happens, so dashboards and automations react within a second or two of the physical event, with no fixed polling interval.
 
 When the connection drops, the integration reconnects automatically with exponential backoff. Entities go to **Unavailable** while the connection is down and recover as soon as the stream is back.
 
 ## Known limitations
 
-- The integration requires an active internet connection as it communicates via the Hayward cloud API
+- The integration requires an active internet connection as it communicates via the Vistapool cloud API
 - Sensor availability depends on which modules are physically installed on your controller
 
 ## Troubleshooting
 
 ### Entities show "Unavailable"
 
-Check your internet connection and verify the controller is online in the Hayward app. The integration will automatically reconnect when the connection is restored.
+Check your internet connection and verify the controller is online in the Vistapool app. The integration will automatically reconnect when the connection is restored.
 
 ### Reauth notification appears
 

--- a/source/_integrations/vistapool.markdown
+++ b/source/_integrations/vistapool.markdown
@@ -20,6 +20,15 @@ The **Vistapool** integration connects Home Assistant to **Hayward-branded pool 
 
 It communicates with the official Hayward cloud API using real-time push updates (no polling), giving you instant visibility and control over your pool equipment.
 
+### Use case
+
+Vistapool turns your pool controller into a live source of data and a remote that you can tie into the rest of your home. Once set up, you can keep an eye on water chemistry, get notified when something needs attention, and automate routine tasks. Typical things you can do with it:
+
+- Watch water temperature, pH, ORP (redox), and chlorine production from a dashboard.
+- Get a notification when pH or chlorine drift outside the healthy range.
+- Cycle the pool light through its built-in color shows from any automation.
+- Combine pool state with the rest of your home, such as turning off the filtration pump while a high-load appliance is running.
+
 {% include integrations/config_flow.md %}
 
 ## Prerequisites
@@ -59,6 +68,67 @@ If your controller drives a multi-color LED light fixture, the integration expos
 
 - **LED next color**: advance the LED fixture to its next color. The integration briefly toggles the pool light off and back on (or just turns it on if it was off). The physical fixture interprets the power cycle as the color-advance signal, just as the **Next** button under **LED Color** does in the Vistapool app's **Illumination** screen. Available only if your controller reports an LED fixture.
 
+## Examples
+
+The following automations show how you can wire pool state into the rest of your home. Replace the entity IDs with the ones your controller exposes.
+
+Notify when chlorine production drops, which usually means the salt level or cell needs attention:
+
+{% example %}
+automation: |
+  alias: "Pool: low chlorine production"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.my_pool_electrolysis
+      below: 5
+      for:
+        minutes: 30
+  actions:
+    - action: notify.persistent_notification
+      data:
+        title: "Pool chlorine low"
+        message: "The salt cell is producing less than 5 gr/h. Check salt level or clean the cell."
+{% endexample %}
+
+Notify when pH drifts outside the healthy range:
+
+{% example %}
+automation: |
+  alias: "Pool: pH out of range"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.my_pool_ph
+      below: 7.0
+    - trigger: numeric_state
+      entity_id: sensor.my_pool_ph
+      above: 7.6
+  actions:
+    - action: notify.persistent_notification
+      data:
+        title: "Pool pH out of range"
+        message: "pH is {{ states('sensor.my_pool_ph') }}. Healthy range is 7.0 to 7.6."
+{% endexample %}
+
+Cycle the pool light to the next color at sunset every evening:
+
+{% example %}
+automation: |
+  alias: "Pool: advance LED color at sunset"
+  triggers:
+    - trigger: sun
+      event: sunset
+  actions:
+    - action: button.press
+      target:
+        entity_id: button.my_pool_led_next_color
+{% endexample %}
+
+## Data updates
+
+Vistapool uses real-time **cloud push**. Home Assistant subscribes to the Hayward cloud once and the controller streams every change as it happens, so dashboards and automations react within a second or two of the physical event, with no fixed polling interval.
+
+When the connection drops, the integration reconnects automatically with exponential backoff. Entities go to **Unavailable** while the connection is down and recover as soon as the stream is back.
+
 ## Known limitations
 
 - The integration requires an active internet connection as it communicates via the Hayward cloud API
@@ -72,7 +142,7 @@ Check your internet connection and verify the controller is online in the Haywar
 
 ### Reauth notification appears
 
-Your credentials may have changed or expired. Select the notification to re-enter your Hayward username and password.
+Your stored password is no longer accepted by Vistapool. Select the notification to re-enter your password and restore the connection. Your username stays the same.
 
 ### Entities not updating
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Fleshes out the Vistapool integration page to cover the Gold-tier `docs-use-cases`, `docs-examples`, and `docs-data-update` quality-scale rules.

- New **Use case** subsection under the introduction summarising what people typically do with the integration (water-chemistry dashboards, threshold notifications, LED color cycling, combining pool state with the rest of the home).
- New **Examples** section with three `{% example %}` automation blocks:
  - Notify when chlorine production drops below a threshold.
  - Notify when pH drifts outside the healthy range.
  - Cycle the pool light to the next color at sunset.
- New **Data updates** section explaining the cloud-push delivery model and the integration's reconnect behaviour.
- Tightens the **Reauth notification** troubleshooting entry to match the in-UI wording introduced by the matching reauth PR in core (password only; username stays the same).

The matching core PR flips the corresponding `quality_scale.yaml` rules (`docs-troubleshooting`, `docs-data-update`, `docs-examples`, `docs-known-limitations`, `docs-supported-devices`, `docs-supported-functions`, `docs-use-cases`) from `todo` to `done`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: <fill in once the core vistapool-quality-docs PR is open>
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards