### PR TITLE
Add Culiplan integration docs

### DIFF
--- a/source/_integrations/culiplan.markdown
+++ b/source/_integrations/culiplan.markdown
@@ -1,0 +1,95 @@
+---
+title: Culiplan
+description: Use your Culiplan meal-planning account inside Home Assistant.
+ha_category:
+  - Binary sensor
+  - Calendar
+  - Sensor
+  - To-do list
+ha_release: 2026.7
+ha_iot_class: Cloud Push
+ha_quality_scale: silver
+ha_config_flow: true
+ha_codeowners:
+  - '@culiplan'
+ha_domain: culiplan
+ha_platforms:
+  - binary_sensor
+  - calendar
+  - diagnostics
+  - sensor
+  - todo
+ha_integration_type: service
+---
+
+[Culiplan](https://culiplan.com/) is a cloud meal-planning service that helps households plan recipes, keep a pantry, and generate shopping lists.
+
+The Culiplan {% term integration %} surfaces your meal plan, shopping list and pantry inside Home Assistant, and registers a Large Language Model (LLM) API so Conversation Agents (such as the OpenAI or Google Generative AI conversation integrations) can answer meal-planning questions and take actions on your behalf.
+
+## Prerequisites
+
+A Culiplan account is required. You can create one for free at [culiplan.com](https://culiplan.com/).
+
+The integration uses OAuth2 with PKCE for authentication. No client credentials, API keys or self-hosted setup are required.
+
+{% include integrations/config_flow.md %}
+
+## Data updates
+
+Culiplan uses a hybrid model:
+
+- A persistent Socket.IO connection pushes meal-plan and shopping-list changes in real time.
+- A REST poll runs every 5 minutes as a safety net to recover from missed events.
+
+## Entities
+
+The integration creates the following entities per Culiplan account:
+
+### Calendar
+
+- `calendar.culiplan_meal_plan` - Upcoming planned meals. Each event corresponds to a meal slot (breakfast, lunch, dinner, etc.) with the recipe title as the event summary.
+
+### To-do list
+
+- `todo.culiplan_shopping_list` - Your active shopping list. Items can be added, completed and removed from Home Assistant and changes sync back to Culiplan.
+
+### Sensors
+
+- `sensor.culiplan_planned_meals_this_week` - Number of meals planned in the current week.
+- `sensor.culiplan_shopping_list_open_items` - Number of unchecked items on the shopping list.
+- `sensor.culiplan_pantry_items` - Number of items currently tracked in your pantry.
+
+### Binary sensor
+
+- `binary_sensor.culiplan_connected` - Indicates whether the Socket.IO push channel is currently connected.
+
+## LLM API
+
+When the integration is configured, it registers an LLM API named **Culiplan** via Home Assistant's LLM helper. Any Conversation Agent that supports LLM APIs (for example `openai_conversation`, `google_generative_ai_conversation`, `anthropic`) can be pointed at this API to give the assistant the following tools:
+
+- Look up upcoming planned meals.
+- Search the user's recipe library.
+- Read and modify the active shopping list.
+- Read the pantry.
+- Schedule a recipe into the meal plan.
+
+To use it, open the configuration of your Conversation Agent and select **Culiplan** as the LLM API.
+
+## Reauthentication
+
+If your Culiplan refresh token expires or is revoked, Home Assistant will start a reauthentication flow. Open **Settings** > **Devices & services**, locate Culiplan, and follow the instructions to sign in again.
+
+{% include integrations/option_flow.md %}
+
+## Removing the integration
+
+This integration follows standard integration removal.
+
+{% include integrations/remove_device_service.md %}
+
+After removal, Home Assistant will no longer hold any Culiplan tokens. You may also revoke the Home Assistant connection from your Culiplan account settings.
+
+## Known limitations
+
+- The pantry sensor and pantry LLM tool are capped at the first 100 items per account.
+- When more than one Culiplan account is configured, the LLM API is routed to the first configured entry.

--- a/source/_integrations/culiplan.markdown
+++ b/source/_integrations/culiplan.markdown
@@ -2,10 +2,7 @@
 title: Culiplan
 description: Use your Culiplan meal-planning account inside Home Assistant.
 ha_category:
-  - Binary sensor
   - Calendar
-  - Sensor
-  - To-do list
 ha_release: 2026.7
 ha_iot_class: Cloud Push
 ha_quality_scale: silver
@@ -14,17 +11,14 @@ ha_codeowners:
   - '@culiplan'
 ha_domain: culiplan
 ha_platforms:
-  - binary_sensor
   - calendar
   - diagnostics
-  - sensor
-  - todo
 ha_integration_type: service
 ---
 
 [Culiplan](https://culiplan.com/) is a cloud meal-planning service that helps households plan recipes, keep a pantry, and generate shopping lists.
 
-The Culiplan {% term integration %} surfaces your meal plan, shopping list and pantry inside Home Assistant, and registers a Large Language Model (LLM) API so Conversation Agents (such as the OpenAI or Google Generative AI conversation integrations) can answer meal-planning questions and take actions on your behalf.
+The Culiplan {% term integration %} surfaces your meal plan inside Home Assistant, and registers a Large Language Model (LLM) API so Conversation Agents (such as the OpenAI or Google Generative AI conversation integrations) can answer meal-planning questions and take actions on your behalf.
 
 ## Prerequisites
 
@@ -38,48 +32,34 @@ The integration uses OAuth2 with PKCE for authentication. No client credentials,
 
 Culiplan uses a hybrid model:
 
-- A persistent Socket.IO connection pushes meal-plan and shopping-list changes in real time.
+- A persistent Socket.IO connection pushes meal-plan updates in real time.
 - A REST poll runs every 5 minutes as a safety net to recover from missed events.
 
 ## Entities
 
-The integration creates the following entities per Culiplan account:
+The integration creates the following entity per Culiplan account:
 
 ### Calendar
 
 - `calendar.culiplan_meal_plan` - Upcoming planned meals. Each event corresponds to a meal slot (breakfast, lunch, dinner, etc.) with the recipe title as the event summary.
 
-### To-do list
-
-- `todo.culiplan_shopping_list` - Your active shopping list. Items can be added, completed and removed from Home Assistant and changes sync back to Culiplan.
-
-### Sensors
-
-- `sensor.culiplan_planned_meals_this_week` - Number of meals planned in the current week.
-- `sensor.culiplan_shopping_list_open_items` - Number of unchecked items on the shopping list.
-- `sensor.culiplan_pantry_items` - Number of items currently tracked in your pantry.
-
-### Binary sensor
-
-- `binary_sensor.culiplan_connected` - Indicates whether the Socket.IO push channel is currently connected.
+Additional entities (shopping list todo, pantry/meals sensors, and an expiring-pantry binary sensor) will be added as the matching platform follow-up PRs land in Home Assistant Core.
 
 ## LLM API
 
 When the integration is configured, it registers an LLM API named **Culiplan** via Home Assistant's LLM helper. Any Conversation Agent that supports LLM APIs (for example `openai_conversation`, `google_generative_ai_conversation`, `anthropic`) can be pointed at this API to give the assistant the following tools:
 
-- Look up upcoming planned meals.
-- Search the user's recipe library.
-- Read and modify the active shopping list.
-- Read the pantry.
-- Schedule a recipe into the meal plan.
+- Look up the current meal plan (optionally filtered by date).
+- Add an item to the active shopping list.
+- Read the pantry (optionally filtered to items expiring soon).
+- Search recipes by a list of ingredients.
+- Fetch a single recipe by id.
 
 To use it, open the configuration of your Conversation Agent and select **Culiplan** as the LLM API.
 
 ## Reauthentication
 
 If your Culiplan refresh token expires or is revoked, Home Assistant will start a reauthentication flow. Open **Settings** > **Devices & services**, locate Culiplan, and follow the instructions to sign in again.
-
-{% include integrations/option_flow.md %}
 
 ## Removing the integration
 
@@ -88,8 +68,3 @@ This integration follows standard integration removal.
 {% include integrations/remove_device_service.md %}
 
 After removal, Home Assistant will no longer hold any Culiplan tokens. You may also revoke the Home Assistant connection from your Culiplan account settings.
-
-## Known limitations
-
-- The pantry sensor and pantry LLM tool are capped at the first 100 items per account.
-- When more than one Culiplan account is configured, the LLM API is routed to the first configured entry.


### PR DESCRIPTION
## Proposed change

Adds documentation for the Culiplan integration at `source/_integrations/culiplan.markdown`.

Culiplan is a cloud meal-planning service. The integration uses OAuth2 (application_credentials with PKCE) and exposes a calendar platform, plus an LLM API for Conversation Agents. (Additional platforms — to-do, sensor, binary_sensor — will follow in separate PRs once the initial integration is merged.)

This docs page supports the Culiplan Home Assistant Core integration submission. The Core PR references this page via `manifest.json` (`documentation: https://www.home-assistant.io/integrations/culiplan`).

The `ha_release` value is set to `2026.7` as a placeholder — please adjust during merge if needed.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#173216
- Link to parent pull request in the Brands repository: home-assistant/brands#10471
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
