### PR TITLE
Whirlpool: document oven stop button

### DIFF
--- a/source/_integrations/whirlpool.markdown
+++ b/source/_integrations/whirlpool.markdown
@@ -2,8 +2,10 @@
 title: Whirlpool Appliances
 description: Instructions on how to integrate Whirlpool appliances with Home Assistant.
 ha_category:
+  - Button
   - Climate
   - Hub
+  - Number
   - Select
 ha_release: '2022.10'
 ha_iot_class: Cloud Push
@@ -14,8 +16,10 @@ ha_codeowners:
 ha_domain: whirlpool
 ha_platforms:
   - binary_sensor
+  - button
   - climate
   - diagnostics
+  - number
   - select
   - sensor
 ha_integration_type: hub
@@ -67,7 +71,9 @@ Brand:
 This {% term integration %} maps appliances to entities in Home Assistant. A single appliance may be represented by one or more entities.
 
 - [Binary Sensor](#binary_sensor)
+- [Button](#button)
 - [Climate](#climate)
+- [Number](#number)
 - [Select](#select)
 - [Sensor](#sensor)
 
@@ -76,6 +82,12 @@ This {% term integration %} maps appliances to entities in Home Assistant. A sin
 The binary sensor platform provides the following functionality:
 
 - state of the washer/dryer machine door (open/closed)
+
+### Button
+
+The button platform provides the following functionality:
+
+- stop the current cooking program for an oven cavity
 
 ### Climate
 
@@ -88,6 +100,12 @@ The following actions are also available:
 - [**turn on/off**](/integrations/climate#action-climateturn_on)
 - [**fan mode**](/integrations/climate#action-climateset_fan_mode) (`low`, `medium`, `high`)
 - [**swing mode**](/integrations/climate#action-climateset_swing_mode) (`off`, `horizontal`)
+
+### Number
+
+The number platform provides the following functionality:
+
+- set the target temperature for an oven cavity
 
 ### Select
 

--- a/source/_integrations/whirlpool.markdown
+++ b/source/_integrations/whirlpool.markdown
@@ -5,7 +5,6 @@ ha_category:
   - Button
   - Climate
   - Hub
-  - Number
   - Select
 ha_release: '2022.10'
 ha_iot_class: Cloud Push
@@ -19,7 +18,6 @@ ha_platforms:
   - button
   - climate
   - diagnostics
-  - number
   - select
   - sensor
 ha_integration_type: hub
@@ -73,7 +71,6 @@ This {% term integration %} maps appliances to entities in Home Assistant. A sin
 - [Binary Sensor](#binary_sensor)
 - [Button](#button)
 - [Climate](#climate)
-- [Number](#number)
 - [Select](#select)
 - [Sensor](#sensor)
 
@@ -100,12 +97,6 @@ The following actions are also available:
 - [**turn on/off**](/integrations/climate#action-climateturn_on)
 - [**fan mode**](/integrations/climate#action-climateset_fan_mode) (`low`, `medium`, `high`)
 - [**swing mode**](/integrations/climate#action-climateset_swing_mode) (`off`, `horizontal`)
-
-### Number
-
-The number platform provides the following functionality:
-
-- set the target temperature for an oven cavity
 
 ### Select
 


### PR DESCRIPTION
## Proposed change

Documents the new oven control entities added to the Whirlpool integration:

- A `button` entity to stop the current cooking program for an oven cavity.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#173411, home-assistant/core#173412, home-assistant/core#173413
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards