### PR TITLE
Cover: document "closed" triggers (Labs feature)

### DIFF
--- a/source/_integrations/cover.markdown
+++ b/source/_integrations/cover.markdown
@@ -16,7 +16,7 @@ related:
     title: Dashboard
 ---
 
-Home Assistant can give you an interface to control covers such as rollershutters, blinds, and garage doors.
+Home Assistant can give you an interface to control covers such as roller shutters, blinds, and garage doors.
 
 {% include integrations/building_block_integration.md %}
 
@@ -30,7 +30,6 @@ A cover can have the following states:
 - **Closed**: The cover has reached the closed position.
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
-
 
 How the state of a cover is represented in the frontend depends on the device class.
 
@@ -58,8 +57,12 @@ The following device classes are supported for covers.
 - **garage**: Control of a garage door that provides access to a garage.
 - **gate**: Control of a gate. Gates are found outside of a structure and are typically part of a fence.
 - **shade**: Control of shades, which are a continuous plane of material or connected cells that expanded or collapsed over an opening, such as window shades.
-- **shutter**: Control of shutters. Shutters are linked slats that can be raised or lowered to cover an opening, such as window or door roller shutters. Some shutters (for example, some indoor or exterior window shutters) swing out/in to cover an opening or may be tilted to provide partial cover.
+- **shutter**: Control of shutters. Shutters are linked slats that can be raised or lowered to cover an opening, such as window or door roller shutters. Some shutters, for example, some indoor or exterior window shutters, swing out or in to cover an opening or may be tilted to provide partial cover.
 - **window**: Control of a physical window that opens and closes or may tilt.
+
+{% include integrations/triggers.md %}
+
+{% include integrations/conditions.md %}
 
 ## Actions
 
@@ -131,3 +134,71 @@ automation:
       data:
         tilt_position: 50
 ```
+
+## Cover automation examples
+
+You can use cover triggers and conditions to adjust lighting, remind yourself when something is still open, and run routines that depend on whether a cover is open or closed.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: turn off the office lamp when the blind opens after sunrise
+
+If daylight is enough for the room, this automation turns off the office lamp when the blind opens in the morning.
+
+- **Trigger**: Blind opened
+  - **Target**: Office blind
+- **Action**: Turn off light
+  - **Target**: Office lamp
+
+{% details "YAML example for turning off the office lamp" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the office lamp when the blind opens"
+  triggers:
+    - trigger: cover.blind_opened
+      target:
+        entity_id: cover.office_blind
+  conditions:
+    - condition: sun
+      after: sunrise
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.office_lamp
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: close the bedroom shutter at sunset if it is still open
+
+At sunset, this automation checks whether the bedroom shutter is still open. If it is, Home Assistant closes it for the night.
+
+- **Trigger**: Sun: Sunset
+- **Condition**: Shutter is open
+  - **Target**: Bedroom shutter
+- **Action**: Close cover
+
+{% details "YAML example for closing the bedroom shutter at sunset" %}
+
+{% example %}
+automation: |
+  alias: "Close the bedroom shutter at sunset"
+  triggers:
+    - trigger: sun
+      event: sunset
+  conditions:
+    - condition: cover.shutter_is_open
+      target:
+        entity_id: cover.bedroom_shutter
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.bedroom_shutter
+{% endexample %}
+
+{% enddetails %}
+
+## Known limitations
+
+The triggers and conditions documented on this page work only with `cover` entities that use the `awning`, `blind`, `curtain`, `shade`, or `shutter` device class.

--- a/source/_triggers/cover.awning_closed.markdown
+++ b/source/_triggers/cover.awning_closed.markdown
@@ -1,0 +1,156 @@
+---
+title: "Awning closed"
+trigger: cover.awning_closed
+domain: cover
+description: "Triggers after one or more awnings close."
+related_triggers:
+  - cover.awning_opened
+---
+
+The **Awning closed** trigger fires when a targeted awning changes to closed. Use it when you want Home Assistant to react as soon as an awning closes.
+
+This trigger is useful for lighting, notifications, and routines that should run as soon as an awning closes.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Awning closed**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your awning is in, like your patio or living room. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the awning must stay closed before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple awnings are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted awning closes, **First** to fire only when the first targeted awning closes, or **All** to fire only after every targeted awning is closed. The default is **Each**.
+  required: false
+For at least:
+  description: How long the awning must stay closed before the trigger fires. The default is `0` (fires immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `cover.awning_closed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: cover.awning_closed
+  target:
+    entity_id: cover.patio_awning
+{% endexample %}
+
+This fires when `cover.patio_awning` changes to closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple awnings are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the awning must stay closed before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works only with `cover` entities that use the `awning` device class.
+- If an awning comes back from `unavailable` or `unknown`, that recovery does not count as the closing.
+- The `for` option fires the automation only if the awning stays closed for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the nearby light when the awning closes after sunset
+
+When the awning closes after dark, this automation turns on a nearby light so the area stays easy to use.
+
+- **Trigger**: Awning closed
+  - **Target**: Patio awning
+- **Action**: Turn on light
+  - **Target**: Patio lights
+
+{% details "YAML example for turning on the nearby light when the awning closes" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the nearby light when the awning closes"
+  triggers:
+    - trigger: cover.awning_closed
+      target:
+        entity_id: cover.patio_awning
+  conditions:
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.patio_lights
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the awning closes while you are away
+
+If the awning changes while nobody is home, this automation sends a notification so you can check whether it was expected.
+
+- **Trigger**: Awning closed
+  - **Target**: Patio awning
+  - **For at least**: 00:00:10
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification when the awning closes" %}
+
+{% example %}
+automation: |
+  alias: "Notify me if the awning closes while I am away"
+  triggers:
+    - trigger: cover.awning_closed
+      target:
+        entity_id: cover.patio_awning
+      options:
+        for: "00:00:10"
+  conditions:
+    - condition: state
+      entity_id: person.morgan
+      state: "not_home"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Awning changed"
+        message: >
+          The awning closed while nobody was home.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/cover.blind_closed.markdown
+++ b/source/_triggers/cover.blind_closed.markdown
@@ -1,0 +1,156 @@
+---
+title: "Blind closed"
+trigger: cover.blind_closed
+domain: cover
+description: "Triggers after one or more blinds close."
+related_triggers:
+  - cover.blind_opened
+---
+
+The **Blind closed** trigger fires when a targeted blind changes to closed. Use it when you want Home Assistant to react as soon as a blind closes.
+
+This trigger is useful for lighting, notifications, and routines that should run as soon as a blind closes.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Blind closed**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your blind is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the blind must stay closed before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple blinds are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted blind closes, **First** to fire only when the first targeted blind closes, or **All** to fire only after every targeted blind is closed. The default is **Each**.
+  required: false
+For at least:
+  description: How long the blind must stay closed before the trigger fires. The default is `0` (fires immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `cover.blind_closed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: cover.blind_closed
+  target:
+    entity_id: cover.office_blind
+{% endexample %}
+
+This fires when `cover.office_blind` changes to closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple blinds are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the blind must stay closed before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works only with `cover` entities that use the `blind` device class.
+- If a blind comes back from `unavailable` or `unknown`, that recovery does not count as the closing.
+- The `for` option fires the automation only if the blind stays closed for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the nearby light when the blind closes after sunset
+
+When the blind closes after dark, this automation turns on a nearby light so the area stays easy to use.
+
+- **Trigger**: Blind closed
+  - **Target**: Office blind
+- **Action**: Turn on light
+  - **Target**: Office lamp
+
+{% details "YAML example for turning on the nearby light when the blind closes" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the nearby light when the blind closes"
+  triggers:
+    - trigger: cover.blind_closed
+      target:
+        entity_id: cover.office_blind
+  conditions:
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.office_lamp
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the blind closes while you are away
+
+If the blind changes while nobody is home, this automation sends a notification so you can check whether it was expected.
+
+- **Trigger**: Blind closed
+  - **Target**: Office blind
+  - **For at least**: 00:00:10
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification when the blind closes" %}
+
+{% example %}
+automation: |
+  alias: "Notify me if the blind closes while I am away"
+  triggers:
+    - trigger: cover.blind_closed
+      target:
+        entity_id: cover.office_blind
+      options:
+        for: "00:00:10"
+  conditions:
+    - condition: state
+      entity_id: person.morgan
+      state: "not_home"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Blind changed"
+        message: >
+          The blind closed while nobody was home.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/cover.curtain_closed.markdown
+++ b/source/_triggers/cover.curtain_closed.markdown
@@ -1,0 +1,156 @@
+---
+title: "Curtain closed"
+trigger: cover.curtain_closed
+domain: cover
+description: "Triggers after one or more curtains close."
+related_triggers:
+  - cover.curtain_opened
+---
+
+The **Curtain closed** trigger fires when a targeted curtain changes to closed. Use it when you want Home Assistant to react as soon as a curtain closes.
+
+This trigger is useful for lighting, notifications, and routines that should run as soon as a curtain closes.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Curtain closed**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your curtain is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the curtain must stay closed before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple curtains are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted curtain closes, **First** to fire only when the first targeted curtain closes, or **All** to fire only after every targeted curtain is closed. The default is **Each**.
+  required: false
+For at least:
+  description: How long the curtain must stay closed before the trigger fires. The default is `0` (fires immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `cover.curtain_closed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: cover.curtain_closed
+  target:
+    entity_id: cover.living_room_curtain
+{% endexample %}
+
+This fires when `cover.living_room_curtain` changes to closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple curtains are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the curtain must stay closed before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works only with `cover` entities that use the `curtain` device class.
+- If a curtain comes back from `unavailable` or `unknown`, that recovery does not count as the closing.
+- The `for` option fires the automation only if the curtain stays closed for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the nearby light when the curtain closes after sunset
+
+When the curtain closes after dark, this automation turns on a nearby light so the area stays easy to use.
+
+- **Trigger**: Curtain closed
+  - **Target**: Living room curtain
+- **Action**: Turn on light
+  - **Target**: Living room lamp
+
+{% details "YAML example for turning on the nearby light when the curtain closes" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the nearby light when the curtain closes"
+  triggers:
+    - trigger: cover.curtain_closed
+      target:
+        entity_id: cover.living_room_curtain
+  conditions:
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room_lamp
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the curtain closes while you are away
+
+If the curtain changes while nobody is home, this automation sends a notification so you can check whether it was expected.
+
+- **Trigger**: Curtain closed
+  - **Target**: Living room curtain
+  - **For at least**: 00:00:10
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification when the curtain closes" %}
+
+{% example %}
+automation: |
+  alias: "Notify me if the curtain closes while I am away"
+  triggers:
+    - trigger: cover.curtain_closed
+      target:
+        entity_id: cover.living_room_curtain
+      options:
+        for: "00:00:10"
+  conditions:
+    - condition: state
+      entity_id: person.morgan
+      state: "not_home"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Curtain changed"
+        message: >
+          The curtain closed while nobody was home.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/cover.shade_closed.markdown
+++ b/source/_triggers/cover.shade_closed.markdown
@@ -1,0 +1,156 @@
+---
+title: "Shade closed"
+trigger: cover.shade_closed
+domain: cover
+description: "Triggers after one or more shades close."
+related_triggers:
+  - cover.shade_opened
+---
+
+The **Shade closed** trigger fires when a targeted shade changes to closed. Use it when you want Home Assistant to react as soon as a shade closes.
+
+This trigger is useful for lighting, notifications, and routines that should run as soon as a shade closes.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Shade closed**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your shade is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the shade must stay closed before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple shades are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shade closes, **First** to fire only when the first targeted shade closes, or **All** to fire only after every targeted shade is closed. The default is **Each**.
+  required: false
+For at least:
+  description: How long the shade must stay closed before the trigger fires. The default is `0` (fires immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `cover.shade_closed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: cover.shade_closed
+  target:
+    entity_id: cover.bedroom_shade
+{% endexample %}
+
+This fires when `cover.bedroom_shade` changes to closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple shades are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the shade must stay closed before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works only with `cover` entities that use the `shade` device class.
+- If a shade comes back from `unavailable` or `unknown`, that recovery does not count as the closing.
+- The `for` option fires the automation only if the shade stays closed for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the nearby light when the shade closes after sunset
+
+When the shade closes after dark, this automation turns on a nearby light so the area stays easy to use.
+
+- **Trigger**: Shade closed
+  - **Target**: Bedroom shade
+- **Action**: Turn on light
+  - **Target**: Bedroom lamp
+
+{% details "YAML example for turning on the nearby light when the shade closes" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the nearby light when the shade closes"
+  triggers:
+    - trigger: cover.shade_closed
+      target:
+        entity_id: cover.bedroom_shade
+  conditions:
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.bedroom_lamp
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the shade closes while you are away
+
+If the shade changes while nobody is home, this automation sends a notification so you can check whether it was expected.
+
+- **Trigger**: Shade closed
+  - **Target**: Bedroom shade
+  - **For at least**: 00:00:10
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification when the shade closes" %}
+
+{% example %}
+automation: |
+  alias: "Notify me if the shade closes while I am away"
+  triggers:
+    - trigger: cover.shade_closed
+      target:
+        entity_id: cover.bedroom_shade
+      options:
+        for: "00:00:10"
+  conditions:
+    - condition: state
+      entity_id: person.morgan
+      state: "not_home"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Shade changed"
+        message: >
+          The shade closed while nobody was home.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/cover.shutter_closed.markdown
+++ b/source/_triggers/cover.shutter_closed.markdown
@@ -1,0 +1,156 @@
+---
+title: "Shutter closed"
+trigger: cover.shutter_closed
+domain: cover
+description: "Triggers after one or more shutters close."
+related_triggers:
+  - cover.shutter_opened
+---
+
+The **Shutter closed** trigger fires when a targeted shutter changes to closed. Use it when you want Home Assistant to react as soon as a shutter closes.
+
+This trigger is useful for lighting, notifications, and routines that should run as soon as a shutter closes.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Shutter closed**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your shutter is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the shutter must stay closed before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple shutters are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shutter closes, **First** to fire only when the first targeted shutter closes, or **All** to fire only after every targeted shutter is closed. The default is **Each**.
+  required: false
+For at least:
+  description: How long the shutter must stay closed before the trigger fires. The default is `0` (fires immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `cover.shutter_closed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: cover.shutter_closed
+  target:
+    entity_id: cover.kitchen_shutter
+{% endexample %}
+
+This fires when `cover.kitchen_shutter` changes to closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple shutters are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the shutter must stay closed before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works only with `cover` entities that use the `shutter` device class.
+- If a shutter comes back from `unavailable` or `unknown`, that recovery does not count as the closing.
+- The `for` option fires the automation only if the shutter stays closed for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the nearby light when the shutter closes after sunset
+
+When the shutter closes after dark, this automation turns on a nearby light so the area stays easy to use.
+
+- **Trigger**: Shutter closed
+  - **Target**: Kitchen shutter
+- **Action**: Turn on light
+  - **Target**: Kitchen ceiling light
+
+{% details "YAML example for turning on the nearby light when the shutter closes" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the nearby light when the shutter closes"
+  triggers:
+    - trigger: cover.shutter_closed
+      target:
+        entity_id: cover.kitchen_shutter
+  conditions:
+    - condition: sun
+      after: sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.kitchen_ceiling
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the shutter closes while you are away
+
+If the shutter changes while nobody is home, this automation sends a notification so you can check whether it was expected.
+
+- **Trigger**: Shutter closed
+  - **Target**: Kitchen shutter
+  - **For at least**: 00:00:10
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification when the shutter closes" %}
+
+{% example %}
+automation: |
+  alias: "Notify me if the shutter closes while I am away"
+  triggers:
+    - trigger: cover.shutter_closed
+      target:
+        entity_id: cover.kitchen_shutter
+      options:
+        for: "00:00:10"
+  conditions:
+    - condition: state
+      entity_id: person.morgan
+      state: "not_home"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Shutter changed"
+        message: >
+          The shutter closed while nobody was home.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}


### PR DESCRIPTION
## Proposed change

- Add the cover Labs trigger split pages for the closed device-class variants.
- Update the cover integration page to include split trigger and condition docs, and add cover automation examples.
- Preserve the existing inline cover action documentation.

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: addresses #44908

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards