### PR TITLE
Add Yoto sensors documentation

### DIFF
--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -3,6 +3,7 @@ title: Yoto
 description: Instructions on how to integrate Yoto players with Home Assistant.
 ha_category:
   - Media Player
+  - Sensor
   - Time
 ha_iot_class: Cloud Push
 ha_release: 2026.6
@@ -14,12 +15,13 @@ ha_codeowners:
 ha_domain: yoto
 ha_platforms:
   - media_player
+  - sensor
   - time
 ha_integration_type: hub
 ha_dhcp: true
 ---
 
-The **Yoto** {% term integration %} lets you control your [Yoto](https://yotoplay.com) audio players from Home Assistant. You can play and pause cards, change the volume, skip tracks, seek within a track, see what is currently playing, and browse your card library to start a specific card, chapter, or track.
+The **Yoto** {% term integration %} lets you control your [Yoto](https://yotoplay.com) audio players from Home Assistant. You can play and pause cards, change the volume, skip tracks, seek within a track, see what is currently playing, and browse your card library to start a specific card, chapter, or track. You can also monitor each player's battery level, what is loaded in the card slot, and its Wi-Fi connection.
 
 The integration talks to the official Yoto cloud over OAuth2 and receives playback updates over MQTT, so changes that happen on the player show up in Home Assistant almost immediately. Online and offline detection still relies on the cloud API and can lag by up to 5 minutes.
 
@@ -104,6 +106,20 @@ Yoto players can switch between a day display and a night display. Each player p
 
 - **Day mode start**: The time the player switches to day mode.
 - **Night mode start**: The time the player switches to night mode.
+
+### Sensors
+
+Each Yoto player also provides several sensors:
+
+- **Battery**: the player's battery charge.
+- **Card slot**: what is loaded in the player, such as a physical card or streaming content.
+- **Day mode**: whether the player is in day or night mode.
+
+These diagnostic sensors are also available:
+
+- **Power source**: how the player is currently powered.
+- **SSID**: the Wi-Fi network the player is connected to.
+- **Wi-Fi RSSI**: the Wi-Fi signal strength. Disabled by default.
 
 ## Data updates
 

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -21,7 +21,7 @@ ha_integration_type: hub
 ha_dhcp: true
 ---
 
-The **Yoto** {% term integration %} lets you control your [Yoto](https://yotoplay.com) audio players from Home Assistant. You can play and pause cards, change the volume, skip tracks, seek within a track, see what is currently playing, and browse your card library to start a specific card, chapter, or track. You can also monitor each player's battery level, what is loaded in the card slot, and its Wi-Fi signal strength.
+The **Yoto** {% term integration %} lets you control your [Yoto](https://yotoplay.com) audio players from Home Assistant. You can play and pause cards, change the volume, skip tracks, seek within a track, see what is currently playing, and browse your card library to start a specific card, chapter, or track. You can also monitor each player's battery level, what is loaded in the card slot, and its current day or night mode.
 
 The integration talks to the official Yoto cloud over OAuth2 and receives playback updates over MQTT, so changes that happen on the player show up in Home Assistant almost immediately. Online and offline detection still relies on the cloud API and can lag by up to 5 minutes.
 
@@ -114,12 +114,6 @@ Each Yoto player also provides several sensors:
 - **Battery**: the player's battery charge.
 - **Card slot**: what is loaded in the player, such as a physical card or streaming content.
 - **Day mode**: the player's current mode (day or night).
-
-These diagnostic sensors are also available:
-
-- **Power source**: how the player is currently powered.
-- **SSID**: the Wi-Fi network the player is connected to.
-- **Wi-Fi RSSI**: the Wi-Fi signal strength. Disabled by default.
 
 ## Data updates
 

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -21,7 +21,7 @@ ha_integration_type: hub
 ha_dhcp: true
 ---
 
-The **Yoto** {% term integration %} lets you control your [Yoto](https://yotoplay.com) audio players from Home Assistant. You can play and pause cards, change the volume, skip tracks, seek within a track, see what is currently playing, and browse your card library to start a specific card, chapter, or track. You can also monitor each player's battery level, what is loaded in the card slot, and its Wi-Fi connection.
+The **Yoto** {% term integration %} lets you control your [Yoto](https://yotoplay.com) audio players from Home Assistant. You can play and pause cards, change the volume, skip tracks, seek within a track, see what is currently playing, and browse your card library to start a specific card, chapter, or track. You can also monitor each player's battery level, what is loaded in the card slot, and its Wi-Fi signal strength.
 
 The integration talks to the official Yoto cloud over OAuth2 and receives playback updates over MQTT, so changes that happen on the player show up in Home Assistant almost immediately. Online and offline detection still relies on the cloud API and can lag by up to 5 minutes.
 
@@ -113,7 +113,7 @@ Each Yoto player also provides several sensors:
 
 - **Battery**: the player's battery charge.
 - **Card slot**: what is loaded in the player, such as a physical card or streaming content.
-- **Day mode**: whether the player is in day or night mode.
+- **Day mode**: the player's current mode (day or night).
 
 These diagnostic sensors are also available:
 


### PR DESCRIPTION
## Proposed change

Documents the new sensor platform for the Yoto integration. Each player now exposes battery, card slot, and day mode sensors. Adds a **Sensors** section under **Supported functionality** and lists `sensor` in the platforms and `Sensor` in the categories.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#173292
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
