### PR TITLE
Update remote_keyboard with new "exclusive" param

### DIFF
--- a/source/_integrations/keyboard_remote.markdown
+++ b/source/_integrations/keyboard_remote.markdown
@@ -20,7 +20,7 @@ Receive signals from a keyboard and use it as a remote control.
 
 This {% term integration %} allows you to use one or more keyboards as remote controls. It will fire `keyboard_remote_command_received` events which can then be used in automation rules.
 
-The `evdev` package is used to interface with the keyboard and thus this is Linux only. It also means you can't use your normal keyboard for this because `evdev` will block it.
+The `evdev` package is used to interface with the keyboard and thus this is Linux only. By default, the integration grabs the device exclusively, which means other applications will not receive its events. Set `exclusive: false` to share the device.
 
 To enable the Keyboard Remote {% term integration %}, add it to your {% term "`configuration.yaml`" %} file.
 {% include integrations/restart_ha_after_config_inclusion.md %}
@@ -51,6 +51,16 @@ emulate_key_hold_repeat:
   required: false
   type: float
   default: 0.033
+exclusive:
+  description: >
+    When `true`, grabs the device exclusively so that no other client
+    (including the system) receives its events while Home Assistant is running.
+    Set to `false` if other applications also need to receive input from the
+    same device (for example, using a gamepad both as a remote and to play a
+    game).
+  required: false
+  type: boolean
+  default: true
 device_descriptor:
   description: Path to the local event input device file that corresponds to the keyboard.
   required: false


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

The remote_keyboard integration now support "exclusive" parameter.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173229
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
