### PR TITLE
Cover: document "is.closed" conditions (Labs feature)

### DIFF
--- a/source/_conditions/cover.awning_is_closed.markdown
+++ b/source/_conditions/cover.awning_is_closed.markdown
@@ -1,0 +1,151 @@
+---
+title: "Awning is closed"
+condition: cover.awning_is_closed
+domain: cover
+description: "Tests if one or more awnings are closed."
+related_conditions:
+  - cover.awning_is_open
+---
+
+The **Awning is closed** condition passes when one or more targeted awnings are currently closed. Use it when an automation should continue only if an awning is still closed at the moment the automation runs.
+
+This condition is useful for reminders, lighting checks, and routines that depend on whether an awning is closed.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Awning is closed**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your awning is in, like your patio or living room. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the awning must have stayed closed before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple awnings are targeted, controls how results combine. Pick **Any** to pass if at least one targeted awning is closed, or **All** to pass only when every targeted awning is closed. The default is **Any**.
+  required: false
+For at least:
+  description: How long the awning must have stayed closed before the condition passes. The default is `0` (passes immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `cover.awning_is_closed`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: cover.awning_is_closed
+  target:
+    entity_id: cover.patio_awning
+{% endexample %}
+
+This passes when `cover.patio_awning` is currently closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple awnings are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the awning must have stayed closed before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works only with `cover` entities that use the `awning` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted awning is closed.
+- With **All**, the condition passes only if every available targeted awning is closed. If every targeted awning is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: open the awning at sunrise if it is still closed
+
+At sunrise, this automation checks whether the awning is still closed. If it is, Home Assistant opens it to let in daylight.
+
+- **Trigger**: Sun: Sunrise
+- **Condition**: Awning is closed
+  - **Target**: Patio awning
+- **Action**: Open cover
+
+{% details "YAML example for opening the awning at sunrise" %}
+
+{% example %}
+automation: |
+  alias: "Open the awning at sunrise"
+  triggers:
+    - trigger: sun
+      event: sunrise
+  conditions:
+    - condition: cover.awning_is_closed
+      target:
+        entity_id: cover.patio_awning
+  actions:
+    - action: cover.open_cover
+      target:
+        entity_id: cover.patio_awning
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on the nearby light if the awning is still closed when motion is detected
+
+If the awning is still closed when motion is detected, this automation turns on a nearby light so the area is easier to see.
+
+- **Trigger**: Motion detected
+- **Condition**: Awning is closed
+  - **Target**: Patio awning
+- **Action**: Turn on light
+  - **Target**: Patio lights
+
+{% details "YAML example for turning on a nearby light when the awning stays closed" %}
+
+{% example %}
+automation: |
+  alias: "Turn on a nearby light when the awning is closed"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+  conditions:
+    - condition: cover.awning_is_closed
+      target:
+        entity_id: cover.patio_awning
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.patio_lights
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/cover.blind_is_closed.markdown
+++ b/source/_conditions/cover.blind_is_closed.markdown
@@ -1,0 +1,151 @@
+---
+title: "Blind is closed"
+condition: cover.blind_is_closed
+domain: cover
+description: "Tests if one or more blinds are closed."
+related_conditions:
+  - cover.blind_is_open
+---
+
+The **Blind is closed** condition passes when one or more targeted blinds are currently closed. Use it when an automation should continue only if a blind is still closed at the moment the automation runs.
+
+This condition is useful for reminders, lighting checks, and routines that depend on whether a blind is closed.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Blind is closed**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your blind is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the blind must have stayed closed before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple blinds are targeted, controls how results combine. Pick **Any** to pass if at least one targeted blind is closed, or **All** to pass only when every targeted blind is closed. The default is **Any**.
+  required: false
+For at least:
+  description: How long the blind must have stayed closed before the condition passes. The default is `0` (passes immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `cover.blind_is_closed`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: cover.blind_is_closed
+  target:
+    entity_id: cover.office_blind
+{% endexample %}
+
+This passes when `cover.office_blind` is currently closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple blinds are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the blind must have stayed closed before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works only with `cover` entities that use the `blind` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted blind is closed.
+- With **All**, the condition passes only if every available targeted blind is closed. If every targeted blind is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: open the blind at sunrise if it is still closed
+
+At sunrise, this automation checks whether the blind is still closed. If it is, Home Assistant opens it to let in daylight.
+
+- **Trigger**: Sun: Sunrise
+- **Condition**: Blind is closed
+  - **Target**: Office blind
+- **Action**: Open cover
+
+{% details "YAML example for opening the blind at sunrise" %}
+
+{% example %}
+automation: |
+  alias: "Open the blind at sunrise"
+  triggers:
+    - trigger: sun
+      event: sunrise
+  conditions:
+    - condition: cover.blind_is_closed
+      target:
+        entity_id: cover.office_blind
+  actions:
+    - action: cover.open_cover
+      target:
+        entity_id: cover.office_blind
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on the nearby light if the blind is still closed when motion is detected
+
+If the blind is still closed when motion is detected, this automation turns on a nearby light so the area is easier to see.
+
+- **Trigger**: Motion detected
+- **Condition**: Blind is closed
+  - **Target**: Office blind
+- **Action**: Turn on light
+  - **Target**: Office lamp
+
+{% details "YAML example for turning on a nearby light when the blind stays closed" %}
+
+{% example %}
+automation: |
+  alias: "Turn on a nearby light when the blind is closed"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+  conditions:
+    - condition: cover.blind_is_closed
+      target:
+        entity_id: cover.office_blind
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.office_lamp
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/cover.curtain_is_closed.markdown
+++ b/source/_conditions/cover.curtain_is_closed.markdown
@@ -1,0 +1,151 @@
+---
+title: "Curtain is closed"
+condition: cover.curtain_is_closed
+domain: cover
+description: "Tests if one or more curtains are closed."
+related_conditions:
+  - cover.curtain_is_open
+---
+
+The **Curtain is closed** condition passes when one or more targeted curtains are currently closed. Use it when an automation should continue only if a curtain is still closed at the moment the automation runs.
+
+This condition is useful for reminders, lighting checks, and routines that depend on whether a curtain is closed.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Curtain is closed**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your curtain is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the curtain must have stayed closed before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple curtains are targeted, controls how results combine. Pick **Any** to pass if at least one targeted curtain is closed, or **All** to pass only when every targeted curtain is closed. The default is **Any**.
+  required: false
+For at least:
+  description: How long the curtain must have stayed closed before the condition passes. The default is `0` (passes immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `cover.curtain_is_closed`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: cover.curtain_is_closed
+  target:
+    entity_id: cover.living_room_curtain
+{% endexample %}
+
+This passes when `cover.living_room_curtain` is currently closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple curtains are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the curtain must have stayed closed before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works only with `cover` entities that use the `curtain` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted curtain is closed.
+- With **All**, the condition passes only if every available targeted curtain is closed. If every targeted curtain is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: open the curtain at sunrise if it is still closed
+
+At sunrise, this automation checks whether the curtain is still closed. If it is, Home Assistant opens it to let in daylight.
+
+- **Trigger**: Sun: Sunrise
+- **Condition**: Curtain is closed
+  - **Target**: Living room curtain
+- **Action**: Open cover
+
+{% details "YAML example for opening the curtain at sunrise" %}
+
+{% example %}
+automation: |
+  alias: "Open the curtain at sunrise"
+  triggers:
+    - trigger: sun
+      event: sunrise
+  conditions:
+    - condition: cover.curtain_is_closed
+      target:
+        entity_id: cover.living_room_curtain
+  actions:
+    - action: cover.open_cover
+      target:
+        entity_id: cover.living_room_curtain
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on the nearby light if the curtain is still closed when motion is detected
+
+If the curtain is still closed when motion is detected, this automation turns on a nearby light so the area is easier to see.
+
+- **Trigger**: Motion detected
+- **Condition**: Curtain is closed
+  - **Target**: Living room curtain
+- **Action**: Turn on light
+  - **Target**: Living room lamp
+
+{% details "YAML example for turning on a nearby light when the curtain stays closed" %}
+
+{% example %}
+automation: |
+  alias: "Turn on a nearby light when the curtain is closed"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+  conditions:
+    - condition: cover.curtain_is_closed
+      target:
+        entity_id: cover.living_room_curtain
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room_lamp
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/cover.shade_is_closed.markdown
+++ b/source/_conditions/cover.shade_is_closed.markdown
@@ -1,0 +1,151 @@
+---
+title: "Shade is closed"
+condition: cover.shade_is_closed
+domain: cover
+description: "Tests if one or more shades are closed."
+related_conditions:
+  - cover.shade_is_open
+---
+
+The **Shade is closed** condition passes when one or more targeted shades are currently closed. Use it when an automation should continue only if a shade is still closed at the moment the automation runs.
+
+This condition is useful for reminders, lighting checks, and routines that depend on whether a shade is closed.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Shade is closed**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your shade is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the shade must have stayed closed before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple shades are targeted, controls how results combine. Pick **Any** to pass if at least one targeted shade is closed, or **All** to pass only when every targeted shade is closed. The default is **Any**.
+  required: false
+For at least:
+  description: How long the shade must have stayed closed before the condition passes. The default is `0` (passes immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `cover.shade_is_closed`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: cover.shade_is_closed
+  target:
+    entity_id: cover.bedroom_shade
+{% endexample %}
+
+This passes when `cover.bedroom_shade` is currently closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple shades are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the shade must have stayed closed before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works only with `cover` entities that use the `shade` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted shade is closed.
+- With **All**, the condition passes only if every available targeted shade is closed. If every targeted shade is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: open the shade at sunrise if it is still closed
+
+At sunrise, this automation checks whether the shade is still closed. If it is, Home Assistant opens it to let in daylight.
+
+- **Trigger**: Sun: Sunrise
+- **Condition**: Shade is closed
+  - **Target**: Bedroom shade
+- **Action**: Open cover
+
+{% details "YAML example for opening the shade at sunrise" %}
+
+{% example %}
+automation: |
+  alias: "Open the shade at sunrise"
+  triggers:
+    - trigger: sun
+      event: sunrise
+  conditions:
+    - condition: cover.shade_is_closed
+      target:
+        entity_id: cover.bedroom_shade
+  actions:
+    - action: cover.open_cover
+      target:
+        entity_id: cover.bedroom_shade
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on the nearby light if the shade is still closed when motion is detected
+
+If the shade is still closed when motion is detected, this automation turns on a nearby light so the area is easier to see.
+
+- **Trigger**: Motion detected
+- **Condition**: Shade is closed
+  - **Target**: Bedroom shade
+- **Action**: Turn on light
+  - **Target**: Bedroom lamp
+
+{% details "YAML example for turning on a nearby light when the shade stays closed" %}
+
+{% example %}
+automation: |
+  alias: "Turn on a nearby light when the shade is closed"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+  conditions:
+    - condition: cover.shade_is_closed
+      target:
+        entity_id: cover.bedroom_shade
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.bedroom_lamp
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/cover.shutter_is_closed.markdown
+++ b/source/_conditions/cover.shutter_is_closed.markdown
@@ -1,0 +1,151 @@
+---
+title: "Shutter is closed"
+condition: cover.shutter_is_closed
+domain: cover
+description: "Tests if one or more shutters are closed."
+related_conditions:
+  - cover.shutter_is_open
+---
+
+The **Shutter is closed** condition passes when one or more targeted shutters are currently closed. Use it when an automation should continue only if a shutter is still closed at the moment the automation runs.
+
+This condition is useful for reminders, lighting checks, and routines that depend on whether a shutter is closed.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Shutter is closed**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area your shutter is in, like your living room or bedroom. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, enter how long the shutter must have stayed closed before the condition passes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple shutters are targeted, controls how results combine. Pick **Any** to pass if at least one targeted shutter is closed, or **All** to pass only when every targeted shutter is closed. The default is **Any**.
+  required: false
+For at least:
+  description: How long the shutter must have stayed closed before the condition passes. The default is `0` (passes immediately).
+  required: false
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `cover.shutter_is_closed`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: cover.shutter_is_closed
+  target:
+    entity_id: cover.kitchen_shutter
+{% endexample %}
+
+This passes when `cover.kitchen_shutter` is currently closed.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple shutters are targeted, controls how results combine. Accepts
+    `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the shutter must have stayed closed before the condition
+    passes. Accepts a duration like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition works only with `cover` entities that use the `shutter` device class.
+- Entities in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- With **Any**, the condition passes if at least one available targeted shutter is closed.
+- With **All**, the condition passes only if every available targeted shutter is closed. If every targeted shutter is `unavailable` or `unknown`, **All** passes and **Any** fails.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: open the shutter at sunrise if it is still closed
+
+At sunrise, this automation checks whether the shutter is still closed. If it is, Home Assistant opens it to let in daylight.
+
+- **Trigger**: Sun: Sunrise
+- **Condition**: Shutter is closed
+  - **Target**: Kitchen shutter
+- **Action**: Open cover
+
+{% details "YAML example for opening the shutter at sunrise" %}
+
+{% example %}
+automation: |
+  alias: "Open the shutter at sunrise"
+  triggers:
+    - trigger: sun
+      event: sunrise
+  conditions:
+    - condition: cover.shutter_is_closed
+      target:
+        entity_id: cover.kitchen_shutter
+  actions:
+    - action: cover.open_cover
+      target:
+        entity_id: cover.kitchen_shutter
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on the nearby light if the shutter is still closed when motion is detected
+
+If the shutter is still closed when motion is detected, this automation turns on a nearby light so the area is easier to see.
+
+- **Trigger**: Motion detected
+- **Condition**: Shutter is closed
+  - **Target**: Kitchen shutter
+- **Action**: Turn on light
+  - **Target**: Kitchen ceiling light
+
+{% details "YAML example for turning on a nearby light when the shutter stays closed" %}
+
+{% example %}
+automation: |
+  alias: "Turn on a nearby light when the shutter is closed"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+  conditions:
+    - condition: cover.shutter_is_closed
+      target:
+        entity_id: cover.kitchen_shutter
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.kitchen_ceiling
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}


### PR DESCRIPTION
## Proposed change

- Add the cover Labs condition split pages for checking whether a supported cover device class is closed.
- Document the UI flow, YAML form, options, and examples for each closed condition.

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: addresses #44908

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards