### PR TITLE
Document Duco daily write limit in system information

### DIFF
--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -363,8 +363,6 @@ Setting the fan speed or preset mode fails with a notification in the Home Assis
 
 > The Duco device has reached its daily write limit. Try again tomorrow.
 
-If you see this message, use the steps below to verify the current limit status in the Duco section of **System information**.
-
 #### Description
 
 The Duco box enforces a daily API write limit of 200 write requests. When the limit is reached, the box rejects further write requests until the quota resets shortly after midnight.

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -363,18 +363,18 @@ Setting the fan speed or preset mode fails with a notification in the Home Assis
 
 > The Duco device has reached its daily write limit. Try again tomorrow.
 
-If you see this message, you can verify the current limit status under **Settings** > **System** > **Repairs**. Open the {% icon "mdi:dots-vertical" %} menu in the top-right corner, select **System information**, and review the Duco section.
+If you see this message, use the steps below to verify the current limit status in the Duco section of **System information**.
 
 #### Description
 
-The Duco box enforces a daily API write limit of 200 write requests. When the limit is reached, the box rejects further write requests until the quota resets around midnight.
+The Duco box enforces a daily API write limit of 200 write requests. When the limit is reached, the box rejects further write requests until the quota resets shortly after midnight.
 
 #### Resolution
 
 1. Under **Settings** > **System** > **Repairs**, open the {% icon "mdi:dots-vertical" %} menu in the top-right corner.
 2. Select **System information**.
 3. Review the Duco section to confirm that the daily write limit has been reached.
-4. Wait until the next day for the quota to reset.
+4. Wait until shortly after midnight for the quota to reset.
 5. To avoid hitting the limit, reduce the frequency of automations that change the ventilation state.
 
 ## Reconfiguring the integration

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -363,13 +363,19 @@ Setting the fan speed or preset mode fails with a notification in the Home Assis
 
 > The Duco device has reached its daily write limit. Try again tomorrow.
 
+If you see this message, you can verify the current limit status under **Settings** > **System** > **Repairs**. Open the {% icon "mdi:dots-vertical" %} menu in the top-right corner, select **System information**, and review the Duco section.
+
 #### Description
 
-The Duco box enforces a write rate limit of 200 write requests per day. When the limit is reached, the box rejects further write requests until the quota resets around midnight.
+The Duco box enforces a daily API write limit of 200 write requests. When the limit is reached, the box rejects further write requests until the quota resets around midnight.
 
 #### Resolution
 
-Wait until midnight for the quota to reset. To avoid hitting the limit, reduce the frequency of automations that change the ventilation state.
+1. Under **Settings** > **System** > **Repairs**, open the {% icon "mdi:dots-vertical" %} menu in the top-right corner.
+2. Select **System information**.
+3. Review the Duco section to confirm that the daily write limit has been reached.
+4. Wait until the next day for the quota to reset.
+5. To avoid hitting the limit, reduce the frequency of automations that change the ventilation state.
 
 ## Reconfiguring the integration
 

--- a/source/_integrations/duco.markdown
+++ b/source/_integrations/duco.markdown
@@ -369,11 +369,12 @@ The Duco box enforces a daily API write limit of 200 write requests. When the li
 
 #### Resolution
 
-1. Under **Settings** > **System** > **Repairs**, open the {% icon "mdi:dots-vertical" %} menu in the top-right corner.
-2. Select **System information**.
-3. Review the Duco section to confirm that the daily write limit has been reached.
-4. Wait until shortly after midnight for the quota to reset.
-5. To avoid hitting the limit, reduce the frequency of automations that change the ventilation state.
+1. Check if the daily write limit has been reached. 
+   - Under **Settings** > **System** > **Repairs**, open the {% icon "mdi:dots-vertical" %} menu in the top-right corner.
+   - Select **System information**.
+   - In the Duco section, you should see if the daily write limit has been reached.
+2. If the limit has been reached, wait until shortly after midnight for the quota to reset.
+3. To avoid hitting the limit again, reduce the frequency of automations that change the ventilation state.
 
 ## Reconfiguring the integration
 


### PR DESCRIPTION
## Proposed change

Adds next-branch documentation for the Duco rate-limit troubleshooting section.
It explains that when Home Assistant shows the daily write limit message, you can verify the current status under **Settings** > **System** > **Repairs**, open the three dots {% icon \"mdi:dots-vertical\" %} menu, select **System information**, and review the Duco section.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173324
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards