### PR TITLE
Fix misleading number saying how many integrations there are in Home Assisitant

### DIFF
--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -15,6 +15,8 @@
   <div>
     <a href='https://demo.home-assistant.io' target='_blank'>View live demos</a>
     <a href='/integrations/'>Browse {{ integration_count | minus: 1 | divided_by: 100 | floor | times: 100 }}+ integrations</a>
+    <!--  Subtracting 1 forces a conservative buffer so milestones only flip over 
+  after safely exceeding the baseline (e.g., 1600 stays at 1500+ until 1601). -->
   </div>
 </div>
 

--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -6,7 +6,7 @@
 {%- assign tot = 0 -%}
 {%- for comp in site.integrations -%}
   {%- if comp.ha_category and comp.title -%}
-    {%- assign tot = tot | plus: 1 -%}
+    {%- assign tot = tot -%}
   {%- endif -%}
 {%- endfor -%}
 
@@ -14,7 +14,7 @@
   <a href='/installation/' class="primary">Get started <iconify-icon inline icon='mdi:arrow-right'></iconify-icon></a>
   <div>
     <a href='https://demo.home-assistant.io' target='_blank'>View live demos</a>
-    <a href='/integrations/'>Browse {{ tot | minus: 1 | divided_by: 100 | floor | times: 100 }}+ integrations</a>
+    <a href='/integrations/'>Browse {{ tot | divided_by: 100 | floor | times: 100 }}+ integrations</a>
   </div>
 </div>
 

--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -5,7 +5,7 @@
 
 {%- assign integration_count = 0 -%}
 {%- for comp in site.integrations -%}
-  {%- if comp.ha_category and comp.title -%}
+  {%- if comp.ha_category -%}
     {%- assign integration_count = integration_count | plus: 1 -%}
   {%- endif -%}
 {%- endfor -%}
@@ -14,10 +14,23 @@
   <a href='/installation/' class="primary">Get started <iconify-icon inline icon='mdi:arrow-right'></iconify-icon></a>
   <div>
     <a href='https://demo.home-assistant.io' target='_blank'>View live demos</a>
-    <a href='/integrations/'>Browse {{ integration_count | minus: 1 | divided_by: 100 | floor | times: 100 }}+ integrations</a>
-    <!--  Subtracting 1 forces a conservative buffer so milestones only flip over 
-  after safely exceeding the baseline (e.g., 1600 stays at 1500+ until 1601). -->
   </div>
+  
+  {%- comment -%}
+    Liquid integer division automatically truncates decimals (floors).
+    Using (count - 1) handles the exact milestone edge case cleanly.
+  {%- endcomment -%}
+  {%- if integration_count > 0 -%}
+    {%- assign milestone = integration_count | minus: 1 | divided_by: 100 | times: 100 -%}
+  {%- comment -%}
+    Subtracting 1 forces a conservative buffer so milestones only flip over 
+    after safely exceeding the baseline (e.g., 1600 stays at 1500+ until 1601).
+  {%- endcomment -%}
+  {%- else -%}
+    {%- assign milestone = 0 -%}
+  {%- endif -%}
+
+  <a href='/integrations/'>Browse {{ milestone }}+ integrations</a>
 </div>
 
 <div class="hero-socialproof">

--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -3,7 +3,7 @@
   Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts.
 </p>
 
-{%- assign integration_count = 0 -%}
+{%- assign integration_count = 0 -% }
 {%- for comp in site.integrations -%}
   {%- if comp.ha_category -%}
     {%- assign integration_count = integration_count | plus: 1 -%}
@@ -14,23 +14,20 @@
   <a href='/installation/' class="primary">Get started <iconify-icon inline icon='mdi:arrow-right'></iconify-icon></a>
   <div>
     <a href='https://demo.home-assistant.io' target='_blank'>View live demos</a>
-  </div>
-  
-  {%- comment -%}
-    Liquid integer division automatically truncates decimals (floors).
-    Using (count - 1) handles the exact milestone edge case cleanly.
-  {%- endcomment -%}
-  {%- if integration_count > 0 -%}
-    {%- assign milestone = integration_count | minus: 1 | divided_by: 100 | times: 100 -%}
-  {%- comment -%}
-    Subtracting 1 forces a conservative buffer so milestones only flip over 
-    after safely exceeding the baseline (e.g., 1600 stays at 1500+ until 1601).
-  {%- endcomment -%}
-  {%- else -%}
-    {%- assign milestone = 0 -%}
-  {%- endif -%}
 
-  <a href='/integrations/'>Browse {{ milestone }}+ integrations</a>
+    {%- if integration_count > 0 -%}
+      {%- assign milestone = integration_count | minus: 1 | divided_by: 100 | times: 100 -%}
+    {%- else -%}
+      {%- assign milestone = 0 -%}
+    {%- endif -%}
+
+    {# Kept INSIDE this nested div to fix the layout shift #}
+    <a href='/integrations/'>Browse {{ milestone }}+ integrations</a>
+    {%- comment -%}
+      Subtracting 1 forces a conservative buffer so milestones only flip over 
+      after safely exceeding the baseline (e.g., 1600 stays at 1500+ until 1601).
+    {%- endcomment -%}
+  </div>
 </div>
 
 <div class="hero-socialproof">

--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -14,7 +14,7 @@
   <a href='/installation/' class="primary">Get started <iconify-icon inline icon='mdi:arrow-right'></iconify-icon></a>
   <div>
     <a href='https://demo.home-assistant.io' target='_blank'>View live demos</a>
-    <a href='/integrations/'>Browse {{ integration_count | minus: 1 | divided_by: 100 | floor | times: 100 }}+ integrations</a>
+    <a href='/integrations/'>Browse {{ integration_count | minus: 1 | divided_by: 100 | times: 100 }}+ integrations</a>
    {%- comment -%}
     Subtracting 1 forces a conservative buffer so milestones only flip over 
     after safely exceeding the baseline (e.g., 1600 stays at 1500+ until 1601).

--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -5,20 +5,16 @@
 
 {%- assign tot = 0 -%}
 {%- for comp in site.integrations -%}
-{%- if comp.ha_category -%}
-{%- if comp.ha_category.first -%}
-{%- assign tot = tot | plus: comp.ha_category.size -%}
-{%- else -%}
-{%- assign tot = tot | plus: 1 -%}
-{%- endif -%}
-{%- endif %}
+  {%- if comp.ha_category and comp.title -%}
+    {%- assign tot = tot | plus: 1 -%}
+  {%- endif -%}
 {%- endfor -%}
 
 <div class='hero-buttons'>
   <a href='/installation/' class="primary">Get started <iconify-icon inline icon='mdi:arrow-right'></iconify-icon></a>
   <div>
     <a href='https://demo.home-assistant.io' target='_blank'>View live demos</a>
-    <a href='/integrations/'>Browse {{ tot | minus: 1 | divided_by: 100 | round | times: 100 }}+ integrations</a>
+    <a href='/integrations/'>Browse {{ tot | minus: 1 | divided_by: 100 | floor | times: 100 }}+ integrations</a>
   </div>
 </div>
 
@@ -43,4 +39,3 @@
     </div>
   </div> -->
 </div>
-

--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -3,9 +3,9 @@
   Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts.
 </p>
 
-{%- assign integration_count = 0 -% }
+{%- assign integration_count = 0 -%}
 {%- for comp in site.integrations -%}
-  {%- if comp.ha_category -%}
+  {%- if comp.ha_category and comp.title -%}
     {%- assign integration_count = integration_count | plus: 1 -%}
   {%- endif -%}
 {%- endfor -%}
@@ -14,19 +14,11 @@
   <a href='/installation/' class="primary">Get started <iconify-icon inline icon='mdi:arrow-right'></iconify-icon></a>
   <div>
     <a href='https://demo.home-assistant.io' target='_blank'>View live demos</a>
-
-    {%- if integration_count > 0 -%}
-      {%- assign milestone = integration_count | minus: 1 | divided_by: 100 | times: 100 -%}
-    {%- else -%}
-      {%- assign milestone = 0 -%}
-    {%- endif -%}
-
-    {# Kept INSIDE this nested div to fix the layout shift #}
-    <a href='/integrations/'>Browse {{ milestone }}+ integrations</a>
-    {%- comment -%}
-      Subtracting 1 forces a conservative buffer so milestones only flip over 
-      after safely exceeding the baseline (e.g., 1600 stays at 1500+ until 1601).
-    {%- endcomment -%}
+    <a href='/integrations/'>Browse {{ integration_count | minus: 1 | divided_by: 100 | floor | times: 100 }}+ integrations</a>
+   {%- comment -%}
+    Subtracting 1 forces a conservative buffer so milestones only flip over 
+    after safely exceeding the baseline (e.g., 1600 stays at 1500+ until 1601).
+   {%- endcomment -%}
   </div>
 </div>
 

--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -6,7 +6,7 @@
 {%- assign tot = 0 -%}
 {%- for comp in site.integrations -%}
   {%- if comp.ha_category and comp.title -%}
-    {%- assign tot = tot -%}
+    {%- assign tot = tot | plus: 1 -%}
   {%- endif -%}
 {%- endfor -%}
 
@@ -14,7 +14,7 @@
   <a href='/installation/' class="primary">Get started <iconify-icon inline icon='mdi:arrow-right'></iconify-icon></a>
   <div>
     <a href='https://demo.home-assistant.io' target='_blank'>View live demos</a>
-    <a href='/integrations/'>Browse {{ tot | divided_by: 100 | floor | times: 100 }}+ integrations</a>
+    <a href='/integrations/'>Browse {{ tot | minus: 1 | divided_by: 100 | floor | times: 100 }}+ integrations</a>
   </div>
 </div>
 

--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -3,10 +3,10 @@
   Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts.
 </p>
 
-{%- assign tot = 0 -%}
+{%- assign integration_count = 0 -%}
 {%- for comp in site.integrations -%}
   {%- if comp.ha_category and comp.title -%}
-    {%- assign tot = tot | plus: 1 -%}
+    {%- assign integration_count = integration_count | plus: 1 -%}
   {%- endif -%}
 {%- endfor -%}
 
@@ -14,7 +14,7 @@
   <a href='/installation/' class="primary">Get started <iconify-icon inline icon='mdi:arrow-right'></iconify-icon></a>
   <div>
     <a href='https://demo.home-assistant.io' target='_blank'>View live demos</a>
-    <a href='/integrations/'>Browse {{ tot | minus: 1 | divided_by: 100 | floor | times: 100 }}+ integrations</a>
+    <a href='/integrations/'>Browse {{ integration_count | minus: 1 | divided_by: 100 | floor | times: 100 }}+ integrations</a>
   </div>
 </div>
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The Home Assistant welcome page says there are 3600+ integrations but in reality the amount is closer to around 1400-1450 (at the time of writing this) in core/homeassistant/components and 1500-1550 (also at the time of writing this) in home-assistant.io/source/_integrations

This pr addresses that issue by using different calculations to help make the number more accurate since the button only leads to core integrations

The old method counted every single platform entry and category mapping, this new method counts the amount of folders in the home-assistant.io/source/_integrations (or something like that)

It also floors instead of rounding because 1550 integrations is not 1600+

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

What surprised me is that despite my extensive research for any issues or prs related to this misleading number I could not find any issues related to it or any prs related to it. This is quite confusing since its one of the first things any person that has accessed the HA website has seen, and every HA user has seen that misleading number.

I want to know why that number is the way it is, if there was an issue that was closed talking about that number, I would love for someone to reference it.

Because if were talking in just integrations there aren't 3600 core integrations in Home Assistant
Now an alternative to keep the 3600+ (if you wanted to keep the number correct) would be 
```html
<a href='/integrations/'>Browse over {{ tot | minus: 1 | divided_by: 100 | floor | times: 100 }}+ integrated services </a>
```
But it has to be floored because 3550 is not 3600+

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
