### PR TITLE
media_player: document triggers (Labs feature)

### DIFF
--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -33,6 +33,10 @@ A media player can have the following states:
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
 
+{% include integrations/triggers.md %}
+
+{% include integrations/conditions.md %}
+
 ## Actions
 
 ### Media control actions
@@ -294,6 +298,73 @@ media_player.living_room:
       media_content_type: album
       media_content_id: A:ALBUMARTIST/Beatles/Abbey%20Road
 ```
+
+## Media player automation examples
+
+Here are a few examples of how you can use Media player triggers and conditions in automations.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: dim the room when a movie starts
+
+When the living room TV starts playing, dim the lights so the room is ready for watching.
+
+- **Trigger**: Media player started playing
+  - **Target**: Living room TV
+- **Action**: Turn on light
+  - **Target**: Living room lights
+
+{% details "YAML example for dimming the room when a movie starts" %}
+
+{% example %}
+automation: |
+  alias: "Dim the room when the TV starts playing"
+  triggers:
+    - trigger: media_player.started_playing
+      target:
+        entity_id: media_player.living_room_tv
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room_lights
+      data:
+        brightness_pct: 25
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a bedtime reminder if audio is still playing
+
+At bedtime, check whether the bedroom speaker is still playing, and send a notification if it is.
+
+- **Trigger**: Time: 23:00
+- **Condition**: Media player is playing
+  - **Target**: Bedroom speaker
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a bedtime playback reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me when audio is still playing at bedtime"
+  triggers:
+    - trigger: time
+      at: "23:00:00"
+  conditions:
+    - condition: media_player.is_playing
+      target:
+        entity_id: media_player.bedroom_speaker
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          Bedroom audio is still playing.
+{% endexample %}
+
+{% enddetails %}
 
 ## Device class
 

--- a/source/_triggers/media_player.muted.markdown
+++ b/source/_triggers/media_player.muted.markdown
@@ -1,0 +1,163 @@
+---
+title: "Media player muted"
+trigger: media_player.muted
+domain: media_player
+description: "Triggers after one or more media players are muted."
+related_triggers:
+  - media_player.unmuted
+  - media_player.volume_changed
+---
+
+The **Media player muted** trigger fires when a media player becomes muted. Use it when you want Home Assistant to react when someone silences a TV, speaker, or receiver.
+
+Use **Media player muted** to adjust nearby lighting for quiet listening, pause another routine that depends on audio, or send a notification when a shared media player is muted.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Media player muted** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the media player you want to watch. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Media player muted**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Each**.
+7. Under **For at least**, enter how long the media player must stay muted before the trigger fires. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - **Each**: Fires every time any targeted media player is muted (default).
+    - **First**: Fires when the first targeted media player is muted.
+    - **All**: Fires when every targeted media player is muted.
+For at least:
+  description: How long the media player must stay muted before the trigger fires. The default is `0` (fires immediately).
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, this trigger is referred to as `media_player.muted`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: media_player.muted
+  target:
+    entity_id: media_player.office_speaker
+{% endexample %}
+
+This fires when the office speaker becomes muted.
+
+To wait until all targeted media players have stayed muted for 2 minutes:
+
+{% example %}
+trigger: |
+  trigger: media_player.muted
+  target:
+    area_id: living_room
+  options:
+    behavior: last
+    for: "00:02:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - `any` (**Each** in the UI, default): fires every time any targeted media player is muted.
+    - `first` (**First** in the UI): fires when the first targeted media player is muted.
+    - `last` (**All** in the UI): fires when every targeted media player is muted.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the media player must stay muted before the trigger fires. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works when the media player reports that it is muted. If the integration does not expose mute state changes, this trigger will not fire.
+- Media players that are `unavailable` or `unknown` do not count as muted until they report a supported state again.
+- If you want to react when sound returns, use [Media player unmuted](/triggers/media_player.unmuted/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on a status light when a speaker is muted
+
+When the office speaker is muted during a call, turn on a desk light so the room still has a visual cue.
+
+- **Trigger**: Media player muted
+  - **Target**: Office speaker
+- **Action**: Turn on light
+  - **Target**: Desk light
+
+{% details "YAML example for a mute status light" %}
+
+{% example %}
+automation: |
+  alias: "Show a mute status light"
+  triggers:
+    - trigger: media_player.muted
+      target:
+        entity_id: media_player.office_speaker
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.office_desk
+      data:
+        color_name: "red"
+        brightness_pct: 50
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: pause a fan routine when the TV is muted for a while
+
+If the living room TV stays muted for 10 minutes, turn off a noisy fan so the room stays quiet.
+
+- **Trigger**: Media player muted
+  - **Target**: Living room TV
+  - **For at least**: 00:10:00
+- **Action**: Turn off switch
+  - **Target**: Fan plug
+
+{% details "YAML example for turning off a fan after the TV is muted" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the fan when the TV stays muted"
+  triggers:
+    - trigger: media_player.muted
+      target:
+        entity_id: media_player.living_room_tv
+      options:
+        for: "00:10:00"
+  actions:
+    - action: switch.turn_off
+      target:
+        entity_id: switch.fan_plug
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/media_player.paused_playing.markdown
+++ b/source/_triggers/media_player.paused_playing.markdown
@@ -1,0 +1,164 @@
+---
+title: "Media player paused playing"
+trigger: media_player.paused_playing
+domain: media_player
+description: "Triggers after one or more media players pause playing."
+related_triggers:
+  - media_player.started_playing
+  - media_player.stopped_playing
+---
+
+The **Media player paused playing** trigger fires when playback pauses on a media player. Use it when you want Home Assistant to react during a break without waiting for playback to stop completely.
+
+Use **Media player paused playing** to raise the lights, lower background noise, or send a reminder when something has been left paused for a while.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Media player paused playing** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the media player you want to watch. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Media player paused playing**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Each**.
+7. Under **For at least**, enter how long playback must stay paused before the trigger fires. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - **Each**: Fires every time any targeted media player pauses (default).
+    - **First**: Fires when the first targeted media player pauses.
+    - **All**: Fires when every targeted media player pauses.
+For at least:
+  description: How long playback must stay paused before the trigger fires. The default is `0` (fires immediately).
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, this trigger is referred to as `media_player.paused_playing`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: media_player.paused_playing
+  target:
+    entity_id: media_player.living_room_tv
+{% endexample %}
+
+This fires when playback pauses on the living room TV.
+
+To wait until playback has stayed paused for 15 minutes:
+
+{% example %}
+trigger: |
+  trigger: media_player.paused_playing
+  target:
+    entity_id: media_player.kitchen_speaker
+  options:
+    for: "00:15:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - `any` (**Each** in the UI, default): fires every time any targeted media player pauses.
+    - `first` (**First** in the UI): fires when the first targeted media player pauses.
+    - `last` (**All** in the UI): fires when every targeted media player pauses.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long playback must stay paused before the trigger fires. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger fires for a paused state. If playback stops completely, use [Media player stopped playing](/triggers/media_player.stopped_playing/) instead.
+- Media players that are `unavailable` or `unknown` do not count as paused until they report a supported playback state again.
+- If you want to react when playback starts again, use [Media player started playing](/triggers/media_player.started_playing/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: raise the lights when the TV is paused
+
+When the living room TV is paused, brighten the room so it is easier to move around.
+
+- **Trigger**: Media player paused playing
+  - **Target**: Living room TV
+- **Action**: Turn on light
+  - **Target**: Living room lights
+
+{% details "YAML example for brightening the room when playback pauses" %}
+
+{% example %}
+automation: |
+  alias: "Raise the lights when the TV is paused"
+  triggers:
+    - trigger: media_player.paused_playing
+      target:
+        entity_id: media_player.living_room_tv
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room_lights
+      data:
+        brightness_pct: 70
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: remind you about paused audio after 15 minutes
+
+If the kitchen speaker stays paused for 15 minutes, send a reminder so you can decide whether to resume it.
+
+- **Trigger**: Media player paused playing
+  - **Target**: Kitchen speaker
+  - **For at least**: 00:15:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a paused audio reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me about paused kitchen audio"
+  triggers:
+    - trigger: media_player.paused_playing
+      target:
+        entity_id: media_player.kitchen_speaker
+      options:
+        for: "00:15:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          Kitchen audio has been paused for 15 minutes.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/media_player.started_playing.markdown
+++ b/source/_triggers/media_player.started_playing.markdown
@@ -1,0 +1,159 @@
+---
+title: "Media player started playing"
+trigger: media_player.started_playing
+domain: media_player
+description: "Triggers after one or more media players start playing."
+related_triggers:
+  - media_player.paused_playing
+  - media_player.stopped_playing
+---
+
+The **Media player started playing** trigger fires when a media player starts playback. Use it when you want Home Assistant to react as soon as music, video, or radio begins.
+
+Use **Media player started playing** to dim lights, close blinds, or start another device that should run while audio or video is playing.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Media player started playing** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the media player you want to watch. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Media player started playing**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Each**.
+7. Under **For at least**, enter how long playback must continue before the trigger fires. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - **Each**: Fires every time any targeted media player starts playing (default).
+    - **First**: Fires when the first targeted media player starts playing.
+    - **All**: Fires when every targeted media player starts playing.
+For at least:
+  description: How long playback must continue before the trigger fires. The default is `0` (fires immediately).
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, this trigger is referred to as `media_player.started_playing`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: media_player.started_playing
+  target:
+    entity_id: media_player.living_room_tv
+{% endexample %}
+
+This fires when the living room TV starts playing.
+
+To wait until all targeted speakers have played for 30 seconds:
+
+{% example %}
+trigger: |
+  trigger: media_player.started_playing
+  target:
+    area_id: downstairs
+  options:
+    behavior: last
+    for: "00:00:30"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - `any` (**Each** in the UI, default): fires every time any targeted media player starts playing.
+    - `first` (**First** in the UI): fires when the first targeted media player starts playing.
+    - `last` (**All** in the UI): fires when every targeted media player starts playing.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long playback must continue before the trigger fires. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger fires when playback starts. If you only want to react after a change in volume, use [Media player volume changed](/triggers/media_player.volume_changed/) instead.
+- Media players that are `unavailable` or `unknown` do not count as playing until they report a supported playback state again.
+- If you want to react when playback pauses, use [Media player paused playing](/triggers/media_player.paused_playing/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: dim the room when the TV starts playing
+
+When the living room TV starts a movie, dim the lights for more comfortable viewing.
+
+- **Trigger**: Media player started playing
+  - **Target**: Living room TV
+- **Action**: Turn on light
+  - **Target**: Living room lights
+
+{% details "YAML example for dimming the room when the TV starts playing" %}
+
+{% example %}
+automation: |
+  alias: "Dim the room when the TV starts playing"
+  triggers:
+    - trigger: media_player.started_playing
+      target:
+        entity_id: media_player.living_room_tv
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room_lights
+      data:
+        brightness_pct: 25
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: close the blinds when audio starts in the den
+
+When the den media player starts playing during the afternoon, close the blinds to reduce glare.
+
+- **Trigger**: Media player started playing
+  - **Target**: Den media player
+- **Action**: Close cover
+  - **Target**: Den blinds
+
+{% details "YAML example for closing blinds when playback starts" %}
+
+{% example %}
+automation: |
+  alias: "Close the den blinds when playback starts"
+  triggers:
+    - trigger: media_player.started_playing
+      target:
+        entity_id: media_player.den_receiver
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.den_blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/media_player.stopped_playing.markdown
+++ b/source/_triggers/media_player.stopped_playing.markdown
@@ -1,0 +1,159 @@
+---
+title: "Media player stopped playing"
+trigger: media_player.stopped_playing
+domain: media_player
+description: "Triggers after one or more media players stop playing."
+related_triggers:
+  - media_player.paused_playing
+  - media_player.started_playing
+---
+
+The **Media player stopped playing** trigger fires when playback stops on a media player. Use it when you want Home Assistant to react after listening or watching ends.
+
+Use **Media player stopped playing** to turn off lights, return a room to its normal state, or start another routine only when playback is fully finished.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Media player stopped playing** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the media player you want to watch. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Media player stopped playing**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Each**.
+7. Under **For at least**, enter how long playback must stay stopped before the trigger fires. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - **Each**: Fires every time any targeted media player stops playing (default).
+    - **First**: Fires when the first targeted media player stops playing.
+    - **All**: Fires when every targeted media player stops playing.
+For at least:
+  description: How long playback must stay stopped before the trigger fires. The default is `0` (fires immediately).
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, this trigger is referred to as `media_player.stopped_playing`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: media_player.stopped_playing
+  target:
+    entity_id: media_player.living_room_tv
+{% endexample %}
+
+This fires when playback stops on the living room TV.
+
+To wait until all targeted media players have stayed stopped for 5 minutes:
+
+{% example %}
+trigger: |
+  trigger: media_player.stopped_playing
+  target:
+    area_id: media_room
+  options:
+    behavior: last
+    for: "00:05:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - `any` (**Each** in the UI, default): fires every time any targeted media player stops playing.
+    - `first` (**First** in the UI): fires when the first targeted media player stops playing.
+    - `last` (**All** in the UI): fires when every targeted media player stops playing.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long playback must stay stopped before the trigger fires. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger is for playback stopping. If playback is only paused, use [Media player paused playing](/triggers/media_player.paused_playing/) instead.
+- Media players that are `unavailable` or `unknown` do not count as stopped until they report a supported playback state again.
+- If you want to react as soon as playback begins, use [Media player started playing](/triggers/media_player.started_playing/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off a bias light when the TV stops
+
+When the living room TV stops playing, turn off the bias light behind it.
+
+- **Trigger**: Media player stopped playing
+  - **Target**: Living room TV
+- **Action**: Turn off light
+  - **Target**: TV bias light
+
+{% details "YAML example for turning off a bias light when playback stops" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the bias light when the TV stops"
+  triggers:
+    - trigger: media_player.stopped_playing
+      target:
+        entity_id: media_player.living_room_tv
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.tv_bias_light
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: restore the thermostat after music ends
+
+When the patio speakers stop playing, set the patio climate back to a more comfortable temperature.
+
+- **Trigger**: Media player stopped playing
+  - **Target**: Patio speakers
+- **Action**: Set temperature
+  - **Target**: Patio thermostat
+
+{% details "YAML example for restoring temperature after playback stops" %}
+
+{% example %}
+automation: |
+  alias: "Restore the patio temperature when music ends"
+  triggers:
+    - trigger: media_player.stopped_playing
+      target:
+        entity_id: media_player.patio_speakers
+  actions:
+    - action: climate.set_temperature
+      target:
+        entity_id: climate.patio
+      data:
+        temperature: 22
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/media_player.turned_off.markdown
+++ b/source/_triggers/media_player.turned_off.markdown
@@ -1,0 +1,157 @@
+---
+title: "Media player turned off"
+trigger: media_player.turned_off
+domain: media_player
+description: "Triggers after one or more media players turn off."
+related_triggers:
+  - media_player.turned_on
+  - media_player.stopped_playing
+---
+
+The **Media player turned off** trigger fires when a media player turns off. Use it when you want Home Assistant to react when the device itself powers down, not only when playback stops.
+
+Use **Media player turned off** to switch off related lights, lock up a room after a projector is shut down, or end routines that only make sense while a media player is on.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Media player turned off** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the media player you want to watch. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Media player turned off**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Each**.
+7. Under **For at least**, enter how long the media player must stay off before the trigger fires. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - **Each**: Fires every time any targeted media player turns off (default).
+    - **First**: Fires when the first targeted media player turns off.
+    - **All**: Fires when every targeted media player turns off.
+For at least:
+  description: How long the media player must stay off before the trigger fires. The default is `0` (fires immediately).
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, this trigger is referred to as `media_player.turned_off`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: media_player.turned_off
+  target:
+    entity_id: media_player.bedroom_tv
+{% endexample %}
+
+This fires when the bedroom TV turns off.
+
+To wait until all targeted media players have stayed off for 2 minutes:
+
+{% example %}
+trigger: |
+  trigger: media_player.turned_off
+  target:
+    area_id: upstairs
+  options:
+    behavior: last
+    for: "00:02:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - `any` (**Each** in the UI, default): fires every time any targeted media player turns off.
+    - `first` (**First** in the UI): fires when the first targeted media player turns off.
+    - `last` (**All** in the UI): fires when every targeted media player turns off.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the media player must stay off before the trigger fires. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger reacts to the power state. If the device stays on but playback ends, use [Media player stopped playing](/triggers/media_player.stopped_playing/) instead.
+- Media players that are `unavailable` or `unknown` do not count as off until they report a supported power state again.
+- If you want to react when the device powers on, use [Media player turned on](/triggers/media_player.turned_on/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off the bias light when the TV powers down
+
+When the bedroom TV turns off, also turn off the light behind it.
+
+- **Trigger**: Media player turned off
+  - **Target**: Bedroom TV
+- **Action**: Turn off light
+  - **Target**: TV bias light
+
+{% details "YAML example for turning off a bias light when the TV powers down" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the TV bias light when the TV turns off"
+  triggers:
+    - trigger: media_player.turned_off
+      target:
+        entity_id: media_player.bedroom_tv
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.bedroom_tv_bias_light
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: lock the media room when the projector turns off
+
+When the projector turns off at the end of the night, lock the door to the media room.
+
+- **Trigger**: Media player turned off
+  - **Target**: Projector
+- **Action**: Lock lock
+  - **Target**: Media room door
+
+{% details "YAML example for locking a room after the projector turns off" %}
+
+{% example %}
+automation: |
+  alias: "Lock the media room when the projector turns off"
+  triggers:
+    - trigger: media_player.turned_off
+      target:
+        entity_id: media_player.projector
+  actions:
+    - action: lock.lock
+      target:
+        entity_id: lock.media_room_door
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/media_player.turned_on.markdown
+++ b/source/_triggers/media_player.turned_on.markdown
@@ -1,0 +1,159 @@
+---
+title: "Media player turned on"
+trigger: media_player.turned_on
+domain: media_player
+description: "Triggers after one or more media players turn on."
+related_triggers:
+  - media_player.turned_off
+  - media_player.started_playing
+---
+
+The **Media player turned on** trigger fires when a media player powers on. Use it when you want Home Assistant to react as soon as the device becomes available for use, even before playback starts.
+
+Use **Media player turned on** to prepare the room, set a source, or turn on supporting devices whenever a TV, speaker, or receiver powers up.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Media player turned on** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the media player you want to watch. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Media player turned on**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Each**.
+7. Under **For at least**, enter how long the media player must stay on before the trigger fires. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - **Each**: Fires every time any targeted media player turns on (default).
+    - **First**: Fires when the first targeted media player turns on.
+    - **All**: Fires when every targeted media player turns on.
+For at least:
+  description: How long the media player must stay on before the trigger fires. The default is `0` (fires immediately).
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, this trigger is referred to as `media_player.turned_on`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: media_player.turned_on
+  target:
+    entity_id: media_player.family_room_tv
+{% endexample %}
+
+This fires when the family room TV turns on.
+
+To wait until all targeted media players have stayed on for 30 seconds:
+
+{% example %}
+trigger: |
+  trigger: media_player.turned_on
+  target:
+    area_id: downstairs
+  options:
+    behavior: last
+    for: "00:00:30"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - `any` (**Each** in the UI, default): fires every time any targeted media player turns on.
+    - `first` (**First** in the UI): fires when the first targeted media player turns on.
+    - `last` (**All** in the UI): fires when every targeted media player turns on.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the media player must stay on before the trigger fires. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger reacts to the power state. If the media player was already on and only playback starts, use [Media player started playing](/triggers/media_player.started_playing/) instead.
+- Media players that are `unavailable` or `unknown` do not count as on until they report a supported power state again.
+- If you want to react when the device powers off, use [Media player turned off](/triggers/media_player.turned_off/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on a bias light when the TV powers on
+
+When the family room TV turns on, also turn on the light behind it.
+
+- **Trigger**: Media player turned on
+  - **Target**: Family room TV
+- **Action**: Turn on light
+  - **Target**: TV bias light
+
+{% details "YAML example for turning on a bias light when the TV powers on" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the TV bias light when the TV turns on"
+  triggers:
+    - trigger: media_player.turned_on
+      target:
+        entity_id: media_player.family_room_tv
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.family_room_tv_bias_light
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: set the receiver source when it turns on
+
+When the receiver powers on, switch it to the TV source automatically.
+
+- **Trigger**: Media player turned on
+  - **Target**: Receiver
+- **Action**: Select media player source
+  - **Target**: Receiver
+
+{% details "YAML example for selecting a source when the receiver powers on" %}
+
+{% example %}
+automation: |
+  alias: "Set the receiver source when it turns on"
+  triggers:
+    - trigger: media_player.turned_on
+      target:
+        entity_id: media_player.receiver
+  actions:
+    - action: media_player.select_source
+      target:
+        entity_id: media_player.receiver
+      data:
+        source: "TV"
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/media_player.unmuted.markdown
+++ b/source/_triggers/media_player.unmuted.markdown
@@ -1,0 +1,157 @@
+---
+title: "Media player unmuted"
+trigger: media_player.unmuted
+domain: media_player
+description: "Triggers after one or more media players are unmuted."
+related_triggers:
+  - media_player.muted
+  - media_player.started_playing
+---
+
+The **Media player unmuted** trigger fires when a media player stops being muted. Use it when you want Home Assistant to react as soon as sound is available again.
+
+Use **Media player unmuted** to restore lighting, resume a routine that depends on audio, or send a notification when a shared media player is ready to play sound again.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Media player unmuted** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the media player you want to watch. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Media player unmuted**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Each**.
+7. Under **For at least**, enter how long the media player must stay unmuted before the trigger fires. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - **Each**: Fires every time any targeted media player is unmuted (default).
+    - **First**: Fires when the first targeted media player is unmuted.
+    - **All**: Fires when every targeted media player is unmuted.
+For at least:
+  description: How long the media player must stay unmuted before the trigger fires. The default is `0` (fires immediately).
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, this trigger is referred to as `media_player.unmuted`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: media_player.unmuted
+  target:
+    entity_id: media_player.office_speaker
+{% endexample %}
+
+This fires when the office speaker becomes unmuted.
+
+To wait until all targeted media players have stayed unmuted for 1 minute:
+
+{% example %}
+trigger: |
+  trigger: media_player.unmuted
+  target:
+    area_id: downstairs
+  options:
+    behavior: last
+    for: "00:01:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - `any` (**Each** in the UI, default): fires every time any targeted media player is unmuted.
+    - `first` (**First** in the UI): fires when the first targeted media player is unmuted.
+    - `last` (**All** in the UI): fires when every targeted media player is unmuted.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the media player must stay unmuted before the trigger fires. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger works when the media player reports that it is no longer muted.
+- Media players that are `unavailable` or `unknown` do not count as unmuted until they report a supported state again.
+- If you want to react when sound is silenced, use [Media player muted](/triggers/media_player.muted/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off a status light when sound returns
+
+When the office speaker is unmuted, turn off the desk light that shows a muted status.
+
+- **Trigger**: Media player unmuted
+  - **Target**: Office speaker
+- **Action**: Turn off light
+  - **Target**: Desk light
+
+{% details "YAML example for clearing a mute status light" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the mute status light"
+  triggers:
+    - trigger: media_player.unmuted
+      target:
+        entity_id: media_player.office_speaker
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.office_desk
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: resume a fan when the TV is no longer muted
+
+When the living room TV is unmuted again, turn the fan plug back on.
+
+- **Trigger**: Media player unmuted
+  - **Target**: Living room TV
+- **Action**: Turn on switch
+  - **Target**: Fan plug
+
+{% details "YAML example for restoring a fan when sound returns" %}
+
+{% example %}
+automation: |
+  alias: "Turn the fan back on when the TV is unmuted"
+  triggers:
+    - trigger: media_player.unmuted
+      target:
+        entity_id: media_player.living_room_tv
+  actions:
+    - action: switch.turn_on
+      target:
+        entity_id: switch.fan_plug
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/media_player.volume_changed.markdown
+++ b/source/_triggers/media_player.volume_changed.markdown
@@ -1,0 +1,181 @@
+---
+title: "Media player volume changed"
+trigger: media_player.volume_changed
+domain: media_player
+description: "Triggers after the volume of one or more media players changes."
+related_triggers:
+  - media_player.volume_crossed_threshold
+  - media_player.started_playing
+---
+
+The **Media player volume changed** trigger fires when a media player's volume changes and the new value matches the threshold rule you set. Use it when you want to react to a new volume level, not just to playback starting or stopping.
+
+Use **Media player volume changed** to adjust lights when volume gets high, send a notification when volume drops too low, or react to any change for logging and other routines.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Media player volume changed** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the media player you want to watch. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Media player volume changed**.
+6. Under **Threshold**, set what kind of volume change should fire the trigger:
+   - Select **Any change** to fire on any volume change.
+   - Select **Above** or **Below** to fire when the new volume is above or below a threshold.
+   - Select **In range** or **Outside range** to fire when the new volume lands inside or outside a range.
+   - For each option, you can enter a fixed percentage from 0 to 100, or use an `input_number`, `number`, or `sensor` entity with `%` as the unit.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Threshold:
+  description: |
+    Controls which volume changes fire the trigger:
+
+    - **Any change**: fires on any volume change.
+    - **Above** or **Below** (exclusive): fires only when the new volume is strictly above or below the threshold.
+    - **In range** (exclusive): fires only when the new volume is strictly between the lower and upper bounds.
+    - **Outside range** (inclusive): fires when the new volume is at or beyond either bound.
+
+    Use a fixed percentage from 0 to 100, or use an `input_number`, `number`, or `sensor` entity with `%` as the unit.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, this trigger is referred to as `media_player.volume_changed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: media_player.volume_changed
+  target:
+    entity_id: media_player.living_room_receiver
+  options:
+    threshold:
+      type: above
+      value:
+        number: 60
+{% endexample %}
+
+This fires when the receiver volume changes to a value above 60%.
+
+To use a {% term helper %} you created separately as a dynamic threshold:
+
+{% example %}
+trigger: |
+  trigger: media_player.volume_changed
+  target:
+    entity_id: media_player.living_room_receiver
+  options:
+    threshold:
+      type: above
+      value:
+        entity: input_number.media_volume_limit
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+threshold:
+  description: |
+    A mapping that defines which volume changes fire the trigger:
+
+    - `type: any`: fires on any volume change.
+    - `type: above` (exclusive): fires when the new volume is strictly above `value`.
+    - `type: below` (exclusive): fires when the new volume is strictly below `value`.
+    - `type: between` (exclusive): fires when the new volume is strictly between `value_min` and `value_max`.
+    - `type: outside` (inclusive): fires when the new volume is at or beyond `value_min` or `value_max`.
+
+    For a fixed threshold, use `number` with a percentage from 0 to 100. For a dynamic threshold, use `entity` with an `input_number`, `number`, or `sensor` entity that uses `%` as the unit.
+  required: true
+  type: map
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+## Good to know
+
+- This trigger fires when the new volume matches the threshold rule. If you only want to react when volume crosses a level, use [Media player volume crossed threshold](/triggers/media_player.volume_crossed_threshold/).
+- Threshold helper entities must use `%` as the unit. If you want to adjust the limit from the UI, create a {% term helper %} separately first.
+- Media players that are `unavailable` or `unknown` do not provide usable volume values until they report a supported state again.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: lower the lights when movie volume goes high
+
+When the receiver volume changes above 60%, dim the room a little more.
+
+- **Trigger**: Media player volume changed
+  - **Target**: Living room receiver
+  - **Threshold**: Above 60%
+- **Action**: Turn on light
+  - **Target**: Living room lights
+
+{% details "YAML example for dimming lights when volume gets high" %}
+
+{% example %}
+automation: |
+  alias: "Dim the lights when volume goes high"
+  triggers:
+    - trigger: media_player.volume_changed
+      target:
+        entity_id: media_player.living_room_receiver
+      options:
+        threshold:
+          type: above
+          value:
+            number: 60
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room_lights
+      data:
+        brightness_pct: 20
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: remind you when music volume drops too low
+
+When the kitchen speaker volume changes below 15%, send a notification so you know why it sounds quiet.
+
+- **Trigger**: Media player volume changed
+  - **Target**: Kitchen speaker
+  - **Threshold**: Below 15%
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a low-volume reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me when the kitchen speaker volume is low"
+  triggers:
+    - trigger: media_player.volume_changed
+      target:
+        entity_id: media_player.kitchen_speaker
+      options:
+        threshold:
+          type: below
+          value:
+            number: 15
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          The kitchen speaker volume is below 15%.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/media_player.volume_crossed_threshold.markdown
+++ b/source/_triggers/media_player.volume_crossed_threshold.markdown
@@ -1,0 +1,198 @@
+---
+title: "Media player volume crossed threshold"
+trigger: media_player.volume_crossed_threshold
+domain: media_player
+description: "Triggers after the volume of one or more media players crosses a threshold."
+related_triggers:
+  - media_player.volume_changed
+  - media_player.muted
+---
+
+The **Media player volume crossed threshold** trigger fires when volume crosses a threshold you define. Use it when you care about the crossing itself, like moving above a limit or dropping below one, instead of every volume update.
+
+Use **Media player volume crossed threshold** to react when listening gets too loud, when background music becomes too quiet, or when volume moves into or out of a range.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use **Media player volume crossed threshold** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the media player you want to watch. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Media player volume crossed threshold**.
+6. Under **Threshold**, set the volume level or range that must be crossed.
+7. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Each**.
+8. Under **For at least**, enter how long the crossed state must remain true before the trigger fires. The default is `0`.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Threshold:
+  description: |
+    The volume level or range that must be crossed. You can use a fixed percentage from 0 to 100, or use an `input_number`, `number`, or `sensor` entity with `%` as the unit.
+Trigger when:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - **Each**: Fires every time any targeted media player crosses the threshold (default).
+    - **First**: Fires when the first targeted media player crosses the threshold.
+    - **All**: Fires when every targeted media player crosses the threshold.
+For at least:
+  description: How long the crossed state must remain true before the trigger fires. The default is `0` (fires immediately).
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, this trigger is referred to as `media_player.volume_crossed_threshold`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: media_player.volume_crossed_threshold
+  target:
+    entity_id: media_player.living_room_receiver
+  options:
+    threshold:
+      type: above
+      value:
+        number: 65
+{% endexample %}
+
+This fires when the receiver volume crosses above 65%.
+
+To use a {% term helper %} you created separately as a dynamic threshold:
+
+{% example %}
+trigger: |
+  trigger: media_player.volume_crossed_threshold
+  target:
+    entity_id: media_player.living_room_receiver
+  options:
+    threshold:
+      type: above
+      value:
+        entity: input_number.media_volume_limit
+    for: "00:00:30"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+threshold:
+  description: |
+    A mapping that defines which threshold crossing fires the trigger:
+
+    - `type: above`: fires when the volume crosses above `value`.
+    - `type: below`: fires when the volume crosses below `value`.
+    - `type: between`: fires when the volume crosses into the range between `value_min` and `value_max`.
+    - `type: outside`: fires when the volume crosses out of the range and moves to or beyond `value_min` or `value_max`.
+
+    For a fixed threshold, use `number` with a percentage from 0 to 100. For a dynamic threshold, use `entity` with an `input_number`, `number`, or `sensor` entity that uses `%` as the unit.
+  required: true
+  type: map
+behavior:
+  description: |
+    When multiple media players are targeted, controls how the trigger fires:
+
+    - `any` (**Each** in the UI, default): fires every time any targeted media player crosses the threshold.
+    - `first` (**First** in the UI): fires when the first targeted media player crosses the threshold.
+    - `last` (**All** in the UI): fires when every targeted media player crosses the threshold.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the crossed state must remain true before the trigger fires. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- This trigger fires only when the volume crosses the threshold. If volume changes again without crossing it, the trigger does not fire.
+- Threshold helper entities must use `%` as the unit. If you want to adjust the limit from the UI, create a {% term helper %} separately first.
+- Media players that are `unavailable` or `unknown` do not provide usable volume values until they report a supported state again.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: lower the lights when volume crosses above 65%
+
+When the receiver volume crosses above 65%, dim the room for a theater-like scene.
+
+- **Trigger**: Media player volume crossed threshold
+  - **Target**: Living room receiver
+  - **Threshold**: Above 65%
+- **Action**: Turn on light
+  - **Target**: Living room lights
+
+{% details "YAML example for dimming lights when volume crosses a limit" %}
+
+{% example %}
+automation: |
+  alias: "Dim the lights when receiver volume crosses 65%"
+  triggers:
+    - trigger: media_player.volume_crossed_threshold
+      target:
+        entity_id: media_player.living_room_receiver
+      options:
+        threshold:
+          type: above
+          value:
+            number: 65
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room_lights
+      data:
+        brightness_pct: 15
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a notification when nursery audio drops below 20%
+
+When the nursery speaker volume crosses below 20%, send a notification so you can turn it back up if needed.
+
+- **Trigger**: Media player volume crossed threshold
+  - **Target**: Nursery speaker
+  - **Threshold**: Below 20%
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a low-volume nursery notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify me when nursery audio drops below 20%"
+  triggers:
+    - trigger: media_player.volume_crossed_threshold
+      target:
+        entity_id: media_player.nursery_speaker
+      options:
+        threshold:
+          type: below
+          value:
+            number: 20
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          Nursery audio dropped below 20% volume.
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}


### PR DESCRIPTION
## Proposed change

- add split-page documentation for the `media_player` Labs triggers
- update the `media_player` integration page with trigger and condition list includes plus automation examples
- keep existing inline action documentation intact

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: related to #44923

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards