### PR TITLE
Cover: document "opened" triggers (Labs feature)

### DIFF
--- a/source/_triggers/cover.awning_opened.markdown
+++ b/source/_triggers/cover.awning_opened.markdown
@@ -1,0 +1,153 @@
+---
+title: "Awning opened"
+trigger: cover.awning_opened
+domain: cover
+description: "Triggers after one or more awnings open."
+related_triggers:
+  - cover.awning_closed
+---
+
+The **Awning opened** trigger fires when a targeted awning changes to open. Use it when you want Home Assistant to react as soon as an awning opens.
+
+This trigger is useful for comfort, notifications, and routines that should run as soon as an awning opens.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Awning opened**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your awning is in, like your patio or living room. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the awning must stay open before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple awnings are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted awning opens, **First** to fire only when the first targeted awning opens, or **All** to fire only after every targeted awning is open. The default is **Each**.
+  required: false
+For at least:
+  description: How long the awning must stay open before the trigger fires. The default is `0` (fires immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `cover.awning_opened`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: cover.awning_opened
+  target:
+    entity_id: cover.patio_awning
+{% endexample %}
+
+This fires when `cover.patio_awning` changes to open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple awnings are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the awning must stay open before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works only with `cover` entities that use the `awning` device class.
+- If an awning comes back from `unavailable` or `unknown`, that recovery does not count as the opening.
+- The `for` option fires the automation only if the awning stays open for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the patio fan when the awning opens
+
+When the awning opens, this automation starts the patio fan right away to make the space more comfortable.
+
+- **Trigger**: Awning opened
+  - **Target**: Patio awning
+- **Action**: Turn on fan
+  - **Target**: Patio fan
+
+{% details "YAML example for turning on the patio fan when the awning opens" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the patio fan when the awning opens"
+  triggers:
+    - trigger: cover.awning_opened
+      target:
+        entity_id: cover.patio_awning
+  actions:
+    - action: fan.turn_on
+      target:
+        entity_id: fan.patio_fan
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the awning opens while you are away
+
+If the awning changes while nobody is home, this automation sends a notification so you can check whether it was expected.
+
+- **Trigger**: Awning opened
+  - **Target**: Patio awning
+  - **For at least**: 00:00:10
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification when the awning opens" %}
+
+{% example %}
+automation: |
+  alias: "Notify me if the awning opens while I am away"
+  triggers:
+    - trigger: cover.awning_opened
+      target:
+        entity_id: cover.patio_awning
+      options:
+        for: "00:00:10"
+  conditions:
+    - condition: state
+      entity_id: person.morgan
+      state: "not_home"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Awning changed"
+        message: >
+          The awning opened while nobody was home.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/cover.blind_opened.markdown
+++ b/source/_triggers/cover.blind_opened.markdown
@@ -1,0 +1,156 @@
+---
+title: "Blind opened"
+trigger: cover.blind_opened
+domain: cover
+description: "Triggers after one or more blinds open."
+related_triggers:
+  - cover.blind_closed
+---
+
+The **Blind opened** trigger fires when a targeted blind changes to open. Use it when you want Home Assistant to react as soon as a blind opens.
+
+This trigger is useful for lighting, notifications, and routines that should run as soon as a blind opens.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Blind opened**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your blind is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the blind must stay open before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple blinds are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted blind opens, **First** to fire only when the first targeted blind opens, or **All** to fire only after every targeted blind is open. The default is **Each**.
+  required: false
+For at least:
+  description: How long the blind must stay open before the trigger fires. The default is `0` (fires immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `cover.blind_opened`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: cover.blind_opened
+  target:
+    entity_id: cover.office_blind
+{% endexample %}
+
+This fires when `cover.office_blind` changes to open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple blinds are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the blind must stay open before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works only with `cover` entities that use the `blind` device class.
+- If a blind comes back from `unavailable` or `unknown`, that recovery does not count as the opening.
+- The `for` option fires the automation only if the blind stays open for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off the nearby light when the blind opens after sunrise
+
+When daylight is enough for the room, this automation turns off a nearby light as soon as the blind opens.
+
+- **Trigger**: Blind opened
+  - **Target**: Office blind
+- **Action**: Turn off light
+  - **Target**: Office lamp
+
+{% details "YAML example for turning off the nearby light when the blind opens" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the nearby light when the blind opens"
+  triggers:
+    - trigger: cover.blind_opened
+      target:
+        entity_id: cover.office_blind
+  conditions:
+    - condition: sun
+      after: sunrise
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.office_lamp
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the blind opens while you are away
+
+If the blind changes while nobody is home, this automation sends a notification so you can check whether it was expected.
+
+- **Trigger**: Blind opened
+  - **Target**: Office blind
+  - **For at least**: 00:00:10
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification when the blind opens" %}
+
+{% example %}
+automation: |
+  alias: "Notify me if the blind opens while I am away"
+  triggers:
+    - trigger: cover.blind_opened
+      target:
+        entity_id: cover.office_blind
+      options:
+        for: "00:00:10"
+  conditions:
+    - condition: state
+      entity_id: person.morgan
+      state: "not_home"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Blind changed"
+        message: >
+          The blind opened while nobody was home.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/cover.curtain_opened.markdown
+++ b/source/_triggers/cover.curtain_opened.markdown
@@ -1,0 +1,156 @@
+---
+title: "Curtain opened"
+trigger: cover.curtain_opened
+domain: cover
+description: "Triggers after one or more curtains open."
+related_triggers:
+  - cover.curtain_closed
+---
+
+The **Curtain opened** trigger fires when a targeted curtain changes to open. Use it when you want Home Assistant to react as soon as a curtain opens.
+
+This trigger is useful for lighting, notifications, and routines that should run as soon as a curtain opens.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Curtain opened**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your curtain is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the curtain must stay open before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple curtains are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted curtain opens, **First** to fire only when the first targeted curtain opens, or **All** to fire only after every targeted curtain is open. The default is **Each**.
+  required: false
+For at least:
+  description: How long the curtain must stay open before the trigger fires. The default is `0` (fires immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `cover.curtain_opened`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: cover.curtain_opened
+  target:
+    entity_id: cover.living_room_curtain
+{% endexample %}
+
+This fires when `cover.living_room_curtain` changes to open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple curtains are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the curtain must stay open before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works only with `cover` entities that use the `curtain` device class.
+- If a curtain comes back from `unavailable` or `unknown`, that recovery does not count as the opening.
+- The `for` option fires the automation only if the curtain stays open for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off the nearby light when the curtain opens after sunrise
+
+When daylight is enough for the room, this automation turns off a nearby light as soon as the curtain opens.
+
+- **Trigger**: Curtain opened
+  - **Target**: Living room curtain
+- **Action**: Turn off light
+  - **Target**: Living room lamp
+
+{% details "YAML example for turning off the nearby light when the curtain opens" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the nearby light when the curtain opens"
+  triggers:
+    - trigger: cover.curtain_opened
+      target:
+        entity_id: cover.living_room_curtain
+  conditions:
+    - condition: sun
+      after: sunrise
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.living_room_lamp
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the curtain opens while you are away
+
+If the curtain changes while nobody is home, this automation sends a notification so you can check whether it was expected.
+
+- **Trigger**: Curtain opened
+  - **Target**: Living room curtain
+  - **For at least**: 00:00:10
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification when the curtain opens" %}
+
+{% example %}
+automation: |
+  alias: "Notify me if the curtain opens while I am away"
+  triggers:
+    - trigger: cover.curtain_opened
+      target:
+        entity_id: cover.living_room_curtain
+      options:
+        for: "00:00:10"
+  conditions:
+    - condition: state
+      entity_id: person.morgan
+      state: "not_home"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Curtain changed"
+        message: >
+          The curtain opened while nobody was home.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/cover.shade_opened.markdown
+++ b/source/_triggers/cover.shade_opened.markdown
@@ -1,0 +1,156 @@
+---
+title: "Shade opened"
+trigger: cover.shade_opened
+domain: cover
+description: "Triggers after one or more shades open."
+related_triggers:
+  - cover.shade_closed
+---
+
+The **Shade opened** trigger fires when a targeted shade changes to open. Use it when you want Home Assistant to react as soon as a shade opens.
+
+This trigger is useful for lighting, notifications, and routines that should run as soon as a shade opens.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Shade opened**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your shade is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the shade must stay open before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple shades are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shade opens, **First** to fire only when the first targeted shade opens, or **All** to fire only after every targeted shade is open. The default is **Each**.
+  required: false
+For at least:
+  description: How long the shade must stay open before the trigger fires. The default is `0` (fires immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `cover.shade_opened`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: cover.shade_opened
+  target:
+    entity_id: cover.bedroom_shade
+{% endexample %}
+
+This fires when `cover.bedroom_shade` changes to open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple shades are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the shade must stay open before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works only with `cover` entities that use the `shade` device class.
+- If a shade comes back from `unavailable` or `unknown`, that recovery does not count as the opening.
+- The `for` option fires the automation only if the shade stays open for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off the nearby light when the shade opens after sunrise
+
+When daylight is enough for the room, this automation turns off a nearby light as soon as the shade opens.
+
+- **Trigger**: Shade opened
+  - **Target**: Bedroom shade
+- **Action**: Turn off light
+  - **Target**: Bedroom lamp
+
+{% details "YAML example for turning off the nearby light when the shade opens" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the nearby light when the shade opens"
+  triggers:
+    - trigger: cover.shade_opened
+      target:
+        entity_id: cover.bedroom_shade
+  conditions:
+    - condition: sun
+      after: sunrise
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.bedroom_lamp
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the shade opens while you are away
+
+If the shade changes while nobody is home, this automation sends a notification so you can check whether it was expected.
+
+- **Trigger**: Shade opened
+  - **Target**: Bedroom shade
+  - **For at least**: 00:00:10
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification when the shade opens" %}
+
+{% example %}
+automation: |
+  alias: "Notify me if the shade opens while I am away"
+  triggers:
+    - trigger: cover.shade_opened
+      target:
+        entity_id: cover.bedroom_shade
+      options:
+        for: "00:00:10"
+  conditions:
+    - condition: state
+      entity_id: person.morgan
+      state: "not_home"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Shade changed"
+        message: >
+          The shade opened while nobody was home.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/cover.shutter_opened.markdown
+++ b/source/_triggers/cover.shutter_opened.markdown
@@ -1,0 +1,156 @@
+---
+title: "Shutter opened"
+trigger: cover.shutter_opened
+domain: cover
+description: "Triggers after one or more shutters open."
+related_triggers:
+  - cover.shutter_closed
+---
+
+The **Shutter opened** trigger fires when a targeted shutter changes to open. Use it when you want Home Assistant to react as soon as a shutter opens.
+
+This trigger is useful for lighting, notifications, and routines that should run as soon as a shutter opens.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Shutter opened**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area your shutter is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, enter how long the shutter must stay open before the trigger fires. Leave it at zero to fire right away.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple shutters are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shutter opens, **First** to fire only when the first targeted shutter opens, or **All** to fire only after every targeted shutter is open. The default is **Each**.
+  required: false
+For at least:
+  description: How long the shutter must stay open before the trigger fires. The default is `0` (fires immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `cover.shutter_opened`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: cover.shutter_opened
+  target:
+    entity_id: cover.kitchen_shutter
+{% endexample %}
+
+This fires when `cover.kitchen_shutter` changes to open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple shutters are targeted, controls when the trigger fires.
+    Accepts `any`, `first`, or `last`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the shutter must stay open before the trigger fires.
+    Accepts a duration like `00:00:10` for 10 seconds.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works only with `cover` entities that use the `shutter` device class.
+- If a shutter comes back from `unavailable` or `unknown`, that recovery does not count as the opening.
+- The `for` option fires the automation only if the shutter stays open for the entire time you set.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off the nearby light when the shutter opens after sunrise
+
+When daylight is enough for the room, this automation turns off a nearby light as soon as the shutter opens.
+
+- **Trigger**: Shutter opened
+  - **Target**: Kitchen shutter
+- **Action**: Turn off light
+  - **Target**: Kitchen ceiling light
+
+{% details "YAML example for turning off the nearby light when the shutter opens" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the nearby light when the shutter opens"
+  triggers:
+    - trigger: cover.shutter_opened
+      target:
+        entity_id: cover.kitchen_shutter
+  conditions:
+    - condition: sun
+      after: sunrise
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.kitchen_ceiling
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the shutter opens while you are away
+
+If the shutter changes while nobody is home, this automation sends a notification so you can check whether it was expected.
+
+- **Trigger**: Shutter opened
+  - **Target**: Kitchen shutter
+  - **For at least**: 00:00:10
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification when the shutter opens" %}
+
+{% example %}
+automation: |
+  alias: "Notify me if the shutter opens while I am away"
+  triggers:
+    - trigger: cover.shutter_opened
+      target:
+        entity_id: cover.kitchen_shutter
+      options:
+        for: "00:00:10"
+  conditions:
+    - condition: state
+      entity_id: person.morgan
+      state: "not_home"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Shutter changed"
+        message: >
+          The shutter opened while nobody was home.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}


### PR DESCRIPTION
## Proposed change

- Add the cover Labs trigger split pages for the opened device-class variants.
- Document the UI flow, YAML form, options, and examples for each opened trigger.

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: addresses #44908

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards