### PR TITLE
Swisscom documentation

### DIFF
--- a/source/_integrations/swisscom.markdown
+++ b/source/_integrations/swisscom.markdown
@@ -35,6 +35,7 @@ All models share the same web interface, so they work the same way with this int
 To set up the integration, you need the following:
 
 - The IP address of your Internet-Box. By default, this is `192.168.1.1`.
+- The administrator username. By default, this is `admin`.
 - The administrator password for your Internet-Box. This is the password you use to sign in to the router's web interface.
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/swisscom.markdown
+++ b/source/_integrations/swisscom.markdown
@@ -41,11 +41,11 @@ To set up the integration, you need the following:
 
 {% configuration_basic %}
 Host:
-description: "The IP address of your Internet-Box. By default, this is `192.168.1.1`."
+  description: "The IP address of your Internet-Box. By default, this is `192.168.1.1`."
 Username:
-description: "The administrator username for your Internet-Box. By default, this is `admin`."
+  description: "The administrator username for your Internet-Box. By default, this is `admin`."
 Password:
-description: "The administrator password for your Internet-Box. This is the password you use to sign in to the router's web interface."
+  description: "The administrator password for your Internet-Box. This is the password you use to sign in to the router's web interface."
 {% endconfiguration_basic %}
 
 ## Supported functionality

--- a/source/_integrations/swisscom.markdown
+++ b/source/_integrations/swisscom.markdown
@@ -1,41 +1,72 @@
 ---
 title: Swisscom Internet-Box
-description: Instructions on how to integrate Swisscom Internet-Box into Home Assistant.
+description: Instructions on how to integrate the Swisscom Internet-Box into Home Assistant.
 ha_category:
   - Presence detection
 ha_release: 0.32
 ha_domain: swisscom
 ha_iot_class: Local Polling
+ha_config_flow: true
 ha_platforms:
   - device_tracker
-ha_integration_type: integration
-related:
-  - docs: /docs/configuration/
-    title: Configuration file
+ha_integration_type: hub
 ha_quality_scale: legacy
+related:
+  - docs: /integrations/device_tracker/
+    title: Device tracker
 ---
 
-The **Swisscom Internet-Box** {% term integration %} offers presence detection by looking at connected devices to an [Internet-Box](https://www.swisscom.ch/en/residential/help/device/internet-router.html) router from [Swisscom](https://www.swisscom.ch) which is an Internet provider in Switzerland.
+The **Swisscom Internet-Box** {% term integration %} offers presence detection by looking at the devices connected to your [Internet-Box](https://www.swisscom.ch/en/residential/help/device/internet-router.html) router. The Internet-Box is the router provided by [Swisscom](https://www.swisscom.ch), an Internet provider in Switzerland.
 
-{% note %}
-There are three models of Internet-Box (light, standard and plus). The platform has only been tested on the Internet-Box plus but the others should work as well because they have the same web interface.
-{% endnote %}
+With this integration, you can use the presence of phones, tablets, and other devices on your home network to trigger automations. For example, you can turn the lights off when everyone leaves home, or send a notification when someone arrives.
 
-To use an Internet-Box router in your installation, add the following to your {% term "`configuration.yaml`" %} file.
-{% include integrations/restart_ha_after_config_inclusion.md %}
+## Supported devices
 
-```yaml
-# Example configuration.yaml entry
-device_tracker:
-  - platform: swisscom
-```
+The following Internet-Box models are supported:
 
-{% configuration %}
-host:
-  description: The IP address of your router.
-  required: false
-  default: 192.168.1.1
-  type: string
-{% endconfiguration %}
+- Internet-Box light
+- Internet-Box standard
+- Internet-Box plus
 
-See the [device tracker integration page](/integrations/device_tracker/) for instructions how to configure the people to be tracked.
+All models share the same web interface, so they work the same way with this integration.
+
+## Prerequisites
+
+To set up the integration, you need the following:
+
+- The IP address of your Internet-Box. By default, this is `192.168.1.1`.
+- The administrator password for your Internet-Box. This is the password you use to sign in to the router's web interface.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Host:
+description: "The IP address of your Internet-Box. By default, this is `192.168.1.1`."
+Username:
+description: "The administrator username for your Internet-Box. By default, this is `admin`."
+Password:
+description: "The administrator password for your Internet-Box. This is the password you use to sign in to the router's web interface."
+{% endconfiguration_basic %}
+
+## Supported functionality
+
+The integration creates a {% term "device tracker" %} entity for each device known to your Internet-Box. Each entity reports whether the device is currently connected to your network, along with the following attributes:
+
+- Hostname
+- IP address
+- MAC address
+
+You can use these entities to track the presence of people in your home. For more information on how to assign tracked devices to people, see the [device tracker integration page](/integrations/device_tracker/).
+
+## Data updates
+
+Home Assistant {% term polling polls %} your Internet-Box every 30 seconds to retrieve the list of connected devices and update their connection status.
+
+## Troubleshooting
+
+If the setup fails or the integration stops working, check the following:
+
+- Make sure the IP address of your Internet-Box is correct and reachable from Home Assistant.
+- Make sure the administrator password is correct. The integration signs in to your Internet-Box to read the list of connected devices, so it needs valid administrator credentials.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/swisscom.markdown
+++ b/source/_integrations/swisscom.markdown
@@ -10,7 +10,7 @@ ha_config_flow: true
 ha_platforms:
   - device_tracker
 ha_integration_type: hub
-ha_quality_scale: legacy
+ha_quality_scale: bronze
 related:
   - docs: /integrations/device_tracker/
     title: Device tracker

--- a/source/_integrations/swisscom.markdown
+++ b/source/_integrations/swisscom.markdown
@@ -80,4 +80,9 @@ If the setup fails or the integration stops working, check the following:
 - Make sure the IP address of your Internet-Box is correct and reachable from Home Assistant.
 - Make sure the administrator password is correct. The integration signs in to your Internet-Box to read the list of connected devices, so it needs valid administrator credentials.
 
+
+## Removing the integration
+
+This integration follows standard integration removal.
+
 {% include integrations/remove_device_service.md %}

--- a/source/_integrations/swisscom.markdown
+++ b/source/_integrations/swisscom.markdown
@@ -48,6 +48,16 @@ Password:
   description: "The administrator password for your Internet-Box. This is the password you use to sign in to the router's web interface."
 {% endconfiguration_basic %}
 
+## Migrating from YAML configuration
+
+If you previously configured the Swisscom Internet-Box through `configuration.yaml`:
+
+1. Set up the integration through the UI to provide your administrator credentials.
+2. Remove the `device_tracker` Swisscom entry from your `configuration.yaml` file.
+3. Restart Home Assistant.
+
+A repair issue in {% my integrations title="**Settings** > **Devices & services**" %} will guide you through the same steps.
+
 ## Supported functionality
 
 The integration creates a {% term "device tracker" %} entity for each device known to your Internet-Box. Each entity reports whether the device is currently connected to your network, along with the following attributes:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This updates the Swisscom Internet-Box documentation to match the revamp of the integration in the parent PR, which moves it from a YAML-only `device_tracker` platform to a UI-based config flow.

The old page only described the legacy `configuration.yaml` setup, which no longer works reliably on recent Internet-Box firmware (the legacy platform queried the router unauthenticated). The integration now uses authenticated admin credentials, so the docs needed a rewrite to explain the new setup.

What changed on the page:

- Replaced the YAML setup example and `configuration` block with the standard config flow include and a `configuration_basic` block describing the **Host**, **Username**, and **Password** fields.
- Updated the front matter to add `ha_config_flow: true` and set `ha_integration_type` to `hub` to match the new manifest.
- Restructured the page to follow the integration page template, with sections for supported devices, prerequisites, configuration, supported functionality, data updates, troubleshooting, and removing the integration.
- Documented the device tracker entities and their attributes (hostname, IP address, MAC address), and the 30-second polling interval.
- Removed the legacy YAML instructions, since the YAML platform is deprecated and being phased out.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#171816
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
