### PR TITLE
lg_netcast: document trigger

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -66,6 +66,7 @@
     "Mosquitto",
     "Multiday",
     "Nabu Casa",
+    "Netcast",
     "nginx",
     "Nijhof",
     "Nmap",

--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -22,64 +22,6 @@ The **LG Netcast** {% term integration %} allows you to control a LG Smart TV ru
 
 {% include integrations/triggers.md %}
 
-## LG Netcast automation examples
-
-These examples show common automations using the LG Netcast integration.
-
-{% include docs/paste_yaml_tip.md %}
-
-### Automation: turn on the TV with Wake-on-LAN
-
-When something requests the LG Netcast TV to turn on, send a Wake-on-LAN magic packet to power it on over the network. The [Wake-on-LAN integration](/integrations/wake_on_lan/) must be set up before using this example.
-
-- **Trigger**: Device is requested to turn on
-  - **Device**: Living room LG TV (`media_player.lg_netcast_tv`)
-- **Action**: Send magic packet
-  - **MAC address**: `AA-BB-CC-DD-EE-FF`
-
-{% details "YAML example for turning on the TV with Wake-on-LAN" %}
-
-{% example %}
-automation: |
-  alias: "Turn on LG Netcast TV with Wake-on-LAN"
-  triggers:
-    - trigger: lg_netcast.turn_on
-      entity_id: media_player.lg_netcast_tv
-  actions:
-    - action: wake_on_lan.send_magic_packet
-      data:
-        mac: "AA-BB-CC-DD-EE-FF"
-{% endexample %}
-
-{% enddetails %}
-
-### Automation: send a notification when the TV is requested to turn on
-
-When something requests the LG Netcast TV to turn on, send a notification to your phone.
-
-- **Trigger**: Device is requested to turn on
-  - **Device**: Living room LG TV (`media_player.lg_netcast_tv`)
-- **Action**: Send a notification message
-  - **Target**: My Device (`notify.my_device`)
-
-{% details "YAML example for sending a notification when the TV is requested to turn on" %}
-
-{% example %}
-automation: |
-  alias: "Notify when LG Netcast TV is requested to turn on"
-  triggers:
-    - trigger: lg_netcast.turn_on
-      entity_id: media_player.lg_netcast_tv
-  actions:
-    - action: notify.send_message
-      target:
-        entity_id: notify.my_device
-      data:
-        message: "The living room TV was requested to turn on."
-{% endexample %}
-
-{% enddetails %}
-
 ## Change channel through play_media action
 
 The `play_media` action can be used in a script to switch to the specified TV channel. It selects the major channel number according to the `media_content_id` parameter:
@@ -207,3 +149,61 @@ data:
   num_repeats: 5
   delay_secs: 0.3
 ```
+
+## LG Netcast automation examples
+
+These examples show common automations using the LG Netcast integration.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: turn on the TV with Wake-on-LAN
+
+When something requests the LG Netcast TV to turn on, send a Wake-on-LAN magic packet to power it on over the network. The [Wake-on-LAN integration](/integrations/wake_on_lan/) must be set up before using this example.
+
+- **Trigger**: Device is requested to turn on
+  - **Device**: Living room LG TV (`media_player.lg_netcast_tv`)
+- **Action**: Send magic packet
+  - **MAC address**: `AA-BB-CC-DD-EE-FF`
+
+{% details "YAML example for turning on the TV with Wake-on-LAN" %}
+
+{% example %}
+automation: |
+  alias: "Turn on LG Netcast TV with Wake-on-LAN"
+  triggers:
+    - trigger: lg_netcast.turn_on
+      entity_id: media_player.lg_netcast_tv
+  actions:
+    - action: wake_on_lan.send_magic_packet
+      data:
+        mac: "AA-BB-CC-DD-EE-FF"
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a notification when the TV is requested to turn on
+
+When something requests the LG Netcast TV to turn on, send a notification to your phone.
+
+- **Trigger**: Device is requested to turn on
+  - **Device**: Living room LG TV (`media_player.lg_netcast_tv`)
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for sending a notification when the TV is requested to turn on" %}
+
+{% example %}
+automation: |
+  alias: "Notify when LG Netcast TV is requested to turn on"
+  triggers:
+    - trigger: lg_netcast.turn_on
+      entity_id: media_player.lg_netcast_tv
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The living room TV was requested to turn on."
+{% endexample %}
+
+{% enddetails %}

--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -16,7 +16,8 @@ ha_codeowners:
 ha_integration_type: device
 ---
 
-The **LG Netcast** {% term integration %} allows you to control a LG Smart TV running NetCast 3.0 (LG Smart TV models released in 2012) and NetCast 4.0 (LG Smart TV models released in 2013). For the new LG WebOS TV's use the [webostv](/integrations/webostv#media-player) platform.
+The **LG Netcast** {% term integration %} allows you to control a LG Smart TV running NetCast 3.0 (LG Smart TV models released in 2012) and NetCast 4.0 (LG Smart TV models released in 2013).
+For the new LG WebOS TV's use the [LG webOS TV](/integrations/webostv#media-player) platform.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -20,36 +20,65 @@ The **LG Netcast** {% term integration %} allows you to control a LG Smart TV ru
 
 {% include integrations/config_flow.md %}
 
-## Turn on action
+{% include integrations/triggers.md %}
 
-Home Assistant can turn on an LG Netcast TV if you specify an action provided by an {% term integration %} like [HDMI-CEC](/integrations/hdmi_cec/) or [WakeOnLan](/integrations/wake_on_lan/).
+## LG Netcast automation examples
 
-1. To create an automation, go to {% my integrations title="**Settings** > **Devices & services**" %} and open the device page.
-2. Under **Automations**, select the + icon to create an automation with that device.
-3. In the dialog, select the **Device is requested to turn on** automation.
+These examples show common automations using the LG Netcast integration.
 
-Automations can also be created using an automation action:
+{% include docs/paste_yaml_tip.md %}
 
-The example below shows how you can use the `turn_on_action` with the [`wake_on_lan` integration](/integrations/wake_on_lan/).
+### Automation: turn on the TV with Wake-on-LAN
 
-```yaml
-# Example configuration.yaml entry
-wake_on_lan: # enables `wake_on_lan` integration
+When something requests the LG Netcast TV to turn on, send a Wake-on-LAN magic packet to power it on over the network. The [Wake-on-LAN integration](/integrations/wake_on_lan/) must be set up before using this example.
 
-# Enables the `lg_netcast` media player
-automation:
-  - alias: "Turn On Living Room TV with WakeOnLan"
-    triggers:
-      - trigger: lg_netcast.turn_on
-        entity_id: media_player.lg_netcast_smart_tv
-    actions:
-      - action: wake_on_lan.send_magic_packet
-        data:
-          mac: AA-BB-CC-DD-EE-FF
-          broadcast_address: 11.22.33.44
-```
+- **Trigger**: Device is requested to turn on
+  - **Device**: Living room LG TV (`media_player.lg_netcast_tv`)
+- **Action**: Send magic packet
+  - **MAC address**: `AA-BB-CC-DD-EE-FF`
 
-Any other [actions](/docs/automation/action/) to power on the device can be configured.
+{% details "YAML example for turning on the TV with Wake-on-LAN" %}
+
+{% example %}
+automation: |
+  alias: "Turn on LG Netcast TV with Wake-on-LAN"
+  triggers:
+    - trigger: lg_netcast.turn_on
+      entity_id: media_player.lg_netcast_tv
+  actions:
+    - action: wake_on_lan.send_magic_packet
+      data:
+        mac: "AA-BB-CC-DD-EE-FF"
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a notification when the TV is requested to turn on
+
+When something requests the LG Netcast TV to turn on, send a notification to your phone.
+
+- **Trigger**: Device is requested to turn on
+  - **Device**: Living room LG TV (`media_player.lg_netcast_tv`)
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for sending a notification when the TV is requested to turn on" %}
+
+{% example %}
+automation: |
+  alias: "Notify when LG Netcast TV is requested to turn on"
+  triggers:
+    - trigger: lg_netcast.turn_on
+      entity_id: media_player.lg_netcast_tv
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The living room TV was requested to turn on."
+{% endexample %}
+
+{% enddetails %}
 
 ## Change channel through play_media action
 
@@ -67,7 +96,7 @@ data:
 
 ## Remote
 
-The LG Netcast remote platform creates a `Remote` entity for each configured TV. This entity allows you to send remote control commands. To power on the TV, use the turn on automation trigger described above.
+The LG Netcast remote platform creates a `Remote` entity for each configured TV. This entity allows you to send remote control commands. To power on the TV, use the [Device is requested to turn on](/triggers/lg_netcast.turn_on/) trigger.
 
 ### Action: Send command
 

--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -164,7 +164,7 @@ When something requests the LG Netcast TV to turn on, send a Wake-on-LAN magic p
 - **Trigger**: Device is requested to turn on
   - **Device**: Living room LG TV (`media_player.lg_netcast_tv`)
 - **Action**: Send magic packet
-  - **MAC address**: `AA-BB-CC-DD-EE-FF`
+  - **MAC address**: `AA:BB:CC:DD:EE:FF`
 
 {% details "YAML example for turning on the TV with Wake-on-LAN" %}
 
@@ -177,7 +177,7 @@ automation: |
   actions:
     - action: wake_on_lan.send_magic_packet
       data:
-        mac: "AA-BB-CC-DD-EE-FF"
+        mac: "AA:BB:CC:DD:EE:FF"
 {% endexample %}
 
 {% enddetails %}

--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -17,7 +17,7 @@ ha_integration_type: device
 ---
 
 The **LG Netcast** {% term integration %} allows you to control a LG Smart TV running NetCast 3.0 (LG Smart TV models released in 2012) and NetCast 4.0 (LG Smart TV models released in 2013).
-For the new LG WebOS TV's use the [LG webOS TV](/integrations/webostv#media-player) platform.
+For the new LG webOS TV's use the [LG webOS TV](/integrations/webostv#media-player) platform.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_triggers/lg_netcast.turn_on.markdown
+++ b/source/_triggers/lg_netcast.turn_on.markdown
@@ -62,7 +62,7 @@ entity_id:
 
 ## Good to know
 
-- This trigger fires when Home Assistant *requests* the TV to turn on, not when the TV reports that it turned on. You need to provide an action (such as Wake-on-LAN or HDMI-CEC) to actually power on the device.
+- This trigger fires when Home Assistant _requests_ the TV to turn on, not when the TV reports that it turned on. You need to provide an action (such as Wake-on-LAN or HDMI-CEC) to actually power on the device.
 - Both `media_player` and `remote` entities for the same LG Netcast device share the same turn-on trigger.
 - If you want to react when the TV actually reports that it is on, use [Media player turned on](/triggers/media_player.turned_on/) instead.
 

--- a/source/_triggers/lg_netcast.turn_on.markdown
+++ b/source/_triggers/lg_netcast.turn_on.markdown
@@ -1,0 +1,127 @@
+---
+title: "Device is requested to turn on"
+trigger: lg_netcast.turn_on
+domain: lg_netcast
+description: "Triggers when something requests an LG Netcast TV to turn on."
+related_triggers:
+  - media_player.turned_on
+---
+
+The **Device is requested to turn on** trigger fires when Home Assistant requests an LG Netcast TV to power on. Use it to react to that request and perform the actual turn-on action, such as sending a Wake-on-LAN packet or an HDMI-CEC command.
+
+LG Netcast TVs cannot be turned on by Home Assistant directly. Instead, Home Assistant fires this trigger when something (an automation, a script, or the UI) calls the turn-on action for the device. You can then use an automation to carry out whichever method your TV supports, such as Wake-on-LAN.
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Under **By device**, select your LG Netcast device.
+5. From the triggers shown for that device, select **Device is requested to turn on**.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The LG Netcast device to watch for a turn-on request.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lg_netcast.turn_on`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lg_netcast.turn_on
+  entity_id: media_player.lg_netcast_tv
+{% endexample %}
+
+This fires when something requests the LG Netcast TV to turn on.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+trigger:
+  description: The trigger type. For this trigger, use `lg_netcast.turn_on`.
+  required: true
+  type: string
+device_id:
+  description: One or more device IDs of LG Netcast devices to watch. At least one of `device_id` or `entity_id` must be set.
+  required: false
+  type: [string, list]
+entity_id:
+  description: One or more entity IDs of LG Netcast entities to watch. At least one of `device_id` or `entity_id` must be set.
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+## Good to know
+
+- This trigger fires when Home Assistant *requests* the TV to turn on, not when the TV reports that it turned on. You need to provide an action (such as Wake-on-LAN or HDMI-CEC) to actually power on the device.
+- Both `media_player` and `remote` entities for the same LG Netcast device share the same turn-on trigger.
+- If you want to react when the TV actually reports that it is on, use [Media player turned on](/triggers/media_player.turned_on/) instead.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the TV with Wake-on-LAN
+
+When something requests the LG Netcast TV to turn on, send a Wake-on-LAN magic packet to power it on over the network.
+
+- **Trigger**: Device is requested to turn on
+  - **Device**: Living room LG TV (`media_player.lg_netcast_tv`)
+- **Action**: Send magic packet
+  - **MAC address**: `AA-BB-CC-DD-EE-FF`
+
+{% details "YAML example for turning on the TV with Wake-on-LAN" %}
+
+{% example %}
+automation: |
+  alias: "Turn on LG Netcast TV with Wake-on-LAN"
+  triggers:
+    - trigger: lg_netcast.turn_on
+      entity_id: media_player.lg_netcast_tv
+  actions:
+    - action: wake_on_lan.send_magic_packet
+      data:
+        mac: "AA-BB-CC-DD-EE-FF"
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a notification when the TV is requested to turn on
+
+When something requests the LG Netcast TV to turn on, send a notification to your phone.
+
+- **Trigger**: Device is requested to turn on
+  - **Device**: Living room LG TV (`media_player.lg_netcast_tv`)
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for sending a notification when the TV is requested to turn on" %}
+
+{% example %}
+automation: |
+  alias: "Notify when LG Netcast TV is requested to turn on"
+  triggers:
+    - trigger: lg_netcast.turn_on
+      entity_id: media_player.lg_netcast_tv
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The living room TV was requested to turn on."
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/lg_netcast.turn_on.markdown
+++ b/source/_triggers/lg_netcast.turn_on.markdown
@@ -77,7 +77,7 @@ When something requests the LG Netcast TV to turn on, send a Wake-on-LAN magic p
 - **Trigger**: Device is requested to turn on
   - **Device**: Living room LG TV (`media_player.lg_netcast_tv`)
 - **Action**: Send magic packet
-  - **MAC address**: `AA-BB-CC-DD-EE-FF`
+  - **MAC address**: `AA:BB:CC:DD:EE:FF`
 
 {% details "YAML example for turning on the TV with Wake-on-LAN" %}
 

--- a/source/_triggers/lg_netcast.turn_on.markdown
+++ b/source/_triggers/lg_netcast.turn_on.markdown
@@ -90,7 +90,7 @@ automation: |
   actions:
     - action: wake_on_lan.send_magic_packet
       data:
-        mac: "AA-BB-CC-DD-EE-FF"
+        mac: "AA:BB:CC:DD:EE:FF"
 {% endexample %}
 
 {% enddetails %}


### PR DESCRIPTION
## Proposed change

Add a split-page trigger doc for `lg_netcast.turn_on` and update the integration page.

### Changes

- **New**: `source/_triggers/lg_netcast.turn_on.markdown` - split-page trigger documentation for the "Device is requested to turn on" trigger
- **Updated**: `source/_integrations/lg_netcast.markdown` - replaced the old inline "Turn on action" section with `{% include integrations/triggers.md %}` and a new automation examples section; updated the Remote section to link to the new trigger page

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/44920

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards