### PR TITLE
media_player: document conditions (Labs feature)

### DIFF
--- a/source/_conditions/media_player.is_muted.markdown
+++ b/source/_conditions/media_player.is_muted.markdown
@@ -1,0 +1,170 @@
+---
+title: "Media player is muted"
+condition: media_player.is_muted
+domain: media_player
+description: "Tests if one or more media players are muted."
+related_conditions:
+  - media_player.is_unmuted
+  - media_player.is_volume
+---
+
+The **Media player is muted** condition passes when the selected media player is muted. Use it when an automation should continue only if sound is currently silenced.
+
+Use **Media player is muted** to avoid sending spoken announcements over a muted speaker, to change lighting only during quiet listening, or to branch into a different action when a TV is muted.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use **Media player is muted** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the media player you want to evaluate. You can also select an area, a floor, a device, or a label.
+5. From the conditions shown for that target, select **Media player is muted**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Any**.
+7. Under **For at least**, enter how long the media player must stay muted before the condition passes. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - **Any**: Passes if at least one targeted media player is muted (default).
+    - **All**: Passes only when every targeted media player is muted.
+For at least:
+  description: How long the media player must stay muted before the condition passes. The default is `0` (passes immediately).
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `media_player.is_muted`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: media_player.is_muted
+  target:
+    entity_id: media_player.office_speaker
+{% endexample %}
+
+This passes when the office speaker is muted.
+
+To require all targeted media players to stay muted for 5 minutes:
+
+{% example %}
+condition: |
+  condition: media_player.is_muted
+  target:
+    area_id: upstairs
+  options:
+    behavior: all
+    for: "00:05:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one targeted media player is muted.
+    - `all` (**All** in the UI): passes only when every targeted media player is muted.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the media player must stay muted before the condition passes. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition depends on the media player reporting its mute state.
+- Media players that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
+- If you want the opposite test, use [Media player is not muted](/conditions/media_player.is_unmuted/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: send a text alert only when the TV is muted
+
+When the doorbell rings, send a mobile notification only if the living room TV is muted.
+
+- **Trigger**: Doorbell pressed
+- **Condition**: Media player is muted
+  - **Target**: Living room TV
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a notification that checks whether the TV is muted" %}
+
+{% example %}
+automation: |
+  alias: "Notify me when the doorbell rings and the TV is muted"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.front_doorbell
+      to: "on"
+  conditions:
+    - condition: media_player.is_muted
+      target:
+        entity_id: media_player.living_room_tv
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          Someone is at the front door.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: set a quiet scene only when every bedroom speaker is muted
+
+At bedtime, turn off a reading light only if all bedroom speakers are already muted.
+
+- **Trigger**: Time: 22:30
+- **Condition**: Media player is muted
+  - **Target**: Bedroom area
+  - **Condition passes if**: All
+- **Action**: Turn off light
+  - **Target**: Reading light
+
+{% details "YAML example for a quiet bedtime scene" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the reading light when all bedroom speakers are muted"
+  triggers:
+    - trigger: time
+      at: "22:30:00"
+  conditions:
+    - condition: media_player.is_muted
+      target:
+        area_id: bedroom
+      options:
+        behavior: all
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id: light.reading_light
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/media_player.is_not_playing.markdown
+++ b/source/_conditions/media_player.is_not_playing.markdown
@@ -1,0 +1,168 @@
+---
+title: "Media player is not playing"
+condition: media_player.is_not_playing
+domain: media_player
+description: "Tests if one or more media players are not playing."
+related_conditions:
+  - media_player.is_playing
+  - media_player.is_paused
+---
+
+The **Media player is not playing** condition passes when the selected media player is not currently playing media. Use it when an automation should run only when audio or video is not actively in progress.
+
+Use **Media player is not playing** to start a noisy appliance, begin cleaning, or run reminders only when a room is not actively being used for playback.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use **Media player is not playing** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the media player you want to evaluate. You can also select an area, a floor, a device, or a label.
+5. From the conditions shown for that target, select **Media player is not playing**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Any**.
+7. Under **For at least**, enter how long the media player must stay in a non-playing state before the condition passes. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - **Any**: Passes if at least one targeted media player is not playing (default).
+    - **All**: Passes only when every targeted media player is not playing.
+For at least:
+  description: How long the media player must stay in a non-playing state before the condition passes. The default is `0` (passes immediately).
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `media_player.is_not_playing`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: media_player.is_not_playing
+  target:
+    entity_id: media_player.living_room_tv
+{% endexample %}
+
+This passes when the living room TV is not playing media.
+
+To require all targeted media players to stay in a non-playing state for 15 minutes:
+
+{% example %}
+condition: |
+  condition: media_player.is_not_playing
+  target:
+    area_id: downstairs
+  options:
+    behavior: all
+    for: "00:15:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one targeted media player is not playing.
+    - `all` (**All** in the UI): passes only when every targeted media player is not playing.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the media player must stay in a non-playing state before the condition passes. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition covers any non-playing state. If you only want to check for paused playback, use [Media player is paused](/conditions/media_player.is_paused/).
+- Media players that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
+- If you need to confirm that playback is active, use [Media player is playing](/conditions/media_player.is_playing/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: start the vacuum only when the TV is not playing
+
+When everyone leaves home, start the vacuum only if the living room TV is not playing.
+
+- **Trigger**: Person leaves home
+- **Condition**: Media player is not playing
+  - **Target**: Living room TV
+- **Action**: Start vacuuming
+  - **Target**: Robot vacuum
+
+{% details "YAML example for starting the vacuum only when playback is idle" %}
+
+{% example %}
+automation: |
+  alias: "Start the vacuum only when the TV is not playing"
+  triggers:
+    - trigger: zone
+      entity_id: person.alex
+      zone: zone.home
+      event: leave
+  conditions:
+    - condition: media_player.is_not_playing
+      target:
+        entity_id: media_player.living_room_tv
+  actions:
+    - action: vacuum.start
+      target:
+        entity_id: vacuum.main_floor
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: open the blinds only when every player in the room is not playing
+
+At sunrise, open the media room blinds only if every targeted media player is not playing.
+
+- **Trigger**: Sun rises
+- **Condition**: Media player is not playing
+  - **Target**: Media room
+  - **Condition passes if**: All
+- **Action**: Open cover
+  - **Target**: Media room blinds
+
+{% details "YAML example for opening blinds when the room is quiet" %}
+
+{% example %}
+automation: |
+  alias: "Open the blinds only when the media room is quiet"
+  triggers:
+    - trigger: sun
+      event: sunrise
+  conditions:
+    - condition: media_player.is_not_playing
+      target:
+        area_id: media_room
+      options:
+        behavior: all
+  actions:
+    - action: cover.open_cover
+      target:
+        entity_id: cover.media_room_blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/media_player.is_off.markdown
+++ b/source/_conditions/media_player.is_off.markdown
@@ -1,0 +1,168 @@
+---
+title: "Media player is off"
+condition: media_player.is_off
+domain: media_player
+description: "Tests if one or more media players are off."
+related_conditions:
+  - media_player.is_on
+  - media_player.is_not_playing
+---
+
+The **Media player is off** condition passes when the selected media player is turned off. Use it when an automation should continue only if the device is powered down.
+
+Use **Media player is off** to avoid powering on related equipment too early, to run quiet-time routines only when a TV is off, or to decide whether another action still needs to happen.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use **Media player is off** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the media player you want to evaluate. You can also select an area, a floor, a device, or a label.
+5. From the conditions shown for that target, select **Media player is off**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Any**.
+7. Under **For at least**, enter how long the media player must stay off before the condition passes. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - **Any**: Passes if at least one targeted media player is off (default).
+    - **All**: Passes only when every targeted media player is off.
+For at least:
+  description: How long the media player must stay off before the condition passes. The default is `0` (passes immediately).
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `media_player.is_off`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: media_player.is_off
+  target:
+    entity_id: media_player.bedroom_tv
+{% endexample %}
+
+This passes when the bedroom TV is off.
+
+To require all targeted media players to stay off for 10 minutes:
+
+{% example %}
+condition: |
+  condition: media_player.is_off
+  target:
+    area_id: upstairs
+  options:
+    behavior: all
+    for: "00:10:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one targeted media player is off.
+    - `all` (**All** in the UI): passes only when every targeted media player is off.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the media player must stay off before the condition passes. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition checks whether the device is powered off. If the device is still on but playback has ended, use [Media player is not playing](/conditions/media_player.is_not_playing/) instead.
+- Media players that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
+- If you want the opposite test, use [Media player is on](/conditions/media_player.is_on/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: only run the vacuum when the TV is off
+
+When everyone leaves home, start the vacuum only if the bedroom TV is off.
+
+- **Trigger**: Person leaves home
+- **Condition**: Media player is off
+  - **Target**: Bedroom TV
+- **Action**: Start vacuuming
+  - **Target**: Robot vacuum
+
+{% details "YAML example for starting the vacuum only when the TV is off" %}
+
+{% example %}
+automation: |
+  alias: "Start the vacuum only when the TV is off"
+  triggers:
+    - trigger: zone
+      entity_id: person.alex
+      zone: zone.home
+      event: leave
+  conditions:
+    - condition: media_player.is_off
+      target:
+        entity_id: media_player.bedroom_tv
+  actions:
+    - action: vacuum.start
+      target:
+        entity_id: vacuum.main_floor
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: lock up only when all media players are off
+
+At night, lock the media room door only if every media player in that room is off.
+
+- **Trigger**: Time: 23:30
+- **Condition**: Media player is off
+  - **Target**: Media room
+  - **Condition passes if**: All
+- **Action**: Lock lock
+  - **Target**: Media room door
+
+{% details "YAML example for locking up when all media players are off" %}
+
+{% example %}
+automation: |
+  alias: "Lock the media room when all media players are off"
+  triggers:
+    - trigger: time
+      at: "23:30:00"
+  conditions:
+    - condition: media_player.is_off
+      target:
+        area_id: media_room
+      options:
+        behavior: all
+  actions:
+    - action: lock.lock
+      target:
+        entity_id: lock.media_room_door
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/media_player.is_on.markdown
+++ b/source/_conditions/media_player.is_on.markdown
@@ -1,0 +1,168 @@
+---
+title: "Media player is on"
+condition: media_player.is_on
+domain: media_player
+description: "Tests if one or more media players are on."
+related_conditions:
+  - media_player.is_off
+  - media_player.is_playing
+---
+
+The **Media player is on** condition passes when the selected media player is turned on. Use it when an automation should continue only if the device is powered and ready.
+
+Use **Media player is on** to send follow-up commands only to active devices, to decide whether a room is in use, or to guard actions that only make sense when a TV, speaker, or receiver is already on.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use **Media player is on** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the media player you want to evaluate. You can also select an area, a floor, a device, or a label.
+5. From the conditions shown for that target, select **Media player is on**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Any**.
+7. Under **For at least**, enter how long the media player must stay on before the condition passes. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - **Any**: Passes if at least one targeted media player is on (default).
+    - **All**: Passes only when every targeted media player is on.
+For at least:
+  description: How long the media player must stay on before the condition passes. The default is `0` (passes immediately).
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `media_player.is_on`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: media_player.is_on
+  target:
+    entity_id: media_player.receiver
+{% endexample %}
+
+This passes when the receiver is on.
+
+To require all targeted media players to stay on for 1 minute:
+
+{% example %}
+condition: |
+  condition: media_player.is_on
+  target:
+    area_id: downstairs
+  options:
+    behavior: all
+    for: "00:01:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one targeted media player is on.
+    - `all` (**All** in the UI): passes only when every targeted media player is on.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the media player must stay on before the condition passes. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition checks whether the device is on, even if nothing is playing yet.
+- Media players that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
+- If you need to make sure playback has actually started, use [Media player is playing](/conditions/media_player.is_playing/) instead.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: only set the source when the receiver is already on
+
+When you press a dashboard button, change the receiver source only if it is already on.
+
+- **Trigger**: Button pressed
+- **Condition**: Media player is on
+  - **Target**: Receiver
+- **Action**: Select media player source
+  - **Target**: Receiver
+
+{% details "YAML example for setting a source only when the receiver is on" %}
+
+{% example %}
+automation: |
+  alias: "Set the receiver source only when it is on"
+  triggers:
+    - trigger: state
+      entity_id: input_button.receiver_source_button
+  conditions:
+    - condition: media_player.is_on
+      target:
+        entity_id: media_player.receiver
+  actions:
+    - action: media_player.select_source
+      target:
+        entity_id: media_player.receiver
+      data:
+        source: "TV"
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: start a movie scene only when all room devices are on
+
+When the movie scene button is pressed, close the blinds only if every targeted media player in the room is already on.
+
+- **Trigger**: Button pressed
+- **Condition**: Media player is on
+  - **Target**: Media room
+  - **Condition passes if**: All
+- **Action**: Close cover
+  - **Target**: Media room blinds
+
+{% details "YAML example for starting a scene only when room devices are on" %}
+
+{% example %}
+automation: |
+  alias: "Close the blinds only when all room devices are on"
+  triggers:
+    - trigger: state
+      entity_id: input_button.movie_scene
+  conditions:
+    - condition: media_player.is_on
+      target:
+        area_id: media_room
+      options:
+        behavior: all
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.media_room_blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/media_player.is_paused.markdown
+++ b/source/_conditions/media_player.is_paused.markdown
@@ -1,0 +1,168 @@
+---
+title: "Media player is paused"
+condition: media_player.is_paused
+domain: media_player
+description: "Tests if one or more media players are paused."
+related_conditions:
+  - media_player.is_playing
+  - media_player.is_not_playing
+---
+
+The **Media player is paused** condition passes when the selected media player is paused. Use it when an automation should continue only during a playback break.
+
+Use **Media player is paused** to raise lights during a pause, show a reminder on a dashboard, or run an action only when media is ready to resume.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use **Media player is paused** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the media player you want to evaluate. You can also select an area, a floor, a device, or a label.
+5. From the conditions shown for that target, select **Media player is paused**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Any**.
+7. Under **For at least**, enter how long playback must stay paused before the condition passes. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - **Any**: Passes if at least one targeted media player is paused (default).
+    - **All**: Passes only when every targeted media player is paused.
+For at least:
+  description: How long playback must stay paused before the condition passes. The default is `0` (passes immediately).
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `media_player.is_paused`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: media_player.is_paused
+  target:
+    entity_id: media_player.living_room_tv
+{% endexample %}
+
+This passes when playback is paused on the living room TV.
+
+To require all targeted media players to stay paused for 5 minutes:
+
+{% example %}
+condition: |
+  condition: media_player.is_paused
+  target:
+    area_id: downstairs
+  options:
+    behavior: all
+    for: "00:05:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one targeted media player is paused.
+    - `all` (**All** in the UI): passes only when every targeted media player is paused.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long playback must stay paused before the condition passes. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition checks for paused playback specifically. If the device has stopped or is idle, use [Media player is not playing](/conditions/media_player.is_not_playing/) instead.
+- Media players that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
+- If you want the opposite test, use [Media player is playing](/conditions/media_player.is_playing/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: brighten the room only when the TV is paused
+
+When you press a remote shortcut, brighten the living room only if the TV is paused.
+
+- **Trigger**: Button pressed
+- **Condition**: Media player is paused
+  - **Target**: Living room TV
+- **Action**: Turn on light
+  - **Target**: Living room lights
+
+{% details "YAML example for brightening the room during a pause" %}
+
+{% example %}
+automation: |
+  alias: "Brighten the room only when the TV is paused"
+  triggers:
+    - trigger: state
+      entity_id: input_button.pause_lights
+  conditions:
+    - condition: media_player.is_paused
+      target:
+        entity_id: media_player.living_room_tv
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room_lights
+      data:
+        brightness_pct: 75
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: show a reminder only when all room players are paused
+
+At bedtime, show a dashboard reminder only if every targeted media player in the media room is paused.
+
+- **Trigger**: Time: 22:00
+- **Condition**: Media player is paused
+  - **Target**: Media room
+  - **Condition passes if**: All
+- **Action**: Turn on switch
+  - **Target**: Reminder indicator
+
+{% details "YAML example for a paused playback reminder" %}
+
+{% example %}
+automation: |
+  alias: "Show a reminder only when all media room players are paused"
+  triggers:
+    - trigger: time
+      at: "22:00:00"
+  conditions:
+    - condition: media_player.is_paused
+      target:
+        area_id: media_room
+      options:
+        behavior: all
+  actions:
+    - action: switch.turn_on
+      target:
+        entity_id: switch.media_room_reminder
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/media_player.is_playing.markdown
+++ b/source/_conditions/media_player.is_playing.markdown
@@ -1,0 +1,171 @@
+---
+title: "Media player is playing"
+condition: media_player.is_playing
+domain: media_player
+description: "Tests if one or more media players are playing."
+related_conditions:
+  - media_player.is_not_playing
+  - media_player.is_paused
+---
+
+The **Media player is playing** condition passes when the selected media player is actively playing media. Use it when an automation should continue only during active audio or video playback.
+
+Use **Media player is playing** to send reminders only while something is on, to adjust lighting for movie watching, or to stop another routine from interrupting playback.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use **Media player is playing** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the media player you want to evaluate. You can also select an area, a floor, a device, or a label.
+5. From the conditions shown for that target, select **Media player is playing**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Any**.
+7. Under **For at least**, enter how long playback must stay active before the condition passes. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - **Any**: Passes if at least one targeted media player is playing (default).
+    - **All**: Passes only when every targeted media player is playing.
+For at least:
+  description: How long playback must stay active before the condition passes. The default is `0` (passes immediately).
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `media_player.is_playing`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: media_player.is_playing
+  target:
+    entity_id: media_player.bedroom_speaker
+{% endexample %}
+
+This passes when the bedroom speaker is playing.
+
+To require all targeted media players to stay in a playing state for 2 minutes:
+
+{% example %}
+condition: |
+  condition: media_player.is_playing
+  target:
+    area_id: downstairs
+  options:
+    behavior: all
+    for: "00:02:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one targeted media player is playing.
+    - `all` (**All** in the UI): passes only when every targeted media player is playing.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long playback must stay active before the condition passes. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition checks for active playback. If the device is on but idle, the condition does not pass.
+- Media players that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
+- If you want the opposite test, use [Media player is not playing](/conditions/media_player.is_not_playing/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: send a bedtime reminder if the bedroom speaker is still playing
+
+At bedtime, send a notification only if the bedroom speaker is still playing.
+
+- **Trigger**: Time: 23:00
+- **Condition**: Media player is playing
+  - **Target**: Bedroom speaker
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a bedtime playback reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me when bedroom audio is still playing at bedtime"
+  triggers:
+    - trigger: time
+      at: "23:00:00"
+  conditions:
+    - condition: media_player.is_playing
+      target:
+        entity_id: media_player.bedroom_speaker
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          Bedroom audio is still playing.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: dim the room only when every media player in it is playing
+
+When the movie scene starts, dim the room only if every targeted media player in the media room is already playing.
+
+- **Trigger**: Button pressed
+- **Condition**: Media player is playing
+  - **Target**: Media room
+  - **Condition passes if**: All
+- **Action**: Turn on light
+  - **Target**: Media room lights
+
+{% details "YAML example for dimming the room only when playback is active" %}
+
+{% example %}
+automation: |
+  alias: "Dim the room only when all media room players are playing"
+  triggers:
+    - trigger: state
+      entity_id: input_button.movie_scene
+  conditions:
+    - condition: media_player.is_playing
+      target:
+        area_id: media_room
+      options:
+        behavior: all
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.media_room_lights
+      data:
+        brightness_pct: 20
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/media_player.is_unmuted.markdown
+++ b/source/_conditions/media_player.is_unmuted.markdown
@@ -1,0 +1,170 @@
+---
+title: "Media player is not muted"
+condition: media_player.is_unmuted
+domain: media_player
+description: "Tests if one or more media players are not muted."
+related_conditions:
+  - media_player.is_muted
+  - media_player.is_playing
+---
+
+The **Media player is not muted** condition passes when the selected media player is not muted. Use it when an automation should continue only if audio is available.
+
+Use **Media player is not muted** to send spoken announcements, start audio-related routines, or avoid relying on a speaker that is currently muted.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use **Media player is not muted** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the media player you want to evaluate. You can also select an area, a floor, a device, or a label.
+5. From the conditions shown for that target, select **Media player is not muted**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Any**.
+7. Under **For at least**, enter how long the media player must stay unmuted before the condition passes. The default is `0`.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - **Any**: Passes if at least one targeted media player is not muted (default).
+    - **All**: Passes only when every targeted media player is not muted.
+For at least:
+  description: How long the media player must stay unmuted before the condition passes. The default is `0` (passes immediately).
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `media_player.is_unmuted`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: media_player.is_unmuted
+  target:
+    entity_id: media_player.kitchen_speaker
+{% endexample %}
+
+This passes when the kitchen speaker is not muted.
+
+To require all targeted media players to stay unmuted for 1 minute:
+
+{% example %}
+condition: |
+  condition: media_player.is_unmuted
+  target:
+    area_id: downstairs
+  options:
+    behavior: all
+    for: "00:01:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one targeted media player is not muted.
+    - `all` (**All** in the UI): passes only when every targeted media player is not muted.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the media player must stay unmuted before the condition passes. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- This condition depends on the media player reporting that it is not muted.
+- Media players that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
+- If you need the opposite test, use [Media player is muted](/conditions/media_player.is_muted/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: announce the washer only when the kitchen speaker is not muted
+
+When the washer finishes, send a spoken message only if the kitchen speaker is not muted.
+
+- **Trigger**: Washer finished
+- **Condition**: Media player is not muted
+  - **Target**: Kitchen speaker
+- **Action**: Play media
+  - **Target**: Kitchen speaker
+
+{% details "YAML example for a spoken washer announcement" %}
+
+{% example %}
+automation: |
+  alias: "Announce the washer only when the speaker is not muted"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.washer_finished
+      to: "on"
+  conditions:
+    - condition: media_player.is_unmuted
+      target:
+        entity_id: media_player.kitchen_speaker
+  actions:
+    - action: media_player.play_media
+      target:
+        entity_id: media_player.kitchen_speaker
+      data:
+        media_content_id: "media-source://tts/washer-finished"
+        media_content_type: "music"
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: start a morning playlist only when every room speaker is not muted
+
+At 07:00, start a script only if every targeted speaker downstairs is not muted.
+
+- **Trigger**: Time: 07:00
+- **Condition**: Media player is not muted
+  - **Target**: Downstairs
+  - **Condition passes if**: All
+- **Action**: Run script
+  - **Target**: Morning playlist
+
+{% details "YAML example for starting a playlist only when speakers are ready" %}
+
+{% example %}
+automation: |
+  alias: "Start the morning playlist only when speakers are not muted"
+  triggers:
+    - trigger: time
+      at: "07:00:00"
+  conditions:
+    - condition: media_player.is_unmuted
+      target:
+        area_id: downstairs
+      options:
+        behavior: all
+  actions:
+    - action: script.turn_on
+      target:
+        entity_id: script.morning_playlist
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/media_player.is_volume.markdown
+++ b/source/_conditions/media_player.is_volume.markdown
@@ -1,0 +1,206 @@
+---
+title: "Volume"
+condition: media_player.is_volume
+domain: media_player
+description: "Tests the volume of one or more media players."
+related_conditions:
+  - media_player.is_muted
+  - media_player.is_playing
+---
+
+The **Volume** condition passes when a media player's volume matches the threshold rule you define. Use it when an automation should continue only if volume is above, below, within, or outside a range.
+
+Use **Volume** to protect quiet hours, to allow a routine only when the room is already loud enough, or to branch based on the current listening level.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use **Volume** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the media player you want to evaluate. You can also select an area, a floor, a device, or a label.
+5. From the conditions shown for that target, select **Volume**.
+6. Under **Threshold**, set the volume level or range the condition should check.
+7. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Any**.
+8. Under **For at least**, enter how long the volume must meet the threshold before the condition passes. The default is `0`.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Threshold:
+  description: |
+    The volume level or range the condition checks. You can use a fixed percentage from 0 to 100, or use an `input_number`, `number`, or `sensor` entity with `%` as the unit.
+Condition passes if:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - **Any**: Passes if at least one targeted media player meets the threshold (default).
+    - **All**: Passes only when every targeted media player meets the threshold.
+For at least:
+  description: How long the volume must meet the threshold before the condition passes. The default is `0` (passes immediately).
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `media_player.is_volume`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: media_player.is_volume
+  target:
+    entity_id: media_player.living_room_receiver
+  options:
+    threshold:
+      type: below
+      value:
+        number: 35
+{% endexample %}
+
+This passes when the receiver volume is below 35%.
+
+To use a {% term helper %} you created separately as a dynamic threshold:
+
+{% example %}
+condition: |
+  condition: media_player.is_volume
+  target:
+    entity_id: media_player.living_room_receiver
+  options:
+    threshold:
+      type: below
+      value:
+        entity: input_number.quiet_hours_volume
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+threshold:
+  description: |
+    The volume level or range the condition checks:
+
+    - `type: above` (exclusive): passes when the volume is strictly above `value`.
+    - `type: below` (exclusive): passes when the volume is strictly below `value`.
+    - `type: between` (exclusive): passes when the volume is strictly between `value_min` and `value_max`.
+    - `type: outside` (inclusive): passes when the volume is at or beyond `value_min` or `value_max`.
+
+    For a fixed threshold, use `number` with a percentage from 0 to 100. For a dynamic threshold, use `entity` with an `input_number`, `number`, or `sensor` entity that uses `%` as the unit.
+  required: true
+  type: map
+behavior:
+  description: |
+    When multiple media players are targeted, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one targeted media player meets the threshold.
+    - `all` (**All** in the UI): passes only when every targeted media player meets the threshold.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the volume must meet the threshold before the condition passes. Accepts a duration string in `HH:MM:SS` format.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Threshold helper entities must use `%` as the unit. If you want to adjust the limit from the UI, create a {% term helper %} separately first.
+- Media players that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
+- If you want to react to the moment volume crosses a limit, use [Media player volume crossed threshold](/triggers/media_player.volume_crossed_threshold/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: only send a voice message when the receiver is quiet enough
+
+When the washer finishes, send a spoken announcement only if the receiver volume is below 35%.
+
+- **Trigger**: Washer finished
+- **Condition**: Volume
+  - **Target**: Living room receiver
+  - **Threshold**: Below 35%
+- **Action**: Play media
+  - **Target**: Living room receiver
+
+{% details "YAML example for a quiet-hours voice announcement" %}
+
+{% example %}
+automation: |
+  alias: "Send a voice message only when the receiver is quiet enough"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.washer_finished
+      to: "on"
+  conditions:
+    - condition: media_player.is_volume
+      target:
+        entity_id: media_player.living_room_receiver
+      options:
+        threshold:
+          type: below
+          value:
+            number: 35
+  actions:
+    - action: media_player.play_media
+      target:
+        entity_id: media_player.living_room_receiver
+      data:
+        media_content_id: "media-source://tts/washer-finished"
+        media_content_type: "music"
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: only start the cleaning robot when every player is below a volume limit
+
+When everyone leaves home, start the robot vacuum only if every targeted media player downstairs is below 20% volume.
+
+- **Trigger**: Person leaves home
+- **Condition**: Volume
+  - **Target**: Downstairs
+  - **Threshold**: Below 20%
+  - **Condition passes if**: All
+- **Action**: Start vacuuming
+  - **Target**: Robot vacuum
+
+{% details "YAML example for checking room volume before starting the robot vacuum" %}
+
+{% example %}
+automation: |
+  alias: "Start the vacuum only when every player is quiet"
+  triggers:
+    - trigger: zone
+      entity_id: person.alex
+      zone: zone.home
+      event: leave
+  conditions:
+    - condition: media_player.is_volume
+      target:
+        area_id: downstairs
+      options:
+        threshold:
+          type: below
+          value:
+            number: 20
+        behavior: all
+  actions:
+    - action: vacuum.start
+      target:
+        entity_id: vacuum.main_floor
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}


### PR DESCRIPTION
## Proposed change

- add split-page documentation for the `media_player` Labs conditions
- keep the trigger and action migration work separate so this PR stays focused on conditions only
- preserve the existing inline action documentation scope

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant.io/pull/45725
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: related to #44923

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards