### PR TITLE
schedule: document triggers & conditions (Labs feature)

### DIFF
--- a/source/_conditions/schedule.is_off.markdown
+++ b/source/_conditions/schedule.is_off.markdown
@@ -1,0 +1,154 @@
+---
+title: "Schedule is off"
+condition: schedule.is_off
+domain: schedule
+description: "Tests if one or more schedule blocks are currently not active."
+related_conditions:
+  - schedule.is_on
+---
+
+The **Schedule is off** condition is useful when an automation should continue only while a schedule is inactive. Use it to avoid interruptions during blocked times, or to wait until one or more scheduled routines have finished.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the schedule you want to check. You can also select an area, a floor, a device, or a label.
+5. From the conditions shown for that target, select **Schedule is off**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, set how long the schedule must have been inactive.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple schedules are targeted, controls whether **Any** targeted schedule must be inactive or **All** targeted schedules must be inactive.
+  required: false
+  default: Any
+For at least:
+  description: How long the schedule must have been inactive for the condition to pass.
+  required: false
+  default: 00:00:00
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `schedule.is_off`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: schedule.is_off
+  target:
+    entity_id: schedule.quiet_time
+  options:
+    for: "00:30:00"
+{% endexample %}
+
+This passes when `schedule.quiet_time` has been inactive for 30 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: When multiple schedules are targeted, controls whether `any` or `all` targeted schedules must be inactive.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the schedule must have been inactive for the condition to pass. Accepts a duration string like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- A schedule in the `unknown` or `unavailable` state does not match this condition.
+- If you use **For at least**, the schedule must stay inactive for the entire time.
+- To check for the opposite state, use [Schedule is on](/conditions/schedule.is_on/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: send a reminder when the front door opens outside your delivery schedule
+
+If you use a schedule to track when deliveries are expected, you can send yourself a reminder when the door opens outside that time.
+
+- **Trigger**: State: Front door opened
+- **Condition**: Schedule is off
+  - **Target**: Delivery schedule
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for sending a reminder when the front door opens outside your delivery schedule" %}
+
+{% example %}
+automation: |
+  alias: "Send a reminder when the front door opens outside the delivery schedule"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.front_door
+      to: "on"
+  conditions:
+    - condition: schedule.is_off
+      target:
+        entity_id: schedule.delivery_window
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The front door opened outside the delivery schedule."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: start the robot vacuum only when both quiet-time schedules are off
+
+If you use schedules to keep certain times interruption-free, you can start your robot vacuum only when both of those schedules are no longer active.
+
+- **Trigger**: Time: 14:00
+- **Condition**: Schedule is off
+  - **Target**: Quiet time schedule, Meeting schedule
+  - **Condition passes if**: All
+- **Action**: Start vacuum cleaner
+  - **Target**: Living room vacuum
+
+{% details "YAML example for starting the robot vacuum when both quiet-time schedules are off" %}
+
+{% example %}
+automation: |
+  alias: "Start the robot vacuum when both quiet-time schedules are off"
+  triggers:
+    - trigger: time
+      at: "14:00:00"
+  conditions:
+    - condition: schedule.is_off
+      target:
+        entity_id:
+          - schedule.quiet_time
+          - schedule.meeting_time
+      options:
+        behavior: all
+  actions:
+    - action: vacuum.start
+      target:
+        entity_id: vacuum.living_room
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/schedule.is_on.markdown
+++ b/source/_conditions/schedule.is_on.markdown
@@ -1,0 +1,150 @@
+---
+title: "Schedule is on"
+condition: schedule.is_on
+domain: schedule
+description: "Tests if one or more schedule blocks are currently active."
+related_conditions:
+  - schedule.is_off
+---
+
+The **Schedule is on** condition is useful when an automation should continue only while a schedule block is active. Use it to limit automations to certain times, or to check whether a routine is currently in effect before doing something.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the schedule you want to check. You can also select an area, a floor, a device, or a label.
+5. From the conditions shown for that target, select **Schedule is on**.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, set how long the schedule block must have been active.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple schedules are targeted, controls whether **Any** targeted schedule must be active or **All** targeted schedules must be active.
+  required: false
+  default: Any
+For at least:
+  description: How long the schedule block must have been active for the condition to pass.
+  required: false
+  default: 00:00:00
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `schedule.is_on`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: schedule.is_on
+  target:
+    entity_id: schedule.evening_routine
+  options:
+    for: "00:30:00"
+{% endexample %}
+
+This passes when `schedule.evening_routine` has been active for 30 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: When multiple schedules are targeted, controls whether `any` or `all` targeted schedules must be active.
+  required: false
+  type: string
+  default: any
+for:
+  description: How long the schedule block must have been active for the condition to pass. Accepts a duration string like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- A schedule in the `unknown` or `unavailable` state does not match this condition.
+- If you use **For at least**, the schedule must stay active for the entire time.
+- To check for the opposite state, use [Schedule is off](/conditions/schedule.is_off/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: turn on the hallway light when motion is detected during the night schedule
+
+If you only want a motion-based automation at certain times, you can use a schedule to decide when it is allowed to run.
+
+- **Trigger**: State: Motion detected
+- **Condition**: Schedule is on
+  - **Target**: Night hallway schedule
+- **Action**: Turn on light
+  - **Target**: Hallway light
+
+{% details "YAML example for turning on the hallway light during the night schedule" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the hallway light during the night schedule"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+  conditions:
+    - condition: schedule.is_on
+      target:
+        entity_id: schedule.night_hallway
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.hallway
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on the coffee machine only after the morning schedule has been active for 20 minutes
+
+If you want a little delay at the start of your morning routine, you can check whether the schedule has already been active for a while.
+
+- **Trigger**: Time: 06:50
+- **Condition**: Schedule is on
+  - **Target**: Morning kitchen schedule
+  - **For at least**: 00:20:00
+- **Action**: Turn on switch
+  - **Target**: Coffee machine plug
+
+{% details "YAML example for turning on the coffee machine after the morning schedule has been active for 20 minutes" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the coffee machine after the morning schedule has been active for 20 minutes"
+  triggers:
+    - trigger: time
+      at: "06:50:00"
+  conditions:
+    - condition: schedule.is_on
+      target:
+        entity_id: schedule.morning_kitchen
+      options:
+        for: "00:20:00"
+  actions:
+    - action: switch.turn_on
+      target:
+        entity_id: switch.coffee_machine
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_integrations/schedule.markdown
+++ b/source/_integrations/schedule.markdown
@@ -108,8 +108,9 @@ schedule:
       type: icon
     "monday|tuesday|wednesday|thursday|friday|saturday|sunday":
       description: A schedule for each day of the week.
-      required: true
+      required: false
       type: list
+      default: []
       keys:
         from:
           description: The start time to mark the schedule as active/on.
@@ -130,10 +131,8 @@ schedule:
 
 A schedule entity exports state attributes that can be useful in automations and templates.
 
-| Attribute | Description |
-| ----- | ----- |
-| `next_event` | A datetime object containing the next time the schedule is going to change state. |
-| `key_1`, `key_2`, ... | The mapping values from **Additional data** / `data` settings of a time block when the respective block is active. |
+- `next_event`: A datetime object containing the next time the schedule is going to change state.
+- `key_1`, `key_2`, ...: The mapping values from **Additional data** or `data` settings of a time block when that block is active.
 
 ## Behavior at block boundaries
 
@@ -148,38 +147,9 @@ When two time blocks on the same day touch (for example, one block from `07:00` 
 
 Overlapping time blocks on the same day are not allowed and are rejected during configuration validation.
 
-## Automation example
+{% include integrations/triggers.md %}
 
-A schedule creates an on/off schedule entity that is `on` within the times set. You can use the `light_schedule` example from above in an automation to turn on a light when the schedule is active.
-
-```yaml
-triggers:
-  - trigger: state
-    entity_id:
-      - schedule.light_schedule
-    to: "on"
-actions:
-  - action: light.turn_on
-    target:
-      entity_id: light.kitchen
-    data:
-      brightness_pct: "{{ state_attr('schedule.light_schedule', 'brightness') }}"
-      kelvin: "{{ state_attr('schedule.light_schedule', 'color_temp') }}"
-```
-
-Another automation can be added to turn the lights off once the schedule is inactive:
-
-```yaml
-triggers:
-  - trigger: state
-    entity_id:
-      - schedule.light_schedule
-    to: "off"
-actions:
-  - action: light.turn_off
-    target:
-      entity_id: light.kitchen
-```
+{% include integrations/conditions.md %}
 
 ## Actions
 
@@ -256,20 +226,78 @@ data:
     {% endfor %}
 ```
 
-If you want to run the above action both once per day and whenever one of the schedules changes, you can create an {% term automation %} that combines a time-based {% term trigger %} with an {% term event %} trigger per entity.
+If you want to run the above action once per day, you can create an {% term automation %} with a time-based {% term trigger %}.
 
 ```yaml
 triggers:
   - trigger: time
     at: "07:30:00"
-  - trigger: event
-    event_type: entity_registry_updated
-    event_data:
-      action: update
-      entity_id: schedule.vacuum_robot
-  - trigger: event
-    event_type: entity_registry_updated
-    event_data:
-      action: update
-      entity_id: schedule.air_purifier
 ```
+
+## Schedule automation examples
+
+You can use a schedule to decide when an automation should start, or to check whether a routine is currently active.
+Here are two examples you can adapt to your own schedules.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: turn on the porch light when the evening schedule starts
+
+If you use a schedule to define when your porch light should be active, you can start the light automatically when that schedule block begins.
+
+- **Trigger**: Schedule block started
+  - **Target**: Evening porch light schedule
+- **Action**: Turn on light
+  - **Target**: Porch light
+
+{% details "YAML example for turning on the porch light when the evening schedule starts" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the porch light when the evening schedule starts"
+  triggers:
+    - trigger: schedule.turned_on
+      target:
+        entity_id: schedule.evening_porch_light
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.porch
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: start the robot vacuum only when both quiet-time schedules are off
+
+If you use schedules to keep certain times interruption-free, you can start your robot vacuum only when both of those schedules are no longer active.
+
+- **Trigger**: Time: 14:00
+- **Condition**: Schedule is off
+  - **Target**: Quiet time schedule, Meeting schedule
+  - **Condition passes if**: All
+- **Action**: Start vacuum cleaner
+  - **Target**: Living room vacuum
+
+{% details "YAML example for starting the robot vacuum when both quiet-time schedules are off" %}
+
+{% example %}
+automation: |
+  alias: "Start the robot vacuum when both quiet-time schedules are off"
+  triggers:
+    - trigger: time
+      at: "14:00:00"
+  conditions:
+    - condition: schedule.is_off
+      target:
+        entity_id:
+          - schedule.quiet_time
+          - schedule.meeting_time
+      options:
+        behavior: all
+  actions:
+    - action: vacuum.start
+      target:
+        entity_id: vacuum.living_room
+{% endexample %}
+
+{% enddetails %}

--- a/source/_triggers/schedule.turned_off.markdown
+++ b/source/_triggers/schedule.turned_off.markdown
@@ -1,0 +1,143 @@
+---
+title: "Schedule block ended"
+trigger: schedule.turned_off
+domain: schedule
+description: "Triggers when a schedule block ends."
+related_triggers:
+  - schedule.turned_on
+---
+
+The **Schedule block ended** trigger is useful when you want something to happen as soon as a scheduled time block finishes. Use it to turn something off at the end of a routine, or to wait until a schedule has been inactive for a while before continuing.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the schedule you want to monitor. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Schedule block ended**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, set how long the schedule must stay inactive before the trigger fires.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple schedules are targeted, controls whether the trigger fires for **Each** schedule, only the **First** schedule, or after **All** targeted schedules end a block.
+  required: false
+  default: Each
+For at least:
+  description: How long the schedule must stay inactive before the trigger fires.
+  required: false
+  default: 00:00:00
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `schedule.turned_off`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: schedule.turned_off
+  target:
+    entity_id: schedule.focus_time
+  options:
+    for: "00:30:00"
+{% endexample %}
+
+This fires when `schedule.focus_time` has been inactive for 30 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: When multiple schedules are targeted, controls whether the trigger fires for `each`, `first`, or `all`.
+  required: false
+  type: string
+  default: each
+for:
+  description: How long the schedule must stay inactive before the trigger fires. Accepts a duration string like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- A schedule in the `unknown` or `unavailable` state does not trigger this automation.
+- If another schedule block starts before the **For at least** time finishes, the timer resets.
+- To react when a schedule block starts instead, use [Schedule block started](/triggers/schedule.turned_on/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off the heater when the office schedule ends
+
+If you use a schedule to define office hours, you can turn off a space heater as soon as that schedule block finishes.
+
+- **Trigger**: Schedule block ended
+  - **Target**: Office heating schedule
+- **Action**: Turn off switch
+  - **Target**: Office heater
+
+{% details "YAML example for turning off the heater when the office schedule ends" %}
+
+{% example %}
+automation: |
+  alias: "Turn off the heater when the office schedule ends"
+  triggers:
+    - trigger: schedule.turned_off
+      target:
+        entity_id: schedule.office_heating
+  actions:
+    - action: switch.turn_off
+      target:
+        entity_id: switch.office_heater
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a reminder if the quiet-time schedule has been off for 15 minutes
+
+If a quiet period has ended and stayed inactive for a while, you can send yourself a reminder that the room is ready to use again.
+
+- **Trigger**: Schedule block ended
+  - **Target**: Quiet-time schedule
+  - **For at least**: 00:15:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for sending a reminder after quiet time has ended" %}
+
+{% example %}
+automation: |
+  alias: "Send a reminder after quiet time has ended"
+  triggers:
+    - trigger: schedule.turned_off
+      target:
+        entity_id: schedule.quiet_time
+      options:
+        for: "00:15:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "Quiet time ended 15 minutes ago."
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/schedule.turned_on.markdown
+++ b/source/_triggers/schedule.turned_on.markdown
@@ -1,0 +1,141 @@
+---
+title: "Schedule block started"
+trigger: schedule.turned_on
+domain: schedule
+description: "Triggers when a schedule block starts."
+related_triggers:
+  - schedule.turned_off
+---
+
+The **Schedule block started** trigger is useful when you want an automation to begin exactly when a scheduled time block starts. Use it to turn something on at the start of a routine, or to begin a follow-up action after a schedule has been active for a while.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the schedule you want to monitor. You can also select an area, a floor, a device, or a label.
+5. From the triggers shown for that target, select **Schedule block started**.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, set how long the schedule block must stay active before the trigger fires.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple schedules are targeted, controls whether the trigger fires for **Each** schedule, only the **First** schedule, or after **All** targeted schedules start a block.
+  required: false
+  default: Each
+For at least:
+  description: How long the schedule block must stay active before the trigger fires.
+  required: false
+  default: 00:00:00
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `schedule.turned_on`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: schedule.turned_on
+  target:
+    entity_id: schedule.morning_routine
+  options:
+    for: "00:15:00"
+{% endexample %}
+
+This fires when `schedule.morning_routine` has been active for 15 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+behavior:
+  description: When multiple schedules are targeted, controls whether the trigger fires for `each`, `first`, or `all`.
+  required: false
+  type: string
+  default: each
+for:
+  description: How long the schedule block must stay active before the trigger fires. Accepts a duration string like `00:05:00` for five minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- A schedule in the `unknown` or `unavailable` state does not trigger this automation.
+- If the schedule stops being active before the **For at least** time finishes, the timer resets.
+- To react when a schedule block ends instead, use [Schedule block ended](/triggers/schedule.turned_off/).
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the porch light when the evening schedule starts
+
+If you use a schedule to define when your porch light should be active, you can start the light automatically when that schedule block begins.
+
+- **Trigger**: Schedule block started
+  - **Target**: Evening porch light schedule
+- **Action**: Turn on light
+  - **Target**: Porch light
+
+{% details "YAML example for turning on the porch light when the evening schedule starts" %}
+
+{% example %}
+automation: |
+  alias: "Turn on the porch light when the evening schedule starts"
+  triggers:
+    - trigger: schedule.turned_on
+      target:
+        entity_id: schedule.evening_porch_light
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.porch
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: start the kitchen fan after the ventilation schedule has been active for 10 minutes
+
+If you want a short delay before starting ventilation, you can wait until the schedule block has been active for a while.
+
+- **Trigger**: Schedule block started
+  - **Target**: Kitchen ventilation schedule
+  - **For at least**: 00:10:00
+- **Action**: Turn on fan
+  - **Target**: Kitchen fan
+
+{% details "YAML example for starting the kitchen fan after the ventilation schedule has been active for 10 minutes" %}
+
+{% example %}
+automation: |
+  alias: "Start the kitchen fan after 10 minutes"
+  triggers:
+    - trigger: schedule.turned_on
+      target:
+        entity_id: schedule.kitchen_ventilation
+      options:
+        for: "00:10:00"
+  actions:
+    - action: fan.turn_on
+      target:
+        entity_id: fan.kitchen
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Documents triggers and conditions for the schedule integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/44932

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards