### PR TITLE
Cover: document "is.open" conditions (Labs feature)

### DIFF
--- a/source/_conditions/cover.awning_is_open.markdown
+++ b/source/_conditions/cover.awning_is_open.markdown
@@ -1,0 +1,156 @@
+---
+title: "Awning is open"
+condition: cover.awning_is_open
+domain: cover
+description: "Tests if one or more awnings are open."
+related_conditions:
+  - cover.awning_is_closed
+---
+
+The **Awning is open** condition passes when one or more targeted awnings are currently open. Use it when an automation should continue only if an awning is still open at the moment the automation runs.
+
+This condition is useful for reminders, lighting checks, and routines that depend on whether an awning is open.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Awning is open**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your awning is in, like your patio or living room. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the awning must have stayed open before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple awnings are targeted, controls how results combine. Pick **Any** to pass if at least one targeted awning is open, or **All** to pass only when every targeted awning is open. The default is **Any**.
+  required: false
+For at least:
+  description: How long the awning must have stayed open before the condition passes. The default is `0` (passes immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `cover.awning_is_open`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: cover.awning_is_open
+  target:
+    entity_id: cover.patio_awning
+{% endexample %}
+
+This passes when `cover.patio_awning` is currently open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple awnings are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the awning must have stayed open before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works only with `cover` entities that use the `awning` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted awning is open.
+- With **All**, the condition passes only if every available targeted awning is open. If every targeted awning is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: close the awning at sunset if it is still open
+
+At sunset, this automation checks whether the awning is still open. If it is, Home Assistant closes it for the night.
+
+- **Trigger**: Sun: Sunset
+- **Condition**: Awning is open
+  - **Target**: Patio awning
+- **Action**: Close cover
+
+{% details "YAML example for closing the awning at sunset" %}
+
+{% example %}
+automation: |
+  alias: "Close the awning at sunset"
+  triggers:
+    - trigger: sun
+      event: sunset
+  conditions:
+    - condition: cover.awning_is_open
+      target:
+        entity_id: cover.patio_awning
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.patio_awning
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the awning is still open when you leave home
+
+When you leave home, this automation checks whether the awning is still open. If it is, Home Assistant sends a reminder so you can close it.
+
+- **Trigger**: Person leaves home zone
+- **Condition**: Awning is open
+  - **Target**: Patio awning
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for checking the awning when you leave home" %}
+
+{% example %}
+automation: |
+  alias: "Warn me if the awning is open when I leave home"
+  triggers:
+    - trigger: zone
+      entity_id: person.morgan
+      zone: zone.home
+      event: leave
+  conditions:
+    - condition: cover.awning_is_open
+      target:
+        entity_id: cover.patio_awning
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Cover still open"
+        message: >
+          The awning is still open while you are leaving.
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/cover.blind_is_open.markdown
+++ b/source/_conditions/cover.blind_is_open.markdown
@@ -1,0 +1,156 @@
+---
+title: "Blind is open"
+condition: cover.blind_is_open
+domain: cover
+description: "Tests if one or more blinds are open."
+related_conditions:
+  - cover.blind_is_closed
+---
+
+The **Blind is open** condition passes when one or more targeted blinds are currently open. Use it when an automation should continue only if a blind is still open at the moment the automation runs.
+
+This condition is useful for reminders, lighting checks, and routines that depend on whether a blind is open.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Blind is open**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your blind is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the blind must have stayed open before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple blinds are targeted, controls how results combine. Pick **Any** to pass if at least one targeted blind is open, or **All** to pass only when every targeted blind is open. The default is **Any**.
+  required: false
+For at least:
+  description: How long the blind must have stayed open before the condition passes. The default is `0` (passes immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `cover.blind_is_open`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: cover.blind_is_open
+  target:
+    entity_id: cover.office_blind
+{% endexample %}
+
+This passes when `cover.office_blind` is currently open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple blinds are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the blind must have stayed open before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works only with `cover` entities that use the `blind` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted blind is open.
+- With **All**, the condition passes only if every available targeted blind is open. If every targeted blind is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: close the blind at sunset if it is still open
+
+At sunset, this automation checks whether the blind is still open. If it is, Home Assistant closes it for the night.
+
+- **Trigger**: Sun: Sunset
+- **Condition**: Blind is open
+  - **Target**: Office blind
+- **Action**: Close cover
+
+{% details "YAML example for closing the blind at sunset" %}
+
+{% example %}
+automation: |
+  alias: "Close the blind at sunset"
+  triggers:
+    - trigger: sun
+      event: sunset
+  conditions:
+    - condition: cover.blind_is_open
+      target:
+        entity_id: cover.office_blind
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.office_blind
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the blind is still open when you leave home
+
+When you leave home, this automation checks whether the blind is still open. If it is, Home Assistant sends a reminder so you can close it.
+
+- **Trigger**: Person leaves home zone
+- **Condition**: Blind is open
+  - **Target**: Office blind
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for checking the blind when you leave home" %}
+
+{% example %}
+automation: |
+  alias: "Warn me if the blind is open when I leave home"
+  triggers:
+    - trigger: zone
+      entity_id: person.morgan
+      zone: zone.home
+      event: leave
+  conditions:
+    - condition: cover.blind_is_open
+      target:
+        entity_id: cover.office_blind
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Cover still open"
+        message: >
+          The blind is still open while you are leaving.
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/cover.curtain_is_open.markdown
+++ b/source/_conditions/cover.curtain_is_open.markdown
@@ -1,0 +1,156 @@
+---
+title: "Curtain is open"
+condition: cover.curtain_is_open
+domain: cover
+description: "Tests if one or more curtains are open."
+related_conditions:
+  - cover.curtain_is_closed
+---
+
+The **Curtain is open** condition passes when one or more targeted curtains are currently open. Use it when an automation should continue only if a curtain is still open at the moment the automation runs.
+
+This condition is useful for reminders, lighting checks, and routines that depend on whether a curtain is open.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Curtain is open**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your curtain is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the curtain must have stayed open before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple curtains are targeted, controls how results combine. Pick **Any** to pass if at least one targeted curtain is open, or **All** to pass only when every targeted curtain is open. The default is **Any**.
+  required: false
+For at least:
+  description: How long the curtain must have stayed open before the condition passes. The default is `0` (passes immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `cover.curtain_is_open`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: cover.curtain_is_open
+  target:
+    entity_id: cover.living_room_curtain
+{% endexample %}
+
+This passes when `cover.living_room_curtain` is currently open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple curtains are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the curtain must have stayed open before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works only with `cover` entities that use the `curtain` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted curtain is open.
+- With **All**, the condition passes only if every available targeted curtain is open. If every targeted curtain is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: close the curtain at sunset if it is still open
+
+At sunset, this automation checks whether the curtain is still open. If it is, Home Assistant closes it for the night.
+
+- **Trigger**: Sun: Sunset
+- **Condition**: Curtain is open
+  - **Target**: Living room curtain
+- **Action**: Close cover
+
+{% details "YAML example for closing the curtain at sunset" %}
+
+{% example %}
+automation: |
+  alias: "Close the curtain at sunset"
+  triggers:
+    - trigger: sun
+      event: sunset
+  conditions:
+    - condition: cover.curtain_is_open
+      target:
+        entity_id: cover.living_room_curtain
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.living_room_curtain
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the curtain is still open when you leave home
+
+When you leave home, this automation checks whether the curtain is still open. If it is, Home Assistant sends a reminder so you can close it.
+
+- **Trigger**: Person leaves home zone
+- **Condition**: Curtain is open
+  - **Target**: Living room curtain
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for checking the curtain when you leave home" %}
+
+{% example %}
+automation: |
+  alias: "Warn me if the curtain is open when I leave home"
+  triggers:
+    - trigger: zone
+      entity_id: person.morgan
+      zone: zone.home
+      event: leave
+  conditions:
+    - condition: cover.curtain_is_open
+      target:
+        entity_id: cover.living_room_curtain
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Cover still open"
+        message: >
+          The curtain is still open while you are leaving.
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/cover.shade_is_open.markdown
+++ b/source/_conditions/cover.shade_is_open.markdown
@@ -1,0 +1,156 @@
+---
+title: "Shade is open"
+condition: cover.shade_is_open
+domain: cover
+description: "Tests if one or more shades are open."
+related_conditions:
+  - cover.shade_is_closed
+---
+
+The **Shade is open** condition passes when one or more targeted shades are currently open. Use it when an automation should continue only if a shade is still open at the moment the automation runs.
+
+This condition is useful for reminders, lighting checks, and routines that depend on whether a shade is open.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Shade is open**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your shade is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the shade must have stayed open before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple shades are targeted, controls how results combine. Pick **Any** to pass if at least one targeted shade is open, or **All** to pass only when every targeted shade is open. The default is **Any**.
+  required: false
+For at least:
+  description: How long the shade must have stayed open before the condition passes. The default is `0` (passes immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `cover.shade_is_open`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: cover.shade_is_open
+  target:
+    entity_id: cover.bedroom_shade
+{% endexample %}
+
+This passes when `cover.bedroom_shade` is currently open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple shades are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the shade must have stayed open before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works only with `cover` entities that use the `shade` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted shade is open.
+- With **All**, the condition passes only if every available targeted shade is open. If every targeted shade is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: close the shade at sunset if it is still open
+
+At sunset, this automation checks whether the shade is still open. If it is, Home Assistant closes it for the night.
+
+- **Trigger**: Sun: Sunset
+- **Condition**: Shade is open
+  - **Target**: Bedroom shade
+- **Action**: Close cover
+
+{% details "YAML example for closing the shade at sunset" %}
+
+{% example %}
+automation: |
+  alias: "Close the shade at sunset"
+  triggers:
+    - trigger: sun
+      event: sunset
+  conditions:
+    - condition: cover.shade_is_open
+      target:
+        entity_id: cover.bedroom_shade
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.bedroom_shade
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the shade is still open when you leave home
+
+When you leave home, this automation checks whether the shade is still open. If it is, Home Assistant sends a reminder so you can close it.
+
+- **Trigger**: Person leaves home zone
+- **Condition**: Shade is open
+  - **Target**: Bedroom shade
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for checking the shade when you leave home" %}
+
+{% example %}
+automation: |
+  alias: "Warn me if the shade is open when I leave home"
+  triggers:
+    - trigger: zone
+      entity_id: person.morgan
+      zone: zone.home
+      event: leave
+  conditions:
+    - condition: cover.shade_is_open
+      target:
+        entity_id: cover.bedroom_shade
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Cover still open"
+        message: >
+          The shade is still open while you are leaving.
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/cover.shutter_is_open.markdown
+++ b/source/_conditions/cover.shutter_is_open.markdown
@@ -1,0 +1,156 @@
+---
+title: "Shutter is open"
+condition: cover.shutter_is_open
+domain: cover
+description: "Tests if one or more shutters are open."
+related_conditions:
+  - cover.shutter_is_closed
+---
+
+The **Shutter is open** condition passes when one or more targeted shutters are currently open. Use it when an automation should continue only if a shutter is still open at the moment the automation runs.
+
+This condition is useful for reminders, lighting checks, and routines that depend on whether a shutter is open.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Shutter is open**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your shutter is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the shutter must have stayed open before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple shutters are targeted, controls how results combine. Pick **Any** to pass if at least one targeted shutter is open, or **All** to pass only when every targeted shutter is open. The default is **Any**.
+  required: false
+For at least:
+  description: How long the shutter must have stayed open before the condition passes. The default is `0` (passes immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `cover.shutter_is_open`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: cover.shutter_is_open
+  target:
+    entity_id: cover.kitchen_shutter
+{% endexample %}
+
+This passes when `cover.kitchen_shutter` is currently open.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple shutters are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the shutter must have stayed open before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works only with `cover` entities that use the `shutter` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted shutter is open.
+- With **All**, the condition passes only if every available targeted shutter is open. If every targeted shutter is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: close the shutter at sunset if it is still open
+
+At sunset, this automation checks whether the shutter is still open. If it is, Home Assistant closes it for the night.
+
+- **Trigger**: Sun: Sunset
+- **Condition**: Shutter is open
+  - **Target**: Kitchen shutter
+- **Action**: Close cover
+
+{% details "YAML example for closing the shutter at sunset" %}
+
+{% example %}
+automation: |
+  alias: "Close the shutter at sunset"
+  triggers:
+    - trigger: sun
+      event: sunset
+  conditions:
+    - condition: cover.shutter_is_open
+      target:
+        entity_id: cover.kitchen_shutter
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.kitchen_shutter
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: notify you if the shutter is still open when you leave home
+
+When you leave home, this automation checks whether the shutter is still open. If it is, Home Assistant sends a reminder so you can close it.
+
+- **Trigger**: Person leaves home zone
+- **Condition**: Shutter is open
+  - **Target**: Kitchen shutter
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for checking the shutter when you leave home" %}
+
+{% example %}
+automation: |
+  alias: "Warn me if the shutter is open when I leave home"
+  triggers:
+    - trigger: zone
+      entity_id: person.morgan
+      zone: zone.home
+      event: leave
+  conditions:
+    - condition: cover.shutter_is_open
+      target:
+        entity_id: cover.kitchen_shutter
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Cover still open"
+        message: >
+          The shutter is still open while you are leaving.
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}


### PR DESCRIPTION
## Proposed change

- Add the cover Labs condition split pages for checking whether a supported cover device class is open.
- Document the UI flow, YAML form, options, and examples for each open condition.

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: addresses #44908

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards