### PR TITLE
UniFi Protect: document public API camera streams as the default

### DIFF
--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -114,18 +114,14 @@ check that this is done. To check and enable the feature:
 
 {% include integrations/config_flow.md %}
 
-### Public API camera streams
+## Configuration options
 
-By default, the integration sources camera live streams from the official UniFi Protect public API. To use the legacy behavior instead, you can turn this off, and the integration sources streams from each camera's RTSP(S) URLs through UniFi Protect's private API, as described above. Your camera entities stay the same either way.
+The integration provides the following configuration options. Go to {% my integrations title="**Settings** > **Devices & services**" %}, select **UniFi Protect**, then select the cogwheel {% icon "mdi:cog-outline" %} (**Configure**).
 
-#### Turning off the Public API camera streams option
-
-The option is turned on by default. To turn it off:
-
-1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select **UniFi Protect**.
-2. Select **Configure**, and turn off **Use the public API for camera streams**.
-
-When the option is on and a camera is online but has no active public API stream, Home Assistant suggests a repair named **No stream is available for camera**. Confirming the repair has Home Assistant create the highest quality RTSPS stream for that camera through the UniFi Protect public API. You can also turn on a stream directly in UniFi Protect under _Share Livestream_. Offline cameras don't trigger this repair.
+{% configuration_basic %}
+Use the public API for camera streams:
+    description: "When enabled (default), the integration sources camera live streams from the official UniFi Protect public API instead of each camera's RTSP(S) URLs. Your camera entities stay the same either way. When a camera is online but has no active public API stream, Home Assistant suggests a **No stream is available for camera** repair, which creates the highest-quality RTSPS stream for that camera via the UniFi Protect public API. You can also turn on a stream directly in UniFi Protect under _Share Livestream_. Offline cameras don't trigger this repair. When you turn off **Use the public API for camera streams**, the integration sources streams from each camera's RTSP(S) URLs through UniFi Protect's private API."
+{% endconfiguration_basic %}
 
 ## Device support
 

--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -116,11 +116,16 @@ check that this is done. To check and enable the feature:
 
 ### Public API camera streams
 
-By default, the integration sources camera live streams from each camera's RTSP(S) URLs through UniFi Protect's private API, as described above. With this option, it sources them from the official UniFi Protect public API instead. To turn this on, go to {% my integrations title="**Settings** > **Devices & services**" %}, select **UniFi Protect**, select **Configure**, and turn on **Use the public API for camera streams (experimental)**.
+By default, the integration sources camera live streams from the official UniFi Protect public API. To use the legacy behavior instead, you can turn this off, and the integration sources streams from each camera's RTSP(S) URLs through UniFi Protect's private API, as described above. Your camera entities stay the same either way.
 
-This option is _experimental_ and turned off by default. It works well for smaller setups, but on installations with many cameras the public API request rate limit can slow down or briefly interrupt startup. It is expected to become the default once UniFi Protect provides stream information more efficiently. Turning the option off returns to the standard RTSP(S) stream handling, and your camera entities stay the same either way.
+#### Turning off the Public API camera streams option
 
-When the option is on and a camera is online but has no active public API stream, the integration suggests a repair to activate one. You can also turn on a stream directly in UniFi Protect under _Share Livestream_. Offline cameras don't trigger this repair.
+The option is turned on by default. To turn it off:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select **UniFi Protect**.
+2. Select **Configure**, and turn off **Use the public API for camera streams**.
+
+When the option is on and a camera is online but has no active public API stream, Home Assistant suggests a repair named **No stream is available for camera**. Confirming the repair has Home Assistant create the highest quality RTSPS stream for that camera through the UniFi Protect public API. You can also turn on a stream directly in UniFi Protect under _Share Livestream_. Offline cameras don't trigger this repair.
 
 ## Device support
 

--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -114,6 +114,14 @@ check that this is done. To check and enable the feature:
 
 {% include integrations/config_flow.md %}
 
+### Public API camera streams
+
+By default, the integration sources camera live streams from each camera's RTSP(S) URLs through UniFi Protect's private API, as described above. With this option, it sources them from the official UniFi Protect public API instead. To turn this on, go to {% my integrations title="**Settings** > **Devices & services**" %}, select **UniFi Protect**, select **Configure**, and turn on **Use the public API for camera streams (experimental)**.
+
+This option is _experimental_ and turned off by default. It works well for smaller setups, but on installations with many cameras the public API request rate limit can slow down or briefly interrupt startup. It is expected to become the default once UniFi Protect provides stream information more efficiently. Turning the option off returns to the standard RTSP(S) stream handling, and your camera entities stay the same either way.
+
+When the option is on and a camera is online but has no active public API stream, the integration suggests a repair to activate one. You can also turn on a stream directly in UniFi Protect under _Share Livestream_. Offline cameras don't trigger this repair.
+
 ## Device support
 
 All known UniFi Protect devices should be supported. Each UniFi Protect device will get a variety of entities added for


### PR DESCRIPTION
## Proposed change

Document that the UniFi Protect integration now sources camera live streams from the official UniFi Protect public API **by default**. The **Use the public API for camera streams** option is on by default and can be turned off to fall back to the legacy private RTSP(S) stream handling; the camera entities are unaffected either way.

When the option is on and an online camera has no active public API stream, the integration suggests the **No stream is available for camera** repair, which has Home Assistant create the highest quality RTSPS stream for that camera through the public API.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#173339
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
