### PR TITLE
Event: document trigger (Labs feature)

### DIFF
--- a/source/_integrations/event.markdown
+++ b/source/_integrations/event.markdown
@@ -97,8 +97,9 @@ automation: |
       - trigger: event.received
         target:
           entity_id: event.front_door_doorbell
-        event_type:
-          - ring
+        options:
+          event_type:
+            - ring
     actions:
       - action: notify.send_message
         target:
@@ -116,7 +117,7 @@ Use this automation to activate a scene when a remote control button is pressed 
 - **Trigger**: Event received
   - **Target**: Living room remote (`event.living_room_remote_on_button`)
   - **Event type**: Double press
-- **Action**: Activate a scene
+- **Action**: Activate scene
 
 {% details "YAML example for activating a scene on a remote double press" %}
 
@@ -127,8 +128,9 @@ automation: |
       - trigger: event.received
         target:
           entity_id: event.living_room_remote_on_button
-        event_type:
-          - double_short_release
+        options:
+          event_type:
+            - double_short_release
     actions:
       - action: scene.turn_on
         target:

--- a/source/_integrations/event.markdown
+++ b/source/_integrations/event.markdown
@@ -10,8 +10,8 @@ ha_codeowners:
   - '@home-assistant/core'
 ha_integration_type: entity
 related:
-  - docs: /docs/automation/trigger/#event-trigger
-    title: Event triggers
+  - docs: /triggers/event.received/
+    title: Event received trigger
   - docs: /docs/configuration/customizing-devices/
     title: Customizing devices
   - docs: /dashboards/
@@ -20,17 +20,17 @@ related:
 
 Events are signals that are emitted when something happens, for example, when a user presses a physical button like a doorbell or when a button on a remote control is pressed.
 
-The **Event** {% term integration %} provides {% term entities %} that trigger state change events, as do all other entity integrations.
+The **Event** {% term integration %} provides {% term entities %} that represent these momentary signals from physical devices.
 
-These events do not capture a state in the traditional sense. For example, a doorbell does not have a state such as "on" or "off" but instead is momentarily pressed. Some events can have variations in the type of event that is emitted. For example, maybe your remote control is capable of emitting a single press, a double press, or a long press.
+These events do not capture a state in the traditional sense. For example, a doorbell does not have a state such as "on" or "off" but instead is momentarily pressed. Some events can have variations in the type of event that is emitted. For example, a remote control might emit a single press, a double press, or a long press.
 
-The event entity can capture these events in the physical world and makes them available in Home Assistant as an entity.
+The event entity captures these events from the physical world and makes them available in Home Assistant as an entity.
 
 {% include integrations/building_block_integration.md %}
 
 ## The state of an event entity
 
-The event entity does not capture a state such as **On** or **Off**. Instead, an event entity keeps track of the timestamp when the emitted event has last been detected.
+The event entity does not capture a state such as **On** or **Off**. Instead, an event entity keeps track of the timestamp when the emitted event was last detected.
 
 <p class='img'>
   <img src='/images/integrations/event/event_timestamp.png' alt='Event entity with timestamp value in state and event type "pressed"'>
@@ -42,107 +42,13 @@ In addition, the entity can have the following states:
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
 
-Because the state of an event entity in Home Assistant is a timestamp, it means we can use it in our automations. For example:
-
-```yaml
-triggers:
-  - trigger: state
-    entity_id: event.doorbell
-actions:
-  - action: notify.frenck
-    data:
-      message: "Ding Dong! Someone is at the door!"
-```
-
 ## Event types
 
-Besides the timestamp of the last event, the event entity also keeps track of the event type that has last been emitted. This can be used in automations to trigger different actions based on the type of event.
+Besides the timestamp of the last event, the event entity also keeps track of the event type that was last emitted. This lets you trigger different automation actions based on the type of event.
 
-This allows you, for example, to trigger a different action when the button on a remote control is pressed once or twice, if your remote control is capable of emitting these different types of events.
+For example, you can trigger a different action when a remote control button is pressed once versus twice, if your remote control can emit those different event types.
 
-When combining that with the [choose action](/docs/scripts/#choose-a-group-of-actions) script, you can assign multiple different actions to a single event entity. In the following example, short- or long-pressing the button on the remote will trigger a different scene:
-
-```yaml
-triggers:
-  - trigger: state
-    entity_id: event.hue_remote_control
-actions:
-  - alias: "Choose an action based on the type of event"
-    choose:
-      - conditions:
-        - alias: "Normal evening scene if the button was pressed"
-          condition: state
-          entity_id: event.hue_remote_control_on_button
-          attribute: "event_type"
-          state: "short_release"
-        sequence:
-          - scene: scene.living_room_evening
-      - conditions:
-        - alias: "Scene for watching a movie if the button was long-pressed"
-          condition: state
-          entity_id: event.hue_remote_control_on_button
-          attribute: "event_type"
-          state: "long_release"
-        sequence:
-          - scene: scene.living_room_movie
-```
-
-When creating automations in the automation editor in the UI, the event types are available as a dropdown list, depending on the event entity you are using. This means you don't have to remember the different event types and can easily select them.
-
-## Automating on a button press
-
-This section shows a similar example to the example automation shown above in YAML. It's an automation that is triggered by an event state change, but shows how to implement it in the UI. To start an automation triggered by a button press (or a button press pattern), follow these steps.
-
-### Prerequisites
-
-- You have a device that takes button presses as inputs, such as a Tuo Smart Button, VTM31SN dimmer by Inovelli, or the Matter Pushbutton Module by Innovation Matters
-- The device has been added to Home Assistant
-
-### To automate on a button press
-
-1. If you like, give your button event entity a friendly name.
-   - Under {% my integrations title="**Settings** > **Devices & services**" %}, select the **Matter** integration card and select the device.
-   - On the **Events** card, select the button entity.
-     ![Select the button entity](/images/integrations/event/matter_button_event_entity.png)
-   - Under **Name**, enter the new friendly name.
-     ![Change the entity name](/images/integrations/event/matter_button_rename.png)
-2. Go to {% my automations title="**Settings** > **Automations & scenes**" %} and select **Create Automation**.
-
-    ![The automation editor.](/images/getting-started/automation-editor.png)
-
-   - Then, select **Create new automation**. This brings up an empty automation page.
-
-     ![The start of a new automation.](/images/getting-started/new-automation.png)
-3. Define what should {% term trigger %} the automation to run.
-   - Select **Add trigger**, then, select **Entity** > **State**.
-   - Type `event` and select your button entity.
-   - **Important**: Leave the other fields **empty**.
-     ![Select button event as trigger](/images/integrations/event/matter_trigger_on_button_event.png)
-4. Prevent the automation from running on unavailable or unknown states.
-   - On the trigger you just created, select the three dots {% icon "mdi:dots-vertical" %} menu and select **Edit in YAML**.
-   - Add the following lines at the bottom of the YAML editor:
-     ```yaml
-     not_from:
-       - unavailable
-     not_to:
-       - unavailable
-       - unknown
-     ```
-       - Note: The `not_from` section prevents running when the entity returns from being unavailable (e.g. when an ESPHome device finishes rebooting). This cannot currently be achieved with the visual condition editors.
-5. Define the condition when something should happen.
-   - Under **Then do**, select **Add action**.
-   - Type `choose` and select **Add condition**.
-   - Select **Entity** > **State** and select your button event entity from the list.
-   - Under **Attribute**, select **Event type**.
-   - Under **State**, select the state change you want to act as trigger, for example **Pressed once**.
-     - **Pressed once** is the event type. But the state of this event is the timestamp of when the button was pressed. This is why we automate on the state change so that it is triggered every time the button is pressed.
-     ![Condition - button pressed](/images/integrations/event/matter_condition_button_pressed.png)
-6. Define what should happen when your automation is triggered (when the button is pressed, for example).
-   - Select **Add action** and define your action.
-7. Repeat these steps for each event type you want to monitor.
-   - In this example, we want to do something else when the button was pressed twice.
-     ![Condition - add another option when the button is pressed twice](/images/integrations/event/matter_button_option_2.png)
-8. **Save** the automation.
+When creating automations in the UI, the event types are available as a dropdown list, depending on the event entity you are using. This means you don't have to remember or look up the different event types.
 
 ## Device class
 
@@ -164,6 +70,69 @@ The following device classes are supported by event entities:
 
 ### Video tutorial
 
-This comprehensive video tutorial explains how events work in Home Assistant and how you can set up Emulated Roku to control a media player using a physical remote control.
+This video tutorial explains how events work in Home Assistant and how you can set up Emulated Roku to control a media player using a physical remote control.
 
 <lite-youtube videoid="nDHh1OjyuMA" videotitle="Event Triggers Unveiled: Control the Home Assistant Media Player with Your Remote Control!" posterquality="maxresdefault"></lite-youtube>
+
+{% include integrations/triggers.md %}
+
+## Event automation examples
+
+### Automation: send a notification when the doorbell rings
+
+Use this automation to get a message on your phone whenever someone presses the doorbell.
+
+- **Trigger**: Event received
+  - **Target**: Front door doorbell (`event.front_door_doorbell`)
+  - **Event type**: Ring
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a doorbell ring notification" %}
+
+{% example %}
+automation: |
+  - alias: "Notify me when the doorbell rings"
+    triggers:
+      - trigger: event.received
+        target:
+          entity_id: event.front_door_doorbell
+        event_type:
+          - ring
+    actions:
+      - action: notify.send_message
+        target:
+          entity_id: notify.my_device
+        data:
+          message: "Someone is at the front door."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on a scene when the remote is double-pressed
+
+Use this automation to activate a scene when a remote control button is pressed twice.
+
+- **Trigger**: Event received
+  - **Target**: Living room remote (`event.living_room_remote_on_button`)
+  - **Event type**: Double press
+- **Action**: Activate a scene
+
+{% details "YAML example for activating a scene on a remote double press" %}
+
+{% example %}
+automation: |
+  - alias: "Activate movie scene on remote double press"
+    triggers:
+      - trigger: event.received
+        target:
+          entity_id: event.living_room_remote_on_button
+        event_type:
+          - double_short_release
+    actions:
+      - action: scene.turn_on
+        target:
+          entity_id: scene.living_room_movie
+{% endexample %}
+
+{% enddetails %}

--- a/source/_triggers/event.markdown
+++ b/source/_triggers/event.markdown
@@ -2,13 +2,18 @@
 title: "Manual event received"
 trigger: event
 domain: homeassistant
-description: "Triggers when an event is received."
+description: "Triggers when an event is fired on the Home Assistant event bus."
 related_triggers:
+  - event.received
   - homeassistant
   - state
 ---
 
-The **Manual event received** trigger is useful when you want an automation to react to an event on the Home Assistant event bus. Use it when an integration, a script, or an API call fires an event and you want to match the event type, event data, or the user who triggered it.
+The **Manual event received** trigger fires an automation when a named event is emitted on the Home Assistant event bus. Use it when an integration, a script, or an API call fires an internal event and you want to match the event type, event data, or the user who triggered it.
+
+{% note %}
+This trigger listens to the internal Home Assistant event bus. It is not the same as the [**Event received**](/triggers/event.received/) trigger, which fires when a physical event entity — such as a doorbell or a remote control button — detects an event type. If you want to react to a button press or doorbell ring, use the [**Event received**](/triggers/event.received/) trigger instead.
+{% endnote %}
 
 {% include triggers/ui_header.md %}
 

--- a/source/_triggers/event.received.markdown
+++ b/source/_triggers/event.received.markdown
@@ -40,23 +40,18 @@ trigger: |
   trigger: event.received
   target:
     entity_id: event.front_door_doorbell
-  event_type:
-    - ring
+  options:
+    event_type:
+      - ring
 {% endexample %}
 
 This fires every time `event.front_door_doorbell` receives a `ring` event.
 
 ### Options in YAML
 
+YAML uses an `options` mapping for trigger-specific settings.
+
 {% options_yaml %}
-trigger:
-  description: "The trigger type. For this trigger, use `event.received`."
-  required: true
-  type: string
-target:
-  description: "The event entity or entities to monitor. You can target a single entity, a device, an area, a floor, or a label."
-  required: true
-  type: map
 event_type:
   description: "One or more event types to match. The available event types depend on the target entity. Use a list for multiple types."
   required: true
@@ -95,8 +90,9 @@ automation: |
       - trigger: event.received
         target:
           entity_id: event.front_door_doorbell
-        event_type:
-          - ring
+        options:
+          event_type:
+            - ring
     actions:
       - action: notify.send_message
         target:
@@ -114,7 +110,7 @@ Use this automation to activate a scene when a remote control button is pressed 
 - **Trigger**: Event received
   - **Target**: Living room remote (`event.living_room_remote_on_button`)
   - **Event type**: Double press
-- **Action**: Activate a scene
+- **Action**: Activate scene
 
 {% details "YAML example for activating a scene on a remote double press" %}
 
@@ -125,8 +121,9 @@ automation: |
       - trigger: event.received
         target:
           entity_id: event.living_room_remote_on_button
-        event_type:
-          - double_short_release
+        options:
+          event_type:
+            - double_short_release
     actions:
       - action: scene.turn_on
         target:

--- a/source/_triggers/event.received.markdown
+++ b/source/_triggers/event.received.markdown
@@ -1,0 +1,140 @@
+---
+title: "Event received"
+trigger: event.received
+domain: event
+description: "Triggers when one or more event entities receive a matching event type."
+related_triggers:
+  - event
+  - state
+---
+
+The **Event received** trigger runs an automation when a physical event entity — such as a doorbell, a remote control button, or a motion sensor — detects a specific type of event. Use it when you want to react to a particular event type, like a doorbell ring or a double press, rather than any state change on the entity.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity you want to monitor.
+5. From the triggers shown for that target, select **Event received**.
+6. Under **Event type**, select one or more event types you want to match.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Event type:
+  description: "The event types to trigger on. Select one or more types. The available types depend on the target entity. Required."
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `event.received`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: event.received
+  target:
+    entity_id: event.front_door_doorbell
+  event_type:
+    - ring
+{% endexample %}
+
+This fires every time `event.front_door_doorbell` receives a `ring` event.
+
+### Options in YAML
+
+{% options_yaml %}
+trigger:
+  description: "The trigger type. For this trigger, use `event.received`."
+  required: true
+  type: string
+target:
+  description: "The event entity or entities to monitor. You can target a single entity, a device, an area, a floor, or a label."
+  required: true
+  type: map
+event_type:
+  description: "One or more event types to match. The available event types depend on the target entity. Use a list for multiple types."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+## Good to know
+
+- This trigger fires only when the entity receives one of the specified event types. Changes to `unavailable` or `unknown` do not fire the trigger.
+- The available event types depend on the entity. For example, a doorbell might support `ring`, while a remote control might support `short_release` and `long_release`.
+- You can select multiple event types in a single trigger to react to any of them.
+- To trigger on any event type from an entity, use the [**State** trigger](/docs/automation/trigger/#state-trigger) instead.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: send a notification when the doorbell rings
+
+Use this automation to get a message on your phone whenever someone presses your doorbell.
+
+- **Trigger**: Event received
+  - **Target**: Front door doorbell (`event.front_door_doorbell`)
+  - **Event type**: Ring
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a doorbell ring notification" %}
+
+{% example %}
+automation: |
+  - alias: "Notify me when the doorbell rings"
+    triggers:
+      - trigger: event.received
+        target:
+          entity_id: event.front_door_doorbell
+        event_type:
+          - ring
+    actions:
+      - action: notify.send_message
+        target:
+          entity_id: notify.my_device
+        data:
+          message: "Someone is at the front door."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn on a scene when the remote is double-pressed
+
+Use this automation to activate a scene when a remote control button is pressed twice.
+
+- **Trigger**: Event received
+  - **Target**: Living room remote (`event.living_room_remote_on_button`)
+  - **Event type**: Double press
+- **Action**: Activate a scene
+
+{% details "YAML example for activating a scene on a remote double press" %}
+
+{% example %}
+automation: |
+  - alias: "Activate movie scene on remote double press"
+    triggers:
+      - trigger: event.received
+        target:
+          entity_id: event.living_room_remote_on_button
+        event_type:
+          - double_short_release
+    actions:
+      - action: scene.turn_on
+        target:
+          entity_id: scene.living_room_movie
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}


### PR DESCRIPTION

## Proposed change

Documents new trigger for the [Event](https://www.home-assistant.io/integrations/event/) integration.

Also edits the [Manual event received](https://www.home-assistant.io/triggers/event/) trigger (domain: `homeassistant`) to clarify their differences.

Previews:
- [Event](https://deploy-preview-45803--home-assistant-docs.netlify.app/integrations/event/)
  - [Event received](https://deploy-preview-45803--home-assistant-docs.netlify.app/triggers/event.received/) trigger
- [Manual event received](https://deploy-preview-45803--home-assistant-docs.netlify.app/triggers/event/) trigger (edit)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/44911

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
