### PR TITLE
Add binary sensors to OpenEVSE documentation

### DIFF
--- a/source/_integrations/openevse.markdown
+++ b/source/_integrations/openevse.markdown
@@ -14,6 +14,7 @@ ha_codeowners:
 ha_domain: openevse
 ha_zeroconf: true
 ha_platforms:
+  - binary_sensor
   - number
   - sensor
 ha_integration_type: device
@@ -31,9 +32,20 @@ The **OpenEVSE** {% term integration %} allows you to monitor your [OpenEVSE](ht
 ## Configuration
 
 
+## Binary sensors
+
+The integration provides the following binary sensor entities. The default names are listed below:
+
+- **Divert active**: Whether solar PV divert charging is currently active.
+- **Ethernet connected**: Whether the charger is connected via Ethernet (disabled by default).
+- **Limit active**: Whether a charging limit is currently active (disabled by default).
+- **MQTT connected**: Whether the charger's MQTT client is connected to a broker (disabled by default).
+- **Shaper active**: Whether the power shaper is currently active.
+- **Vehicle connected**: Whether a vehicle is plugged into the charger.
+
 ## Sensors
 
-The integration provides the following sensor entities:
+The integration provides the following sensor entities. The default names are listed below:
 
 - **Charging status**: Current operational state of the charger (for example: **Connected**, **Charging**, **Not Connected**)                                                                          
 - **Charge time elapsed** (seconds): Duration of the current charging session                                                                                                             

--- a/source/_integrations/openevse.markdown
+++ b/source/_integrations/openevse.markdown
@@ -31,7 +31,11 @@ The **OpenEVSE** {% term integration %} allows you to monitor your [OpenEVSE](ht
 {% include integrations/config_flow.md %}
 
 
-## Binary sensors
+## Supported functionality
+
+The **OpenEVSE** {% term integration %} supports the following entities.
+
+### Binary sensors
 
 The integration provides the following binary sensor entities. The default names are listed below:
 
@@ -42,7 +46,7 @@ The integration provides the following binary sensor entities. The default names
 - **Shaper active**: Whether the power shaper is currently active.
 - **Vehicle connected**: Whether a vehicle is plugged into the charger.
 
-## Sensors
+### Sensors
 
 The integration provides the following sensor entities. The default names are listed below:
 

--- a/source/_integrations/openevse.markdown
+++ b/source/_integrations/openevse.markdown
@@ -2,6 +2,7 @@
 title: OpenEVSE
 description: Instructions on how to integrate OpenEVSE charging stations with Home Assistant.
 ha_category:
+  - Binary sensor
   - Car
   - Energy
   - Sensor
@@ -28,8 +29,6 @@ The **OpenEVSE** {% term integration %} allows you to monitor your [OpenEVSE](ht
 - The OpenEVSE charger is on the same network as Home Assistant.
 
 {% include integrations/config_flow.md %}
-
-## Configuration
 
 
 ## Binary sensors


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

This PR documents the new binary sensor entities added to the OpenEVSE integration:

- **Divert active**: Whether solar PV divert charging is currently active.
- **Ethernet connected**: Whether the charger is connected via Ethernet (disabled by default).
- **Limit active**: Whether a charging limit is currently active (disabled by default).
- **MQTT connected**: Whether the charger's MQTT client is connected to a broker (disabled by default).
- **Shaper active**: Whether the power shaper is currently active.
- **Vehicle connected**: Whether a vehicle is plugged into the charger.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/172924
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
